### PR TITLE
fix: add abstractions package changeset

### DIFF
--- a/.changeset/cold-roses-do.md
+++ b/.changeset/cold-roses-do.md
@@ -1,0 +1,5 @@
+---
+'@midnight-ntwrk/wallet-sdk-abstractions': major
+---
+
+Replace `SerializedUnprovenTransaction` with `SerializedTransaction`, a simplified type for holding serialized transaction bytes


### PR DESCRIPTION
This pull request introduces a breaking change to the `@midnight-ntwrk/wallet-sdk-abstractions` package. The main update is the replacement of the `SerializedUnprovenTransaction` type with a new, simplified `SerializedTransaction` type for storing serialized transaction bytes.

Type simplification:

* Replaced `SerializedUnprovenTransaction` with `SerializedTransaction`, streamlining how serialized transaction bytes are handled.