### PR TITLE
[PM-21630]: fixes incorrect keys usage in e2e tests

### DIFF
--- a/packages/e2e-tests/src/tests/balancing.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/balancing.undeployed.test.ts
@@ -200,8 +200,8 @@ describe('Transaction balancing examples', () => {
       const txRecipe = await sender.wallet.transferTransaction(
         outputsToCreate,
         {
-          shieldedSecretKeys: funded.shieldedSecretKeys,
-          dustSecretKey: funded.dustSecretKey,
+          shieldedSecretKeys: sender.shieldedSecretKeys,
+          dustSecretKey: sender.dustSecretKey,
         },
         {
           ttl,
@@ -279,8 +279,8 @@ describe('Transaction balancing examples', () => {
       const txRecipe = await sender.wallet.transferTransaction(
         outputsToCreate,
         {
-          shieldedSecretKeys: funded.shieldedSecretKeys,
-          dustSecretKey: funded.dustSecretKey,
+          shieldedSecretKeys: sender.shieldedSecretKeys,
+          dustSecretKey: sender.dustSecretKey,
         },
         {
           ttl,
@@ -382,8 +382,8 @@ describe('Transaction balancing examples', () => {
       const txRecipe = await sender.wallet.transferTransaction(
         outputsToCreate,
         {
-          shieldedSecretKeys: funded.shieldedSecretKeys,
-          dustSecretKey: funded.dustSecretKey,
+          shieldedSecretKeys: sender.shieldedSecretKeys,
+          dustSecretKey: sender.dustSecretKey,
         },
         {
           ttl,


### PR DESCRIPTION
This pull request updates the transaction balancing end-to-end tests to use the correct secret keys from the `sender` object instead of the `funded` object. This ensures that the tests accurately represent the intended transaction flow and use the appropriate credentials.

Test reliability improvements:

* Updated all instances in `balancing.undeployed.test.ts` where `transferTransaction` was called to pass `sender.shieldedSecretKeys` and `sender.dustSecretKey` instead of `funded.shieldedSecretKeys` and `funded.dustSecretKey`, ensuring the correct keys are used throughout the tests. [[1]](diffhunk://#diff-cb91d337b9f5ea0938ba93b282ac496bb8185ddc8434d1cb81a94465e145fb7bL203-R204) [[2]](diffhunk://#diff-cb91d337b9f5ea0938ba93b282ac496bb8185ddc8434d1cb81a94465e145fb7bL282-R283) [[3]](diffhunk://#diff-cb91d337b9f5ea0938ba93b282ac496bb8185ddc8434d1cb81a94465e145fb7bL385-R386)