### PR TITLE
Deterministically set segment ID during balancing

### DIFF
--- a/.changeset/plain-horses-taste.md
+++ b/.changeset/plain-horses-taste.md
@@ -1,0 +1,11 @@
+---
+'@midnight-ntwrk/wallet-sdk-unshielded-wallet': patch
+'@midnight-ntwrk/wallet-sdk-dust-wallet': patch
+---
+
+feat: deterministically set balancing tx segment id
+
+Replaced `Transaction.fromPartsRandomized` with `Transaction.fromParts` + explicit `intents.set(segmentId, intent)` when building balancing transactions, where `segmentId` is the lowest unused fallible segment in `[1, 65535]`. This makes segment placement deterministic and reproducible instead of random.
+
+- **dust-wallet**: `dryRunFee` and `balanceTransactions` now merge the existing (proof-erased) transactions first, then pick a segment that doesn't collide with any of them before constructing the balancing tx. A new exported `findAvailableSegmentId` helper in `Transacting.ts` drives the lookup.
+- **unshielded-wallet**: `balanceFinalizedTransaction` picks a segment that doesn't collide with the passed-in `FinalizedTransaction` before constructing the balancing tx. `findAvailableSegmentId` was added as a method on `TransactionOps`.

--- a/packages/dust-wallet/src/v1/Transacting.ts
+++ b/packages/dust-wallet/src/v1/Transacting.ts
@@ -403,7 +403,7 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
 
     // @TODO in ledger 8.1.0 will be able to set the segment id when constructing the tx
     const balancingTx = Transaction.fromParts(network, undefined, undefined, undefined);
-    balancingTx.intents = balancingTx.intents!.set(segmentId, intent);
+    balancingTx.intents = new Map([[segmentId, intent]]);
     const erasedBalancing = balancingTx.eraseProofs();
 
     const mergedTx = mergedExisting ? mergedExisting.merge(erasedBalancing) : erasedBalancing;
@@ -552,7 +552,7 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
           const segmentId = mergedExisting ? Option.getOrElse(findAvailableSegmentId(mergedExisting), () => 1) : 1;
 
           const feeTransaction = Transaction.fromParts(networkId, undefined, undefined, undefined);
-          feeTransaction.intents = feeTransaction.intents!.set(segmentId, intent);
+          feeTransaction.intents = new Map([[segmentId, intent]]);
 
           return [feeTransaction, updatedState];
         });

--- a/packages/dust-wallet/src/v1/Transacting.ts
+++ b/packages/dust-wallet/src/v1/Transacting.ts
@@ -130,6 +130,24 @@ export const makeSimulatorTransactingCapability = (
 };
 
 /**
+ * Finds the next available intent segment id in a transaction.
+ *
+ * Fallible intent segments occupy the range `[1, 65535]`; segment `0` is
+ * reserved for the guaranteed section and is never returned.
+ *
+ * @param transaction - Transaction whose intent map is inspected.
+ * @returns `Some(segmentId)` with the lowest unused id, or `None` if all
+ *   65535 fallible segments are taken.
+ */
+export const findAvailableSegmentId = (transaction: AnyTransaction): Option.Option<number> => {
+  const used = new Set(transaction.intents?.keys() ?? []);
+  return pipe(
+    IterableOps.range(1, 65535),
+    IterableOps.findFirst((segmentId) => !used.has(segmentId)),
+  );
+};
+
+/**
  * Distributes the fee across multiple inputs, draining smaller inputs first
  * when the fee exceeds any single input's value.
  */
@@ -377,11 +395,18 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
       [],
     );
 
-    const balancingTx = Transaction.fromPartsRandomized(network, undefined, undefined, intent);
+    // Merge existing transactions first so we can pick a segment that doesn't collide
+    const [first, ...rest] = transactions.map((tx) => tx.eraseProofs());
+    const mergedExisting = first ? rest.reduce((acc, tx) => acc.merge(tx), first) : undefined;
 
-    // Erase proofs on everything and merge
+    const segmentId = mergedExisting ? Option.getOrElse(findAvailableSegmentId(mergedExisting), () => 1) : 1;
+
+    // @TODO in ledger 8.1.0 will be able to set the segment id when constructing the tx
+    const balancingTx = Transaction.fromParts(network, undefined, undefined, undefined);
+    balancingTx.intents = balancingTx.intents!.set(segmentId, intent);
     const erasedBalancing = balancingTx.eraseProofs();
-    const mergedTx = transactions.reduce((acc, tx) => acc.merge(tx.eraseProofs()), erasedBalancing);
+
+    const mergedTx = mergedExisting ? mergedExisting.merge(erasedBalancing) : erasedBalancing;
 
     return this.calculateFee(mergedTx, ledgerParams);
   }
