### PR TITLE
fix(infra): indexer waits for node, wallet tests wait for chain-indexer caught up

### DIFF
--- a/infra/compose/docker-compose-dynamic.yml
+++ b/infra/compose/docker-compose-dynamic.yml
@@ -34,10 +34,10 @@ services:
       APP__INFRA__SECRET: '${APP_INFRA_SECRET}'
 
     healthcheck:
-      test: ['CMD-SHELL', 'cat /var/run/indexer-standalone/running']
-      interval: 60s
+      test: ['CMD-SHELL', 'curl -fs http://localhost:8088/ready']
+      interval: 5s
       timeout: 5s
-      retries: 3
+      retries: 36
       start_period: 60s
     depends_on:
       node:
@@ -56,10 +56,15 @@ services:
     volumes:
       - node-data:/data
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:9944/health']
+      test:
+        - 'CMD-SHELL'
+        - >
+          curl -fs -H 'Content-Type: application/json' -d
+          '{"id":1,"jsonrpc":"2.0","method":"chain_getBlockHash","params":[1]}' http://localhost:9944 | grep -q
+          '"result":"0x'
       interval: 2s
       timeout: 5s
-      retries: 5
+      retries: 30
       start_period: 5s
     environment:
       CFG_PRESET: 'dev'


### PR DESCRIPTION
## Summary

Opened to assist @jtsang586 with E2E test failures on the wallet side. Tightens two healthchecks in `infra/compose/docker-compose-dynamic.yml` to enforce two startup ordering principles that K8s already applies in cloud mode:

1. **Ensure the node is actually ticking before the indexer starts indexing.** Otherwise, if anything fails during startup, it is hard to tell from the logs whether the indexer is broken or the node simply hasn't produced any blocks yet, the two failure modes look similar and pollute each other in test reports. The previous node healthcheck (`curl -f http://localhost:9944/health`) returned 200 as soon as the substrate HTTP layer was reachable, well before block production. The new healthcheck issues a `chain_getBlockHash(1)` RPC and only passes once the response carries a non-null hash, i.e. block 1 actually exists on chain. The indexer service's `depends_on: condition: service_healthy` then blocks until that gate is reached, so a test failure can be unambiguously attributed.

2. **chain-indexer should catch up with the node before indexer-api receives requests.** This is the expected behaviour of the indexer and is what Kubernetes enforces in cloud mode via the `/ready` readiness probe (returns 503 with "indexer has not yet caught up with the node" until chain-indexer flags caught-up). The previous compose healthcheck (`cat /var/run/indexer-standalone/running`) only proved the entrypoint script had touched a file, so wallet tests gated on `condition: service_healthy` could fire GraphQL queries while chain-indexer was still catching up and receive 503s. The check is now `curl -fs http://localhost:8088/ready`, so the compose-level health gate now matches the K8s-level readiness gate.