### PR TITLE
chore(deps): upgrade ledger and proof-server to 8.1.0

### DIFF
--- a/.changeset/spicy-teams-pull.md
+++ b/.changeset/spicy-teams-pull.md
@@ -1,0 +1,13 @@
+---
+'@midnight-ntwrk/wallet-sdk-address-format': patch
+'@midnight-ntwrk/wallet-sdk-capabilities': patch
+'@midnight-ntwrk/wallet-sdk-dust-wallet': patch
+'@midnight-ntwrk/wallet-sdk-facade': patch
+'@midnight-ntwrk/wallet-sdk-node-client': patch
+'@midnight-ntwrk/wallet-sdk-prover-client': patch
+'@midnight-ntwrk/wallet-sdk-shielded': patch
+'@midnight-ntwrk/wallet-sdk-unshielded-wallet': patch
+'@midnight-ntwrk/wallet-sdk-utilities': patch
+---
+
+Bump `@midnight-ntwrk/ledger-v8` from `^8.0.3` to `^8.1.0`. Internal balancing flows in `dust-wallet`, `unshielded-wallet`, and `shielded-wallet` are refactored to use the new ledger 8.1.0 builder API (`Transaction.addIntent`, `Transaction.addZswapOffer`) instead of post-construction field mutation on `Transaction.fromParts(...)`. No public API changes; consumers must resolve `@midnight-ntwrk/ledger-v8` to `>=8.1.0`.

--- a/infra/compose/docker-compose-dynamic.yml
+++ b/infra/compose/docker-compose-dynamic.yml
@@ -1,6 +1,6 @@
 services:
   proof-server:
-    image: 'ghcr.io/midnight-ntwrk/proof-server:8.0.3'
+    image: 'ghcr.io/midnight-ntwrk/proof-server:8.1.0'
     container_name: proof-server_$TESTCONTAINERS_UID
     cap_drop:
       - ALL

--- a/infra/compose/docker-compose-remote-dynamic.yml
+++ b/infra/compose/docker-compose-remote-dynamic.yml
@@ -1,6 +1,6 @@
 services:
   proof-server:
-    image: 'ghcr.io/midnight-ntwrk/proof-server:8.0.3'
+    image: 'ghcr.io/midnight-ntwrk/proof-server:8.1.0'
     container_name: proof-server_$TESTCONTAINERS_UID
     cap_drop:
       - ALL

--- a/packages/address-format/package.json
+++ b/packages/address-format/package.json
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@scure/base": "^2.0.0",
     "@subsquid/scale-codec": "^4.0.1"
   },

--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -44,7 +44,7 @@
     }
   },
   "dependencies": {
-    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
     "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.1",
     "@midnight-ntwrk/wallet-sdk-node-client": "^1.1.1",

--- a/packages/dust-wallet/package.json
+++ b/packages/dust-wallet/package.json
@@ -28,7 +28,7 @@
     }
   },
   "dependencies": {
-    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
     "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
     "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.0",

--- a/packages/dust-wallet/src/v1/Transacting.ts
+++ b/packages/dust-wallet/src/v1/Transacting.ts
@@ -401,9 +401,7 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
 
     const segmentId = mergedExisting ? Option.getOrElse(findAvailableSegmentId(mergedExisting), () => 1) : 1;
 
-    // @TODO in ledger 8.1.0 will be able to set the segment id when constructing the tx
-    const balancingTx = Transaction.fromParts(network, undefined, undefined, undefined);
-    balancingTx.intents = new Map([[segmentId, intent]]);
+    const balancingTx = Transaction.fromParts(network).addIntent({ tag: 'specific', value: segmentId }, intent);
     const erasedBalancing = balancingTx.eraseProofs();
 
     const mergedTx = mergedExisting ? mergedExisting.merge(erasedBalancing) : erasedBalancing;
@@ -552,8 +550,10 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
           const mergedExisting = first ? rest.reduce((acc, tx) => acc.merge(tx), first) : undefined;
           const segmentId = mergedExisting ? Option.getOrElse(findAvailableSegmentId(mergedExisting), () => 1) : 1;
 
-          const feeTransaction = Transaction.fromParts(networkId, undefined, undefined, undefined);
-          feeTransaction.intents = new Map([[segmentId, intent]]);
+          const feeTransaction = Transaction.fromParts(networkId).addIntent(
+            { tag: 'specific', value: segmentId },
+            intent,
+          );
 
           return [feeTransaction, updatedState];
         });

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@cardano-sdk/key-management": "^0.29.12",
-    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnight-ntwrk/midnight-js-network-id": "^3.1.0",
     "@midnight-ntwrk/wallet-sdk-abstractions": "workspace:*",
     "@midnight-ntwrk/wallet-sdk-address-format": "workspace:*",

