### PR TITLE
chore: bump indexer image, bridge+events epics plus contract unshieldedBalances fix

### DIFF
--- a/infra/compose/docker-compose-dynamic.yml
+++ b/infra/compose/docker-compose-dynamic.yml
@@ -19,7 +19,7 @@ services:
       start_period: 10s
 
   indexer:
-    image: 'ghcr.io/midnight-ntwrk/indexer-standalone:4.3.4-pre-alpha.1-l9a1-n2a1-event-fcdadde'
+    image: 'ghcr.io/midnight-ntwrk/indexer-standalone:4.3.4-pre-alpha.5-l9a1-n2a1-bridge-and-public-events-balances-fix-5d2a847'
     container_name: indexer_$TESTCONTAINERS_UID
     cap_drop:
       - ALL

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   indexer:
-    image: 'ghcr.io/midnight-ntwrk/indexer-standalone:4.3.4-pre-alpha.1-l9a1-n2a1-event-fcdadde'
+    image: 'ghcr.io/midnight-ntwrk/indexer-standalone:4.3.4-pre-alpha.5-l9a1-n2a1-bridge-and-public-events-balances-fix-5d2a847'
     container_name: indexer_$TESTCONTAINERS_UID
     cap_drop:
       - ALL


### PR DESCRIPTION
Bumps the compose indexer from `indexer-standalone:4.3.4-pre-alpha.1-l9a1-n2a1-event-fcdadde` to `indexer-standalone:4.3.4-pre-alpha.5-l9a1-n2a1-bridge-and-public-events-balances-fix-5d2a847`.

**Bug fix (the extra change beyond the epics):** `ContractAction.unshieldedBalances` always returned empty on the pinned image; fixed for both the ledger-8 and ledger-9 paths, details in midnightntwrk/midnight-indexer#1245. The fix applies to blocks indexed from now on; existing indexer DBs need a reset or a backfill (procedure to be posted in the same ticket). This compose is unaffected (fresh DB every run), but the qanet, preview, preprod and mainnet indexer APIs still carry pre-fix data and will be backfilled.

Beyond the fix, the image is a strict superset of the pinned event-only build: same events work, plus the c2m-bridge surface, plus latest main, on the same ledger 9.0.1.0-alpha.1 + node 2.0.0-alpha.1 base the 2.0.0-canary SDK targets. Cut from midnightntwrk/midnight-indexer#1242 (epics: midnightntwrk/midnight-indexer#1102 bridge, midnightntwrk/midnight-indexer#1185 public contract events).

Notes: both new GraphQL surfaces are `@beta`. `unshieldedTransactions`' `transaction` field can now resolve as a new `BridgeClaimTransaction` type, only when bridge claims exist (never on this compose's fresh dev chains), so `__typename` handling should tolerate the new variants but current behaviour is unchanged.