### PR TITLE
chore: switch npm registry from GitHub Packages to npmjs.org

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,7 +4,7 @@ npmPublishRegistry: "https://npm.pkg.github.com/"
 
 npmScopes:
   midnight-ntwrk:
-    npmAlwaysAuth: true
-    npmRegistryServer: "https://npm.pkg.github.com"
+    npmAlwaysAuth: false
+    npmRegistryServer: "https://registry.npmjs.org"
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs


### PR DESCRIPTION
## Summary

Switch npm registry from GitHub Packages to npmjs.org for public package resolution.

## Changes

- Switch `npmRegistryServer` from `npm.pkg.github.com` to `registry.npmjs.org`
- Remove `npmAlwaysAuth` requirement