--- a/packages/facade/package.json
+++ b/packages/facade/package.json
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
     "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
     "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.0",

--- a/packages/node-client/package.json
+++ b/packages/node-client/package.json
@@ -48,7 +48,7 @@
     "@effect/rpc": "^0.75.1",
     "@effect/sql": "^0.51.1",
     "@effect/workflow": "^0.18.0",
-    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnight-ntwrk/wallet-sdk-prover-client": "^1.2.1",
     "@types/tar-stream": "^3.1.4",
     "tar-stream": "^3.2.0",

--- a/packages/prover-client/package.json
+++ b/packages/prover-client/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@effect/platform": "^0.96.0",
-    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnight-ntwrk/wallet-sdk-utilities": "^1.1.1",
     "@midnight-ntwrk/zkir-v2": "^2.1.0",
     "effect": "^3.19.19",

--- a/packages/prover-client/src/effect/test/httpProverClient.test.ts
+++ b/packages/prover-client/src/effect/test/httpProverClient.test.ts
@@ -27,7 +27,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import * as HttpProverClient from '../HttpProverClient.js';
 import * as ProverClient from '../ProverClient.js';
 
-const PROOF_SERVER_IMAGE: string = 'ghcr.io/midnight-ntwrk/proof-server:8.0.3';
+const PROOF_SERVER_IMAGE: string = 'ghcr.io/midnight-ntwrk/proof-server:8.1.0';
 const PROOF_SERVER_PORT: number = 6300;
 
 const timeout_minutes = (mins: number) => 1_000 * 60 * mins;

--- a/packages/shielded-wallet/package.json
+++ b/packages/shielded-wallet/package.json
@@ -28,7 +28,7 @@
     }
   },
   "dependencies": {
-    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
     "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
     "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.0",

--- a/packages/shielded-wallet/src/v1/Transacting.ts
+++ b/packages/shielded-wallet/src/v1/Transacting.ts
@@ -155,9 +155,10 @@ export class TransactingCapabilityImplementation<
         Imbalances.empty(),
       );
 
-      const balancedTx = ledger.Transaction.fromParts(this.networkId, guaranteed);
-      // workaround as Transaction.fromParts does not accept fallible offers with specific segments
-      balancedTx.fallibleOffer = fallibleOffers.size > 0 ? fallibleOffers : undefined;
+      const balancedTx = Array.from(fallibleOffers.entries()).reduce(
+        (tx, [segment, offer]) => tx.addZswapOffer({ tag: 'specific', value: segment }, offer),
+        ledger.Transaction.fromParts(this.networkId, guaranteed),
+      );
       return [balancedTx, afterGuaranteed];
     });
   }

