### PR TITLE
chore: update e2e tests with new unshielded wallet api

### DIFF
--- a/packages/e2e-tests/src/tests/balanceConstant.remote.test.ts
+++ b/packages/e2e-tests/src/tests/balanceConstant.remote.test.ts
@@ -51,7 +51,7 @@ describe('Balance constant', () => {
   beforeEach(async () => {
     const fixture = getFixture();
 
-    walletFacade = await utils.buildWalletFacade(seed, fixture);
+    walletFacade = utils.buildWalletFacade(seed, fixture);
     await walletFacade.start(shieldedSecretKey, dustSecretKey);
   }, syncTimeout);
 
@@ -74,7 +74,7 @@ describe('Balance constant', () => {
       expect(syncedState.shielded.balances[shieldedTokenRaw] ?? 0n).toBe(expectedShieldedBalance);
       expect(syncedState.shielded.balances[nativeTokenHash] ?? 0n).toBe(expectedTokenOneBalance);
       expect(syncedState.shielded.balances[nativeTokenHash2] ?? 0n).toBe(expectedTokenTwoBalance);
-      expect(syncedState.unshielded.balances.get(unshieldedTokenRaw) ?? 0n).toBe(expectedUnshieldedBalance);
+      expect(syncedState.unshielded.balances[unshieldedTokenRaw] ?? 0n).toBe(expectedUnshieldedBalance);
       expect(syncedState.dust.walletBalance(new Date())).toBe(expectedDustBalance);
       expect(syncedState.shielded.availableCoins.length).toBeGreaterThanOrEqual(3);
       expect(syncedState.shielded.pendingCoins.length).toBe(0);
@@ -97,7 +97,7 @@ describe('Balance constant', () => {
       expect(syncedState.shielded.balances[shieldedTokenRaw] ?? 0n).toBe(expectedDustBalance);
       expect(syncedState.shielded.balances[nativeTokenHash] ?? 0n).toBe(expectedTokenOneBalance);
       expect(syncedState.shielded.balances[nativeTokenHash2] ?? 0n).toBe(expectedTokenTwoBalance);
-      expect(syncedState.unshielded.balances.get(unshieldedTokenRaw) ?? 0n).toBe(expectedUnshieldedBalance);
+      expect(syncedState.unshielded.balances[unshieldedTokenRaw] ?? 0n).toBe(expectedUnshieldedBalance);
       expect(syncedState.dust.walletBalance(new Date())).toBe(expectedDustBalance);
       expect(syncedState.shielded.availableCoins.length).toBeGreaterThanOrEqual(3);
       expect(syncedState.shielded.pendingCoins.length).toBe(0);

--- a/packages/e2e-tests/src/tests/balancing.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/balancing.undeployed.test.ts
@@ -52,7 +52,7 @@ describe('Transaction balancing examples', () => {
   beforeEach(async () => {
     await allure.step('Distribute coins to sender', async function () {
       fixture = getFixture();
-      fundedFacade = await utils.buildWalletFacade(fundedSeed, fixture);
+      fundedFacade = utils.buildWalletFacade(fundedSeed, fixture);
       await fundedFacade.start(fundedShieldedSecretKey, fundedDustSecretKey);
 
       const initialState = await utils.waitForSyncFacade(fundedFacade);
@@ -118,7 +118,7 @@ describe('Transaction balancing examples', () => {
         // expect(finalState.shielded.transactionHistory.length).toBe(initialState.shielded.transactionHistory.length + 2);
         await utils.waitForFacadePendingClear(senderFacade);
       };
-      senderFacade = await utils.buildWalletFacade(senderSeed, fixture);
+      senderFacade = utils.buildWalletFacade(senderSeed, fixture);
       await senderFacade.start(senderShieldedSecretKey, senderDustSecretKey);
       const state = await utils.waitForSyncFacade(senderFacade);
       const walletAddress = utils.getShieldedAddress(NetworkId.NetworkId.Undeployed, state.shielded.address);
@@ -144,7 +144,7 @@ describe('Transaction balancing examples', () => {
       const receiver1SecretKey = ledger.ZswapSecretKeys.fromSeed(utils.getShieldedSeed(receiver1Seed));
       const receiver1DustSecretKey = ledger.DustSecretKey.fromSeed(utils.getDustSeed(receiver1Seed));
 
-      receiver1 = await utils.buildWalletFacade(receiver1Seed, fixture);
+      receiver1 = utils.buildWalletFacade(receiver1Seed, fixture);
       await receiver1.start(receiver1SecretKey, receiver1DustSecretKey);
 
       const initialState = await utils.waitForSyncFacade(senderFacade);
@@ -234,7 +234,7 @@ describe('Transaction balancing examples', () => {
       const receiver1SecretKey = ledger.ZswapSecretKeys.fromSeed(utils.getShieldedSeed(receiver1Seed));
       const receiver1DustSecretKey = ledger.DustSecretKey.fromSeed(utils.getDustSeed(receiver1Seed));
 
-      receiver1 = await utils.buildWalletFacade(receiver1Seed, fixture);
+      receiver1 = utils.buildWalletFacade(receiver1Seed, fixture);
       await receiver1.start(receiver1SecretKey, receiver1DustSecretKey);
 
       const initialState = await utils.waitForSyncFacade(senderFacade);
@@ -326,9 +326,9 @@ describe('Transaction balancing examples', () => {
       const output2 = 10_000_000n;
       const output3 = 3_000_000n;
 
-      receiver1 = await utils.buildWalletFacade(randomBytes(32).toString('hex'), fixture);
-      receiver2 = await utils.buildWalletFacade(randomBytes(32).toString('hex'), fixture);
-      receiver3 = await utils.buildWalletFacade(randomBytes(32).toString('hex'), fixture);
+      receiver1 = utils.buildWalletFacade(randomBytes(32).toString('hex'), fixture);
+      receiver2 = utils.buildWalletFacade(randomBytes(32).toString('hex'), fixture);
+      receiver3 = utils.buildWalletFacade(randomBytes(32).toString('hex'), fixture);
 
       const initialState = await utils.waitForSyncFacade(senderFacade);
       const initialBalance = initialState.shielded.balances[shieldedTokenRaw] ?? 0n;
@@ -459,7 +459,7 @@ describe('Transaction balancing examples', () => {
       allure.feature('Transaction balancing');
       allure.story('Error when trying to transfer all available tdust');
 
-      receiver1 = await utils.buildWalletFacade(randomBytes(32).toString('hex'), fixture);
+      receiver1 = utils.buildWalletFacade(randomBytes(32).toString('hex'), fixture);
 
       const initialState = await utils.waitForSyncFacade(senderFacade);
       const initialBalance = initialState.shielded.balances[shieldedTokenRaw] ?? 0n;
@@ -520,7 +520,7 @@ describe('Transaction balancing examples', () => {
       const output1 = 1_000_000n;
       const walletFees = 159620n;
 
-      receiver1 = await utils.buildWalletFacade(randomBytes(32).toString('hex'), fixture);
+      receiver1 = utils.buildWalletFacade(randomBytes(32).toString('hex'), fixture);
 
       const initialState = await utils.waitForSyncFacade(senderFacade);
       const initialBalance = initialState.shielded.balances[shieldedTokenRaw] ?? 0n;
@@ -649,7 +649,7 @@ describe('Transaction balancing examples', () => {
 
       await utils.closeWallet(receiver1);
 
-      receiver1 = await utils.buildWalletFacade(randomBytes(32).toString('hex'), fixture);
+      receiver1 = utils.buildWalletFacade(randomBytes(32).toString('hex'), fixture);
 
       const finalReceiverWalletState = await utils.waitForSyncFacade(receiver1);
       const finalWalletBalancer = finalReceiverWalletState.shielded.balances[shieldedTokenRaw] ?? 0n;
@@ -674,7 +674,7 @@ describe('Transaction balancing examples', () => {
       const receiver1SecretKey = ledger.ZswapSecretKeys.fromSeed(utils.getShieldedSeed(receiver1Seed));
       const receiver1DustSecretKey = ledger.DustSecretKey.fromSeed(utils.getDustSeed(receiver1Seed));
 
-      receiver1 = await utils.buildWalletFacade(receiver1Seed, fixture);
+      receiver1 = utils.buildWalletFacade(receiver1Seed, fixture);
       await receiver1.start(receiver1SecretKey, receiver1DustSecretKey);
       const initialState = await utils.waitForSyncFacade(senderFacade);
       logger.info(initialState.shielded.balances);

--- a/packages/e2e-tests/src/tests/fundedWallet.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/fundedWallet.undeployed.test.ts
@@ -37,7 +37,7 @@ describe('Funded wallet', () => {
   beforeEach(async () => {
     await allure.step('Start a funded wallet', async function () {
       const fixture = getFixture();
-      wallet = await utils.buildWalletFacade(seedFunded, fixture);
+      wallet = utils.buildWalletFacade(seedFunded, fixture);
       await wallet.start(fundedSecretKey, fundedDustSecretKey);
     });
   });
@@ -64,9 +64,9 @@ describe('Funded wallet', () => {
         500000000000000n,
       );
       expect(state?.unshielded.balances).toHaveLength(1);
-      expect(state?.unshielded.balances.get(unshieldedTokenRaw)).toBe(2_500_000_000_000_000n);
+      expect(state?.unshielded.balances[unshieldedTokenRaw]).toBe(2_500_000_000_000_000n);
       expect(
-        state?.unshielded.balances.get('0000000000000000000000000000000000000000000000000000000000000002'),
+        state?.unshielded.balances['0000000000000000000000000000000000000000000000000000000000000002'],
       ).toBeUndefined();
       expect(state?.dust.totalCoins).toHaveLength(5);
       expect(state?.dust.walletBalance(new Date())).toBe(12500000000000000000000000n);
@@ -100,13 +100,13 @@ describe('Funded wallet', () => {
 
       const unshieldedCoins = state.unshielded.totalCoins;
       expect(unshieldedCoins).toHaveLength(5);
-      expect(utils.isArrayUnique(unshieldedCoins.map((c) => c.intentHash))).toBeTruthy();
+      expect(utils.isArrayUnique(unshieldedCoins.map((c) => c.utxo.intentHash))).toBeTruthy();
       unshieldedCoins.forEach((c) => {
-        expect(c.value).toBe(500000000000000n);
-        expect(c.outputNo).toBe(0);
-        expect(typeof c.owner).toBe('string');
-        expect(typeof c.type).toBe('string');
-        expect(c.registeredForDustGeneration).toBe(true);
+        expect(c.utxo.value).toBe(500000000000000n);
+        expect(c.utxo.outputNo).toBe(0);
+        expect(typeof c.utxo.owner).toBe('string');
+        expect(typeof c.utxo.type).toBe('string');
+        expect(c.meta.registeredForDustGeneration).toBe(true);
       });
 
       const dustCoins = state.dust.totalCoins;
@@ -149,13 +149,13 @@ describe('Funded wallet', () => {
 
       const unshieldedCoins = state.unshielded.availableCoins;
       expect(unshieldedCoins).toHaveLength(5);
-      expect(utils.isArrayUnique(unshieldedCoins.map((c) => c.intentHash))).toBeTruthy();
+      expect(utils.isArrayUnique(unshieldedCoins.map((c) => c.utxo.intentHash))).toBeTruthy();
       unshieldedCoins.forEach((c) => {
-        expect(c.value).toBe(500000000000000n);
-        expect(c.outputNo).toBe(0);
-        expect(typeof c.owner).toBe('string');
-        expect(typeof c.type).toBe('string');
-        expect(c.registeredForDustGeneration).toBe(true);
+        expect(c.utxo.value).toBe(500000000000000n);
+        expect(c.utxo.outputNo).toBe(0);
+        expect(typeof c.utxo.owner).toBe('string');
+        expect(typeof c.utxo.type).toBe('string');
+        expect(c.meta.registeredForDustGeneration).toBe(true);
       });
 
       const dustCoins = state.dust.availableCoins;

--- a/packages/e2e-tests/src/tests/nativeTokenTransfer.remote.test.ts
+++ b/packages/e2e-tests/src/tests/nativeTokenTransfer.remote.test.ts
@@ -67,8 +67,8 @@ describe('Token transfer', () => {
     fixture = getFixture();
     networkId = fixture.getNetworkId();
 
-    wallet = await utils.buildWalletFacade(fundedSeed, fixture);
-    wallet2 = await utils.buildWalletFacade(receivingSeed, fixture);
+    wallet = utils.buildWalletFacade(fundedSeed, fixture);
+    wallet2 = utils.buildWalletFacade(receivingSeed, fixture);
 
     await wallet.start(initialFundedSecretKey, fundedDustSecretKey);
     await wallet2.start(initialReceiverSecretKey, receiverDustSecretKey);
@@ -113,7 +113,7 @@ describe('Token transfer', () => {
       await Promise.all([utils.waitForSyncFacade(sender), utils.waitForSyncFacade(receiver)]);
       const initialState = await firstValueFrom(sender.state());
       const initialShieldedBalance = initialState.shielded.balances[shieldedTokenRaw];
-      const initialUnshieldedBalance = initialState.unshielded.balances.get(unshieldedTokenRaw);
+      const initialUnshieldedBalance = initialState.unshielded.balances[unshieldedTokenRaw];
       const initialDustBalance = initialState.dust.walletBalance(new Date());
       logger.info(`Wallet 1: ${initialShieldedBalance} shielded tokens`);
       logger.info(`Wallet 1: ${initialUnshieldedBalance} shielded tokens`);
@@ -124,7 +124,7 @@ describe('Token transfer', () => {
       const initialReceiverState = await firstValueFrom(receiver.state());
       const initialReceiverShieldedBalance1 = initialReceiverState.shielded.balances[nativeToken1Raw];
       const initialReceiverShieldedBalance2 = initialReceiverState.shielded.balances[nativeToken2Raw];
-      const initialReceiverUnshieldedBalance = initialReceiverState.unshielded.balances.get(unshieldedTokenRaw);
+      const initialReceiverUnshieldedBalance = initialReceiverState.unshielded.balances[unshieldedTokenRaw];
       const initialReceiverDustBalance = initialReceiverState.dust.walletBalance(new Date());
       logger.info(`Wallet 2: ${initialReceiverShieldedBalance1} native token 1`);
       logger.info(`Wallet 2: ${initialReceiverShieldedBalance2} native token 2`);
@@ -194,7 +194,7 @@ describe('Token transfer', () => {
       // logger.info(walletStateTrimmed(finalState));
       const senderFinalShieldedBalance1 = finalState.shielded.balances[nativeToken1Raw];
       const senderFinalShieldedBalance2 = finalState.shielded.balances[nativeToken2Raw];
-      const senderFinalUnshieldedBalance = finalState.unshielded.balances.get(unshieldedTokenRaw);
+      const senderFinalUnshieldedBalance = finalState.unshielded.balances[unshieldedTokenRaw];
       const senderFinalDustBalance = finalState.dust.walletBalance(new Date(3 * 1000));
       logger.info(`Wallet 1 final available dust: ${senderFinalDustBalance}`);
       logger.info(`Wallet 1 final available shielded coins: ${senderFinalShieldedBalance1}`);
@@ -223,7 +223,7 @@ describe('Token transfer', () => {
       // logger.info(walletStateTrimmed(finalState2));
       const receiverFinalShieldedBalance1 = finalState.shielded.balances[nativeToken1Raw];
       const receiverFinalShieldedBalance2 = finalState.shielded.balances[nativeToken2Raw];
-      const receiverFinalUnshieldedBalance = finalState.unshielded.balances.get(unshieldedTokenRaw);
+      const receiverFinalUnshieldedBalance = finalState.unshielded.balances[unshieldedTokenRaw];
       const receiverFinalDustBalance = finalState.dust.walletBalance(new Date(3 * 1000));
       logger.info(`Wallet 2 final available shielded coins: ${receiverFinalShieldedBalance1}`);
       logger.info(`Wallet 2 final available shielded coins: ${receiverFinalShieldedBalance2}`);

--- a/packages/e2e-tests/src/tests/smoke.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/smoke.undeployed.test.ts
@@ -25,10 +25,11 @@ import { CombinedTokenTransfer, WalletFacade } from '@midnight-ntwrk/wallet-sdk-
 import {
   createKeystore,
   PublicKey,
-  WalletBuilder as UnshieldedWalletBuilder,
+  UnshieldedWallet,
+  InMemoryTransactionHistoryStorage,
 } from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
-import { InMemoryTransactionHistoryStorage } from '../../../unshielded-wallet/dist/tx-history-storage/InMemoryTransactionHistoryStorage.js';
 import { DustWallet, DustWalletClass } from '@midnight-ntwrk/wallet-sdk-dust-wallet';
+import { UnshieldedAddress } from '@midnight-ntwrk/wallet-sdk-address-format';
 
 /**
  * Smoke tests
@@ -60,8 +61,8 @@ describe('Smoke tests', () => {
       fixture = getFixture();
       Dust = DustWallet(fixture.getDustWalletConfig());
       Wallet = ShieldedWallet(fixture.getWalletConfig());
-      walletFunded = await utils.buildWalletFacade(seedFunded, fixture);
-      receiverWallet = await utils.buildWalletFacade(seed, fixture);
+      walletFunded = utils.buildWalletFacade(seedFunded, fixture);
+      receiverWallet = utils.buildWalletFacade(seed, fixture);
       await walletFunded.start(fundedSecretKey, fundedDustSecretKey);
       await receiverWallet.start(receiverWalletSecretKey, receiverWalletDustSecretKey);
       logger.info('Two wallets started');
@@ -93,7 +94,7 @@ describe('Smoke tests', () => {
       await Promise.all([utils.waitForSyncFacade(walletFunded), utils.waitForSyncFacade(receiverWallet)]);
       const initialState = await utils.waitForSyncFacade(walletFunded);
       const initialShieldedBalance = initialState.shielded.balances[shieldedTokenRaw];
-      const initialUnshieldedBalance = initialState.unshielded.balances.get(unshieldedTokenRaw);
+      const initialUnshieldedBalance = initialState.unshielded.balances[unshieldedTokenRaw];
       logger.info(`Wallet 1: ${initialShieldedBalance} shielded tokens`);
       logger.info(`Wallet 1: ${initialUnshieldedBalance} unshielded tokens`);
       logger.info(`Wallet 1 total shielded coins: ${initialState.shielded.totalCoins.length}`);
@@ -101,7 +102,7 @@ describe('Smoke tests', () => {
       logger.info(`Wallet 1 available shielded coins: ${initialState.shielded.availableCoins.length}`);
       logger.info(`Wallet 1 available unshielded coins: ${initialState.unshielded.availableCoins.length}`);
       expect(initialState.shielded.balances[shieldedTokenRaw]).toBe(balance);
-      expect(initialState.unshielded.balances.get(unshieldedTokenRaw)).toBe(balance);
+      expect(initialState.unshielded.balances[unshieldedTokenRaw]).toBe(balance);
       expect(Object.keys(initialState.shielded.balances)).toHaveLength(3);
       // expect(initialState.unshielded.balances.size).toBe(3);
 
@@ -109,7 +110,7 @@ describe('Smoke tests', () => {
       const initialBalance2 = initialState2.shielded.balances[shieldedTokenRaw];
       expect(initialBalance2).toBe(undefined);
       expect(Object.keys(initialState2.shielded.balances)).toHaveLength(0);
-      expect(initialState.unshielded.balances.size).toBe(1);
+      expect(Object.keys(initialState.unshielded.balances)).toHaveLength(1);
       logger.info(`Wallet 2: ${initialBalance2}`);
       logger.info(`Wallet 2 available coins: ${initialState2.shielded.availableCoins.length}`);
 
@@ -130,7 +131,9 @@ describe('Smoke tests', () => {
             {
               type: unshieldedTokenRaw,
               amount: outputValue,
-              receiverAddress: initialState2.unshielded.address,
+              receiverAddress: UnshieldedAddress.codec
+                .encode(NetworkId.NetworkId.Undeployed, initialState2.unshielded.address)
+                .asString(),
             },
           ],
         },
@@ -150,7 +153,7 @@ describe('Smoke tests', () => {
 
       const pendingState = await utils.waitForFacadePending(walletFunded);
       expect(pendingState.shielded.balances[shieldedTokenRaw] ?? 0n).toBeLessThanOrEqual(balance - outputValue);
-      expect(pendingState.unshielded.balances.get(unshieldedTokenRaw) ?? 0n).toBeLessThanOrEqual(balance - outputValue);
+      expect(pendingState.unshielded.balances[unshieldedTokenRaw] ?? 0n).toBeLessThanOrEqual(balance - outputValue);
       expect(pendingState.shielded.totalCoins.length).toBe(7);
       expect(pendingState.unshielded.totalCoins.length).toBe(5);
       expect(pendingState.shielded.availableCoins.length).toBe(6);
@@ -163,7 +166,7 @@ describe('Smoke tests', () => {
       const finalState = await utils.waitForSyncFacade(walletFunded);
       logger.info(`Wallet 1 available coins: ${finalState.shielded.availableCoins.length}`);
       expect(finalState.shielded.balances[shieldedTokenRaw]).toBe(balance - outputValue);
-      expect(finalState.unshielded.balances.get(unshieldedTokenRaw) ?? 0n).toBeLessThanOrEqual(balance - outputValue);
+      expect(finalState.unshielded.balances[unshieldedTokenRaw] ?? 0n).toBeLessThanOrEqual(balance - outputValue);
       expect(finalState.shielded.totalCoins.length).toBe(7);
       expect(finalState.unshielded.totalCoins.length).toBe(5);
       expect(finalState.unshielded.availableCoins.length).toBe(5);
@@ -173,7 +176,7 @@ describe('Smoke tests', () => {
       await utils.waitForFinalizedBalance(receiverWallet.shielded);
       const finalState2 = await utils.waitForSyncFacade(receiverWallet);
       const finalShieldedBalance = finalState2.shielded.balances[shieldedTokenRaw];
-      const finalUnshieldedBalance = finalState2.unshielded.balances.get(unshieldedTokenRaw);
+      const finalUnshieldedBalance = finalState2.unshielded.balances[unshieldedTokenRaw];
       logger.info(finalState2);
       logger.info(`Wallet 2 available coins: ${finalState2.shielded.availableCoins.length}`);
       logger.info(`Wallet 2: ${finalShieldedBalance} shielded tokens`);
@@ -232,12 +235,14 @@ describe('Smoke tests', () => {
       fixture = getFixture();
       const txHistoryStorage = new InMemoryTransactionHistoryStorage();
       const unshieldedKeyStore = createKeystore(utils.getUnshieldedSeed(seedFunded), fixture.getNetworkId());
-      const initialWallet = await UnshieldedWalletBuilder.build({
-        publicKey: PublicKey.fromKeyStore(unshieldedKeyStore),
+      const initialWallet = UnshieldedWallet({
         networkId: fixture.getNetworkId(),
-        indexerUrl: fixture.getIndexerUri(),
+        indexerClientConnection: {
+          indexerHttpUrl: fixture.getIndexerUri(),
+          indexerWsUrl: fixture.getIndexerWsUri(),
+        },
         txHistoryStorage,
-      });
+      }).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeyStore));
       logger.info(`Waiting to sync...`);
       // const syncedState = await utils.waitForSyncUnshielded(initialWallet);
       // TODO add assertion for Tx history
@@ -246,13 +251,14 @@ describe('Smoke tests', () => {
       await initialWallet.stop();
 
       const restoredTxHistory = InMemoryTransactionHistoryStorage.fromSerialized(serializedTxHistory);
-      const restoredWallet = await UnshieldedWalletBuilder.restore({
-        publicKey: PublicKey.fromKeyStore(unshieldedKeyStore),
+      const restoredWallet = UnshieldedWallet({
         networkId: fixture.getNetworkId(),
-        indexerUrl: fixture.getIndexerUri(),
-        serializedState,
+        indexerClientConnection: {
+          indexerHttpUrl: fixture.getIndexerUri(),
+          indexerWsUrl: fixture.getIndexerWsUri(),
+        },
         txHistoryStorage: restoredTxHistory,
-      });
+      }).restore(serializedState);
 
       const restoredState = await utils.waitForSyncUnshielded(restoredWallet);
       expect(restoredState).toBeTruthy();

--- a/packages/e2e-tests/src/tests/utils.ts
+++ b/packages/e2e-tests/src/tests/utils.ts
@@ -27,9 +27,9 @@ import { HDWallet, Roles } from '@midnight-ntwrk/wallet-sdk-hd';
 import { WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
 import {
   createKeystore,
+  InMemoryTransactionHistoryStorage,
   PublicKey,
   UnshieldedWallet,
-  WalletBuilder as unshieldedWalletBuilder,
 } from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
 import { DefaultV1Configuration, DustWallet } from '@midnight-ntwrk/wallet-sdk-dust-wallet';
 
@@ -44,13 +44,12 @@ export const waitForSyncProgress = async (wallet: WalletFacade) =>
     wallet.state().pipe(
       throttleTime(5000),
       tap((state) => {
-        const applyGap = state.unshielded.syncProgress?.applyGap ?? 0n;
+        const applyGap = state.unshielded.progress.highestTransactionId - state.unshielded.progress.appliedId;
         logger.info(`Wallet facade behind by ${applyGap}`);
       }),
-      filter(
-        (state) =>
-          // Let's allow progress only if syncProgress is defined
-          state.unshielded.syncProgress !== undefined && state.unshielded.syncProgress?.applyGap !== 0,
+      filter((state) =>
+        // Let's allow progress only if syncProgress is defined
+        state.unshielded.progress.isStrictlyComplete(),
       ),
     ),
   );
@@ -101,12 +100,14 @@ const restoreUnshieldedWallet = async (
     if (serialized) {
       logger.info(`Unshielded serialize: ${serialized}`);
       const keyStore = createKeystore(getUnshieldedSeed(seed), fixture.getNetworkId());
-      const wallet = await unshieldedWalletBuilder.restore({
-        publicKey: PublicKey.fromKeyStore(keyStore),
+      const wallet = UnshieldedWallet({
         networkId: fixture.getNetworkId(),
-        indexerUrl: fixture.getIndexerWsUri(),
-        serializedState: serialized,
-      });
+        indexerClientConnection: {
+          indexerHttpUrl: fixture.getIndexerUri(),
+          indexerWsUrl: fixture.getIndexerWsUri(),
+        },
+        txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+      }).startWithPublicKey(PublicKey.fromKeyStore(keyStore));
       logger.info(`Restored unshielded wallet from ${path}`);
       return wallet;
     }
@@ -182,7 +183,8 @@ export const provideWallet = async (
     // check if wallet is syncing correctly
     await waitForSyncProgress(restoredWallet);
     const restoredWalletState = await firstValueFrom(restoredWallet.state());
-    const applyGap = restoredWalletState.unshielded.syncProgress?.applyGap;
+    const applyGap =
+      restoredWalletState.unshielded.progress.highestTransactionId - restoredWalletState.unshielded.progress.appliedId;
     logger.info(`Apply gap: ${applyGap}`);
     if ((applyGap ?? 0) < 0) {
       logger.warn('Unable to sync restored wallet. Building wallet facade from scratch');
@@ -244,17 +246,20 @@ export const saveState = async (wallet: WalletFacade, filename: string) => {
   }
 };
 
-export const buildWalletFacade = async (walletSeed: string, fixture: TestContainersFixture) => {
+export const buildWalletFacade = (walletSeed: string, fixture: TestContainersFixture) => {
   const unshieldedKeyStore = createKeystore(getUnshieldedSeed(walletSeed), fixture.getNetworkId());
   const Wallet = ShieldedWallet(fixture.getWalletConfig());
 
   const shieldedWallet = Wallet.startWithShieldedSeed(getShieldedSeed(walletSeed));
 
-  const unshieldedWallet = await unshieldedWalletBuilder.build({
-    publicKey: PublicKey.fromKeyStore(unshieldedKeyStore),
+  const unshieldedWallet = UnshieldedWallet({
     networkId: fixture.getNetworkId(),
-    indexerUrl: fixture.getIndexerWsUri(),
-  });
+    indexerClientConnection: {
+      indexerHttpUrl: fixture.getIndexerUri(),
+      indexerWsUrl: fixture.getIndexerWsUri(),
+    },
+    txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+  }).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeyStore));
 
   const dustSeed = getDustSeed(walletSeed);
   const Dust = DustWallet(fixture.getDustWalletConfig());
@@ -278,17 +283,14 @@ export const closeWallet = async (wallet: WalletFacade) => {
 
 export const waitForSyncUnshielded = (wallet: UnshieldedWallet) =>
   firstValueFrom(
-    wallet.state().pipe(
+    wallet.state.pipe(
       throttleTime(5_000),
       tap((state) => {
-        const applyGap = state.syncProgress?.applyGap;
+        const applyGap = state.state.progress.highestTransactionId - state.state.progress.appliedId;
         // const txs = state.transactionHistory.length;
         logger.info(`Wallet behind by ${applyGap} indices`);
       }),
-      filter(
-        (state) =>
-          state.syncProgress !== undefined && state.syncProgress?.applyGap === 0 && state.syncProgress?.synced === true,
-      ),
+      filter((state) => state.state.progress.isStrictlyComplete()),
     ),
   );
 
@@ -338,14 +340,14 @@ export const waitForSyncFacade = async (facade: WalletFacade) =>
     facade.state().pipe(
       throttleTime(5_000),
       tap((state) => {
-        const applyGap = state.unshielded.syncProgress?.applyGap;
+        const applyGap = state.unshielded.progress.highestTransactionId - state.unshielded.progress.appliedId;
         logger.info(`Wallet facade behind by ${applyGap}`);
       }),
       filter(
         (state) =>
           state.dust.state.progress.isStrictlyComplete() &&
           state.shielded.state.progress.isStrictlyComplete() &&
-          state.unshielded.syncProgress?.synced === true,
+          state.unshielded.progress.isStrictlyComplete(),
       ),
     ),
   );
@@ -405,13 +407,13 @@ export const waitForPending = (wallet: ShieldedWallet) =>
 
 export const waitForBalanceUpdate = (wallet: UnshieldedWallet) =>
   firstValueFrom(
-    wallet.state().pipe(
+    wallet.state.pipe(
       tap((state) => {
-        const balanceSize = state.balances.size;
+        const balanceSize = Object.values(state.balances).length;
         logger.info(`Balance size: ${balanceSize}, waiting for balance to update...`);
       }),
       filter((state) => {
-        return state.balances.size > 0;
+        return Object.values(state.balances).length > 0;
       }),
     ),
   );
@@ -431,7 +433,7 @@ export const waitForDustBalance = (wallet: WalletFacade, expectedDustBalance: bi
 
 export const waitForFinalizedBalanceUnshielded = (wallet: UnshieldedWallet) =>
   firstValueFrom(
-    wallet.state().pipe(
+    wallet.state.pipe(
       tap((state) => {
         const pending = state.pendingCoins.length;
         logger.info(`Wallet pending coins: ${pending}, waiting for pending coins cleared...`);


### PR DESCRIPTION
This pull request refactors several e2e test suites to simplify wallet facade creation and improve consistency in accessing balances and coin metadata. The most significant changes are the removal of unnecessary `await` when calling `utils.buildWalletFacade`, updates to how unshielded balances are accessed, and adjustments to coin metadata checks for dust registration. Additionally, there are improvements to address encoding and wallet construction in the empty wallet tests.

### Wallet Facade Initialization (Consistency & Simplification)
* Removed unnecessary `await` from all calls to `utils.buildWalletFacade`, making wallet initialization synchronous across multiple test files (`balanceConstant.remote.test.ts`, `balancing.undeployed.test.ts`, `dust.undeployed.test.ts`, `emptyWallet.universal.test.ts`). [[1]](diffhunk://#diff-bdfdb195e81fd3ced5301e5006986917e53ee0e63d3a0fedc43ee58e7ccc7e80L54-R54) [[2]](diffhunk://#diff-cb91d337b9f5ea0938ba93b282ac496bb8185ddc8434d1cb81a94465e145fb7bL55-R55) [[3]](diffhunk://#diff-cb91d337b9f5ea0938ba93b282ac496bb8185ddc8434d1cb81a94465e145fb7bL121-R121) [[4]](diffhunk://#diff-cb91d337b9f5ea0938ba93b282ac496bb8185ddc8434d1cb81a94465e145fb7bL147-R147) [[5]](diffhunk://#diff-cb91d337b9f5ea0938ba93b282ac496bb8185ddc8434d1cb81a94465e145fb7bL237-R237) [[6]](diffhunk://#diff-cb91d337b9f5ea0938ba93b282ac496bb8185ddc8434d1cb81a94465e145fb7bL329-R331) [[7]](diffhunk://#diff-cb91d337b9f5ea0938ba93b282ac496bb8185ddc8434d1cb81a94465e145fb7bL462-R462) [[8]](diffhunk://#diff-cb91d337b9f5ea0938ba93b282ac496bb8185ddc8434d1cb81a94465e145fb7bL523-R523) [[9]](diffhunk://#diff-cb91d337b9f5ea0938ba93b282ac496bb8185ddc8434d1cb81a94465e145fb7bL652-R652) [[10]](diffhunk://#diff-cb91d337b9f5ea0938ba93b282ac496bb8185ddc8434d1cb81a94465e145fb7bL677-R677) [[11]](diffhunk://#diff-332966b0afa2f18998c4f778d7b90448d1713a83a5eb5a14fee5f8c40144503bL50-R52) [[12]](diffhunk://#diff-09226ab561fdf43c9ce57ccd8aef15c575e9ee2df091b7a3dcb4909dcd90afedL66-R68)

### Unshielded Balance Access (API Consistency)
* Changed all accesses from `.get(unshieldedTokenRaw)` to `[unshieldedTokenRaw]` for unshielded balances, ensuring consistent usage of object property access rather than `Map` methods. [[1]](diffhunk://#diff-bdfdb195e81fd3ced5301e5006986917e53ee0e63d3a0fedc43ee58e7ccc7e80L77-R77) [[2]](diffhunk://#diff-bdfdb195e81fd3ced5301e5006986917e53ee0e63d3a0fedc43ee58e7ccc7e80L100-R100) [[3]](diffhunk://#diff-332966b0afa2f18998c4f778d7b90448d1713a83a5eb5a14fee5f8c40144503bL66-R67) [[4]](diffhunk://#diff-332966b0afa2f18998c4f778d7b90448d1713a83a5eb5a14fee5f8c40144503bL101-R109) [[5]](diffhunk://#diff-332966b0afa2f18998c4f778d7b90448d1713a83a5eb5a14fee5f8c40144503bL241-R260)

### Coin Metadata for Dust Registration (API Update)
* Updated checks from `coin.registeredForDustGeneration` to `coin.meta.registeredForDustGeneration` for filtering and assertions, reflecting changes in coin metadata structure. [[1]](diffhunk://#diff-332966b0afa2f18998c4f778d7b90448d1713a83a5eb5a14fee5f8c40144503bL101-R109) [[2]](diffhunk://#diff-332966b0afa2f18998c4f778d7b90448d1713a83a5eb5a14fee5f8c40144503bL143-R157) [[3]](diffhunk://#diff-332966b0afa2f18998c4f778d7b90448d1713a83a5eb5a14fee5f8c40144503bL177-R195) [[4]](diffhunk://#diff-332966b0afa2f18998c4f778d7b90448d1713a83a5eb5a14fee5f8c40144503bL241-R260)

### Address Encoding Improvements
* Introduced usage of `UnshieldedAddress.codec.encode(...).asString()` for output and receiver addresses in dust tests, ensuring correct formatting for network-specific addresses. [[1]](diffhunk://#diff-332966b0afa2f18998c4f778d7b90448d1713a83a5eb5a14fee5f8c40144503bL76-R79) [[2]](diffhunk://#diff-332966b0afa2f18998c4f778d7b90448d1713a83a5eb5a14fee5f8c40144503bL264-R272)

### Empty Wallet Test Refactor
* Replaced usage of `WalletBuilder.build` with direct construction via `UnshieldedWallet` and added `InMemoryTransactionHistoryStorage`, aligning with updated SDK APIs and improving test reliability. [[1]](diffhunk://#diff-09226ab561fdf43c9ce57ccd8aef15c575e9ee2df091b7a3dcb4909dcd90afedR26-R34) [[2]](diffhunk://#diff-09226ab561fdf43c9ce57ccd8aef15c575e9ee2df091b7a3dcb4909dcd90afedL119-R128)

These changes collectively improve code clarity, reliability, and maintainability of the test suites.