### PR TITLE
[PM-21643] Fix canary builds when not in pre-mode

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,6 +13,10 @@
     "@midnight-ntwrk/wallet-sdk-docs-snippets",
     "@midnight-ntwrk/wallet-test-website"
   ],
+  "snapshot": {
+    "useCalculatedVersion": true,
+    "prereleaseTemplate": "{tag}"
+  },
   "privatePackages": {
     "version": true,
     "tag": false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -127,8 +127,12 @@ jobs:
             yarn changeset pre exit
           fi
 
+          # Generate snapshot suffix
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          TIMESTAMP=$(date +%Y%m%d%H%M%S)
+
           # Apply snapshot versions
-          yarn changeset version --snapshot canary
+          yarn changeset version --snapshot canary.${TIMESTAMP}-${SHORT_SHA}
 
           # Install dependencies with the new snapshot versions
           yarn install --mode=update-lockfile


### PR DESCRIPTION
# Description

As part of a github workflow, we need to exit “pre” mode for changeset to produce canary builds BUT if we are not in “pre” mode then an error is thrown when the workflow tries to exit “pre” mode.

Exiting pre mode is necessary because canary builds do not work in “pre” mode.

# Proposed Solution

Check to see if we are in pre-mode first before trying to exit.

# Testing

It has been tested locally but the next merge to main will self test it and the canary phase of the CD should pass.
