### PR TITLE
chore: switch npmRegistryServer to npmjs.org

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,7 +4,7 @@ npmPublishRegistry: "https://npm.pkg.github.com/"
 
 npmScopes:
   midnight-ntwrk:
-    npmAlwaysAuth: true
-    npmRegistryServer: "https://npm.pkg.github.com"
+    npmAlwaysAuth: false
+    npmRegistryServer: "https://registry.npmjs.org"
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs


### PR DESCRIPTION
Switch from GitHub Packages to npmjs.org. Note: yarn.lock regeneration needed (not included due to size). Verification: build ✓ (14 packages).