### PR TITLE
fix(prover-client): do not send explicit content-length header to proof server

### DIFF
--- a/.changeset/fix-prover-client-content-length.md
+++ b/.changeset/fix-prover-client-content-length.md
@@ -1,0 +1,8 @@
+---
+'@midnight-ntwrk/wallet-sdk-prover-client': patch
+---
+
+Fix proof-server requests failing with `invalid content-length header` when undici >= 8.2.0 is
+installed as the process-wide fetch dispatcher (which happens transitively by merely importing
+packages such as testcontainers or @effect/platform-node). The HTTP prover client no longer sets
+an explicit `content-length` request header and lets `fetch` derive it from the body instead.

--- a/packages/prover-client/src/effect/HttpProverClient.ts
+++ b/packages/prover-client/src/effect/HttpProverClient.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Chunk, type Context, Duration, Effect, Either, Layer, pipe, Schedule, Stream } from 'effect';
-import { FetchHttpClient, HttpClient, HttpClientRequest, type HttpClientResponse } from '@effect/platform';
+import { FetchHttpClient, HttpBody, HttpClient, HttpClientRequest, type HttpClientResponse } from '@effect/platform';
 import { ProverClient } from './ProverClient.js';
 import {
   ClientError,
@@ -86,7 +86,15 @@ class HttpProverClientImpl implements Context.Tag.Service<ProverClient> {
 
     const proveTxRequest = pipe(
       Effect.succeed(payload),
-      Effect.map((body) => HttpClientRequest.post(url).pipe(HttpClientRequest.bodyUint8Array(body))),
+      Effect.map((body) =>
+        HttpClientRequest.post(url).pipe(
+          // A raw body must be used instead of `bodyUint8Array` so that no explicit `content-length`
+          // header is attached: `fetch` derives the length from the body itself, and an explicit
+          // header is rejected as malformed by undici >= 8.2.0 when it is installed as the global
+          // dispatcher (e.g. transitively via testcontainers or @effect/platform-node).
+          HttpClientRequest.setBody(HttpBody.raw(body, { contentType: 'application/octet-stream' })),
+        ),
+      ),
       Effect.flatMap(HttpClient.execute),
       Effect.flatMap((response: HttpClientResponse.HttpClientResponse) =>
         Effect.gen(function* () {


### PR DESCRIPTION
## Problem

Proving fails with `ClientError: Failed to prove transaction` whenever the npm `undici` package (>= 8.2.0) is present in the process — e.g. in any test importing `testcontainers` or `@effect/platform-node`. Both "should prove a valid transaction" tests in `httpProverClient.test.ts` fail. This is the same regression that previously forced pinning undici back to 8.1.0 (d9531ecf); the combined dependency updates re-introduce it by moving the pin to 8.4.x.

## Root cause

Two things conspire:

1. **npm undici 8 hijacks global fetch on import.** Its `lib/global.js` installs its own `Agent` as the global dispatcher at module load, including under the legacy `Symbol.for('undici.globalDispatcher.1')` slot that Node 22's *bundled* fetch (undici 6.24.1) reads. Merely importing testcontainers reroutes every `fetch()` in the process through npm undici 8 via a `Dispatcher1Wrapper`.
2. **undici 8.2.0 added strict content-length validation** (nodejs/undici#5060, "reject malformed content-length request headers" — value must be a digit-only string). `HttpClientRequest.bodyUint8Array` from `@effect/platform` sets an explicit `content-length` header; Node's bundled fetch *also* computes one from the body, and the duplicated value arriving at undici 8's validator fails the check with `InvalidArgumentError: invalid content-length header`.

Verified in isolation: the same `fetch` POST with an explicit `content-length` header succeeds before `import 'undici'` and fails with `invalid content-length header` after it; without the explicit header it succeeds in both cases.

## Fix

Build the proof-server request body with `HttpBody.raw(body, { contentType: 'application/octet-stream' })` instead of `bodyUint8Array`, so no explicit `content-length` header is attached and `fetch` derives it from the body. This also matches the fetch spec, where `Content-Length` is a forbidden request header (browsers strip it silently anyway), and decouples the prover client from whichever undici version owns the global dispatcher.

This is the only place in the SDK that sends a request body through `FetchHttpClient`, so no other call sites are affected.

## Testing

- `yarn test --filter=@midnight-ntwrk/wallet-sdk-prover-client --force`: 11/11 pass (2 failed before the fix)
- `yarn turbo typecheck lint --filter=@midnight-ntwrk/wallet-sdk-prover-client`: clean
- Effect language-service diagnostics on the changed file: clean