### PR TITLE
fix(dust-wallet): unblock fee balancing under zero-value coin + cohort collapse (#383)

### DIFF
--- a/.changeset/fix-dust-fee-balancer-cohort-collapse.md
+++ b/.changeset/fix-dust-fee-balancer-cohort-collapse.md
@@ -1,0 +1,8 @@
+---
+'@midnight-ntwrk/wallet-sdk-dust-wallet': patch
+---
+
+Fix dust fee balancing failing with `InsufficientFunds` despite ample dust (issue #383). Two compounding defects in the dust wallet's coin selection:
+
+- The local `chooseCoin` now skips zero-value coins, so a freshly-registered dust UTXO with `generatedNow === 0` no longer wastes an iteration as the smallest candidate. The local `CoinSelection` type and `chooseCoin` signature were realigned with the capabilities `CoinRecipe` API, and the variant now passes its configured coin selection through to `getBalanceRecipe`. Note: `CoinsAndBalances.CoinSelection` is no longer parametrized — it changed from `CoinSelection<TInput>` to a polymorphic `CoinSelection`. The prior wiring was non-functional (the variant's `coinSelection` slot was never invoked), so any consumer who customized it had no observable behavior; only the type reference needs updating.
+- `computeBalancingRecipe` now identifies coins by `token.nonce` rather than by `value` when removing the just-picked coin from the working set. Value-equality previously caused a single pick to drop the entire cohort of dust UTXOs sharing the same `generatedNow` (a routine outcome once their backing Night UTXOs reach `maxCap`), making most of the wallet's spendable dust invisible to the balancer.

--- a/packages/dust-wallet/src/v1/CoinsAndBalances.ts
+++ b/packages/dust-wallet/src/v1/CoinsAndBalances.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { type CoinRecipe } from '@midnight-ntwrk/wallet-sdk-capabilities';
 import { DateOps } from '@midnight-ntwrk/wallet-sdk-utilities';
 import { pipe, Array as Arr, Order } from 'effect';
 import { type CoreWallet } from './CoreWallet.js';
@@ -39,10 +40,13 @@ export type UtxoWithFullDustDetails = Readonly<{
   dust: DustGenerationDetails;
 }>;
 
-export type CoinSelection<TInput> = (coins: readonly CoinWithValue<TInput>[]) => CoinWithValue<TInput> | undefined;
+export type CoinSelection = <TCoin extends CoinRecipe>(coins: readonly TCoin[]) => TCoin | undefined;
 
-export const chooseCoin = <TInput>(coins: readonly CoinWithValue<TInput>[]): CoinWithValue<TInput> | undefined =>
-  coins.toSorted((a, b) => Number(a.value - b.value)).at(0);
+export const chooseCoin: CoinSelection = (coins) =>
+  coins
+    .filter((coin) => coin.value > 0n)
+    .toSorted((a, b) => Number(a.value - b.value))
+    .at(0);
 
 export type CoinsAndBalancesCapability<TState> = {
   getWalletBalance(state: TState, time: Date): Balance;

--- a/packages/dust-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/dust-wallet/src/v1/RunningV1Variant.ts
@@ -29,7 +29,7 @@ import {
   StateChange,
   VersionChangeType,
 } from '@midnight-ntwrk/wallet-sdk-runtime/abstractions';
-import { type Dust, type UtxoWithMeta } from './types/Dust.js';
+import { type UtxoWithMeta } from './types/Dust.js';
 import { type KeysCapability } from './Keys.js';
 import { type ChangesResult, type SyncCapability, type SyncService } from './Sync.js';
 import { type SimulatorState } from '@midnight-ntwrk/wallet-sdk-capabilities/simulation';
@@ -76,7 +76,7 @@ export declare namespace RunningV1Variant {
     transactingCapability: TransactingCapability<DustSecretKey, CoreWallet, TTransaction>;
     coinsAndBalancesCapability: CoinsAndBalancesCapability<CoreWallet>;
     keysCapability: KeysCapability<CoreWallet>;
-    coinSelection: CoinSelection<Dust>;
+    coinSelection: CoinSelection;
     transactionHistoryService: TransactionHistoryService;
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/dust-wallet/src/v1/Transacting.ts
+++ b/packages/dust-wallet/src/v1/Transacting.ts
@@ -98,7 +98,7 @@ export type DefaultTransactingConfiguration = {
 };
 
 export type DefaultTransactingContext = {
-  coinSelection: CoinSelection<Dust>;
+  coinSelection: CoinSelection;
   coinsAndBalancesCapability: CoinsAndBalancesCapability<CoreWallet>;
   keysCapability: KeysCapability<CoreWallet>;
 };
@@ -170,14 +170,14 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
 > {
   public readonly networkId: string;
   public readonly costParams: TotalCostParameters;
-  public readonly getCoinSelection: () => CoinSelection<Dust>;
+  public readonly getCoinSelection: () => CoinSelection;
   readonly getCoins: () => CoinsAndBalancesCapability<CoreWallet>;
   readonly getKeys: () => KeysCapability<CoreWallet>;
 
   constructor(
     networkId: NetworkId,
     costParams: TotalCostParameters,
-    getCoinSelection: () => CoinSelection<Dust>,
+    getCoinSelection: () => CoinSelection,
     getCoins: () => CoinsAndBalancesCapability<CoreWallet>,
     getKeys: () => KeysCapability<CoreWallet>,
   ) {
@@ -458,15 +458,16 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
                   })),
                   initialImbalances: CapImbalances.fromEntry('dust', currentFee),
                   feeTokenType: 'dust',
+                  coinSelection: this.getCoinSelection(),
                   transactionCostModel: {
                     inputFeeOverhead: 0n,
                     outputFeeOverhead: 0n,
                   },
                   createOutput: (coin) => coin,
-                  isCoinEqual: (a, b) => a.type === b.type && a.value === b.value,
+                  isCoinEqual: (a, b) => a.token.nonce === b.token.nonce,
                 });
 
-                const recipeInputs = recipe.inputs.map((input) => ({ token: input.token, value: input.value }));
+                const recipeInputs = recipe.inputs.map(({ token, value }) => ({ token, value }));
 
                 const newFee = this.dryRunFee(
                   recipeInputs,

--- a/packages/dust-wallet/src/v1/V1Builder.ts
+++ b/packages/dust-wallet/src/v1/V1Builder.ts
@@ -50,7 +50,6 @@ import {
   type TransactingCapability,
 } from './Transacting.js';
 import { type NetworkId } from './types/ledger.js';
-import { type Dust } from './types/Dust.js';
 import { makeDefaultV1SerializationCapability, type SerializationCapability } from './Serialization.js';
 import { type TotalCostParameters } from './types/transaction.js';
 
@@ -249,7 +248,7 @@ export class V1Builder<
   }
 
   withCoinSelection<TCoinSelectionConfig, TCoinSelectionContext extends Partial<RunningV1Variant.AnyContext>>(
-    coinSelection: (config: TCoinSelectionConfig, getContext: () => TCoinSelectionContext) => CoinSelection<Dust>,
+    coinSelection: (config: TCoinSelectionConfig, getContext: () => TCoinSelectionContext) => CoinSelection,
   ): V1Builder<
     TConfig & TCoinSelectionConfig,
     TContext & TCoinSelectionContext,
@@ -485,7 +484,7 @@ declare namespace V1Builder {
   };
 
   type HasCoinSelection<TConfig, TContext> = {
-    readonly coinSelection: (configuration: TConfig, getContext: () => TContext) => CoinSelection<Dust>;
+    readonly coinSelection: (configuration: TConfig, getContext: () => TContext) => CoinSelection;
   };
 
   type HasCoinsAndBalances<TConfig, TContext> = {

--- a/packages/dust-wallet/src/v1/test/coinSelection.test.ts
+++ b/packages/dust-wallet/src/v1/test/coinSelection.test.ts
@@ -1,0 +1,68 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { getBalanceRecipe, Imbalances } from '@midnight-ntwrk/wallet-sdk-capabilities';
+import { describe, expect, test } from 'vitest';
+import { chooseCoin } from '../CoinsAndBalances.js';
+import { type Dust } from '../types/Dust.js';
+
+const makeDustCoin = (nonce: bigint, value: bigint) => ({
+  type: 'dust' as const,
+  value,
+  token: {
+    initialValue: value,
+    owner: 0n,
+    nonce,
+    seq: 0,
+    ctime: new Date(0),
+    backingNight: '0'.repeat(64),
+    mtIndex: 0n,
+  } satisfies Dust,
+});
+
+describe('chooseCoin filters zero-value coins', () => {
+  test('returns undefined when every coin has value 0', () => {
+    const coins = [makeDustCoin(1n, 0n), makeDustCoin(2n, 0n), makeDustCoin(3n, 0n)];
+    expect(chooseCoin(coins)).toBeUndefined();
+  });
+
+  test('skips zero-value coins and picks the smallest positive coin', () => {
+    const zero = makeDustCoin(1n, 0n);
+    const small = makeDustCoin(2n, 5n);
+    const big = makeDustCoin(3n, 100n);
+
+    const picked = chooseCoin([zero, big, small]);
+
+    expect(picked?.token.nonce).toBe(2n);
+    expect(picked?.value).toBe(5n);
+  });
+});
+
+describe('balancer integration with the dust call-site config', () => {
+  test('balances a multi-coin deficit when a zero-value UTXO sits among a cohort of same-value coins', () => {
+    const cohort = Array.from({ length: 13 }, (_, i) => makeDustCoin(BigInt(i + 1), 100n));
+    const zeroValue = makeDustCoin(99n, 0n);
+
+    const recipe = getBalanceRecipe({
+      coins: [zeroValue, ...cohort],
+      initialImbalances: Imbalances.fromEntry('dust', -350n),
+      feeTokenType: 'dust',
+      coinSelection: chooseCoin,
+      transactionCostModel: { inputFeeOverhead: 0n, outputFeeOverhead: 0n },
+      createOutput: (coin) => coin,
+      isCoinEqual: (a, b) => a.token.nonce === b.token.nonce,
+    });
+
+    expect(recipe.inputs).toHaveLength(4);
+    expect(recipe.inputs.some((i) => i.token.nonce === 99n)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #383. Two compounding defects in the dust wallet's fee-balancer caused `Wallet.InsufficientFunds` to be raised on wallets that had orders of magnitude more spendable dust than the required fee.

- **Zero-value coin trap.** The balancer's default `chooseCoin` picks the smallest-value coin first. A freshly-registered dust UTXO has `generatedNow === 0`, sorting to position 0 and consuming an iteration without reducing the deficit. The dust wallet now passes its local `chooseCoin` (which skips zero-value coins) to `getBalanceRecipe` via the variant's `coinSelection` slot — that slot was previously wired but never invoked.
- **Cohort collapse via value-equality.** The `isCoinEqual` passed to `getBalanceRecipe` compared by `value`, so the balancer's "remove the just-picked coin from the working set" filter dropped *every* coin sharing the same `generatedNow` in a single pass. That's a routine outcome once a wallet's backing Night UTXOs reach `maxCap`. It now compares by `token.nonce` (identity), aligning with every other consumer of the generic balancer.

Together these caused the `Effect.iterate` loop in `computeBalancingRecipe` to converge against an effective working set of ~2 distinct values regardless of the displayed dust total, raising `InsufficientFundsError` when `dryRunFee` exceeded that share.

### Why the changes spread across four files

To pass the local `chooseCoin` to `getBalanceRecipe`, the local `CoinSelection` type had to be realigned with the capabilities `CoinRecipe` API (the balancer's slot requires `TInput extends CoinRecipe`). `CoinsAndBalances.CoinSelection` is no longer parametrized — see the changeset for the type-break note. The prior wiring was non-functional, so this is a type-only break with no behavioral impact for anyone who had customized it.

## Test plan

- [x] `yarn test --filter=@midnight-ntwrk/wallet-sdk-dust-wallet` — 14/14 pass
- [x] `yarn typecheck` workspace-wide — 32/32 pass
- [x] `yarn lint --filter=@midnight-ntwrk/wallet-sdk-dust-wallet` — clean
- [ ] Verify against the qanet reproduction in the issue (14-UTXO wallet, contract-deploy tx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)