### PR TITLE
fix: addresses comments from PR #71

### DIFF
--- a/.changeset/wacky-ties-tease.md
+++ b/.changeset/wacky-ties-tease.md
@@ -2,4 +2,4 @@
 '@midnight-ntwrk/wallet-sdk-unshielded-wallet': patch
 ---
 
-feat: adds tx revet option to unshielded wallet
+feat: adds tx revert option to unshielded wallet

--- a/packages/unshielded-wallet/src/v1/test/transacting.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/transacting.test.ts
@@ -203,7 +203,6 @@ describe('Unshielded wallet transacting', () => {
 
         // Verify that some coins are now pending
         const pendingCountAfterTransfer = HashMap.size(newState.state.pendingUtxos);
-        const availableCountAfterTransfer = HashMap.size(newState.state.availableUtxos);
         expect(pendingCountAfterTransfer).toBeGreaterThan(0);
 
         // Revert the transaction - this should move coins back from pending to available
@@ -211,9 +210,6 @@ describe('Unshielded wallet transacting', () => {
 
         // Verify that pending coins are cleared and moved back to available
         expect(HashMap.size(revertedWallet.state.pendingUtxos)).toBe(0);
-        expect(HashMap.size(revertedWallet.state.availableUtxos)).toBe(
-          availableCountAfterTransfer + pendingCountAfterTransfer,
-        );
 
         // Verify the reverted wallet has the same available coins as the original wallet
         expect(HashMap.size(revertedWallet.state.availableUtxos)).toBe(HashMap.size(wallet.state.availableUtxos));
@@ -255,7 +251,6 @@ describe('Unshielded wallet transacting', () => {
 
         const pendingCountAfterRevert = HashMap.size(walletAfterRevert.state.pendingUtxos);
         expect(pendingCountAfterRevert).toBe(pendingCountAfterTx2 - pendingCountAfterTx1);
-        expect(pendingCountAfterRevert).toBeGreaterThan(0);
 
         const walletAfterBothReverts = transacting.revert(walletAfterRevert, tx2).pipe(EitherOps.getOrThrowLeft);
 


### PR DESCRIPTION
This pull request makes minor adjustments to the unshielded wallet feature, mainly refining the transaction revert functionality and its associated tests.

Testing improvements for transaction revert:

* Updated the test assertions in `transacting.test.ts` to more accurately verify the revert behavior by removing redundant checks and ensuring the wallet's available coins match the original state after a revert. [[1]](diffhunk://#diff-1b79c9caa4840465eb928fab63300cd5ce96a5a34f8161ae26bd77d0a6c60e23L206-L216) [[2]](diffhunk://#diff-1b79c9caa4840465eb928fab63300cd5ce96a5a34f8161ae26bd77d0a6c60e23L258)

Documentation update:

* Fixed a typo in the changeset file to correctly describe the feature as "tx revert option" instead of "tx revet option."