### PR TITLE
fix(hd): return keyOutOfBounds for invalid BIP32 path components

### DIFF
--- a/.changeset/hd-out-of-bounds-derivation.md
+++ b/.changeset/hd-out-of-bounds-derivation.md
@@ -1,0 +1,7 @@
+---
+'@midnight-ntwrk/wallet-sdk-hd': patch
+---
+
+`deriveKeyAt`/`deriveKeysAt` now return `keyOutOfBounds` for invalid BIP32 path components (non-integer, negative, or
+`>= 2^31` account/role/index values) instead of leaking the underlying `invalid child index` error thrown by
+`@scure/bip32`.

--- a/packages/hd/src/HDWallet.ts
+++ b/packages/hd/src/HDWallet.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { HDKey } from '@scure/bip32';
+import { HARDENED_OFFSET, HDKey } from '@scure/bip32';
 
 type ValueOf<T> = T[keyof T];
 
@@ -34,6 +34,11 @@ type HDWalletResult =
 
 const PURPOSE = 44;
 const COIN_TYPE = 2400;
+
+// BIP32 path components (account, role, index) are integers in [0, 2^31);
+// @scure/bip32 inlines this check inside derive() and throws, so guard here
+const isValidChildIndex = (value: number): boolean =>
+  Number.isSafeInteger(value) && value >= 0 && value < HARDENED_OFFSET;
 
 const CompositeDerivationResult = {
   fromResults: <T extends readonly Role[]>(
@@ -121,6 +126,9 @@ export class RoleKey {
 
   // Finally, derive the key at the given index.
   public deriveKeyAt(index: number): DerivationResult {
+    if (![this.account, this.role, index].every(isValidChildIndex)) {
+      return { type: 'keyOutOfBounds' };
+    }
     const path = `m/${PURPOSE}'/${COIN_TYPE}'/${this.account}'/${this.role}/${index}`;
     const derivedKey = this.rootKey.derive(path);
     return derivedKey.privateKey ? { type: 'keyDerived', key: derivedKey.privateKey } : { type: 'keyOutOfBounds' };

--- a/packages/hd/test/tests.test.ts
+++ b/packages/hd/test/tests.test.ts
@@ -21,6 +21,7 @@ import {
   generateRandomSeed,
   HDWallet,
   joinMnemonicWords,
+  type Role,
   Roles,
   validateMnemonic,
 } from '../src/index.js';
@@ -105,6 +106,58 @@ describe('HD Wallet', () => {
         expect(validateMnemonic(joinMnemonicWords(mnemonic))).toBeTruthy();
       }),
     );
+  });
+
+  describe('out-of-bounds derivation returns keyOutOfBounds instead of throwing', () => {
+    const hdWallet = (() => {
+      const result = HDWallet.fromSeed(
+        Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex'),
+      );
+      if (result.type !== 'seedOk') throw new Error('seed setup failed');
+      return result.hdWallet;
+    })();
+
+    // BIP32 non-hardened child indices are integers in [0, 2^31)
+    const invalidIndexArb = fc.oneof(
+      fc.integer({ min: 2 ** 31, max: Number.MAX_SAFE_INTEGER }),
+      fc.integer({ min: Number.MIN_SAFE_INTEGER, max: -1 }),
+      fc.constantFrom(Number.NaN, 0.5, 1.5, Math.PI, Number.POSITIVE_INFINITY),
+    );
+
+    it('deriveKeyAt returns keyOutOfBounds for an invalid index', () => {
+      fc.assert(
+        fc.property(invalidIndexArb, (index) => {
+          const result = hdWallet.selectAccount(0).selectRole(Roles.NightExternal).deriveKeyAt(index);
+          expect(result).toEqual({ type: 'keyOutOfBounds' });
+        }),
+      );
+    });
+
+    it('deriveKeyAt returns keyOutOfBounds for an out-of-bounds account', () => {
+      fc.assert(
+        fc.property(invalidIndexArb, (account) => {
+          const result = hdWallet.selectAccount(account).selectRole(Roles.NightExternal).deriveKeyAt(0);
+          expect(result).toEqual({ type: 'keyOutOfBounds' });
+        }),
+      );
+    });
+
+    it('deriveKeyAt returns keyOutOfBounds for an invalid role smuggled past the type system', () => {
+      // Type cast required because: reproducing an untyped JS caller passing a missing
+      // Roles entry, which resolves to undefined at runtime
+      const role = undefined as unknown as Role;
+      const result = hdWallet.selectAccount(0).selectRole(role).deriveKeyAt(0);
+      expect(result).toEqual({ type: 'keyOutOfBounds' });
+    });
+
+    it('deriveKeysAt reports every requested role as out of bounds for an invalid index', () => {
+      const roles = [Roles.Zswap, Roles.Metadata, Roles.Dust] as const;
+      const result = hdWallet
+        .selectAccount(0)
+        .selectRoles(roles)
+        .deriveKeysAt(2 ** 31);
+      expect(result).toEqual({ type: 'keyOutOfBounds', roles: [Roles.Zswap, Roles.Metadata, Roles.Dust] });
+    });
   });
 
   it('Roundtrip from seed to mnemonic and back should give the same seed', () => {


### PR DESCRIPTION
Fixes #454

## Summary

`RoleKey.deriveKeyAt` interpolates `account`/`role`/`index` straight into the BIP32 derivation path, so any value outside the non-hardened range (non-integer, negative, or `>= 2^31`) escaped as `@scure/bip32`'s thrown `Error: invalid child index: ...` instead of the typed `keyOutOfBounds` result the API models. `CompositeRoleKey.deriveKeysAt` inherited the same behavior. All four repro cases from the issue (`2 ** 31`, `-1`, `1.5`, `NaN`) now return `{ type: 'keyOutOfBounds' }`.

This takes the issue's first suggested approach: guard all three path components against the BIP32 non-hardened child range (integers in `[0, 2^31)`, using `HARDENED_OFFSET` exported by `@scure/bip32`) before deriving, making `deriveKeyAt` total. An explicit guard was chosen over wrapping `derive()` in try/catch so that genuine defects (e.g. deriving after `clear()` wiped the private key) still throw instead of being misreported as out-of-bounds.

## Changes

- `packages/hd/src/HDWallet.ts` — validate `account`, `role`, and `index` in `deriveKeyAt`; return `keyOutOfBounds` on any invalid component
- `packages/hd/test/tests.test.ts` — property-based tests for out-of-range/negative/non-integer indices and accounts (as the issue suggested, these paths were previously never exercised), an invalid role smuggled past the type system, and `deriveKeysAt` reporting all requested roles
- `.changeset/hd-out-of-bounds-derivation.md` — patch changeset

## Testing

- `yarn test --filter=@midnight-ntwrk/wallet-sdk-hd` — 9/9 passing; the 4 new tests were written first and confirmed failing with the `@scure/bip32` throw before the guard was added