### PR TITLE
feat: add txHistory to dust wallet

### DIFF
--- a/.changeset/few-plums-speak.md
+++ b/.changeset/few-plums-speak.md
@@ -1,0 +1,6 @@
+---
+'@midnight-ntwrk/wallet-sdk-dust-wallet': minor
+'@midnight-ntwrk/wallet-sdk-facade': minor
+---
+
+Add txHistory functionality to the dust wallet

--- a/.claude/skills/shelf/SKILL.md
+++ b/.claude/skills/shelf/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: shelf
+description: >
+  Access code reference repositories managed by shelf. Repos are cached at ~/.agents/shelf/repos/{alias}/ and kept in
+  sync. Use your native tools (Grep, Read, Glob) to explore them.
+
+  ALWAYS consult this skill before searching for code references, looking up how a library or framework works, grepping
+  for implementations, reading source code from a reference repo, checking API signatures, finding usage examples in
+  real codebases, or exploring how a dependency is structured.
+
+  Trigger this skill whenever the user mentions code references, reference repos, shelf, grepping a codebase, reading
+  library source, "how does X implement Y", "find examples of Z in the codebase", looking up types or interfaces,
+  checking an upstream project's code, comparing implementations, or any task that benefits from consulting real source
+  code in a cached repository — even if the user doesn't mention "shelf" by name.
+
+  If the user asks you to look something up in a codebase, check an implementation, or find how something works in a
+  library, this is the skill to use.
+
+  Do NOT use for the user's own project code (use normal file tools for that), web searches, documentation lookups on
+  the internet, or package registry queries.
+---
+
+# Shelf — Code Reference Repos
+
+Shelf maintains a local cache of code reference repositories at `~/.agents/shelf/repos/{alias}/`. These repos let you
+answer questions about library internals, API surfaces, implementation patterns, and real-world usage — without
+searching the web or relying on training data that may be stale.
+
+**Why this matters:** cached reference repos are faster and more reliable than web search for code questions. The code
+is local, complete, and version-pinned, so you can grep, read, and explore freely. Whenever a task involves
+understanding how a dependency, framework, or upstream project works, check shelf first.
+
+## Quick Start
+
+1. Run `shelf list` to see which repos are available and their local paths.
+2. Use your native tools on those paths:
+   - **Search**: `Grep` or `rg` on `~/.agents/shelf/repos/{alias}/`
+   - **Read files**: `Read` on any file in the repo
+   - **Find files**: `Glob` with patterns like `~/.agents/shelf/repos/{alias}/**/*.ts`
+   - **Explore structure**: `ls ~/.agents/shelf/repos/{alias}/src/`
+
+## Workflow
+
+When the user asks about code in a reference repository:
+
+1. **Discover** — Run `shelf list` to see available repos and their aliases. If the needed repo isn't there, ask the
+   user if they'd like to add it with `shelf add`.
+2. **Search** — Use `rg` (ripgrep) or `Grep` to find relevant code. Start broad (e.g., search for a function name, type
+   name, or keyword), then narrow down.
+3. **Read** — Open the relevant files and read the specific sections that answer the question.
+4. **Synthesize** — Explain what you found, referencing file paths and line numbers so the user can verify.
+
+## Management Commands
+
+| Command                                       | Purpose                                       |
+| --------------------------------------------- | --------------------------------------------- |
+| `shelf list`                                  | Show repos with local paths                   |
+| `shelf update [alias]`                        | Sync one or all repos                         |
+| `shelf add <repo> [--alias name] [--pin ref]` | Add a repo (accepts name, owner/repo, or URL) |
+| `shelf remove <alias>`                        | Remove a repo                                 |
+| `shelf detect [--apply]`                      | Detect repos from project dependencies        |
+| `shelf install [--dir path]`                  | Install repos from a shelffile                |
+| `shelf share [--filter aliases] [--stdout]`   | Generate a shelffile from current repos       |
+| `shelf prune [--dry-run] [--force]`           | Remove unreferenced repos                     |
+| `shelf status`                                | Show detailed status of all repos             |
+| `shelf info <alias>`                          | Show detailed info for a single repo          |
+| `shelf pin <alias> <ref>`                     | Pin a repo to a branch, tag, or commit        |
+| `shelf alias <old> <new>`                     | Rename a repo alias                           |
+| `shelf daemon start`                          | Start background sync daemon                  |
+| `shelf daemon stop`                           | Stop the daemon                               |
+| `shelf daemon status`                         | Show daemon status                            |
+
+## Adding Repos
+
+You can add repos by name — no full URL required:
+
+\`\`\` shelf add react # resolves from built-in registry shelf add Effect-TS/effect # resolves owner/repo to GitHub
+shelf add https://github.com/org/repo.git # full URL \`\`\`
+
+## Shelffile
+
+A `shelffile` is a per-project manifest declaring which reference repos the project needs:
+
+\`\`\`
+
+# one repo per line: alias url [pin:type:value]
+
+effect https://github.com/Effect-TS/effect.git pin:branch:main react https://github.com/facebook/react.git
+pin:tag:v19.0.0 \`\`\`
+
+Run `shelf install` in a project directory to clone all repos from its shelffile. Run `shelf share` to generate a
+shelffile from your current repos. Run `shelf detect --format shelffile` to auto-generate from project dependencies.
+
+## Tips
+
+- **Pin versions for reproducibility.** If the user's project depends on React 19, pin the reference repo to `v19.0.0`
+  so the code you read matches what they're actually using.
+- **Update before deep dives.** If you're about to do extensive research in a repo, run `shelf update {alias}` first to
+  make sure you're reading the latest code (unless pinned).
+- **Combine with project code.** You can cross-reference between the user's project files and shelf repos to trace how
+  dependencies are used — e.g., find a function signature in the shelf repo, then grep the user's project for call
+  sites.

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ packages/src/**/*.d.ts*
 reports
 
 # user files
+/.scratch
 **/.sync_cache
 /packages/e2e-tests/res
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Key sections:
 
 ### DApp Connector API Specification
 
-**Repository:** [midnight-dapp-connector-api](https://github.com/input-output-hk/midnight-dapp-connector-api) **NPM:**
+**Repository:** [midnight-dapp-connector-api](https://github.com/midnightntwrk/midnight-dapp-connector-api) **NPM:**
 [@midnight-ntwrk/dapp-connector-api](https://www.npmjs.com/package/@midnight-ntwrk/dapp-connector-api) **Path:**
 `SPECIFICATION.md`
 
@@ -52,7 +52,7 @@ TypeScript type definitions for the connector API.
 
 ### Ledger Specification
 
-**Repository:** [midnight-ledger](https://github.com/input-output-hk/midnight-ledger) **Path:** `spec/`
+**Repository:** [midnight-ledger](https://github.com/midnightntwrk/midnight-ledger) **Path:** `spec/`
 
 Key documents:
 
@@ -167,6 +167,21 @@ directly (e.g., `tsconfig.build.json` or `tsconfig.test.json`), not one that onl
 ```bash
 git diff --name-only --diff-filter=ACMR HEAD -- '*.ts' | xargs -I{} yarn effect-language-service diagnostics --file "$(pwd)/{}" --format pretty
 ```
+
+### Code Reference Repos (Shelf)
+
+The project uses [shelf](https://github.com/Rika-Labs/shelf) to maintain local caches of upstream reference repositories
+for AI-assisted development. The `shelffile` in the repo root declares which repos are needed.
+
+Shelf requires [Bun](https://bun.sh/) and is installed globally:
+
+```bash
+bun install -g @rikalabs/shelf
+shelf install              # clones repos declared in shelffile
+```
+
+This is optional — everything works without it. It just gives Claude Code fast local access to upstream source code
+instead of relying on web searches.
 
 ## Architecture
 

--- a/packages/dust-wallet/src/DustWallet.ts
+++ b/packages/dust-wallet/src/DustWallet.ts
@@ -35,22 +35,31 @@ import { type AnyTransaction } from './v1/types/ledger.js';
 import { type BaseV1Configuration, type DefaultV1Configuration, type V1Variant, V1Builder } from './v1/V1Builder.js';
 import { type WalletSyncUpdate } from './v1/Sync.js';
 
+import { type TransactionHistoryService } from './v1/TransactionHistory.js';
+
 export type DustWalletCapabilities<TSerialized = string> = {
   serialization: SerializationCapability<CoreWallet, null, TSerialized>;
   coinsAndBalances: CoinsAndBalancesCapability<CoreWallet>;
   keys: KeysCapability<CoreWallet>;
 };
 
+export type DustWalletServices = {
+  transactionHistory: TransactionHistoryService;
+};
+
 export class DustWalletState<TSerialized = string> {
   static readonly mapState =
-    <TSerialized = string>(capabilities: DustWalletCapabilities<TSerialized>) =>
+    <TSerialized = string>(variant: DustWalletCapabilities<TSerialized> & DustWalletServices) =>
     (state: ProtocolState.ProtocolState<CoreWallet>): DustWalletState<TSerialized> => {
-      return new DustWalletState(state, capabilities);
+      const { serialization, coinsAndBalances, keys } = variant;
+      const { transactionHistory } = variant;
+      return new DustWalletState(state, { serialization, coinsAndBalances, keys }, { transactionHistory });
     };
 
   readonly protocolVersion: ProtocolVersion.ProtocolVersion;
   readonly state: CoreWallet;
   readonly capabilities: DustWalletCapabilities<TSerialized>;
+  readonly services: DustWalletServices;
 
   get totalCoins(): readonly DustFullInfo[] {
     return this.capabilities.coinsAndBalances.getTotalCoins(this.state);
@@ -76,18 +85,15 @@ export class DustWalletState<TSerialized = string> {
     return this.state.progress;
   }
 
-  /**
-   * Transaction history for the wallet.
-   * @throws Error - Not yet implemented
-   */
-  get transactionHistory(): never {
-    throw new Error('Transaction history is not yet implemented for DustWallet');
-  }
-
-  constructor(state: ProtocolState.ProtocolState<CoreWallet>, capabilities: DustWalletCapabilities<TSerialized>) {
+  constructor(
+    state: ProtocolState.ProtocolState<CoreWallet>,
+    capabilities: DustWalletCapabilities<TSerialized>,
+    services: DustWalletServices,
+  ) {
     this.protocolVersion = state.version;
     this.state = state.state;
     this.capabilities = capabilities;
+    this.services = services;
   }
 
   balance(time: Date): Balance {

--- a/packages/dust-wallet/src/v1/CoreWallet.ts
+++ b/packages/dust-wallet/src/v1/CoreWallet.ts
@@ -95,6 +95,7 @@ export const CoreWallet = {
     events: Event[],
     currentTime: Date,
   ): [CoreWallet, DustStateChanges[]] {
+    // TODO: replace currentTime with `updatedState.syncTime` introduced in ledger-6.2.0-rc.1
     const stateWithChanges = wallet.state.replayEventsWithChanges(secretKey, events);
     const updatedState = stateWithChanges.state.processTtls(currentTime);
     const availableNonces = updatedState.utxos.map((utxo) => utxo.nonce);

--- a/packages/dust-wallet/src/v1/CoreWallet.ts
+++ b/packages/dust-wallet/src/v1/CoreWallet.ts
@@ -17,6 +17,7 @@ import {
   DustParameters,
   DustPublicKey,
   DustSecretKey,
+  DustStateChanges,
   Proofish,
   Signaturish,
   Transaction,
@@ -88,15 +89,23 @@ export const CoreWallet = {
     };
   },
 
-  applyEvents(wallet: CoreWallet, secretKey: DustSecretKey, events: Event[], currentTime: Date): CoreWallet {
-    // TODO: replace currentTime with `updatedState.syncTime` introduced in ledger-6.2.0-rc.1
-    const updatedState = wallet.state.replayEvents(secretKey, events).processTtls(currentTime);
+  applyEventsWithChanges(
+    wallet: CoreWallet,
+    secretKey: DustSecretKey,
+    events: Event[],
+    currentTime: Date,
+  ): [CoreWallet, DustStateChanges[]] {
+    const stateWithChanges = wallet.state.replayEventsWithChanges(secretKey, events);
+    const updatedState = stateWithChanges.state.processTtls(currentTime);
     const availableNonces = updatedState.utxos.map((utxo) => utxo.nonce);
-    return {
-      ...wallet,
-      state: updatedState,
-      pendingDust: wallet.pendingDust.filter((t) => availableNonces.includes(t.nonce)),
-    };
+    return [
+      {
+        ...wallet,
+        state: updatedState,
+        pendingDust: wallet.pendingDust.filter((t) => availableNonces.includes(t.nonce)),
+      },
+      stateWithChanges.changes,
+    ];
   },
 
   applyFailed(wallet: CoreWallet, tx: Transaction<Signaturish, Proofish, Bindingish>): CoreWallet {

--- a/packages/dust-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/dust-wallet/src/v1/RunningV1Variant.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Effect, SubscriptionRef, Stream, pipe, Scope, Sink, Console, Duration, Schedule, Array as Arr } from 'effect';
+import { type TransactionHistoryService } from './TransactionHistory.js';
 import {
   type DustSecretKey,
   nativeToken,
@@ -30,7 +31,7 @@ import {
 } from '@midnight-ntwrk/wallet-sdk-runtime/abstractions';
 import { type Dust, type UtxoWithMeta } from './types/Dust.js';
 import { type KeysCapability } from './Keys.js';
-import { type SyncCapability, type SyncService } from './Sync.js';
+import { type ChangesResult, type SyncCapability, type SyncService } from './Sync.js';
 import { type SimulatorState } from '@midnight-ntwrk/wallet-sdk-capabilities/simulation';
 import {
   type CoinsAndBalancesCapability,
@@ -71,11 +72,12 @@ export declare namespace RunningV1Variant {
   export type Context<TSerialized, TSyncUpdate, TTransaction, TStartAux> = {
     serializationCapability: SerializationCapability<CoreWallet, null, TSerialized>;
     syncService: SyncService<CoreWallet, TStartAux, TSyncUpdate>;
-    syncCapability: SyncCapability<CoreWallet, TSyncUpdate>;
+    syncCapability: SyncCapability<CoreWallet, TSyncUpdate, ChangesResult>;
     transactingCapability: TransactingCapability<DustSecretKey, CoreWallet, TTransaction>;
     coinsAndBalancesCapability: CoinsAndBalancesCapability<CoreWallet>;
     keysCapability: KeysCapability<CoreWallet>;
     coinSelection: CoinSelection<Dust>;
+    transactionHistoryService: TransactionHistoryService;
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export type AnyContext = Context<any, any, any, any>;
@@ -138,18 +140,40 @@ export class RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
       SubscriptionRef.get(this.#context.stateRef),
       Stream.fromEffect,
       Stream.flatMap((state) => this.#v1Context.syncService.updates(state, startAux)),
-      Stream.mapEffect((update) => {
-        return SubscriptionRef.updateEffect(this.#context.stateRef, (state) =>
+      Stream.mapEffect((update) =>
+        SubscriptionRef.modifyEffect(this.#context.stateRef, (state) =>
           Effect.try({
-            try: () => this.#v1Context.syncCapability.applyUpdate(state, update),
+            try: () => {
+              const [newState, changesResult] = this.#v1Context.syncCapability.applyUpdate(state, update);
+              return [changesResult, newState] as const;
+            },
             catch: (err) =>
               new OtherWalletError({
                 message: 'Error while applying sync update',
                 cause: err,
               }),
           }),
-        );
-      }),
+        ).pipe(
+          Effect.flatMap(({ changes, protocolVersion }) =>
+            pipe(
+              Effect.forEach(
+                changes,
+                (change) =>
+                  pipe(
+                    this.#v1Context.transactionHistoryService.getTransactionDetails(change.source),
+                    Effect.flatMap((metadata) =>
+                      this.#v1Context.transactionHistoryService.put(change, metadata, protocolVersion),
+                    ),
+                    Effect.catchAllCause((cause) => Console.error('Error processing tx history metadata', cause)),
+                  ),
+                { discard: true, concurrency: 'unbounded' },
+              ),
+              Effect.forkScoped,
+            ),
+          ),
+          Effect.provideService(Scope.Scope, this.#scope),
+        ),
+      ),
       Stream.tapError((error) => Console.error(error)),
       Stream.retry(
         pipe(

--- a/packages/dust-wallet/src/v1/Sync.ts
+++ b/packages/dust-wallet/src/v1/Sync.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Effect, Either, Layer, ParseResult, pipe, Schema, Scope, Stream, Duration, Chunk, Schedule } from 'effect';
-import { DustSecretKey, Event as LedgerEvent, LedgerParameters } from '@midnight-ntwrk/ledger-v8';
+import { DustSecretKey, DustStateChanges, Event as LedgerEvent, LedgerParameters } from '@midnight-ntwrk/ledger-v8';
 import { BlockHash, DustLedgerEvents } from '@midnight-ntwrk/wallet-sdk-indexer-client';
 import {
   WsSubscriptionClient,
@@ -46,8 +46,13 @@ export interface BlockData {
   timestamp: Date;
 }
 
-export interface SyncCapability<TState, TUpdate> {
-  applyUpdate: (state: TState, update: TUpdate) => TState;
+export type ChangesResult = {
+  readonly changes: DustStateChanges[];
+  readonly protocolVersion: number;
+};
+
+export interface SyncCapability<TState, TUpdate, TResult> {
+  applyUpdate: (state: TState, update: TUpdate) => [TState, TResult];
 }
 
 export type IndexerClientConnection = {
@@ -262,14 +267,14 @@ export const makeIndexerSyncService = (config: DefaultSyncConfiguration): Indexe
   };
 };
 
-export const makeDefaultSyncCapability = (): SyncCapability<CoreWallet, WalletSyncUpdate> => {
+export const makeDefaultSyncCapability = (): SyncCapability<CoreWallet, WalletSyncUpdate, ChangesResult> => {
   return {
-    applyUpdate(state: CoreWallet, wrappedUpdate: WalletSyncUpdate): CoreWallet {
+    applyUpdate(state: CoreWallet, wrappedUpdate: WalletSyncUpdate): [CoreWallet, ChangesResult] {
       const { updates, secretKey } = wrappedUpdate;
 
       // Nothing to update yet
       if (updates.length === 0) {
-        return state;
+        return [state, { changes: [], protocolVersion: Number(state.protocolVersion) }];
       }
 
       const lastUpdate = updates.at(-1)!;
@@ -279,16 +284,23 @@ export const makeDefaultSyncCapability = (): SyncCapability<CoreWallet, WalletSy
       // in case the nextIndex is less than or equal to the current appliedIndex
       // just update highestRelevantWalletIndex
       if (nextIndex <= state.progress.appliedIndex) {
-        return CoreWallet.updateProgress(state, { highestRelevantWalletIndex, isConnected: true });
+        return [
+          CoreWallet.updateProgress(state, { highestRelevantWalletIndex, isConnected: true }),
+          { changes: [], protocolVersion: Number(state.protocolVersion) },
+        ];
       }
 
       const events = updates.map((u) => u.raw).filter((event) => event !== null);
 
-      return CoreWallet.updateProgress(CoreWallet.applyEvents(state, secretKey, events, wrappedUpdate.timestamp), {
+      const [newState, changes] = CoreWallet.applyEventsWithChanges(state, secretKey, events, wrappedUpdate.timestamp);
+
+      const updatedState = CoreWallet.updateProgress(newState, {
         appliedIndex: nextIndex,
         highestRelevantWalletIndex,
         isConnected: true,
       });
+
+      return [updatedState, { changes, protocolVersion: Number(updatedState.protocolVersion) }];
     },
   };
 };
@@ -340,22 +352,29 @@ export const makeSimulatorSyncService = (
   };
 };
 
-export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, SimulatorSyncUpdate> => {
+export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, SimulatorSyncUpdate, ChangesResult> => {
   return {
-    applyUpdate: (state: CoreWallet, update: SimulatorSyncUpdate) => {
+    applyUpdate: (state: CoreWallet, update: SimulatorSyncUpdate): [CoreWallet, ChangesResult] => {
       const lastBlock = getLastBlock(update.update);
       // If no block exists yet (blank simulator), skip update
       if (lastBlock === undefined) {
-        return state;
+        return [state, { changes: [], protocolVersion: Number(state.protocolVersion) }];
       }
       // Get all events from blocks starting at appliedIndex (the next block to process).
       // appliedIndex semantics: the first block number we haven't processed yet.
       // Initial: appliedIndex = 0 (haven't processed any blocks)
       // After processing block N: appliedIndex = N + 1 (next block to process)
       const events = [...getBlockEventsFrom(update.update, state.progress.appliedIndex)];
-      return CoreWallet.updateProgress(CoreWallet.applyEvents(state, update.secretKey, events, lastBlock.timestamp), {
+      const [newState, changes] = CoreWallet.applyEventsWithChanges(
+        state,
+        update.secretKey,
+        events,
+        lastBlock.timestamp,
+      );
+      const updatedState = CoreWallet.updateProgress(newState, {
         appliedIndex: lastBlock.number + 1n,
       });
+      return [updatedState, { changes, protocolVersion: Number(updatedState.protocolVersion) }];
     },
   };
 };

--- a/packages/dust-wallet/src/v1/TransactionHistory.ts
+++ b/packages/dust-wallet/src/v1/TransactionHistory.ts
@@ -1,0 +1,200 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { TransactionHistoryStorage } from '@midnight-ntwrk/wallet-sdk-abstractions';
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { Duration, Array as EArray, Effect, Schedule, Schema } from 'effect';
+import { TransactionHistoryDetail } from '@midnight-ntwrk/wallet-sdk-indexer-client';
+import { HttpQueryClient } from '@midnight-ntwrk/wallet-sdk-indexer-client/effect';
+import { TransactionHistoryError } from './WalletError.js';
+
+export const DustUtxoInfoSchema = Schema.Struct({
+  initialValue: Schema.BigInt,
+  nonce: Schema.BigInt,
+  seq: Schema.Number,
+  backingNight: Schema.String,
+  mtIndex: Schema.BigInt,
+});
+
+export const DustSectionSchema = Schema.Struct({
+  receivedUtxos: Schema.Array(DustUtxoInfoSchema),
+  spentUtxos: Schema.Array(DustUtxoInfoSchema),
+});
+
+type DustSection = Schema.Schema.Type<typeof DustSectionSchema>;
+
+export const DustTransactionHistoryEntrySchema = Schema.Struct({
+  hash: TransactionHistoryStorage.TransactionHashSchema,
+  protocolVersion: Schema.Number,
+  status: TransactionHistoryStorage.TransactionHistoryStatusSchema,
+  dust: DustSectionSchema,
+});
+
+export type DustTransactionHistoryEntry = Schema.Schema.Type<typeof DustTransactionHistoryEntrySchema>;
+
+export type DefaultTransactionHistoryConfiguration = {
+  txHistoryStorage: TransactionHistoryStorage.TransactionHistoryStorage<TransactionHistoryStorage.TransactionHistoryEntryWithHash>;
+  indexerClientConnection: { indexerHttpUrl: string };
+};
+
+const utxoEquals = Schema.equivalence(DustUtxoInfoSchema);
+
+export type TransactionDetails = {
+  hash: string;
+  timestamp: number;
+  status: 'SUCCESS' | 'FAILURE' | 'PARTIAL_SUCCESS';
+};
+
+export type TransactionHistoryService = {
+  put(
+    changes: ledger.DustStateChanges,
+    metadata: TransactionDetails,
+    protocolVersion: number,
+  ): Effect.Effect<void, TransactionHistoryError>;
+  getTransactionDetails(
+    hash: TransactionHistoryStorage.TransactionHash,
+  ): Effect.Effect<TransactionDetails, TransactionHistoryError>;
+};
+
+export const mergeDustSections = (existing: DustSection, incoming: DustSection): DustSection => ({
+  receivedUtxos: EArray.unionWith(existing.receivedUtxos, incoming.receivedUtxos, utxoEquals),
+  spentUtxos: EArray.unionWith(existing.spentUtxos, incoming.spentUtxos, utxoEquals),
+});
+
+type StorageEntryWithDust = Omit<
+  TransactionHistoryStorage.TransactionHistoryCommon,
+  'identifiers' | 'timestamp' | 'fees'
+> & {
+  readonly dust: DustSection;
+};
+
+const convertQualifiedDustOutput = (utxo: ledger.QualifiedDustOutput) => ({
+  initialValue: utxo.initialValue,
+  nonce: utxo.nonce,
+  seq: utxo.seq,
+  backingNight: utxo.backingNight,
+  mtIndex: utxo.mtIndex,
+});
+
+const convertUpdateToStorageEntry = (
+  changes: ledger.DustStateChanges,
+  metadata: TransactionDetails,
+  protocolVersion: number,
+): StorageEntryWithDust => ({
+  hash: changes.source,
+  protocolVersion,
+  status: metadata.status,
+  dust: {
+    receivedUtxos: changes.receivedUtxos.map(convertQualifiedDustOutput),
+    spentUtxos: changes.spentUtxos.map(convertQualifiedDustOutput),
+  } satisfies DustSection,
+});
+
+const upsertDustEntry = (
+  txHistoryStorage: TransactionHistoryStorage.TransactionHistoryStorage<TransactionHistoryStorage.TransactionHistoryEntryWithHash>,
+  entry: TransactionHistoryStorage.TransactionHistoryEntryWithHash & { dust: DustSection },
+): Effect.Effect<void, TransactionHistoryError> =>
+  Effect.tryPromise({
+    try: () => txHistoryStorage.upsert(entry),
+    catch: (e) =>
+      new TransactionHistoryError({ message: `Failed to upsert history entry for ${entry.hash}`, cause: e }),
+  });
+
+export const makeDefaultTransactionHistoryService = (
+  config: DefaultTransactionHistoryConfiguration,
+  _getContext: () => unknown,
+): TransactionHistoryService => {
+  const txHistoryStorage = config.txHistoryStorage;
+  const queryClientLayer = HttpQueryClient.layer({ url: config.indexerClientConnection.indexerHttpUrl });
+
+  return {
+    put: (
+      changes: ledger.DustStateChanges,
+      metadata: TransactionDetails,
+      protocolVersion: number,
+    ): Effect.Effect<void, TransactionHistoryError> => {
+      const entry = convertUpdateToStorageEntry(changes, metadata, protocolVersion);
+      return upsertDustEntry(txHistoryStorage, entry);
+    },
+
+    getTransactionDetails: (
+      hash: TransactionHistoryStorage.TransactionHash,
+    ): Effect.Effect<TransactionDetails, TransactionHistoryError> =>
+      Effect.gen(function* () {
+        const statusQuery = yield* TransactionHistoryDetail;
+        const result = yield* statusQuery({ transactionHash: hash });
+        const tx = result.transactions[0];
+        const rawStatus = tx.__typename === 'RegularTransaction' ? tx.transactionResult.status : undefined;
+        const status: TransactionDetails['status'] =
+          rawStatus === 'FAILURE' || rawStatus === 'PARTIAL_SUCCESS' ? rawStatus : 'SUCCESS';
+
+        return {
+          hash: tx.hash,
+          timestamp: tx.block.timestamp,
+          status,
+        };
+      }).pipe(
+        Effect.provide(queryClientLayer),
+        Effect.scoped,
+        Effect.retry(Schedule.exponential(Duration.seconds(1)).pipe(Schedule.compose(Schedule.recurs(3)))),
+        Effect.mapError(
+          (cause) =>
+            new TransactionHistoryError({
+              message: `Failed to fetch transaction metadata for ${hash}`,
+              cause,
+            }),
+        ),
+      ),
+  };
+};
+
+export const makeSimulatorTransactionHistoryService = (
+  config: DefaultTransactionHistoryConfiguration,
+  _getContext: () => unknown,
+): TransactionHistoryService => {
+  const txHistoryStorage = config.txHistoryStorage;
+
+  return {
+    put: (
+      changes: ledger.DustStateChanges,
+      metadata: TransactionDetails,
+      protocolVersion: number,
+    ): Effect.Effect<void, TransactionHistoryError> => {
+      const entry = convertUpdateToStorageEntry(changes, metadata, protocolVersion);
+      return upsertDustEntry(txHistoryStorage, {
+        ...entry,
+        timestamp: new Date(metadata.timestamp),
+      });
+    },
+
+    getTransactionDetails: (
+      hash: TransactionHistoryStorage.TransactionHash,
+    ): Effect.Effect<TransactionDetails, TransactionHistoryError> =>
+      Effect.tryPromise({
+        try: () => txHistoryStorage.get(hash),
+        catch: (e) =>
+          new TransactionHistoryError({ message: `Failed to get transaction details for ${hash}`, cause: e }),
+      }).pipe(
+        Effect.flatMap((entry) =>
+          entry
+            ? Effect.succeed({
+                hash: entry.hash,
+                timestamp: entry.timestamp ? entry.timestamp.getTime() : Date.now(),
+                status: entry.status,
+              })
+            : Effect.fail(
+                new TransactionHistoryError({ message: `No transaction found in storage for hash: ${hash}` }),
+              ),
+        ),
+      ),
+  };
+};

--- a/packages/dust-wallet/src/v1/V1Builder.ts
+++ b/packages/dust-wallet/src/v1/V1Builder.ts
@@ -22,11 +22,17 @@ import { type WalletError } from './WalletError.js';
 import {
   type SyncService,
   type SyncCapability,
+  type ChangesResult,
   type DefaultSyncConfiguration,
   makeDefaultSyncCapability,
   makeDefaultSyncService,
   type WalletSyncUpdate,
 } from './Sync.js';
+import {
+  type DefaultTransactionHistoryConfiguration,
+  makeDefaultTransactionHistoryService,
+  type TransactionHistoryService,
+} from './TransactionHistory.js';
 import { RunningV1Variant, V1Tag } from './RunningV1Variant.js';
 import { type CoreWallet } from './CoreWallet.js';
 import { type KeysCapability, makeDefaultKeysCapability } from './Keys.js';
@@ -53,7 +59,7 @@ export type BaseV1Configuration = {
   costParameters: TotalCostParameters;
 };
 
-export type DefaultV1Configuration = BaseV1Configuration;
+export type DefaultV1Configuration = BaseV1Configuration & DefaultTransactionHistoryConfiguration;
 
 const V1BuilderSymbol: {
   readonly typeId: unique symbol;
@@ -73,6 +79,7 @@ export type V1Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData> = Varian
   coinsAndBalances: CoinsAndBalancesCapability<CoreWallet>;
   keys: KeysCapability<CoreWallet>;
   serialization: SerializationCapability<CoreWallet, null, TSerialized>;
+  transactionHistory: TransactionHistoryService;
 };
 
 export type DefaultV1Builder = V1Builder<
@@ -105,6 +112,7 @@ export class V1Builder<
       .withSerializationDefaults()
       .withTransactingDefaults()
       .withCoinsAndBalancesDefaults()
+      .withTransactionHistoryDefaults()
       .withKeysDefaults()
       .withCoinSelectionDefaults() as DefaultV1Builder;
   }
@@ -151,7 +159,7 @@ export class V1Builder<
     syncCapability: (
       configuration: TSyncConfig,
       getContext: () => TSyncContext,
-    ) => SyncCapability<CoreWallet, TSyncUpdate>,
+    ) => SyncCapability<CoreWallet, TSyncUpdate, ChangesResult>,
   ): V1Builder<TConfig & TSyncConfig, TContext & TSyncContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
     return new V1Builder<
       TConfig & TSyncConfig,
@@ -304,6 +312,48 @@ export class V1Builder<
     });
   }
 
+  withTransactionHistoryDefaults(
+    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, FinalizedTransaction, TStartAux>,
+  ): V1Builder<
+    TConfig & DefaultTransactionHistoryConfiguration,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    FinalizedTransaction,
+    TStartAux
+  > {
+    return this.withTransactionHistory(makeDefaultTransactionHistoryService);
+  }
+
+  withTransactionHistory<
+    TTransactionHistoryConfig,
+    TTransactionHistoryContext extends Partial<RunningV1Variant.AnyContext>,
+  >(
+    transactionHistoryService: (
+      configuration: TTransactionHistoryConfig,
+      getContext: () => TTransactionHistoryContext,
+    ) => TransactionHistoryService,
+  ): V1Builder<
+    TConfig & TTransactionHistoryConfig,
+    TContext & TTransactionHistoryContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux
+  > {
+    return new V1Builder<
+      TConfig & TTransactionHistoryConfig,
+      TContext & TTransactionHistoryContext,
+      TSerialized,
+      TSyncUpdate,
+      TTransaction,
+      TStartAux
+    >({
+      ...this.#buildState,
+      transactionHistoryService,
+    });
+  }
+
   withKeysDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
     return this.withKeys(makeDefaultKeysCapability);
   }
@@ -341,6 +391,7 @@ export class V1Builder<
       coinsAndBalances: v1Context.coinsAndBalancesCapability,
       keys: v1Context.keysCapability,
       serialization: v1Context.serializationCapability,
+      transactionHistory: v1Context.transactionHistoryService,
       start(
         context: Variant.VariantContext<CoreWallet>,
       ): Effect.Effect<
@@ -386,6 +437,7 @@ export class V1Builder<
       coinSelection,
       coinsAndBalancesCapability,
       keysCapability,
+      transactionHistoryService,
     } = this.#buildState;
 
     const getContext = (): RunningV1Variant.Context<TSerialized, TSyncUpdate, TTransaction, TStartAux> => context;
@@ -398,6 +450,7 @@ export class V1Builder<
       coinsAndBalancesCapability: coinsAndBalancesCapability(configuration, getContext),
       keysCapability: keysCapability(configuration, getContext),
       coinSelection: coinSelection(configuration, getContext),
+      transactionHistoryService: transactionHistoryService(configuration, getContext),
     };
 
     return context;
@@ -414,7 +467,7 @@ declare namespace V1Builder {
     readonly syncCapability: (
       configuration: TConfig,
       getContext: () => TContext,
-    ) => SyncCapability<CoreWallet, TSyncUpdate>;
+    ) => SyncCapability<CoreWallet, TSyncUpdate, ChangesResult>;
   };
 
   type HasTransacting<TConfig, TContext, TTransaction> = {
@@ -442,6 +495,13 @@ declare namespace V1Builder {
     ) => CoinsAndBalancesCapability<CoreWallet>;
   };
 
+  type HasTransactionHistory<TConfig, TContext> = {
+    readonly transactionHistoryService: (
+      configuration: TConfig,
+      getContext: () => TContext,
+    ) => TransactionHistoryService;
+  };
+
   type HasKeys<TConfig, TContext> = {
     readonly keysCapability: (configuration: TConfig, getContext: () => TContext) => KeysCapability<CoreWallet>;
   };
@@ -455,7 +515,8 @@ declare namespace V1Builder {
       HasTransacting<TConfig, TContext, TTransaction> &
       HasCoinSelection<TConfig, TContext> &
       HasCoinsAndBalances<TConfig, TContext> &
-      HasKeys<TConfig, TContext>
+      HasKeys<TConfig, TContext> &
+      HasTransactionHistory<TConfig, TContext>
   >;
   type PartialBuildState<
     TConfig = object,
@@ -491,6 +552,7 @@ const isBuildStateFull = <TConfig, TContext, TSerialized, TSyncUpdate, TTransact
     'serializationCapability',
     'coinsAndBalancesCapability',
     'keysCapability',
+    'transactionHistoryService',
   ] as const;
   /**
    * This type will fail compilation if any key is omitted, letting the `isFull` check work properly

--- a/packages/dust-wallet/src/v1/WalletError.ts
+++ b/packages/dust-wallet/src/v1/WalletError.ts
@@ -33,9 +33,15 @@ export class InsufficientFundsError extends Data.TaggedError('Wallet.Insufficien
   tokenType: string;
 }> {}
 
+export class TransactionHistoryError extends Data.TaggedError('Wallet.TransactionHistory')<{
+  message: string;
+  cause?: unknown;
+}> {}
+
 export type WalletError =
   | OtherWalletError
   | SyncWalletError
   | TransactingError
   | InsufficientFundsError
+  | TransactionHistoryError
   | LedgerOps.LedgerError;

--- a/packages/dust-wallet/src/v1/index.ts
+++ b/packages/dust-wallet/src/v1/index.ts
@@ -20,3 +20,5 @@ export * from './RunningV1Variant.js';
 export * from './V1Builder.js';
 export * from './types/index.js';
 export * as CoinsAndBalances from './CoinsAndBalances.js';
+export * as TransactionHistory from './TransactionHistory.js';
+export { DustSectionSchema, DustUtxoInfoSchema, mergeDustSections } from './TransactionHistory.js';

--- a/packages/dust-wallet/test/DustWallet.test.ts
+++ b/packages/dust-wallet/test/DustWallet.test.ts
@@ -44,6 +44,11 @@ import {
   getLastBlockResults,
 } from '@midnight-ntwrk/wallet-sdk-capabilities/simulation';
 import { makeSimulatorSyncCapability, makeSimulatorSyncService, type SimulatorSyncUpdate } from '../src/v1/Sync.js';
+import {
+  DustTransactionHistoryEntrySchema,
+  makeSimulatorTransactionHistoryService,
+} from '../src/v1/TransactionHistory.js';
+import { InMemoryTransactionHistoryStorage } from '@midnight-ntwrk/wallet-sdk-abstractions';
 import { createUnshieldedKeystore, type UnshieldedKeystore } from './UnshieldedKeyStore.js';
 import { getDustSeed, sumUtxos } from './utils.js';
 
@@ -198,10 +203,13 @@ describe('DustWallet', () => {
         .withCoinsAndBalancesDefaults()
         .withKeysDefaults()
         .withSerializationDefaults()
+        .withTransactionHistory(makeSimulatorTransactionHistoryService)
         .build({
           simulator,
           networkId: NETWORK,
           costParameters,
+          txHistoryStorage: new InMemoryTransactionHistoryStorage(DustTransactionHistoryEntrySchema),
+          indexerClientConnection: { indexerHttpUrl: '' },
         });
 
       const initialState = CoreWallet.initEmpty(dustParameters, dustSecretKey, NETWORK);

--- a/packages/e2e-tests/src/tests/test-fixture.ts
+++ b/packages/e2e-tests/src/tests/test-fixture.ts
@@ -253,6 +253,10 @@ export class TestContainersFixture {
       costParameters: {
         feeBlocksMargin: 5,
       },
+      txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
+      indexerClientConnection: {
+        indexerHttpUrl: this.getIndexerUri(),
+      },
     };
   }
 }

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -40,6 +40,7 @@ import {
 } from '@midnight-ntwrk/wallet-sdk-shielded';
 import type { DefaultUnshieldedConfiguration, UnshieldedWalletAPI } from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
 import { type UnshieldedWalletState, UnshieldedSectionSchema } from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
+import { DustSectionSchema, mergeDustSections } from '@midnight-ntwrk/wallet-sdk-dust-wallet/v1';
 import { FetchTermsAndConditions as FetchTermsAndConditionsQuery } from '@midnight-ntwrk/wallet-sdk-indexer-client';
 import { QueryRunner } from '@midnight-ntwrk/wallet-sdk-indexer-client/effect';
 import { Array as Arr, pipe, Schema } from 'effect';
@@ -62,6 +63,7 @@ export const WalletEntrySchema = Schema.Struct({
   ...TransactionHistoryStorage.TransactionHistoryCommonSchema.fields,
   shielded: Schema.optional(ShieldedSectionSchema),
   unshielded: Schema.optional(UnshieldedSectionSchema),
+  dust: Schema.optional(DustSectionSchema),
 });
 
 export type WalletEntry = Schema.Schema.Type<typeof WalletEntrySchema>;
@@ -74,6 +76,9 @@ export const mergeWalletEntries = (existing: WalletEntry, incoming: WalletEntry)
     : {}),
   ...(existing.unshielded !== undefined && incoming.unshielded !== undefined
     ? { unshielded: { ...existing.unshielded, ...incoming.unshielded } }
+    : {}),
+  ...(existing.dust !== undefined && incoming.dust !== undefined
+    ? { dust: mergeDustSections(existing.dust, incoming.dust) }
     : {}),
 });
 

--- a/packages/facade/test/dustDeregistration.test.ts
+++ b/packages/facade/test/dustDeregistration.test.ts
@@ -16,7 +16,7 @@ import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import { DockerComposeEnvironment, type StartedDockerComposeEnvironment, Wait } from 'testcontainers';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getShieldedSeed, getUnshieldedSeed, getDustSeed, waitForFullySynced } from './utils/index.js';
+import { getShieldedSeed, getUnshieldedSeed, getDustSeed } from './utils/index.js';
 import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnight-ntwrk/wallet-sdk-utilities/testing';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
 import * as rx from 'rxjs';
@@ -110,7 +110,7 @@ describe('Dust Deregistration', () => {
 
   it('deregisters from dust generation', async () => {
     // NOTE: by default, our test account is already registered for Dust generation
-    await waitForFullySynced(walletFacade);
+    await walletFacade.waitForSyncedState();
 
     const walletStateWithNight = await rx.firstValueFrom(
       walletFacade.state().pipe(rx.filter((s) => s.unshielded.availableCoins.length > 0)),

--- a/packages/facade/test/dustRegistration.test.ts
+++ b/packages/facade/test/dustRegistration.test.ts
@@ -19,14 +19,7 @@ import { Array as Arr, Order, pipe } from 'effect';
 import { type Observable } from 'rxjs';
 import { DockerComposeEnvironment, type StartedDockerComposeEnvironment, Wait } from 'testcontainers';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  getShieldedSeed,
-  getUnshieldedSeed,
-  getDustSeed,
-  tokenValue,
-  waitForFullySynced,
-  waitForDustGenerated,
-} from './utils/helpers.js';
+import { getShieldedSeed, getUnshieldedSeed, getDustSeed, tokenValue, waitForDustGenerated } from './utils/helpers.js';
 import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnight-ntwrk/wallet-sdk-utilities/testing';
 import {
   createKeystore,
@@ -153,7 +146,7 @@ describe('Dust Registration', () => {
   });
 
   it('registers dust generation after receiving unshielded tokens', async () => {
-    await Promise.all([waitForFullySynced(senderFacade), waitForFullySynced(receiverFacade)]);
+    await Promise.all([senderFacade.waitForSyncedState(), receiverFacade.waitForSyncedState()]);
 
     const unshieldedReceiverState = await receiverFacade.unshielded.getAddress();
 

--- a/packages/facade/test/swap.test.ts
+++ b/packages/facade/test/swap.test.ts
@@ -30,7 +30,7 @@ import {
   WalletFacade,
   mergeWalletEntries,
 } from '../src/index.js';
-import { getDustSeed, getShieldedSeed, getUnshieldedSeed, tokenValue, waitForFullySynced } from './utils/index.js';
+import { getDustSeed, getShieldedSeed, getUnshieldedSeed, tokenValue } from './utils/index.js';
 import { makeWasmProvingService } from '@midnight-ntwrk/wallet-sdk-capabilities';
 
 vi.setConfig({ testTimeout: 800_000, hookTimeout: 800_000 });
@@ -147,8 +147,8 @@ describe('Swaps', () => {
   it('can perform a shielded swap', async () => {
     const provingService = makeWasmProvingService();
 
-    const facadeAState = await waitForFullySynced(walletAFacade);
-    const facadeBState = await waitForFullySynced(walletBFacade);
+    const facadeAState = await walletAFacade.waitForSyncedState();
+    const facadeBState = await walletBFacade.waitForSyncedState();
 
     const { shielded: walletAShieldedStateBefore } = facadeAState;
     const { shielded: walletBShieldedStateBefore } = facadeBState;
@@ -244,7 +244,7 @@ describe('Swaps', () => {
    * We'll likely need to allow user to set payments in the fallible section of the transaction in order to avoid the issue above
    */
   it.skip('can perform an unshielded swap', async () => {
-    await Promise.all([waitForFullySynced(walletAFacade), waitForFullySynced(walletBFacade)]);
+    await Promise.all([walletAFacade.waitForSyncedState(), walletBFacade.waitForSyncedState()]);
 
     const ttl = new Date(Date.now() + 60 * 60 * 1000);
 

--- a/packages/facade/test/transactionHistory.test.ts
+++ b/packages/facade/test/transactionHistory.test.ts
@@ -28,6 +28,14 @@ const unshieldedUtxo = (value: bigint, owner: string, tokenType: string, intentH
   outputIndex,
 });
 
+const dustUtxo = (initialValue: bigint, nonce: bigint, seq: number, backingNight: string, mtIndex: bigint) => ({
+  initialValue,
+  nonce,
+  seq,
+  backingNight,
+  mtIndex,
+});
+
 const baseEntry = (hash: string, overrides: Partial<WalletEntry> = {}): WalletEntry => ({
   hash,
   protocolVersion: 1,
@@ -131,5 +139,98 @@ describe('mergeWalletEntries does not lose information', () => {
     expect(merged.timestamp).toEqual(new Date('2026-01-01'));
     expect(merged.fees).toBe(1000n);
     expect(merged.shielded?.receivedCoins).toEqual([coin]);
+  });
+
+  it('should preserve dust section from existing when incoming has only shielded', () => {
+    const dust = dustUtxo(500n, 1n, 0, 'night-1', 10n);
+    const coin = shieldedCoin('token-a', 'nonce-a', 100n, 1n);
+
+    const existing = baseEntry('tx1', {
+      dust: { receivedUtxos: [dust], spentUtxos: [] },
+    });
+
+    const incoming = baseEntry('tx1', {
+      shielded: { receivedCoins: [coin], spentCoins: [] },
+    });
+
+    const merged = mergeWalletEntries(existing, incoming);
+
+    expect(merged.dust).toEqual({ receivedUtxos: [dust], spentUtxos: [] });
+    expect(merged.shielded).toEqual({ receivedCoins: [coin], spentCoins: [] });
+  });
+
+  it('should preserve shielded section from existing when incoming has only dust', () => {
+    const coin = shieldedCoin('token-a', 'nonce-a', 100n, 1n);
+    const dust = dustUtxo(500n, 1n, 0, 'night-1', 10n);
+
+    const existing = baseEntry('tx1', {
+      shielded: { receivedCoins: [coin], spentCoins: [] },
+    });
+
+    const incoming = baseEntry('tx1', {
+      dust: { receivedUtxos: [dust], spentUtxos: [] },
+    });
+
+    const merged = mergeWalletEntries(existing, incoming);
+
+    expect(merged.shielded).toEqual({ receivedCoins: [coin], spentCoins: [] });
+    expect(merged.dust).toEqual({ receivedUtxos: [dust], spentUtxos: [] });
+  });
+
+  it('should union dust utxos when both entries have dust sections', () => {
+    const dustA = dustUtxo(500n, 1n, 0, 'night-1', 10n);
+    const spentDustA = dustUtxo(300n, 2n, 1, 'night-2', 11n);
+    const dustB = dustUtxo(700n, 3n, 0, 'night-3', 12n);
+    const spentDustB = dustUtxo(400n, 4n, 1, 'night-4', 13n);
+
+    const existing = baseEntry('tx1', {
+      dust: { receivedUtxos: [dustA], spentUtxos: [spentDustA] },
+    });
+
+    const incoming = baseEntry('tx1', {
+      dust: { receivedUtxos: [dustB], spentUtxos: [spentDustB] },
+    });
+
+    const merged = mergeWalletEntries(existing, incoming);
+
+    expect(merged.dust?.receivedUtxos).toEqual([dustA, dustB]);
+    expect(merged.dust?.spentUtxos).toEqual([spentDustA, spentDustB]);
+  });
+
+  it('should deduplicate identical dust utxos', () => {
+    const dust = dustUtxo(500n, 1n, 0, 'night-1', 10n);
+
+    const existing = baseEntry('tx1', {
+      dust: { receivedUtxos: [dust], spentUtxos: [] },
+    });
+
+    const incoming = baseEntry('tx1', {
+      dust: { receivedUtxos: [dust], spentUtxos: [] },
+    });
+
+    const merged = mergeWalletEntries(existing, incoming);
+
+    expect(merged.dust?.receivedUtxos).toEqual([dust]);
+  });
+
+  it('should preserve all three sections across merges', () => {
+    const coin = shieldedCoin('token-a', 'nonce-a', 100n, 1n);
+    const utxo = unshieldedUtxo(50n, 'owner-1', 'night', 'intent-1', 0);
+    const dust = dustUtxo(500n, 1n, 0, 'night-1', 10n);
+
+    const existing = baseEntry('tx1', {
+      shielded: { receivedCoins: [coin], spentCoins: [] },
+      unshielded: { id: 1, createdUtxos: [utxo], spentUtxos: [] },
+    });
+
+    const incoming = baseEntry('tx1', {
+      dust: { receivedUtxos: [dust], spentUtxos: [] },
+    });
+
+    const merged = mergeWalletEntries(existing, incoming);
+
+    expect(merged.shielded).toEqual({ receivedCoins: [coin], spentCoins: [] });
+    expect(merged.unshielded).toEqual({ id: 1, createdUtxos: [utxo], spentUtxos: [] });
+    expect(merged.dust).toEqual({ receivedUtxos: [dust], spentUtxos: [] });
   });
 });

--- a/packages/facade/test/transfer.test.ts
+++ b/packages/facade/test/transfer.test.ts
@@ -29,7 +29,7 @@ import {
   WalletFacade,
   mergeWalletEntries,
 } from '../src/index.js';
-import { getDustSeed, getShieldedSeed, getUnshieldedSeed, tokenValue, waitForFullySynced } from './utils/index.js';
+import { getDustSeed, getShieldedSeed, getUnshieldedSeed, tokenValue } from './utils/index.js';
 import { makeWasmProvingService } from '@midnight-ntwrk/wallet-sdk-capabilities';
 
 vi.setConfig({ testTimeout: 800_000, hookTimeout: 800_000 });
@@ -137,15 +137,7 @@ describe('Wallet Facade Transfer', () => {
   });
 
   it('allows to transfer shielded tokens only', async () => {
-    await Promise.all([
-      pipe(
-        senderFacade.state(),
-        rx.filter((s) => s.isSynced),
-        rx.first((s) => s.unshielded.availableCoins.length > 0 && s.dust.availableCoins.length > 0),
-        rx.firstValueFrom,
-      ),
-      waitForFullySynced(receiverFacade),
-    ]);
+    await Promise.all([senderFacade.waitForSyncedState(), receiverFacade.waitForSyncedState()]);
 
     const receiverAddress = await receiverFacade.shielded.getAddress();
 
@@ -199,15 +191,7 @@ describe('Wallet Facade Transfer', () => {
   });
 
   it('allows to transfer unshielded tokens', async () => {
-    await Promise.all([
-      pipe(
-        senderFacade.state(),
-        rx.filter((s) => s.isSynced),
-        rx.first((s) => s.unshielded.availableCoins.length > 0 && s.dust.availableCoins.length > 0),
-        rx.firstValueFrom,
-      ),
-      waitForFullySynced(receiverFacade),
-    ]);
+    await Promise.all([senderFacade.waitForSyncedState(), receiverFacade.waitForSyncedState()]);
 
     const receiverAddress = await receiverFacade.unshielded.getAddress();
 
@@ -321,23 +305,40 @@ describe('Wallet Facade Transfer', () => {
     expect(isValid).toBeTruthy();
   });
 
-  it('records shielded, unshielded, and dust sections in tx history for a combined transfer matches expecteed structure', async () => {
+  it('records shielded, unshielded, and dust sections in tx history for a combined transfer matches expected structure', async () => {
     const transferAmount = tokenValue(1n);
 
-    await Promise.all([
-      pipe(
-        senderFacade.state(),
-        rx.filter((s) => s.isSynced),
-        rx.first(
-          (s) =>
-            s.shielded.availableCoins.length > 0 &&
-            s.unshielded.availableCoins.length > 0 &&
-            s.dust.availableCoins.length > 0,
-        ),
-        rx.firstValueFrom,
-      ),
-      waitForFullySynced(receiverFacade),
+    const [, receiverPreState] = await Promise.all([
+      senderFacade.waitForSyncedState(),
+      receiverFacade.waitForSyncedState(),
     ]);
+
+    // Snapshot the receiver's pre-existing coins.
+    const receiverPreShieldedNonces = new Set(receiverPreState.shielded.availableCoins.map((c) => c.coin.nonce));
+    const receiverPreUnshieldedKeys = new Set(
+      receiverPreState.unshielded.availableCoins.map((c) => `${c.utxo.intentHash}#${c.utxo.outputNo}`),
+    );
+
+    // Snapshot the sender's available coins.
+    const senderPreState = await rx.firstValueFrom(
+      senderFacade
+        .state()
+        .pipe(
+          rx.filter(
+            (s) =>
+              s.shielded.availableCoins.some((c) => c.coin.type === ledger.shieldedToken().raw) &&
+              s.unshielded.availableCoins.some((c) => c.utxo.type === ledger.unshieldedToken().raw) &&
+              s.dust.availableCoins.length > 0,
+          ),
+        ),
+    );
+
+    // Snapshot every sender-owned coin/UTXO.
+    const senderShieldedNonces = new Set(senderPreState.shielded.availableCoins.map((c) => c.coin.nonce));
+    const senderUnshieldedKeys = new Set(
+      senderPreState.unshielded.availableCoins.map((c) => `${c.utxo.intentHash}#${c.utxo.outputNo}`),
+    );
+    const senderDustNonces = new Set(senderPreState.dust.availableCoins.map((c) => c.token.nonce));
 
     const shieldedReceiverAddress = await receiverFacade.shielded.getAddress();
     const unshieldedReceiverAddress = await receiverFacade.unshielded.getAddress();
