### PR TITLE
chore: bump wallet sdk barrel version to major

### DIFF
--- a/.changeset/many-towns-hear.md
+++ b/.changeset/many-towns-hear.md
@@ -1,0 +1,5 @@
+---
+'@midnight-ntwrk/wallet-sdk': major
+---
+
+First release of wallet-sdk barrel package


### PR DESCRIPTION
# Description

Wallet SDK barrel package bumped to 1.0.0