### PR TITLE
[PM-20671] Add missing main in package.json for abstractions

### DIFF
--- a/.changeset/famous-donkeys-sink.md
+++ b/.changeset/famous-donkeys-sink.md
@@ -1,0 +1,5 @@
+---
+'@midnight-ntwrk/wallet-sdk-abstractions': patch
+---
+
+Adds missing main property in the package.json file for the abstractions package

--- a/packages/abstractions/package.json
+++ b/packages/abstractions/package.json
@@ -3,8 +3,9 @@
   "description": "Domain-specific abstractions for the wallet SDK",
   "version": "1.0.0-beta.8",
   "type": "module",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "author": "Midnight Foundation",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -26,6 +27,15 @@
   "dependencies": {
     "effect": "^3.17.3"
   },
+  "devDependencies": {
+    "eslint": "^9.37.0",
+    "fast-check": "^4.2.0",
+    "publint": "~0.3.14",
+    "rimraf": "^6.0.1",
+    "to-words": "^4.5.1",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  },
   "scripts": {
     "typecheck": "tsc -b ./tsconfig.json --noEmit",
     "test": "vitest run",
@@ -36,14 +46,5 @@
     "dist:publish": "tsc -b ./tsconfig.publish.json",
     "clean": "rimraf --glob dist 'tsconfig.*.tsbuildinfo' && date +%s > .clean-timestamp",
     "publint": "publint --strict"
-  },
-  "devDependencies": {
-    "eslint": "^9.37.0",
-    "fast-check": "^4.2.0",
-    "publint": "~0.3.14",
-    "rimraf": "^6.0.1",
-    "to-words": "^4.5.1",
-    "typescript": "^5.9.3",
-    "vitest": "^3.2.4"
   }
 }


### PR DESCRIPTION
# Description

The main property in the package.json file for the abstractions package is missing.

We need to ensure that this is present.

# Testing

No QA required, its a release fix

