### PR TITLE
[PM-20832] Remove last cache save in CI.yml + fix up turbo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,9 @@ jobs:
           name: build-artifacts-${{ github.run_id }}
           path: .
 
+      # The following 3 steps are the equivalent of running `yarn verify:check`/`turbo verify:check`
+      # They are separated into 3 steps to give better visibility of the errors in the ci.
+      # Future changes to verify:check should be reflected in these steps.
       - name: Run typecheck
         run: yarn typecheck
 
@@ -355,10 +358,3 @@ jobs:
 
       - name: Run publint
         run: yarn publint
-
-      - name: Save turbo cache
-        if: always()
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 #v4.3.0
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}-${{ github.run_id }}-build-publish-${{ github.run_attempt }}

--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
     "vite": "^7.1.11"
   },
   "scripts": {
-    "format": "prettier --write \"**/*.{ts,js,json,yaml,yml,md}\" && turbo run format",
-    "format:check": "prettier --check \"**/*.{ts,js,json,yaml,yml,md}\" && turbo run format:check",
+    "format:root": "prettier --write \"**/*.{ts,js,json,yaml,yml,md}\"",
+    "format:check:root": "prettier --check \"**/*.{ts,js,json,yaml,yml,md}\"",
+    "format": "turbo run format",
+    "format:check": "turbo run format:check",
     "verify": "turbo run verify",
     "verify:check": "turbo run verify:check",
     "verify:test": "turbo run verify:test",

--- a/turbo.json
+++ b/turbo.json
@@ -95,15 +95,29 @@
       "outputs": [],
       "outputLogs": "new-only"
     },
+    "//#format:root": {
+      "cache": false,
+      "inputs": ["**/*.{ts,js,json,yaml,yml,md}", ".prettierrc.json", ".prettierignore"],
+      "outputs": [],
+      "outputLogs": "new-only"
+    },
+    "//#format:check:root": {
+      "cache": false,
+      "inputs": ["**/*.{ts,js,json,yaml,yml,md}", ".prettierrc.json", ".prettierignore"],
+      "outputs": [],
+      "outputLogs": "new-only"
+    },
     "format": {
       "inputs": ["**/*.{ts,js,json,yaml,yml,md}", ".prettierrc.json", "**/.prettierignore"],
       "outputs": [],
-      "outputLogs": "new-only"
+      "outputLogs": "new-only",
+      "dependsOn": ["//#format:root"]
     },
     "format:check": {
       "inputs": ["**/*.{ts,js,json,yaml,yml,md}", ".prettierrc.json", "**/.prettierignore"],
       "outputs": [],
-      "outputLogs": "new-only"
+      "outputLogs": "new-only",
+      "dependsOn": ["//#format:check:root"]
     },
     "verify:check": {
       "dependsOn": ["typecheck", "format:check", "lint"]


### PR DESCRIPTION
# Description

We actually try to save the cache on CI.yml - on the very last task, which is the first unneeded, and it re-uses the same key anyway.

Remove the saving of the cache, it is unneeded.

Added root tasks to turbo so that running yarn format / format:check from the root performs the same as turbo run format / format:check
