### PR TITLE
Fix: make wallet accept sign request for recipes not requiring a sign…

### DIFF
--- a/.changeset/vast-beans-trade.md
+++ b/.changeset/vast-beans-trade.md
@@ -1,0 +1,7 @@
+---
+'@midnight-ntwrk/wallet-sdk-unshielded-wallet': patch
+'@midnight-ntwrk/wallet-sdk-facade': patch
+---
+
+In certain cases valid transactions won't contain any intents, which would cause the `WalletFacade.prototype.signRecipe`
+fail. Now it won't fail and return same recipe

--- a/packages/facade/test/optionalBalancing.test.ts
+++ b/packages/facade/test/optionalBalancing.test.ts
@@ -20,9 +20,10 @@ import { getDustSeed, getShieldedSeed, getUnshieldedSeed, tokenValue } from './u
 import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnight-ntwrk/wallet-sdk-utilities/testing';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
 import { DefaultConfiguration, WalletEntrySchema, WalletFacade, mergeWalletEntries } from '../src/index.js';
-import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnight-ntwrk/wallet-sdk-abstractions';
+import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnight-ntwrk/wallet-sdk-abstractions';
 import { DustWallet } from '@midnight-ntwrk/wallet-sdk-dust-wallet';
 import { makeWasmProvingService } from '@midnight-ntwrk/wallet-sdk-capabilities';
+import { pipe } from 'effect';
 
 vi.setConfig({ testTimeout: 200_000, hookTimeout: 200_000 });
 
