### PR TITLE
fix: increase amount of generated txs to trigger multiple dust usage

### DIFF
--- a/packages/dust-wallet/test/DustWallet.test.ts
+++ b/packages/dust-wallet/test/DustWallet.test.ts
@@ -779,7 +779,7 @@ describe('DustWallet', () => {
         return Transaction.fromParts(NETWORK, undefined, undefined, intent);
       };
 
-      const transferTxs = Array.from({ length: 10 }, () => makeTransferTx(nightTokens[0]));
+      const transferTxs = Array.from({ length: 20 }, () => makeTransferTx(nightTokens[0]));
 
       const balancingTx = yield* wallet.balanceTransactions(dustSecretKey, transferTxs, ttl, currentTime);
 


### PR DESCRIPTION
This pull request increases the number of transfer transactions tested in the `DustWallet` test suite. The change expands the test coverage for transaction balancing by doubling the number of transfer transactions from 10 to 20.

* Test coverage improvement:
  * In `DustWallet.test.ts`, the `transferTxs` array is now generated with 20 transfer transactions instead of 10, providing a more robust test for the `balanceTransactions` method.