### PR TITLE
chore: enter v2 rc in changesets

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,24 @@
+{
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "@midnight-ntwrk/wallet-test-website": "1.0.0-beta.0",
+    "@midnight-ntwrk/wallet-sdk-abstractions": "1.0.0",
+    "@midnight-ntwrk/wallet-sdk-address-format": "3.0.0",
+    "@midnight-ntwrk/wallet-sdk-capabilities": "3.0.0",
+    "@midnight-ntwrk/wallet-sdk-docs-snippets": "1.0.0-beta.1",
+    "@midnight-ntwrk/wallet-sdk-dust-wallet": "1.0.0",
+    "@midnight/wallet-e2e-tests": "0.0.1",
+    "@midnight-ntwrk/wallet-sdk-facade": "1.0.0",
+    "@midnight-ntwrk/wallet-sdk-hd": "3.0.0",
+    "@midnight-ntwrk/wallet-sdk-indexer-client": "1.0.0",
+    "@midnight-ntwrk/wallet-sdk-node-client": "1.0.0",
+    "@midnight-ntwrk/wallet-sdk-prover-client": "1.0.0",
+    "@midnight-ntwrk/wallet-sdk-runtime": "1.0.0",
+    "@midnight-ntwrk/wallet-sdk-shielded": "1.0.0",
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "1.0.0",
+    "@midnight-ntwrk/wallet-sdk-utilities": "1.0.0",
+    "@midnight-ntwrk/wallet-integration-tests": "0.0.1"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
This PR sets the packages version to `rc`