### PR TITLE
[PM-20924] Fix prettier formatting, root tasks to use custom ignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-packages/
 dist/
 coverage/
 reports/

--- a/.prettierignore.root
+++ b/.prettierignore.root
@@ -1,0 +1,15 @@
+# This file is used by the root tasks "format:root" & "format:check:root"
+# It is important that we ignore the "packages" directory, but if we do that in the
+# standard .prettierignore then vscode fails to format.
+#
+# This file is ONLY used by the root tasks.
+#
+
+dist/
+coverage/
+reports/
+.yarnrc.yml
+.changeset/
+.turbo/
+.yarn/
+packages/

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "vite": "^7.1.11"
   },
   "scripts": {
-    "format:root": "prettier --write \"**/*.{ts,js,json,yaml,yml,md}\"",
-    "format:check:root": "prettier --check \"**/*.{ts,js,json,yaml,yml,md}\"",
+    "format:root": "prettier --write --ignore-path .prettierignore.root \"**/*.{ts,js,json,yaml,yml,md}\"",
+    "format:check:root": "prettier --check --ignore-path .prettierignore.root \"**/*.{ts,js,json,yaml,yml,md}\"",
     "format": "turbo run format",
     "format:check": "turbo run format:check",
     "verify": "turbo run verify",

--- a/turbo.json
+++ b/turbo.json
@@ -97,13 +97,13 @@
     },
     "//#format:root": {
       "cache": false,
-      "inputs": ["**/*.{ts,js,json,yaml,yml,md}", ".prettierrc.json", ".prettierignore"],
+      "inputs": ["**/*.{ts,js,json,yaml,yml,md}", ".prettierrc.json", ".prettierignore.root"],
       "outputs": [],
       "outputLogs": "new-only"
     },
     "//#format:check:root": {
       "cache": false,
-      "inputs": ["**/*.{ts,js,json,yaml,yml,md}", ".prettierrc.json", ".prettierignore"],
+      "inputs": ["**/*.{ts,js,json,yaml,yml,md}", ".prettierrc.json", ".prettierignore.root"],
       "outputs": [],
       "outputLogs": "new-only"
     },


### PR DESCRIPTION
# Description

A root task was added to run prettier in the root. We disabled the packages directory in the root. prettierignore, but this caused VSCode to refuse to format anything below the packages directory.

We need to introduce a special .prettierignore (lets say .prettierignore.root) that will be used when running the format:root & format:check:root yarn tasks (which is also called via turbo).

And the ignoring of the packages directory should be removed from .preitterignore in the root.

# Testing

VSCode should resume formatting, and the root tasks should continue to format, but exclude the packages directory.
