### PR TITLE
fix: make test website app private

### DIFF
--- a/apps/test-website/package.json
+++ b/apps/test-website/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "author": "Midnight Foundation",
   "license": "Apache-2.0",
+  "private": true,
   "files": [
     "dist/"
   ],


### PR DESCRIPTION
This pull request makes a small change to the `apps/test-website/package.json` file, marking the package as private to prevent accidental publication to the npm registry.