--- a/packages/shielded-wallet/src/v1/test/transacting.test.ts
+++ b/packages/shielded-wallet/src/v1/test/transacting.test.ts
@@ -260,9 +260,10 @@ describe('V1 Wallet Transacting', () => {
       const transactionValueGuaranteed = shieldedValue(1);
       const guaranteedOffer = makeOutputOffer({ recipient: wallets.B, coin: transactionValueGuaranteed });
       const fallibleOffer = makeOutputOffer({ recipient: wallets.B, coin: transactionValueFallible, segment: 1996 });
-      const tx = ledger.Transaction.fromParts(NetworkId.NetworkId.Undeployed, guaranteedOffer);
-      // workaround, as Transaction.fromParts does not accept fallible offers with specific segments
-      tx.fallibleOffer = new Map([[1996, fallibleOffer]]);
+      const tx = ledger.Transaction.fromParts(NetworkId.NetworkId.Undeployed, guaranteedOffer).addZswapOffer(
+        { tag: 'specific', value: 1996 },
+        fallibleOffer,
+      );
 
       return Effect.gen(function* () {
         const [balancingTransaction] = EitherOps.getOrThrowLeft(

--- a/packages/unshielded-wallet/package.json
+++ b/packages/unshielded-wallet/package.json
@@ -28,7 +28,7 @@
     }
   },
   "dependencies": {
-    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
     "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
     "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.0",

--- a/packages/unshielded-wallet/src/v1/Transacting.ts
+++ b/packages/unshielded-wallet/src/v1/Transacting.ts
@@ -208,9 +208,10 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
       balancingIntent.guaranteedUnshieldedOffer = offer;
 
       const segmentId = Option.getOrElse(this.txOps.findAvailableSegmentId(transaction), () => 1);
-      // @TODO in ledger 8.1.0 will be able to set the segment id when constructing the tx
-      const balancingTx = ledger.Transaction.fromParts(this.networkId, undefined, undefined, undefined);
-      balancingTx.intents = new Map([[segmentId, balancingIntent]]);
+      const balancingTx = ledger.Transaction.fromParts(this.networkId).addIntent(
+        { tag: 'specific', value: segmentId },
+        balancingIntent,
+      );
       return [balancingTx, newState];
     });
   }

--- a/packages/utilities/src/testing/test-containers.ts
+++ b/packages/utilities/src/testing/test-containers.ts
@@ -43,7 +43,7 @@ export const runNodeContainer = (
 export const runProofServerContainer = (
   adjustment: (t: GenericContainer) => GenericContainer = identity,
 ): Effect.Effect<StartedTestContainer, Error, Scope.Scope> => {
-  const container = new GenericContainer('ghcr.io/midnight-ntwrk/proof-server:8.0.3')
+  const container = new GenericContainer('ghcr.io/midnight-ntwrk/proof-server:8.1.0')
     .withEnvironment({
       RUST_BACKTRACE: 'full',
     })

--- a/packages/wallet-integration-tests/package.json
+++ b/packages/wallet-integration-tests/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnight-ntwrk/wallet-api": "^5.0.0",
     "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
     "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",

--- a/packages/wallet-integration-tests/test/proving.test.ts
+++ b/packages/wallet-integration-tests/test/proving.test.ts
@@ -25,7 +25,7 @@ import { GenericContainer, Wait } from 'testcontainers';
 import { describe, expect, it, vi } from 'vitest';
 import { getNonDustImbalance } from './utils.js';
 
-const PROOF_SERVER_IMAGE: string = 'ghcr.io/midnight-ntwrk/proof-server:8.0.3';
+const PROOF_SERVER_IMAGE: string = 'ghcr.io/midnight-ntwrk/proof-server:8.1.0';
 const PROOF_SERVER_PORT: number = 6300;
 
 vi.setConfig({ testTimeout: 300_000, hookTimeout: 300_000 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2136,10 +2136,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/ledger-v8@npm:^8.0.3":
-  version: 8.0.3
-  resolution: "@midnight-ntwrk/ledger-v8@npm:8.0.3::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40midnight-ntwrk%2Fledger-v8%2F8.0.3%2F47e343bc08f4c94162a2f12322e0e0a958743613"
-  checksum: 10c0/a6890ca065285961969f272423b813293b4b1d5af1bb4ac6f404a0ff1f3f8fedb69ec5f1f2c05ab1e67a3e6623d23e7db1cacbe0b6ed847f09e1e2ab64f3c756
+"@midnight-ntwrk/ledger-v8@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@midnight-ntwrk/ledger-v8@npm:8.1.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40midnight-ntwrk%2Fledger-v8%2F8.1.0%2Fc42ed442b6c8c79e28ca5fc13a8764f31eab2f73"
+  checksum: 10c0/12a8b58678dbed60e7280ef1b3f16b465aa93d6fd4d0e1cbbb82730db941999c4354af5ffdfd1048b770afb497792e91cac0317962815dfc7c5471e581a96c40
   languageName: node
   linkType: hard
 
@@ -2176,7 +2176,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/wallet-integration-tests@workspace:packages/wallet-integration-tests"
   dependencies:
-    "@midnight-ntwrk/ledger-v8": "npm:^8.0.3"
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@midnight-ntwrk/wallet-api": "npm:^5.0.0"
     "@midnight-ntwrk/wallet-sdk-abstractions": "npm:^2.1.0"
     "@midnight-ntwrk/wallet-sdk-address-format": "npm:^3.1.1"
@@ -2206,7 +2206,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/wallet-sdk-address-format@workspace:packages/address-format"
   dependencies:
-    "@midnight-ntwrk/ledger-v8": "npm:^8.0.3"
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@scure/base": "npm:^2.0.0"
     "@subsquid/scale-codec": "npm:^4.0.1"
   languageName: unknown
@@ -2223,7 +2223,7 @@ __metadata:
     "@effect/rpc": "npm:^0.75.1"
     "@effect/sql": "npm:^0.51.1"
     "@effect/workflow": "npm:^0.18.0"
-    "@midnight-ntwrk/ledger-v8": "npm:^8.0.3"
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@midnight-ntwrk/wallet-sdk-abstractions": "npm:^2.1.0"
     "@midnight-ntwrk/wallet-sdk-indexer-client": "npm:^1.2.1"
     "@midnight-ntwrk/wallet-sdk-node-client": "npm:^1.1.1"
@@ -2250,7 +2250,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/wallet-sdk-dust-wallet@workspace:packages/dust-wallet"
   dependencies:
-    "@midnight-ntwrk/ledger-v8": "npm:^8.0.3"
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@midnight-ntwrk/wallet-sdk-abstractions": "npm:^2.1.0"
     "@midnight-ntwrk/wallet-sdk-address-format": "npm:^3.1.1"
     "@midnight-ntwrk/wallet-sdk-capabilities": "npm:^3.3.0"
@@ -2267,7 +2267,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/wallet-sdk-facade@workspace:packages/facade"
   dependencies:
-    "@midnight-ntwrk/ledger-v8": "npm:^8.0.3"
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@midnight-ntwrk/wallet-sdk-abstractions": "npm:^2.1.0"
     "@midnight-ntwrk/wallet-sdk-address-format": "npm:^3.1.1"
     "@midnight-ntwrk/wallet-sdk-capabilities": "npm:^3.3.0"
@@ -2350,7 +2350,7 @@ __metadata:
     "@effect/rpc": "npm:^0.75.1"
     "@effect/sql": "npm:^0.51.1"
     "@effect/workflow": "npm:^0.18.0"
-    "@midnight-ntwrk/ledger-v8": "npm:^8.0.3"
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@midnight-ntwrk/wallet-sdk-abstractions": "npm:^2.1.0"
     "@midnight-ntwrk/wallet-sdk-prover-client": "npm:^1.2.1"
     "@midnight-ntwrk/wallet-sdk-utilities": "npm:^1.1.1"
@@ -2371,7 +2371,7 @@ __metadata:
   resolution: "@midnight-ntwrk/wallet-sdk-prover-client@workspace:packages/prover-client"
   dependencies:
     "@effect/platform": "npm:^0.96.0"
-    "@midnight-ntwrk/ledger-v8": "npm:^8.0.3"
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@midnight-ntwrk/wallet-sdk-utilities": "npm:^1.1.1"
     "@midnight-ntwrk/zkir-v2": "npm:^2.1.0"
     effect: "npm:^3.19.19"
@@ -2394,7 +2394,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/wallet-sdk-shielded@workspace:packages/shielded-wallet"
   dependencies:
-    "@midnight-ntwrk/ledger-v8": "npm:^8.0.3"
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@midnight-ntwrk/wallet-sdk-abstractions": "npm:^2.1.0"
     "@midnight-ntwrk/wallet-sdk-address-format": "npm:^3.1.1"
     "@midnight-ntwrk/wallet-sdk-capabilities": "npm:^3.3.0"
@@ -2410,7 +2410,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/wallet-sdk-unshielded-wallet@workspace:packages/unshielded-wallet"
   dependencies:
-    "@midnight-ntwrk/ledger-v8": "npm:^8.0.3"
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@midnight-ntwrk/wallet-sdk-abstractions": "npm:^2.1.0"
     "@midnight-ntwrk/wallet-sdk-address-format": "npm:^3.1.1"
     "@midnight-ntwrk/wallet-sdk-capabilities": "npm:^3.3.0"
@@ -2515,7 +2515,7 @@ __metadata:
   resolution: "@midnight/wallet-e2e-tests@workspace:packages/e2e-tests"
   dependencies:
     "@cardano-sdk/key-management": "npm:^0.29.12"
-    "@midnight-ntwrk/ledger-v8": "npm:^8.0.3"
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@midnight-ntwrk/midnight-js-network-id": "npm:^3.1.0"
     "@midnight-ntwrk/wallet-sdk-abstractions": "workspace:*"
     "@midnight-ntwrk/wallet-sdk-address-format": "workspace:*"


### PR DESCRIPTION
## Summary
- Bumps `@midnight-ntwrk/ledger-v8` from `^8.0.3` → `^8.1.0` across all packages and the proof-server image from `8.0.3` → `8.1.0` in compose files and testcontainers.
- Resolves the two `@TODO in ledger 8.1.0` sites by using the new `Transaction.addIntent(SegmentSpecifier, intent)` API instead of the post-construction `tx.intents = new Map(...)` mutation. Applied the same simplification to one sibling site (no TODO but identical pattern) and a shielded-wallet `fallibleOffer` workaround (+ its test) via `addZswapOffer`.

Closes #419

## Test plan
- [x] `yarn verify` (typecheck + lint + unit tests)
- [x] `yarn test --filter=@midnight-ntwrk/wallet-sdk-shielded -- test/transacting.test.ts` (covers the `addZswapOffer` migration on the `non-standard segment` case)
- [ ] e2e/integration suites that exercise proving against the bumped proof-server image

🤖 Generated with [Claude Code](https://claude.com/claude-code)