### PR TITLE
[PM-21624] Prepare wallet for release via changeset

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@midnight-ntwrk/wallet-sdk-abstractions": "1.0.0-beta.5",


### PR DESCRIPTION
# Description

We need to exit pre-release for an official 1.0.0 release, this PR exits pre-release mode

# Testing

NO QA Required, its an internal release chagne.
