### PR TITLE
test: update endpoints to support new QANet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@
 # Default value for local development.
 NETWORK=undeployed
 
+#NETWORK=qanet
+# QANET_ENV: Selects which QaNet to use when NETWORK=qanet
+# new = new QANet (qanet.midnight.network)
+# old = legacy QANet (qanet.dev)
+#QANET_ENV=new
+
 # APP_INFRA_* variables: Configuration for local infrastructure (Docker Compose)
 #
 # These environment variables are used when running tests against the local Docker Compose

--- a/packages/e2e-tests/src/tests/test-fixture.ts
+++ b/packages/e2e-tests/src/tests/test-fixture.ts
@@ -93,6 +93,10 @@ export class TestContainersFixture {
   public readonly composeEnvironment: StartedDockerComposeEnvironment;
   private readonly uid: string | undefined;
 
+  private isNewQANet(): boolean {
+    return (process.env['QANET_ENV'] ?? 'new') === 'new';
+  }
+
   constructor(composeEnvironment: StartedDockerComposeEnvironment, uid?: string) {
     this.composeEnvironment = composeEnvironment;
     this.uid = uid;
@@ -137,7 +141,9 @@ export class TestContainersFixture {
         return 'https://indexer.devnet.midnight.network/api/v3/graphql';
       }
       case 'qanet': {
-        return 'https://indexer.qanet.dev.midnight.network/api/v3/graphql';
+        return this.isNewQANet()
+          ? 'https://indexer.qanet.midnight.network/api/v3/graphql'
+          : 'https://indexer.qanet.dev.midnight.network/api/v3/graphql';
       }
       case 'preview': {
         return 'https://indexer.preview.midnight.network/api/v3/graphql';
@@ -164,7 +170,9 @@ export class TestContainersFixture {
         return 'wss://indexer.devnet.midnight.network/api/v3/graphql/ws';
       }
       case 'qanet': {
-        return 'wss://indexer.qanet.dev.midnight.network/api/v3/graphql/ws';
+        return this.isNewQANet()
+          ? 'wss://indexer.qanet.midnight.network/api/v3/graphql/ws'
+          : 'wss://indexer.qanet.dev.midnight.network/api/v3/graphql/ws';
       }
       case 'preview': {
         return 'wss://indexer.preview.midnight.network/api/v3/graphql/ws';
@@ -191,7 +199,7 @@ export class TestContainersFixture {
         return 'wss://rpc.devnet.midnight.network';
       }
       case 'qanet': {
-        return 'wss://rpc.qanet.dev.midnight.network';
+        return this.isNewQANet() ? 'wss://rpc.qanet.midnight.network' : 'wss://rpc.qanet.dev.midnight.network';
       }
       case 'preview': {
         return 'wss://rpc.preview.midnight.network';


### PR DESCRIPTION
# Description

Updates e2e test fixture to use the new QANet endpoints instead of qanet.dev.

Tests are able to run against the new QANet.
