### PR TITLE
fix: bump package versions

### DIFF
--- a/.changeset/curvy-eyes-speak.md
+++ b/.changeset/curvy-eyes-speak.md
@@ -1,0 +1,7 @@
+---
+'@midnight-ntwrk/wallet-sdk-address-format': patch
+'@midnight-ntwrk/wallet-sdk-hd': patch
+'@midnight-ntwrk/wallet-sdk-node-client': patch
+---
+
+fix: bump package versions


### PR DESCRIPTION
This pull request makes a small change to bump the package versions for several SDK packages. This ensures that the latest fixes and updates are included in the following packages:

* `@midnight-ntwrk/wallet-sdk-address-format`
* `@midnight-ntwrk/wallet-sdk-hd`
* `@midnight-ntwrk/wallet-sdk-node-client`