### PR TITLE
fix: fix the double exporting of transactionhistory.js

### DIFF
--- a/.changeset/legal-swans-know.md
+++ b/.changeset/legal-swans-know.md
@@ -1,0 +1,6 @@
+---
+'@midnight-ntwrk/wallet-sdk-dust-wallet': patch
+'@midnight-ntwrk/wallet-sdk-facade': patch
+---
+
+Remove the double exporting of TransactionHistory.js

--- a/packages/dust-wallet/src/index.ts
+++ b/packages/dust-wallet/src/index.ts
@@ -11,3 +11,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 export * from './DustWallet.js';
+export { type DustTransactionHistoryEntry, DustSectionSchema, mergeDustSections } from './v1/TransactionHistory.js';

--- a/packages/dust-wallet/src/v1/index.ts
+++ b/packages/dust-wallet/src/v1/index.ts
@@ -21,4 +21,3 @@ export * from './V1Builder.js';
 export * from './types/index.js';
 export * as CoinsAndBalances from './CoinsAndBalances.js';
 export * as TransactionHistory from './TransactionHistory.js';
-export { DustSectionSchema, DustUtxoInfoSchema, mergeDustSections } from './TransactionHistory.js';

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -40,7 +40,7 @@ import {
 } from '@midnight-ntwrk/wallet-sdk-shielded';
 import type { DefaultUnshieldedConfiguration, UnshieldedWalletAPI } from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
 import { type UnshieldedWalletState, UnshieldedSectionSchema } from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
-import { DustSectionSchema, mergeDustSections } from '@midnight-ntwrk/wallet-sdk-dust-wallet/v1';
+import { DustSectionSchema, mergeDustSections } from '@midnight-ntwrk/wallet-sdk-dust-wallet';
 import { FetchTermsAndConditions as FetchTermsAndConditionsQuery } from '@midnight-ntwrk/wallet-sdk-indexer-client';
 import { QueryRunner } from '@midnight-ntwrk/wallet-sdk-indexer-client/effect';
 import { Array as Arr, pipe, Schema } from 'effect';


### PR DESCRIPTION
# Description

We noticed that we are exporting from TransactionHistory twice, once using a named export and the other time using a namespaced export.

This needs to change to follow the same pattern of Shielded/Unshielded

# Testing

QA: Once fixed, all existing tests should continue to pass.
