### PR TITLE
update tests with waitForSyncedState

### DIFF
--- a/packages/e2e-tests/src/tests/balanceConstant.remote.test.ts
+++ b/packages/e2e-tests/src/tests/balanceConstant.remote.test.ts
@@ -67,7 +67,7 @@ describe('Balance constant', () => {
       allure.feature('Balance');
       allure.story('Balance constant when syncing from 0');
 
-      const syncedState = await utils.waitForSyncFacade(wallet.wallet);
+      const syncedState = await wallet.wallet.waitForSyncedState();
       logger.info(inspect(syncedState.shielded.availableCoins, { depth: null }));
       logger.info(inspect(syncedState.unshielded.availableCoins, { depth: null }));
       expect(syncedState.shielded.balances[shieldedTokenRaw]).toBe(expectedShieldedBalance);
@@ -92,7 +92,7 @@ describe('Balance constant', () => {
 
       await utils.saveState(wallet.wallet, filename);
       const restoredWallet = await utils.provideWallet(filename, seed, fixture);
-      const syncedState = await utils.waitForSyncFacade(restoredWallet.wallet);
+      const syncedState = await restoredWallet.wallet.waitForSyncedState();
 
       expect(syncedState.shielded.balances[shieldedTokenRaw]).toBe(expectedDustBalance);
       expect(syncedState.shielded.balances[nativeTokenHash]).toBe(expectedTokenOneBalance);

--- a/packages/e2e-tests/src/tests/dust.remote.test.ts
+++ b/packages/e2e-tests/src/tests/dust.remote.test.ts
@@ -45,7 +45,7 @@ describe('Dust tests', () => {
   test(
     'Able to register Night tokens for Dust generation @healthcheck',
     async () => {
-      const initialState = await utils.waitForSyncFacade(wallet.wallet);
+      const initialState = await wallet.wallet.waitForSyncedState();
       const initialUnshieldedBalance = initialState.unshielded.balances[unshieldedTokenRaw];
       const initialDustBalance = initialState.dust.balance(new Date());
       logger.info(`Wallet: ${initialUnshieldedBalance} unshielded tokens`);
@@ -106,7 +106,7 @@ describe('Dust tests', () => {
   test(
     'Able to deregister night tokens for dust decay @healthcheck',
     async () => {
-      const initialWalletState = await utils.waitForSyncFacade(wallet.wallet);
+      const initialWalletState = await wallet.wallet.waitForSyncedState();
       const initialDustBalance = initialWalletState.dust.balance(new Date());
       logger.info(`Initial Dust Balance: ${initialDustBalance}`);
 

--- a/packages/e2e-tests/src/tests/fundTestWallets.remote.test.ts
+++ b/packages/e2e-tests/src/tests/fundTestWallets.remote.test.ts
@@ -68,7 +68,7 @@ describe('Set up test wallet', () => {
   test(
     'Distributing tokens to test wallet',
     async () => {
-      await Promise.all([utils.waitForSyncFacade(sender.wallet), utils.waitForSyncFacade(receiver.wallet)]);
+      await Promise.all([sender.wallet.waitForSyncedState(), receiver.wallet.waitForSyncedState()]);
       const initialState = await firstValueFrom(sender.wallet.state());
       const initialShieldedBalance = initialState.shielded.balances[shieldedTokenRaw];
       const initialUnshieldedBalance = initialState.unshielded.balances[unshieldedTokenRaw];
@@ -143,7 +143,7 @@ describe('Set up test wallet', () => {
 
       // Register unshielded tokens for dust generation
       await utils.waitForUnshieldedCoinUpdate(receiver.wallet, initialReceiverState.unshielded.availableCoins.length);
-      const receiverStateAfterTransfer = await utils.waitForSyncFacade(receiver.wallet);
+      const receiverStateAfterTransfer = await receiver.wallet.waitForSyncedState();
       const unregisteredNightUtxos = receiverStateAfterTransfer.unshielded.availableCoins.filter(
         (coin) => coin.utxo.type === unshieldedTokenRaw && coin.meta.registeredForDustGeneration === false,
       );
@@ -168,7 +168,7 @@ describe('Set up test wallet', () => {
       const nativeToken1Amount = utils.tNightAmount(25n);
       const nativeToken2Amount = utils.tNightAmount(50n);
 
-      await Promise.all([utils.waitForSyncFacade(sender.wallet), utils.waitForSyncFacade(receiver.wallet)]);
+      await Promise.all([sender.wallet.waitForSyncedState(), receiver.wallet.waitForSyncedState()]);
       const initialState = await firstValueFrom(sender.wallet.state());
       const initialNativeToken1Balance = initialState.shielded.balances[nativeToken1Raw];
       const initialNativeToken2Balance = initialState.shielded.balances[nativeToken2Raw];

--- a/packages/e2e-tests/src/tests/fundedWallet.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/fundedWallet.undeployed.test.ts
@@ -51,7 +51,7 @@ describe('Funded wallet', () => {
       allure.feature('Wallet state');
       allure.story('Wallet state properties - funded');
       logger.info('Waiting for sync...');
-      const state = await utils.waitForSyncFacade(funded.wallet);
+      const state = await funded.wallet.waitForSyncedState();
       logger.info(`Wallet synced. Shielded balance: ${inspect(state.shielded.balances)}`);
       expect(state.shielded.totalCoins).toHaveLength(7);
       expect(state.shielded.balances[rawNativeTokenType]).toBe(2_500_000_000_000_000n);
@@ -79,7 +79,7 @@ describe('Funded wallet', () => {
       allure.epic('Headless wallet');
       allure.feature('Wallet state');
       allure.story('Wallet state properties - funded');
-      const state = await utils.waitForSyncFacade(funded.wallet);
+      const state = await funded.wallet.waitForSyncedState();
       const shieldedCoins = state.shielded.totalCoins;
       expect(shieldedCoins).toHaveLength(7);
       expect(utils.isArrayUnique(shieldedCoins.map((c) => c.coin.nonce))).toBeTruthy();
@@ -128,7 +128,7 @@ describe('Funded wallet', () => {
       allure.epic('Headless wallet');
       allure.feature('Wallet state');
       allure.story('Wallet state properties - funded');
-      const state = await utils.waitForSyncFacade(funded.wallet);
+      const state = await funded.wallet.waitForSyncedState();
       const shieldedCoins = state.shielded.availableCoins;
       expect(shieldedCoins).toHaveLength(7);
       expect(utils.isArrayUnique(shieldedCoins.map((c) => c.coin.nonce))).toBeTruthy();
@@ -178,7 +178,7 @@ describe('Funded wallet', () => {
       allure.epic('Headless wallet');
       allure.feature('Wallet state');
       allure.story('Wallet state properties - funded');
-      const state = await utils.waitForSyncFacade(funded.wallet);
+      const state = await funded.wallet.waitForSyncedState();
       expect(state.shielded.pendingCoins).toHaveLength(0);
       expect(state.unshielded.pendingCoins).toHaveLength(0);
       expect(state.dust.pendingCoins).toHaveLength(0);
@@ -193,7 +193,7 @@ describe('Funded wallet', () => {
   //     allure.epic('Headless wallet');
   //     allure.feature('Wallet state');
   //     allure.story('Wallet state properties - funded');
-  //     const state = await waitForSyncFacade(wallet);
+  //     const state = await wallet.waitForSyncedState();
   //     const txHistory = state.shielded.transactionHistory;
   //     expect(txHistory).toHaveLength(0);
   //     const expectedIdentifiers = new Map(

--- a/packages/e2e-tests/src/tests/multipleWallets.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/multipleWallets.undeployed.test.ts
@@ -14,7 +14,7 @@ import * as ledger from '@midnight-ntwrk/ledger-v7';
 import { firstValueFrom } from 'rxjs';
 import { logger } from './logger.js';
 import { type TestContainersFixture, useTestContainersFixture } from './test-fixture.js';
-import { getShieldedSeed, waitForSyncFacade } from './utils.js';
+import { getShieldedSeed } from './utils.js';
 import * as allure from 'allure-js-commons';
 import { ShieldedWallet, type ShieldedWalletClass } from '@midnight-ntwrk/wallet-sdk-shielded';
 import {
@@ -111,7 +111,7 @@ describe('Syncing', () => {
       allure.story('Syncing wallets concurrently');
 
       const promises = facades.map((facade) => {
-        return waitForSyncFacade(facade);
+        return facade.waitForSyncedState();
       });
 
       await Promise.all(promises);

--- a/packages/e2e-tests/src/tests/nativeTokenTransfer.remote.test.ts
+++ b/packages/e2e-tests/src/tests/nativeTokenTransfer.remote.test.ts
@@ -56,7 +56,7 @@ describe('Token transfer', () => {
     wallet = await utils.provideWallet(filenameWallet, fundedSeed, fixture);
     wallet2 = await utils.provideWallet(filenameWallet2, receivingSeed, fixture);
 
-    const initialState = await utils.waitForSyncFacade(wallet.wallet);
+    const initialState = await wallet.wallet.waitForSyncedState();
     const initialNativeBalance = initialState.shielded.balances[nativeToken1Raw];
     logger.info(`initial balance: ${initialNativeBalance}`);
 
@@ -91,7 +91,7 @@ describe('Token transfer', () => {
       allure.epic('Headless wallet');
       allure.feature('Transactions');
       allure.story('Valid transfer transaction using bech32m address');
-      await Promise.all([utils.waitForSyncFacade(sender.wallet), utils.waitForSyncFacade(receiver.wallet)]);
+      await Promise.all([sender.wallet.waitForSyncedState(), receiver.wallet.waitForSyncedState()]);
       const initialState = await rx.firstValueFrom(sender.wallet.state());
       const initialNative1Balance = initialState.shielded.balances[nativeToken1Raw];
       const initialNative2Balance = initialState.shielded.balances[nativeToken2Raw];
@@ -179,7 +179,7 @@ describe('Token transfer', () => {
           rx.filter((s) => s.shielded.availableCoins.length > initialNumAvailableShieldedCoins),
         ),
       );
-      const finalState = await utils.waitForSyncFacade(sender.wallet);
+      const finalState = await sender.wallet.waitForSyncedState();
       const senderFinalShieldedBalance1 = finalState.shielded.balances[nativeToken1Raw];
       const senderFinalShieldedBalance2 = finalState.shielded.balances[nativeToken2Raw];
       const senderFinalUnshieldedBalance = finalState.unshielded.balances[unshieldedTokenRaw];
@@ -203,7 +203,7 @@ describe('Token transfer', () => {
       expect(finalState.unshielded.pendingCoins.length).toBe(0);
       expect(finalState.unshielded.totalCoins.length).toBeLessThanOrEqual(initialState.shielded.totalCoins.length);
 
-      const finalState2 = await utils.waitForSyncFacade(receiver.wallet);
+      const finalState2 = await receiver.wallet.waitForSyncedState();
       const receiverFinalShieldedBalance1 = finalState2.shielded.balances[nativeToken1Raw];
       const receiverFinalShieldedBalance2 = finalState2.shielded.balances[nativeToken2Raw];
       const receiverFinalShieldedBalance = finalState2.shielded.balances[shieldedTokenRaw];
@@ -230,7 +230,7 @@ describe('Token transfer', () => {
       allure.feature('Transactions');
       allure.story('Valid transfer self-transaction');
 
-      const initialState = await utils.waitForSyncFacade(sender.wallet);
+      const initialState = await sender.wallet.waitForSyncedState();
       const initialBalance = initialState.shielded.balances[shieldedTokenRaw];
       logger.info(initialState.shielded.availableCoins);
       logger.info(`Wallet 1: ${initialBalance}`);
@@ -264,7 +264,7 @@ describe('Token transfer', () => {
 
       await utils.waitForFacadePending(sender.wallet);
       await utils.waitForFacadePendingClear(sender.wallet);
-      const finalState = await utils.waitForSyncFacade(sender.wallet);
+      const finalState = await sender.wallet.waitForSyncedState();
       logger.info(`Wallet 1 available coins: ${finalState.shielded.availableCoins.length}`);
       logger.info(`Wallet 1: ${finalState.shielded.balances[shieldedTokenRaw]}`);
       expect(finalState.shielded.pendingCoins.length).toBe(0);

--- a/packages/e2e-tests/src/tests/smoke.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/smoke.undeployed.test.ts
@@ -87,8 +87,9 @@ describe('Smoke tests', () => {
         utils.getUnshieldedSeed(seedFunded),
         NetworkId.NetworkId.Undeployed,
       );
-      await Promise.all([utils.waitForSyncFacade(funded.wallet), utils.waitForSyncFacade(receiver.wallet)]);
-      const initialState = await utils.waitForSyncFacade(funded.wallet);
+      await utils.sleep(20); // wait for 2+ blocks to pass
+      await Promise.all([funded.wallet.waitForSyncedState(), receiver.wallet.waitForSyncedState()]);
+      const initialState = await funded.wallet.waitForSyncedState();
       const initialShieldedBalance = initialState.shielded.balances[shieldedTokenRaw];
       const initialUnshieldedBalance = initialState.unshielded.balances[unshieldedTokenRaw];
       logger.info(`Wallet 1: ${initialShieldedBalance} shielded tokens`);
@@ -157,7 +158,7 @@ describe('Smoke tests', () => {
 
       logger.info('Waiting for finalized balance...');
       await utils.waitForFacadePendingClear(funded.wallet);
-      const finalState = await utils.waitForSyncFacade(funded.wallet);
+      const finalState = await funded.wallet.waitForSyncedState();
       logger.info(`Wallet 1 available coins: ${finalState.shielded.availableCoins.length}`);
       expect(finalState.shielded.balances[shieldedTokenRaw]).toBe(balance - outputValue);
       expect(finalState.unshielded.balances[unshieldedTokenRaw]).toBeLessThanOrEqual(balance - outputValue);
@@ -169,7 +170,7 @@ describe('Smoke tests', () => {
       expect(finalState.unshielded.pendingCoins.length).toBe(0);
 
       await utils.waitForFinalizedShieldedBalance(receiver.wallet.shielded);
-      const finalState2 = await utils.waitForSyncFacade(receiver.wallet);
+      const finalState2 = await receiver.wallet.waitForSyncedState();
       const finalShieldedBalance = finalState2.shielded.balances[shieldedTokenRaw];
       const finalUnshieldedBalance = finalState2.unshielded.balances[unshieldedTokenRaw];
       logger.info(finalState2);
@@ -196,7 +197,7 @@ describe('Smoke tests', () => {
       allure.epic('Headless wallet');
       allure.feature('Wallet state');
       allure.story('Wallet state properties - serialize');
-      const initialState = await utils.waitForSyncFacade(funded.wallet);
+      const initialState = await funded.wallet.waitForSyncedState();
       const initialStateTxHistory = utils.getTransactionHistoryIds(initialState.shielded);
       const serialized = await funded.wallet.shielded.serializeState();
       const stateObject = JSON.parse(serialized);
@@ -275,7 +276,7 @@ describe('Smoke tests', () => {
       allure.feature('Wallet building');
       allure.story('Building with discardTxHistory undefined');
 
-      const initialState = await utils.waitForSyncFacade(funded.wallet);
+      const initialState = await funded.wallet.waitForSyncedState();
       const publicKey = initialState.dust.publicKey;
       const address = initialState.dust.address;
       const dustBalance = initialState.dust.balance(new Date(3 * 1000));

--- a/packages/e2e-tests/src/tests/tokenTransfer.remote.test.ts
+++ b/packages/e2e-tests/src/tests/tokenTransfer.remote.test.ts
@@ -90,7 +90,7 @@ describe('Token transfer', () => {
       allure.epic('Headless wallet');
       allure.feature('Transactions');
       allure.story('Valid transfer transaction using bech32m address');
-      await Promise.all([utils.waitForSyncFacade(sender.wallet), utils.waitForSyncFacade(receiver.wallet)]);
+      await Promise.all([sender.wallet.waitForSyncedState(), receiver.wallet.waitForSyncedState()]);
       const senderInitialState = await firstValueFrom(sender.wallet.state());
       const initialShieldedBalance = senderInitialState.shielded.balances[shieldedTokenRaw];
       const initialUnshieldedBalance = senderInitialState.unshielded.balances[unshieldedTokenRaw] ?? 0n;
@@ -180,7 +180,7 @@ describe('Token transfer', () => {
       // await waitForTxInHistory(txId, sender);
       // await utils.waitForFacadePendingClear(sender);
       await utils.waitForUnshieldedCoinUpdate(receiver.wallet, initialReceiverState.unshielded.availableCoins.length);
-      const senderFinalState = await utils.waitForSyncFacade(sender.wallet);
+      const senderFinalState = await sender.wallet.waitForSyncedState();
       // logger.info(walletStateTrimmed(finalState));
       const senderFinalShieldedBalance = senderFinalState.shielded.balances[shieldedTokenRaw];
       const senderFinalUnshieldedBalance = senderFinalState.unshielded.balances[unshieldedTokenRaw];
@@ -212,7 +212,7 @@ describe('Token transfer', () => {
       // expect(finalState.transactionHistory.length).toBeGreaterThanOrEqual(initialState.transactionHistory.length + 1);
 
       // await waitForTxInHistory(txId, receiver);
-      const receiverFinalState = await utils.waitForSyncFacade(receiver.wallet);
+      const receiverFinalState = await receiver.wallet.waitForSyncedState();
       // logger.info(walletStateTrimmed(finalState2));
       const receiverFinalShieldedBalance = receiverFinalState.shielded.balances[shieldedTokenRaw] ?? 0n;
       const receiverFinalUnshieldedBalance = receiverFinalState.unshielded.balances[unshieldedTokenRaw] ?? 0n;
@@ -240,7 +240,7 @@ describe('Token transfer', () => {
       allure.feature('Transactions');
       allure.story('Valid transfer self-transaction');
 
-      const initialState = await utils.waitForSyncFacade(sender.wallet);
+      const initialState = await sender.wallet.waitForSyncedState();
       const initialBalance = initialState.shielded.balances[shieldedTokenRaw];
       logger.info(initialState.shielded.availableCoins);
       logger.info(`Wallet 1 shielded balance: ${initialBalance}`);
@@ -288,7 +288,7 @@ describe('Token transfer', () => {
 
       // await utils.waitForTxInHistory(String(txId), sender.shielded);
       await utils.waitForFacadePendingClear(sender.wallet);
-      const finalState = await utils.waitForSyncFacade(sender.wallet);
+      const finalState = await sender.wallet.waitForSyncedState();
       // logger.info(walletStateTrimmed(finalState));
       logger.info(`Wallet 1 available coins: ${finalState.shielded.availableCoins.length}`);
       logger.info(`Wallet 1: ${finalState.shielded.balances[shieldedTokenRaw]}`);
@@ -308,8 +308,8 @@ describe('Token transfer', () => {
     const shieldedToken2 = '0000000000000000000000000000000000000000000000000000000000000002';
     const ttl = new Date(Date.now() + 30 * 60 * 1000);
 
-    const initialStateWallet1 = await utils.waitForSyncFacade(sender.wallet);
-    const initialStateWallet2 = await utils.waitForSyncFacade(receiver.wallet);
+    const initialStateWallet1 = await sender.wallet.waitForSyncedState();
+    const initialStateWallet2 = await receiver.wallet.waitForSyncedState();
 
     // Does walllet have shielded tokens to swap
     const wallet1BalanceToken1 = initialStateWallet1.shielded.balances[shieldedToken1] ?? 0n;
@@ -380,7 +380,7 @@ describe('Token transfer', () => {
       allure.feature('Transactions');
       allure.story('Invalid transaction');
       const initialState = await firstValueFrom(sender.wallet.state());
-      const syncedState = await utils.waitForSyncFacade(sender.wallet);
+      const syncedState = await sender.wallet.waitForSyncedState();
       const initialBalance = syncedState?.shielded.balances[shieldedTokenRaw] ?? 0n;
       logger.info(`Wallet 1 balance is: ${initialBalance}`);
       const balance = 25000000000000000n;
@@ -453,7 +453,7 @@ describe('Token transfer', () => {
       allure.epic('Headless wallet');
       allure.feature('Transactions');
       allure.story('Transaction not proved');
-      const syncedState = await utils.waitForSyncFacade(sender.wallet);
+      const syncedState = await sender.wallet.waitForSyncedState();
       const initialBalance = syncedState?.shielded.balances[shieldedTokenRaw] ?? 0n;
       logger.info(`Wallet 1 balance is: ${initialBalance}`);
 
@@ -512,7 +512,7 @@ describe('Token transfer', () => {
   //     allure.epic('Headless wallet');
   //     allure.feature('Transactions');
   //     allure.story('Invalid address error message');
-  //     const syncedState = await utils.waitForSyncFacade(sender.wallet);
+  //     const syncedState = await sender.wallet.waitForSyncedState();
   //     const initialBalance = syncedState?.shielded.balances[shieldedTokenRaw] ?? 0n;
   //     logger.info(`Wallet 1 balance is: ${initialBalance}`);
   //     const invalidAddress = new ShieldedAddress('invalidCPK', 'invalidEPK');
@@ -552,7 +552,7 @@ describe('Token transfer', () => {
       allure.epic('Headless wallet');
       allure.feature('Transactions');
       allure.story('Invalid amount error message');
-      const syncedState = await utils.waitForSyncFacade(sender.wallet);
+      const syncedState = await sender.wallet.waitForSyncedState();
       const initialBalance = syncedState?.shielded.balances[shieldedTokenRaw] ?? 0n;
       logger.info(`Wallet 1 balance is: ${initialBalance}`);
       // the max amount that we support: Rust u64 max. The entire Midnight supply
@@ -605,7 +605,7 @@ describe('Token transfer', () => {
       allure.epic('Headless wallet');
       allure.feature('Transactions');
       allure.story('Invalid amount error message');
-      const syncedState = await utils.waitForSyncFacade(sender.wallet);
+      const syncedState = await sender.wallet.waitForSyncedState();
       const initialBalance = syncedState?.shielded.balances[shieldedTokenRaw] ?? 0n;
       logger.info(`Wallet 1 balance is: ${initialBalance}`);
 
@@ -645,7 +645,7 @@ describe('Token transfer', () => {
       allure.epic('Headless wallet');
       allure.feature('Transactions');
       allure.story('Invalid amount error message');
-      const syncedState = await utils.waitForSyncFacade(sender.wallet);
+      const syncedState = await sender.wallet.waitForSyncedState();
       const initialBalance = syncedState?.shielded.balances[shieldedTokenRaw] ?? 0n;
       logger.info(`Wallet 1 balance is: ${initialBalance}`);
       const initialState2 = await firstValueFrom(receiver.wallet.state());
@@ -686,7 +686,7 @@ describe('Token transfer', () => {
       allure.epic('Headless wallet');
       allure.feature('Transactions');
       allure.story('Invalid amount error message');
-      const syncedState = await utils.waitForSyncFacade(sender.wallet);
+      const syncedState = await sender.wallet.waitForSyncedState();
       const initialBalance = syncedState?.shielded.balances[shieldedTokenRaw] ?? 0n;
       logger.info(`Wallet 1 balance is: ${initialBalance}`);
 
@@ -714,7 +714,7 @@ describe('Token transfer', () => {
   //   const bech32mAddress =
   //     'mn_shield-addr_undeployed1kav2zmw5u5qtvfpcx0xnkdrsrsmnqpxd8c6rt6nrqs34yy0ttahsxqpmpljwuf6rjg0pzseww9l8xlpjwjf2sxackw69numxqs9ag2hphgx2cfjgtqvqyaeqtx97rpvy0sp2gmc60zreapu488v043';
 
-  //   const syncedState = await utils.waitForSyncFacade(sender.wallet);
+  //   const syncedState = await sender.wallet.waitForSyncedState();
   //   const initialBalance = syncedState?.shielded.balances[shieldedTokenRaw] ?? 0n;
   //   logger.info(`Wallet 1 balance is: ${initialBalance}`);
 
@@ -754,7 +754,7 @@ describe('Token transfer', () => {
   //   allure.story('Tx to addresss from different chain');
   //   const bech32mAddress = 'bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297';
 
-  //   const syncedState = await utils.waitForSyncFacade(sender.wallet);
+  //   const syncedState = await sender.wallet.waitForSyncedState();
   //   const initialBalance = syncedState?.shielded.balances[shieldedTokenRaw] ?? 0n;
   //   logger.info(`Wallet 1 balance is: ${initialBalance}`);
 

--- a/packages/e2e-tests/src/tests/utils.ts
+++ b/packages/e2e-tests/src/tests/utils.ts
@@ -328,18 +328,6 @@ export const waitForSyncShielded = (wallet: ShieldedWallet) =>
     ),
   );
 
-export const waitForSyncFacade = async (facade: WalletFacade) =>
-  await rx.firstValueFrom(
-    facade.state().pipe(
-      rx.throttleTime(5_000),
-      rx.tap((state) => {
-        const applyGap = state.unshielded.progress.highestTransactionId - state.unshielded.progress.appliedId;
-        logger.info(`Wallet facade behind by ${applyGap}`);
-      }),
-      rx.filter((state) => state.isSynced === true),
-    ),
-  );
-
 export const waitForFacadePending = (wallet: WalletFacade) =>
   rx.firstValueFrom(
     wallet.state().pipe(
@@ -376,6 +364,17 @@ export const waitForFacadePendingClear = (wallet: WalletFacade) =>
           state.unshielded.pendingCoins.length == 0 &&
           state.dust.pendingCoins.length == 0,
       ),
+    ),
+  );
+
+export const waitForDustBalance = (wallet: WalletFacade) =>
+  rx.firstValueFrom(
+    wallet.state().pipe(
+      rx.tap((state) => {
+        const dustBalance = state.dust.balance(new Date());
+        logger.info(`Dust balance: ${dustBalance}, waiting for dust balance > 7 * 10^14...`);
+      }),
+      rx.filter((state) => state.dust.balance(new Date()) > 7n * 10n ** 14n),
     ),
   );
 


### PR DESCRIPTION
# Description

- Updates all test files to use native function for waiting until wallet state has synced
- Refactor tests in packages/e2e-tests/src/tests/emptyWallet.universal.test.ts to use individual wallets for serializing and restore rather than through wallet facade.

Note: Due to waiting for syncing now being faster it's exposed an issue with `undeployed` network tests where transactions made using prefunded wallet is returning error: `(FiberFailure) Wallet.Transacting: Not enough Dust generated to pay the fee`. 
This appears to be a bug with undeployed network. Temporary workaround for undeployed tests is to wait 20 seconds for 2+ blocks to be produced before making a transaction. 
