### PR TITLE
fix(node-client): move @midnight-ntwrk/ledger-v8 to dependencies

### DIFF
--- a/.changeset/node-client-ledger-v8-dependency.md
+++ b/.changeset/node-client-ledger-v8-dependency.md
@@ -1,0 +1,6 @@
+---
+'@midnight-ntwrk/wallet-sdk-node-client': patch
+---
+
+Move `@midnight-ntwrk/ledger-v8` from `devDependencies` to `dependencies`. It is used at runtime
+by the `./testing` export, so consumers need it resolved as a regular dependency.

--- a/.changeset/node-client-ledger-v8-dependency.md
+++ b/.changeset/node-client-ledger-v8-dependency.md
@@ -2,5 +2,6 @@
 '@midnight-ntwrk/wallet-sdk-node-client': patch
 ---
 
-Declare `@midnight-ntwrk/ledger-v8` as an optional peer dependency. It is used at runtime by the
-`./testing` export, so consumers of that export need it installed.
+Declare `@midnight-ntwrk/ledger-v8` and `@midnight-ntwrk/wallet-sdk-prover-client` as optional peer
+dependencies. They are used at runtime by the `./testing` export, so consumers of that export need
+them installed.

--- a/.changeset/node-client-ledger-v8-dependency.md
+++ b/.changeset/node-client-ledger-v8-dependency.md
@@ -2,5 +2,5 @@
 '@midnight-ntwrk/wallet-sdk-node-client': patch
 ---
 
-Move `@midnight-ntwrk/ledger-v8` from `devDependencies` to `dependencies`. It is used at runtime
-by the `./testing` export, so consumers need it resolved as a regular dependency.
+Declare `@midnight-ntwrk/ledger-v8` as an optional peer dependency. It is used at runtime by the
+`./testing` export, so consumers of that export need it installed.

--- a/packages/node-client/package.json
+++ b/packages/node-client/package.json
@@ -41,10 +41,14 @@
     "effect": "^3.19.19"
   },
   "peerDependencies": {
-    "@midnight-ntwrk/ledger-v8": "^8.1.0"
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
+    "@midnight-ntwrk/wallet-sdk-prover-client": "^1.2.2"
   },
   "peerDependenciesMeta": {
     "@midnight-ntwrk/ledger-v8": {
+      "optional": true
+    },
+    "@midnight-ntwrk/wallet-sdk-prover-client": {
       "optional": true
     }
   },

--- a/packages/node-client/package.json
+++ b/packages/node-client/package.json
@@ -31,7 +31,6 @@
     }
   },
   "dependencies": {
-    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
     "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
     "@polkadot/api": "^16.5.4",
@@ -41,6 +40,14 @@
     "bn.js": "^5.2.3",
     "effect": "^3.19.19"
   },
+  "peerDependencies": {
+    "@midnight-ntwrk/ledger-v8": "^8.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@midnight-ntwrk/ledger-v8": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@effect/cluster": "0.59.0",
     "@effect/experimental": "0.60.0",
@@ -49,6 +56,7 @@
     "@effect/rpc": "0.75.1",
     "@effect/sql": "0.51.1",
     "@effect/workflow": "0.18.2",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnight-ntwrk/wallet-sdk-prover-client": "^1.2.2",
     "@types/tar-stream": "3.1.4",
     "tar-stream": "3.2.0",

--- a/packages/node-client/package.json
+++ b/packages/node-client/package.json
@@ -31,6 +31,7 @@
     }
   },
   "dependencies": {
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
     "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
     "@polkadot/api": "^16.5.4",
@@ -48,7 +49,6 @@
     "@effect/rpc": "0.75.1",
     "@effect/sql": "0.51.1",
     "@effect/workflow": "0.18.2",
-    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnight-ntwrk/wallet-sdk-prover-client": "^1.2.2",
     "@types/tar-stream": "3.1.4",
     "tar-stream": "3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2363,6 +2363,11 @@ __metadata:
     effect: "npm:^3.19.19"
     tar-stream: "npm:3.2.0"
     tsx: "npm:4.21.0"
+  peerDependencies:
+    "@midnight-ntwrk/ledger-v8": ^8.1.0
+  peerDependenciesMeta:
+    "@midnight-ntwrk/ledger-v8":
+      optional: true
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2365,8 +2365,11 @@ __metadata:
     tsx: "npm:4.21.0"
   peerDependencies:
     "@midnight-ntwrk/ledger-v8": ^8.1.0
+    "@midnight-ntwrk/wallet-sdk-prover-client": ^1.2.2
   peerDependenciesMeta:
     "@midnight-ntwrk/ledger-v8":
+      optional: true
+    "@midnight-ntwrk/wallet-sdk-prover-client":
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

Moves `@midnight-ntwrk/ledger-v8` from `devDependencies` to `dependencies` in `packages/node-client`. It is used at runtime by the package's `./testing` export, so consumers installing the package need it resolved as a regular dependency.