@@ -521,7 +546,13 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
             [],
           );
 
-          const feeTransaction = Transaction.fromPartsRandomized(networkId, undefined, undefined, intent);
+          // Merge existing transactions first so we can pick a segment that doesn't collide
+          const [first, ...rest] = transactions.map((tx) => tx.eraseProofs());
+          const mergedExisting = first ? rest.reduce((acc, tx) => acc.merge(tx), first) : undefined;
+          const segmentId = mergedExisting ? Option.getOrElse(findAvailableSegmentId(mergedExisting), () => 1) : 1;
+
+          const feeTransaction = Transaction.fromParts(networkId, undefined, undefined, undefined);
+          feeTransaction.intents = feeTransaction.intents!.set(segmentId, intent);
 
           return [feeTransaction, updatedState];
         });

--- a/packages/unshielded-wallet/src/v1/Transacting.ts
+++ b/packages/unshielded-wallet/src/v1/Transacting.ts
@@ -209,7 +209,7 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
       const segmentId = Option.getOrElse(this.txOps.findAvailableSegmentId(transaction), () => 1);
       // @TODO in ledger 8.1.0 will be able to set the segment id when constructing the tx
       const balancingTx = ledger.Transaction.fromParts(this.networkId, undefined, undefined, undefined);
-      balancingTx.intents = balancingTx.intents!.set(segmentId, balancingIntent);
+      balancingTx.intents = new Map([[segmentId, balancingIntent]]);
       return [balancingTx, newState];
     });
   }

--- a/packages/unshielded-wallet/src/v1/Transacting.ts
+++ b/packages/unshielded-wallet/src/v1/Transacting.ts
@@ -206,7 +206,11 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
       const balancingIntent = ledger.Intent.new(intent!.ttl);
       balancingIntent.guaranteedUnshieldedOffer = offer;
 
-      return [ledger.Transaction.fromPartsRandomized(this.networkId, undefined, undefined, balancingIntent), newState];
+      const segmentId = Option.getOrElse(this.txOps.findAvailableSegmentId(transaction), () => 1);
+      // @TODO in ledger 8.1.0 will be able to set the segment id when constructing the tx
+      const balancingTx = ledger.Transaction.fromParts(this.networkId, undefined, undefined, undefined);
+      balancingTx.intents = balancingTx.intents!.set(segmentId, balancingIntent);
+      return [balancingTx, newState];
     });
   }
 

--- a/packages/unshielded-wallet/src/v1/TransactionOps.ts
+++ b/packages/unshielded-wallet/src/v1/TransactionOps.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { Either, pipe, Array as Arr } from 'effect';
+import { Either, Option, pipe, Array as Arr, Iterable as IterableOps } from 'effect';
 import { Imbalances } from '@midnight-ntwrk/wallet-sdk-capabilities';
 import * as ledger from '@midnight-ntwrk/ledger-v8';
 import { TransactingError, WalletError } from './WalletError.js';
@@ -32,6 +32,9 @@ export type TransactionOps = {
     segment: number,
   ) => Either.Either<Uint8Array, WalletError>;
   getSegments(transaction: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>): number[];
+  findAvailableSegmentId(
+    transaction: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>,
+  ): Option.Option<number>;
   addSignature<TTransaction extends ledger.UnprovenTransaction | UnboundTransaction>(
     transaction: TTransaction,
     signature: ledger.Signature,
@@ -76,6 +79,15 @@ export const TransactionOps: TransactionOps = {
   },
   getSegments(transaction: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>): number[] {
     return transaction.intents?.keys().toArray() ?? [];
+  },
+  findAvailableSegmentId(
+    transaction: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>,
+  ): Option.Option<number> {
+    const used = new Set(transaction.intents?.keys() ?? []);
+    return pipe(
+      IterableOps.range(1, 65535),
+      IterableOps.findFirst((segmentId) => !used.has(segmentId)),
+    );
   },
   // @TODO - https://shielded.atlassian.net/browse/PM-21260
   addSignature<TTransaction extends ledger.UnprovenTransaction | UnboundTransaction>(


### PR DESCRIPTION
Replaces `Transaction.fromPartsRandomized` with deterministic segment placement when building balancing transactions in both the **dust-wallet** and **unshielded-wallet** capabilities. Previously the balancing intent was assigned to a random fallible segment id, which made transaction layouts non-reproducible and harder to debug. This PR picks the lowest unused fallible segment id (range `[1, 65535]`) that does not collide with any intents in the transactions the balancer is working against.
