### PR TITLE
Add dependabot cooldown of 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,21 +5,29 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 7
 #  - package-ecosystem: "cargo"
 #    directory: "/"
 #    registries: "*"
 #    schedule:
 #      interval: "daily"
+#    cooldown:
+#      default-days: 7
 #
 #  - package-ecosystem: "npm"
 #    directory: "/"
 #    schedule:
 #      interval: "daily"
+#    cooldown:
+#      default-days: 7
 #
 #  - package-ecosystem: "docker"
 #    directory: "/"
 #    schedule:
 #      interval: "weekly"
+#    cooldown:
+#      default-days: 7
 #
 #registries:
 #   github:


### PR DESCRIPTION
## Summary
- Adds `cooldown: default-days: 7` to all package ecosystem entries in dependabot.yml (including commented-out ones)
- Matches the pattern already established in midnight-template-repo