### PR TITLE
chore: remove unshielded state package from changeset

### DIFF
--- a/.changeset/bold-nights-smoke.md
+++ b/.changeset/bold-nights-smoke.md
@@ -1,6 +1,5 @@
 ---
 '@midnight-ntwrk/wallet-sdk-unshielded-wallet': patch
-'@midnight-ntwrk/wallet-sdk-unshielded-state': patch
 '@midnight-ntwrk/wallet-sdk-shielded': patch
 '@midnight-ntwrk/wallet-sdk-address-format': patch
 '@midnight-ntwrk/wallet-sdk-prover-client': patch

--- a/.changeset/lovely-parents-stop.md
+++ b/.changeset/lovely-parents-stop.md
@@ -9,7 +9,6 @@
 '@midnight-ntwrk/wallet-sdk-node-client': patch
 '@midnight-ntwrk/wallet-sdk-prover-client': patch
 '@midnight-ntwrk/wallet-sdk-runtime': patch
-'@midnight-ntwrk/wallet-sdk-unshielded-state': patch
 '@midnight-ntwrk/wallet-sdk-unshielded-wallet': patch
 '@midnight-ntwrk/wallet-sdk-utilities': patch
 '@midnight-ntwrk/wallet-sdk-shielded': patch

--- a/.changeset/mighty-vans-occur.md
+++ b/.changeset/mighty-vans-occur.md
@@ -1,6 +1,5 @@
 ---
 '@midnight-ntwrk/wallet-sdk-unshielded-wallet': patch
-'@midnight-ntwrk/wallet-sdk-unshielded-state': patch
 '@midnight-ntwrk/wallet-sdk-address-format': patch
 '@midnight-ntwrk/wallet-sdk-indexer-client': patch
 '@midnight-ntwrk/wallet-sdk-prover-client': patch

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -13,7 +13,6 @@
     "@midnight-ntwrk/wallet-sdk-node-client": "1.0.0-beta.6",
     "@midnight-ntwrk/wallet-sdk-prover-client": "1.0.0-beta.5",
     "@midnight-ntwrk/wallet-sdk-runtime": "1.0.0-beta.4",
-    "@midnight-ntwrk/wallet-sdk-unshielded-state": "1.0.0-beta.7",
     "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "1.0.0-beta.8",
     "@midnight-ntwrk/wallet-sdk-utilities": "1.0.0-beta.4",
     "@midnight-ntwrk/wallet-sdk-shielded": "1.0.0-beta.6",

--- a/.changeset/short-needles-prove.md
+++ b/.changeset/short-needles-prove.md
@@ -1,6 +1,5 @@
 ---
 '@midnight-ntwrk/wallet-sdk-unshielded-wallet': patch
-'@midnight-ntwrk/wallet-sdk-unshielded-state': patch
 '@midnight-ntwrk/wallet-sdk-address-format': patch
 '@midnight-ntwrk/wallet-sdk-indexer-client': patch
 '@midnight-ntwrk/wallet-sdk-prover-client': patch

--- a/.changeset/smart-camels-feel.md
+++ b/.changeset/smart-camels-feel.md
@@ -1,5 +1,4 @@
 ---
-'@midnight-ntwrk/wallet-sdk-unshielded-state': patch
 '@midnight-ntwrk/wallet-sdk-facade': patch
 ---
 


### PR DESCRIPTION
This pull request removes the `@midnight-ntwrk/wallet-sdk-unshielded-state` package from the changeset configuration and dependency list. The removal affects multiple configuration files and ensures the package is no longer included in patch releases or version management.

Package removal:

* Removed `@midnight-ntwrk/wallet-sdk-unshielded-state` from the dependency list in `.changeset/pre.json`.
* Removed `@midnight-ntwrk/wallet-sdk-unshielded-state` from patch release entries in `.changeset/bold-nights-smoke.md`, `.changeset/lovely-parents-stop.md`, `.changeset/mighty-vans-occur.md`, `.changeset/short-needles-prove.md`, and `.changeset/smart-camels-feel.md`. [[1]](diffhunk://#diff-9b786504be965ae7b93a862715ea8f98a5773a8df7d2adfcbdbaf804b689d71cL3) [[2]](diffhunk://#diff-065bc6404390422fcfe81e24626a7c67990d62b4cd7fb50abcddf4924bb85295L12) [[3]](diffhunk://#diff-cf6810550aab6fbe05b54ada565bc36a91d52ec7248e3524425cec1b38009fceL3) [[4]](diffhunk://#diff-0edac286f4f00df9802dd4fa5e2ba8d09de7b6f82908d3600983ba4f5a2d8d7bL3) [[5]](diffhunk://#diff-1c396f6b671b8d0c19f2f8bb78a70c033f8e43309ea64cbd5ffea4fb92dfb8b6L2)