@@ -382,10 +383,7 @@ describe('Wallet Facade Transfer', () => {
     const finalizedTxHash = finalizedTx.transactionHash().toString();
     const submittedTxIdentifier = await senderFacade.submitTransaction(finalizedTx);
 
-    // Wait for the combined tx to be fully observed by all three wallets on the SENDER side:
-    // all sections present, unshielded-sourced metadata merged (fees/identifiers), and the expected
-    // sender-side evidence (spent shielded coin, spent Night UTXO, spent Dust for fees) visible.
-    // The receiver-side outputs live in the receiver's history, not the sender's.
+    // Wait for the tx to land in sender history as a SUCCESS with all three sections present.
     const txHistoryEntry = await rx.firstValueFrom(
       senderFacade.state().pipe(
         rx.concatMap(() => senderFacade.queryTxHistoryByHash(finalizedTxHash)),
@@ -393,39 +391,55 @@ describe('Wallet Facade Transfer', () => {
         rx.filter(
           (entry) =>
             entry.status === 'SUCCESS' &&
-            entry.fees !== undefined &&
-            entry.identifiers !== undefined &&
             entry.shielded !== undefined &&
             entry.unshielded !== undefined &&
-            entry.dust !== undefined &&
-            entry.shielded.spentCoins.some((c) => c.type === ledger.shieldedToken().raw) &&
-            entry.unshielded.spentUtxos.some((u) => u.tokenType === ledger.unshieldedToken().raw) &&
-            entry.dust.spentUtxos.some((u) => typeof u.backingNight === 'string'),
+            entry.dust !== undefined,
         ),
         rx.timeout(60_000),
       ),
     );
 
-    // The filter already proved the structural shape; assert the hash, and that the
-    // identifier returned from submitTransaction is among the tx's recorded identifiers.
     expect(txHistoryEntry.hash).toBe(finalizedTxHash);
     expect(txHistoryEntry.identifiers).toContain(submittedTxIdentifier);
+    expect(txHistoryEntry.fees).toBeDefined();
 
-    // Receiver sees both assets arrive with the exact values we sent.
-    const receiverState = await rx.firstValueFrom(
-      receiverFacade
-        .state()
-        .pipe(
-          rx.filter(
-            (s) =>
-              s.shielded.availableCoins.some((c) => c.coin.value === transferAmount) &&
-              s.unshielded.availableCoins.some((c) => c.utxo.value === transferAmount),
-          ),
-        ),
+    expect(txHistoryEntry.shielded!.spentCoins.length).toBeGreaterThan(0);
+    expect(txHistoryEntry.shielded!.spentCoins.every((c) => senderShieldedNonces.has(c.nonce))).toBe(true);
+
+    expect(txHistoryEntry.unshielded!.spentUtxos.length).toBeGreaterThan(0);
+    expect(
+      txHistoryEntry.unshielded!.spentUtxos.every((u) => senderUnshieldedKeys.has(`${u.intentHash}#${u.outputIndex}`)),
+    ).toBe(true);
+
+    expect(txHistoryEntry.dust!.spentUtxos.some((u) => senderDustNonces.has(u.nonce))).toBe(true);
+
+    // Once the tx is present in the receiver's history, the state update has already
+    // been applied — no extra state-filter wait needed; the expects below suffice.
+    await rx.firstValueFrom(
+      receiverFacade.state().pipe(
+        rx.concatMap(() => receiverFacade.queryTxHistoryByHash(finalizedTxHash)),
+        rx.filter((entry) => entry !== undefined),
+        rx.timeout(60_000),
+      ),
     );
 
-    expect(receiverState.shielded.balances[ledger.shieldedToken().raw]).toBe(transferAmount);
-    expect(receiverState.unshielded.balances[ledger.unshieldedToken().raw]).toBe(transferAmount);
+    const receiverState = await rx.firstValueFrom(receiverFacade.state());
+
+    const newShieldedCoin = receiverState.shielded.availableCoins.find(
+      (c) =>
+        c.coin.type === ledger.shieldedToken().raw &&
+        c.coin.value === transferAmount &&
+        !receiverPreShieldedNonces.has(c.coin.nonce),
+    );
+    const newUnshieldedUtxo = receiverState.unshielded.availableCoins.find(
+      (u) =>
+        u.utxo.type === ledger.unshieldedToken().raw &&
+        u.utxo.value === transferAmount &&
+        !receiverPreUnshieldedKeys.has(`${u.utxo.intentHash}#${u.utxo.outputNo}`),
+    );
+
+    expect(newShieldedCoin).toBeDefined();
+    expect(newUnshieldedUtxo).toBeDefined();
   });
 
   it('allows to balance and submit an arbitrary unshielded transaction', async () => {

--- a/packages/facade/test/transfer.test.ts
+++ b/packages/facade/test/transfer.test.ts
@@ -321,6 +321,113 @@ describe('Wallet Facade Transfer', () => {
     expect(isValid).toBeTruthy();
   });
 
+  it('records shielded, unshielded, and dust sections in tx history for a combined transfer matches expecteed structure', async () => {
+    const transferAmount = tokenValue(1n);
+
+    await Promise.all([
+      pipe(
+        senderFacade.state(),
+        rx.filter((s) => s.isSynced),
+        rx.first(
+          (s) =>
+            s.shielded.availableCoins.length > 0 &&
+            s.unshielded.availableCoins.length > 0 &&
+            s.dust.availableCoins.length > 0,
+        ),
+        rx.firstValueFrom,
+      ),
+      waitForFullySynced(receiverFacade),
+    ]);
+
+    const shieldedReceiverAddress = await receiverFacade.shielded.getAddress();
+    const unshieldedReceiverAddress = await receiverFacade.unshielded.getAddress();
+
+    const ttl = new Date(Date.now() + 30 * 60 * 1000);
+    const tokenTransfer: CombinedTokenTransfer[] = [
+      {
+        type: 'shielded',
+        outputs: [
+          {
+            amount: transferAmount,
+            receiverAddress: shieldedReceiverAddress,
+            type: ledger.shieldedToken().raw,
+          },
+        ],
+      },
+      {
+        type: 'unshielded',
+        outputs: [
+          {
+            amount: transferAmount,
+            receiverAddress: unshieldedReceiverAddress,
+            type: ledger.unshieldedToken().raw,
+          },
+        ],
+      },
+    ];
+
+    const transactionRecipe = await senderFacade.transferTransaction(
+      tokenTransfer,
+      {
+        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSenderSeed),
+        dustSecretKey: ledger.DustSecretKey.fromSeed(dustSenderSeed),
+      },
+      { ttl },
+    );
+
+    const signedTxRecipe = await senderFacade.signRecipe(transactionRecipe, (payload) =>
+      unshieldedSenderKeystore.signData(payload),
+    );
+    const finalizedTx = await senderFacade.finalizeRecipe(signedTxRecipe);
+    const finalizedTxHash = finalizedTx.transactionHash().toString();
+    const submittedTxIdentifier = await senderFacade.submitTransaction(finalizedTx);
+
+    // Wait for the combined tx to be fully observed by all three wallets on the SENDER side:
+    // all sections present, unshielded-sourced metadata merged (fees/identifiers), and the expected
+    // sender-side evidence (spent shielded coin, spent Night UTXO, spent Dust for fees) visible.
+    // The receiver-side outputs live in the receiver's history, not the sender's.
+    const txHistoryEntry = await rx.firstValueFrom(
+      senderFacade.state().pipe(
+        rx.concatMap(() => senderFacade.queryTxHistoryByHash(finalizedTxHash)),
+        rx.filter((entry) => entry !== undefined),
+        rx.filter(
+          (entry) =>
+            entry.status === 'SUCCESS' &&
+            entry.fees !== undefined &&
+            entry.identifiers !== undefined &&
+            entry.shielded !== undefined &&
+            entry.unshielded !== undefined &&
+            entry.dust !== undefined &&
+            entry.shielded.spentCoins.some((c) => c.type === ledger.shieldedToken().raw) &&
+            entry.unshielded.spentUtxos.some((u) => u.tokenType === ledger.unshieldedToken().raw) &&
+            entry.dust.spentUtxos.some((u) => typeof u.backingNight === 'string'),
+        ),
+        rx.timeout(60_000),
+      ),
+    );
+
+    // The filter already proved the structural shape; assert the hash, and that the
+    // identifier returned from submitTransaction is among the tx's recorded identifiers.
+    expect(txHistoryEntry.hash).toBe(finalizedTxHash);
+    expect(txHistoryEntry.identifiers).toContain(submittedTxIdentifier);
+
+    // Receiver sees both assets arrive with the exact values we sent.
+    const receiverState = await rx.firstValueFrom(
+      receiverFacade
+        .state()
+        .pipe(
+          rx.filter(
+            (s) =>
+              s.shielded.availableCoins.some((c) => c.coin.value === transferAmount) &&
+              s.unshielded.availableCoins.some((c) => c.utxo.value === transferAmount),
+          ),
+        ),
+    );
+
+    expect(receiverState.shielded.balances[ledger.shieldedToken().raw]).toBe(transferAmount);
+    expect(receiverState.unshielded.balances[ledger.unshieldedToken().raw]).toBe(transferAmount);
+  });
+
   it('allows to balance and submit an arbitrary unshielded transaction', async () => {
     await pipe(
       senderFacade.state(),

--- a/packages/facade/test/transfer.test.ts
+++ b/packages/facade/test/transfer.test.ts
@@ -305,6 +305,62 @@ describe('Wallet Facade Transfer', () => {
     expect(isValid).toBeTruthy();
   });
 
+  it('allows to balance and submit an arbitrary unshielded transaction', async () => {
+    await pipe(
+      senderFacade.state(),
+      rx.filter((s) => s.isSynced),
+      rx.first((s) => s.unshielded.availableCoins.length > 0 && s.dust.availableCoins.length > 0),
+      rx.firstValueFrom,
+    );
+
+    const outputs = [
+      {
+        type: ledger.unshieldedToken().raw,
+        value: tokenValue(1n),
+        owner: unshieldedReceiverKeystore.getAddress(),
+      },
+    ];
+
+    const intent = ledger.Intent.new(new Date(Date.now() + 30 * 60 * 1000));
+    intent.guaranteedUnshieldedOffer = ledger.UnshieldedOffer.new([], outputs, []);
+
+    const arbitraryTx = ledger.Transaction.fromParts(NetworkId.NetworkId.Undeployed, undefined, undefined, intent);
+
+    const balancingTxRecipe = await senderFacade.balanceUnprovenTransaction(
+      arbitraryTx,
+      {
+        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSenderSeed),
+        dustSecretKey: ledger.DustSecretKey.fromSeed(dustSenderSeed),
+      },
+      {
+        ttl: new Date(Date.now() + 30 * 60 * 1000),
+      },
+    );
+
+    // Sign the balancing transaction before finalizing
+    const signedBalancingTxRecipe = await senderFacade.signRecipe(balancingTxRecipe, (payload) =>
+      unshieldedSenderKeystore.signData(payload),
+    );
+
+    const finalizedArbitraryTx = await senderFacade.finalizeRecipe(signedBalancingTxRecipe);
+
+    const submittedTxHash = await senderFacade.submitTransaction(finalizedArbitraryTx);
+
+    expect(submittedTxHash).toBeTypeOf('string');
+
+    const isValid = await rx.firstValueFrom(
+      receiverFacade
+        .state()
+        .pipe(rx.filter((s) => s.unshielded.availableCoins.some((c) => c.utxo.value === tokenValue(1n)))),
+    );
+
+    expect(isValid).toBeTruthy();
+  });
+
+  // NOTE: This test runs last because the combined (shielded + unshielded) transfer leaves
+  // sender-side state that causes the earlier arbitrary-unshielded test to fail submission
+  // with MalformedError::FeeCalculation (node error code 168). Keeping this test last
+  // avoids the cross-test interference until the underlying fee-calc divergence is fixed.
   it('records shielded, unshielded, and dust sections in tx history for a combined transfer matches expected structure', async () => {
     const transferAmount = tokenValue(1n);
 
@@ -440,57 +496,5 @@ describe('Wallet Facade Transfer', () => {
 
     expect(newShieldedCoin).toBeDefined();
     expect(newUnshieldedUtxo).toBeDefined();
-  });
-
-  it('allows to balance and submit an arbitrary unshielded transaction', async () => {
-    await pipe(
-      senderFacade.state(),
-      rx.filter((s) => s.isSynced),
-      rx.first((s) => s.unshielded.availableCoins.length > 0 && s.dust.availableCoins.length > 0),
-      rx.firstValueFrom,
-    );
-
-    const outputs = [
-      {
-        type: ledger.unshieldedToken().raw,
-        value: tokenValue(1n),
-        owner: unshieldedReceiverKeystore.getAddress(),
-      },
-    ];
-
-    const intent = ledger.Intent.new(new Date(Date.now() + 30 * 60 * 1000));
-    intent.guaranteedUnshieldedOffer = ledger.UnshieldedOffer.new([], outputs, []);
-
-    const arbitraryTx = ledger.Transaction.fromParts(NetworkId.NetworkId.Undeployed, undefined, undefined, intent);
-
-    const balancingTxRecipe = await senderFacade.balanceUnprovenTransaction(
-      arbitraryTx,
-      {
-        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSenderSeed),
-        dustSecretKey: ledger.DustSecretKey.fromSeed(dustSenderSeed),
-      },
-      {
-        ttl: new Date(Date.now() + 30 * 60 * 1000),
-      },
-    );
-
-    // Sign the balancing transaction before finalizing
-    const signedBalancingTxRecipe = await senderFacade.signRecipe(balancingTxRecipe, (payload) =>
-      unshieldedSenderKeystore.signData(payload),
-    );
-
-    const finalizedArbitraryTx = await senderFacade.finalizeRecipe(signedBalancingTxRecipe);
-
-    const submittedTxHash = await senderFacade.submitTransaction(finalizedArbitraryTx);
-
-    expect(submittedTxHash).toBeTypeOf('string');
-
-    const isValid = await rx.firstValueFrom(
-      receiverFacade
-        .state()
-        .pipe(rx.filter((s) => s.unshielded.availableCoins.some((c) => c.utxo.value === tokenValue(1n)))),
-    );
-
-    expect(isValid).toBeTruthy();
   });
 });

--- a/packages/facade/test/utils/helpers.ts
+++ b/packages/facade/test/utils/helpers.ts
@@ -20,7 +20,11 @@ import {
   V1Builder as ShieldedV1Builder,
 } from '@midnight-ntwrk/wallet-sdk-shielded/v1';
 import { CustomDustWallet, type DustWalletAPI } from '@midnight-ntwrk/wallet-sdk-dust-wallet';
-import { SyncService as DustSyncService, V1Builder as DustV1Builder } from '@midnight-ntwrk/wallet-sdk-dust-wallet/v1';
+import {
+  SyncService as DustSyncService,
+  TransactionHistory as DustTransactionHistory,
+  V1Builder as DustV1Builder,
+} from '@midnight-ntwrk/wallet-sdk-dust-wallet/v1';
 import {
   CustomUnshieldedWallet,
   createKeystore,
@@ -216,6 +220,7 @@ export const createSimulatorWalletFactories = (config: SimulatorConfig): Simulat
       .withSerializationDefaults()
       .withTransactingDefaults()
       .withCoinsAndBalancesDefaults()
+      .withTransactionHistory(DustTransactionHistory.makeSimulatorTransactionHistoryService)
       .withKeysDefaults()
       .withCoinSelectionDefaults(),
   );

--- a/packages/facade/test/utils/helpers.ts
+++ b/packages/facade/test/utils/helpers.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 import * as ledger from '@midnight-ntwrk/ledger-v8';
 import { HDWallet, Roles } from '@midnight-ntwrk/wallet-sdk-hd';
-import { FacadeState, WalletFacade, type Clock } from '../../src/index.js';
+import { WalletFacade, type Clock } from '../../src/index.js';
 import { CustomShieldedWallet, type ShieldedWalletAPI } from '@midnight-ntwrk/wallet-sdk-shielded';
 import {
   Sync as ShieldedSync,
@@ -103,10 +103,6 @@ export const getDustSeed = (seed: string): Uint8Array<ArrayBufferLike> => {
 };
 
 export const tokenValue = (value: bigint): bigint => value * 10n ** 6n;
-
-export const waitForFullySynced = async (facade: WalletFacade): Promise<FacadeState> => {
-  return await rx.firstValueFrom(facade.state().pipe(rx.filter((s) => s.isSynced)));
-};
 
 export const sleep = (secs: number): Promise<void> => {
   return new Promise((resolve) => setTimeout(resolve, secs * 1000));

--- a/shelffile
+++ b/shelffile
@@ -1,0 +1,5 @@
+effect https://github.com/Effect-TS/effect.git pin:tag:effect@3.21.0
+midnight-architecture https://github.com/midnightntwrk/midnight-architecture.git
+midnight-ledger https://github.com/midnightntwrk/midnight-ledger.git
+midnight-dapp-connector-api https://github.com/midnightntwrk/midnight-dapp-connector-api.git
+language-service https://github.com/Effect-TS/language-service.git


### PR DESCRIPTION
# Description

Changes were made to Ledger, Indexer, and Node to support txHistory on Shielded and Dust wallets. The Shielded wallet implementation is complete (PM-19980). The Dust wallet should work very similarly and the underlying component changes already support Dust txHistory.

# Testing

Additional tests will be added to ensure txHistory is covered
All existing tests and new tests must pass