@@ -125,7 +126,7 @@ describe('Optional Balancing', () => {
   const shieldedTokenType = ledger.shieldedToken().raw;
   const unshieldedTokenType = ledger.unshieldedToken().raw;
 
-  const createArbitraryTx = (networkId: NetworkId.NetworkId): ledger.UnprovenTransaction => {
+  const createArbitraryShieldedOffer = () => {
     const coin = ledger.createShieldedCoinInfo(shieldedTokenType, tokenValue(1n));
     const zswapOutput = ledger.ZswapOutput.new(
       coin,
@@ -133,7 +134,11 @@ describe('Optional Balancing', () => {
       ledger.sampleCoinPublicKey(),
       ledger.sampleEncryptionPublicKey(),
     );
-    const zswapOutputOffer = ledger.ZswapOffer.fromOutput(zswapOutput, shieldedTokenType, tokenValue(1n));
+    return ledger.ZswapOffer.fromOutput(zswapOutput, shieldedTokenType, tokenValue(1n));
+  };
+
+  const createArbitraryTx = (networkId: NetworkId.NetworkId): ledger.UnprovenTransaction => {
+    const shieldedOffer = createArbitraryShieldedOffer();
 
     const unshieldedOutput = [
       {
@@ -145,7 +150,7 @@ describe('Optional Balancing', () => {
     const intent = ledger.Intent.new(new Date(Date.now() + 3600));
     intent.guaranteedUnshieldedOffer = ledger.UnshieldedOffer.new([], unshieldedOutput, []);
 
-    return ledger.Transaction.fromParts(networkId, zswapOutputOffer, undefined, intent);
+    return ledger.Transaction.fromParts(networkId, shieldedOffer, undefined, intent);
   };
 
   describe('balanceUnprovenTransaction', () => {
@@ -172,6 +177,28 @@ describe('Optional Balancing', () => {
 
       // Verify unshielded is NOT balanced (unshielded imbalance < 0)
       expect(imbalances.unshielded).toBeLessThan(0n);
+    });
+
+    it('allows to progress to signing when only shielded tokens are being utilized', async () => {
+      await facade.waitForSyncedState();
+
+      const tx = pipe(createArbitraryShieldedOffer(), (offer) =>
+        ledger.Transaction.fromParts(configuration.networkId, offer),
+      );
+      const recipe = await facade.balanceUnprovenTransaction(
+        tx,
+        {
+          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
+          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
+        },
+        { ttl, tokenKindsToBalance: ['shielded'] },
+      );
+
+      const signed = await facade.signRecipe(recipe, () => {
+        throw new Error('Should not be called');
+      });
+
+      expect(signed).toEqual(recipe);
     });
 
     it('only balances unshielded when tokenKindsToBalance is ["unshielded"]', async () => {
@@ -286,6 +313,37 @@ describe('Optional Balancing', () => {
 
       // Verify base tx unshielded is NOT balanced (unshielded imbalance < 0n)
       expect(baseImbalances.unshielded).toBeLessThan(0n);
+    });
+
+    it('allows to progress to signing when only shielded tokens are being utilized', async () => {
+      await facade.waitForSyncedState();
+
+      const tx = await pipe(
+        createArbitraryShieldedOffer(),
+        (offer) => ledger.Transaction.fromParts(configuration.networkId, offer),
+        (tx) =>
+          tx.prove(
+            {
+              check: () => Promise.resolve([]),
+              prove: () => Promise.resolve(tx.mockProve().guaranteedOffer!.outputs.at(0)!.proof.serialize()),
+            },
+            ledger.LedgerParameters.initialParameters().transactionCostModel.runtimeCostModel,
+          ),
+      );
+      const recipe = await facade.balanceUnboundTransaction(
+        tx,
+        {
+          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
+          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
+        },
+        { ttl, tokenKindsToBalance: ['shielded'] },
+      );
+
+      const signed = await facade.signRecipe(recipe, () => {
+        throw new Error('Should not be called');
+      });
+
+      expect(signed).toEqual(recipe);
     });
 
     it('only balances unshielded when tokenKindsToBalance is ["unshielded"]', async () => {
@@ -421,6 +479,30 @@ describe('Optional Balancing', () => {
 
       // Verify unshielded is NOT balanced (no unshielded contribution, imbalance = 0)
       expect(imbalances.unshielded).toBe(0n);
+    });
+
+    it('allows to progress to signing when only shielded tokens are being utilized', async () => {
+      await facade.waitForSyncedState();
+
+      const tx = pipe(
+        createArbitraryShieldedOffer(),
+        (offer) => ledger.Transaction.fromParts(configuration.networkId, offer),
+        (tx) => tx.mockProve(),
+      );
+      const recipe = await facade.balanceFinalizedTransaction(
+        tx,
+        {
+          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
+          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
+        },
+        { ttl, tokenKindsToBalance: ['shielded'] },
+      );
+
+      const signed = await facade.signRecipe(recipe, () => {
+        throw new Error('Should not be called');
+      });
+
+      expect(signed).toEqual(recipe);
     });
 
     it('only balances unshielded when tokenKindsToBalance is ["unshielded"]', async () => {
@@ -567,6 +649,41 @@ describe('Optional Balancing', () => {
       // Verify dust fees ARE paid (dust imbalance > 0n)
       expect(imbalances.dust).toBeGreaterThan(0n);
     });
+
+    it('allows to continue with signing even when no signatures are needed and `payFees` is false', async () => {
+      const { shielded } = await facade.waitForSyncedState();
+
+      const recipe = await facade.initSwap(
+        {
+          shielded: {
+            [shieldedTokenType]: tokenValue(1n),
+          },
+        },
+        [
+          {
+            type: 'shielded',
+            outputs: [
+              {
+                type: shieldedTokenType,
+                receiverAddress: shielded.address,
+                amount: tokenValue(1n),
+              },
+            ],
+          },
+        ],
+        {
+          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
+          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
+        },
+        { ttl, payFees: false },
+      );
+
+      const signed = await facade.signRecipe(recipe, () => {
+        throw new Error('Should not be called');
+      });
+
+      expect(signed).toEqual(recipe);
+    });
   });
 
   describe('transferTransaction', () => {
@@ -626,6 +743,36 @@ describe('Optional Balancing', () => {
 
       // Verify dust fees ARE paid (dust imbalance > 0n)
       expect(imbalances.dust).toBeGreaterThan(0n);
+    });
+
+    it('allows to continue with signing even when no signatures are needed and `payFees` is false', async () => {
+      const { shielded } = await facade.waitForSyncedState();
+
+      const recipe = await facade.transferTransaction(
+        [
+          {
+            type: 'shielded',
+            outputs: [
+              {
+                type: shieldedTokenType,
+                receiverAddress: shielded.address,
+                amount: tokenValue(1n),
+              },
+            ],
+          },
+        ],
+        {
+          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
+          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
+        },
+        { ttl, payFees: false },
+      );
+
+      const signed = await facade.signRecipe(recipe, () => {
+        throw new Error('Should not be called');
+      });
+
+      expect(signed).toEqual(recipe);
     });
   });
 });

--- a/packages/unshielded-wallet/src/v1/Transacting.ts
+++ b/packages/unshielded-wallet/src/v1/Transacting.ts
@@ -14,7 +14,7 @@ import * as ledger from '@midnight-ntwrk/ledger-v8';
 import { NetworkId } from '@midnight-ntwrk/wallet-sdk-abstractions';
 import { Either, Option, pipe, Array as Arr } from 'effect';
 import { CoreWallet } from './CoreWallet.js';
-import { InsufficientFundsError, OtherWalletError, SignError, TransactingError, WalletError } from './WalletError.js';
+import { InsufficientFundsError, OtherWalletError, TransactingError, WalletError } from './WalletError.js';
 import {
   BalanceRecipe,
   CoinSelection,
@@ -345,9 +345,6 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
   ): Either.Either<T, WalletError> {
     return Either.gen(this, function* () {
       const segments = this.txOps.getSegments(transaction);
-      if (!segments.length) {
-        throw new SignError({ message: 'No segments found in the provided transaction' });
-      }
 
       for (const segment of segments) {
         const signedData = yield* this.txOps.getSignatureData(transaction, segment);

--- a/packages/unshielded-wallet/src/v1/test/transacting.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/transacting.test.ts
@@ -262,4 +262,42 @@ describe('Unshielded wallet transacting', () => {
       }),
     );
   });
+
+  describe('when signing', () => {
+    it('does nothing if an unproven transaction does not have any intents', () => {
+      const transacting = makeDefaultTransactingCapability(config, () => context);
+
+      const emptyTx = ledger.Transaction.fromParts(config.networkId);
+      const result = transacting
+        .signUnprovenTransaction(emptyTx, () => {
+          throw new Error('should not be called');
+        })
+        .pipe(EitherOps.getOrThrowLeft);
+
+      expect(result).toBe(emptyTx);
+    });
+
+    it('does nothing if an unbound transaction does not have any intents', async () => {
+      const transacting = makeDefaultTransactingCapability(config, () => context);
+
+      const emptyTx = await ledger.Transaction.fromParts(config.networkId).prove(
+        {
+          prove() {
+            return Promise.resolve(Buffer.from([42]));
+          },
+          check(): Promise<(bigint | undefined)[]> {
+            return Promise.resolve([]);
+          },
+        },
+        ledger.LedgerParameters.initialParameters().transactionCostModel.runtimeCostModel,
+      );
+      const result = transacting
+        .signUnboundTransaction(emptyTx, () => {
+          throw new Error('should not be called');
+        })
+        .pipe(EitherOps.getOrThrowLeft);
+
+      expect(result).toBe(emptyTx);
+    });
+  });
 });


### PR DESCRIPTION
…ature

# Description

In certain use cases, mostly involving DApp Connector integration, user of the Wallet SDK does not have an easy way of checking whether transaction requires unshielded wallet signatures or not. 

# Proposed Solution

Make unshielded wallet return original transaction when receiving a sign request for transaction which does not contain any intents. 

This is known to not be enough in certain circumstances, but it addresses issues faced by some users (https://github.com/midnightntwrk/midnight-wallet/issues/326)


# Important Changes Introduced

None

# Testing

Provided tests should pass. 

In various settings - create a transaction featuring only shielded offers through various APIs and then call `WalletFacade.prototype.signRecipe`. It should pass, returning equivalent recipe back