### PR TITLE
chore: exit changeset pre

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "@midnight-ntwrk/wallet-test-website": "1.0.0-beta.0",


### PR DESCRIPTION
This pull request makes a small configuration update to the `.changeset/pre.json` file, changing the mode from "pre" to "exit" to update the release process.