### PR TITLE
fix(shielded): balance transactions imbalanced only in a fallible segment

### DIFF
--- a/.changeset/fix-shielded-fallible-only-balancing.md
+++ b/.changeset/fix-shielded-fallible-only-balancing.md
@@ -1,0 +1,7 @@
+---
+'@midnight-ntwrk/wallet-sdk-shielded': patch
+---
+
+Fix `balanceTransaction` failing with "Could not create a valid guaranteed offer" when a
+transaction's only imbalance is in a fallible segment. The guaranteed section is now skipped
+when it is already balanced, instead of attempting to build an empty guaranteed offer.

--- a/packages/shielded-wallet/src/v1/Transacting.ts
+++ b/packages/shielded-wallet/src/v1/Transacting.ts
@@ -379,7 +379,7 @@ export class TransactingCapabilityImplementation<
     imbalances: TransactionImbalances,
     coinSelection: CoinSelection<ledger.QualifiedShieldedCoinInfo>,
     targetImbalances: Imbalances,
-  ): Either.Either<{ offer: ledger.ZswapOffer<ledger.PreProof>; newState: CoreWallet }, WalletError> {
+  ): Either.Either<{ offer: ledger.ZswapOffer<ledger.PreProof> | undefined; newState: CoreWallet }, WalletError> {
     return Either.gen(this, function* () {
       const balanceRecipe = yield* Either.try({
         try: () =>
@@ -411,12 +411,13 @@ export class TransactingCapabilityImplementation<
         },
       });
 
-      return yield* pipe(
+      // An empty recipe (e.g. the guaranteed section is already balanced) yields no offer.
+      // Treat that as "nothing to add" rather than a failure, mirroring the fallible section.
+      return pipe(
         this.#prepareOffer(secretKeys, state, balanceRecipe, 0),
-        Either.fromOption(() => {
-          return new OtherWalletError({
-            message: 'Could not create a valid guaranteed offer',
-          });
+        Option.match({
+          onNone: () => ({ offer: undefined, newState: state }),
+          onSome: (result) => result,
         }),
       );
     });

--- a/packages/shielded-wallet/src/v1/test/transacting.test.ts
+++ b/packages/shielded-wallet/src/v1/test/transacting.test.ts
@@ -291,6 +291,46 @@ describe('V1 Wallet Transacting', () => {
       }).pipe(Effect.runPromise);
     });
 
+    it('balances a transaction whose only imbalance is in the fallible section', () => {
+      const wallets = prepareWallets({
+        A: {
+          keys: ledger.ZswapSecretKeys.fromSeed(Buffer.alloc(32, 0)),
+          coins: [shieldedValue(1), shieldedValue(2), shieldedValue(3)],
+        },
+        B: { keys: ledger.ZswapSecretKeys.fromSeed(Buffer.alloc(32, 1)), coins: [] },
+      });
+      const transacting = makeSimulatorTransactingCapability(defaultConfig, () => defaultContext);
+      const proving = makeSimulatorProvingServiceEffect();
+      const transactionValueFallible = shieldedValue(2);
+      // No guaranteed offer: segment 0 is already balanced, only segment 7593 is imbalanced.
+      const fallibleOffer = makeOutputOffer({ recipient: wallets.B, coin: transactionValueFallible, segment: 7593 });
+      const tx = ledger.Transaction.fromParts(NetworkId.NetworkId.Undeployed, undefined, fallibleOffer);
+
+      return Effect.gen(function* () {
+        const [balancingTransaction] = EitherOps.getOrThrowLeft(
+          transacting.balanceTransaction(wallets.A.keys, wallets.A.wallet, tx),
+        );
+
+        expect(balancingTransaction).toBeDefined();
+
+        const balancedTransaction = tx.merge(balancingTransaction!);
+
+        const provenTransaction = yield* proving.prove(balancedTransaction);
+
+        // check that the fallible section of the balancing transaction is correct
+        expect(
+          balancingTransaction!.fallibleOffer
+            ?.entries()
+            .map(([_, delta]) => delta.deltas.get(rawShieldedTokenType) ?? 0n)
+            .reduce((acc, curr) => acc + curr, 0n),
+        ).toEqual(transactionValueFallible);
+
+        // check that the final transaction is balanced in both segments
+        expect(getNonDustImbalance(provenTransaction.imbalances(0), rawShieldedTokenType)).toBe(0n);
+        expect(getNonDustImbalance(provenTransaction.imbalances(1), rawShieldedTokenType)).toBe(0n);
+      }).pipe(Effect.runPromise);
+    });
+
     it('books coins used in balancing', () => {
       const wallets = prepareWallets({
         A: {


### PR DESCRIPTION
## Problem

`balanceTransaction` failed with `Could not create a valid guaranteed offer` when a transaction's only imbalance was in a fallible segment (segment 0 already balanced, an imbalance in segment 1+).

The guaranteed section turned an empty balancing offer into a hard error, while the fallible section treated the identical signal (`#prepareOffer` returning `None`) as a no-op. Same signal, opposite reactions.

## Fix

Make `#balanceGuaranteedSection` symmetric with the fallible section: an empty offer now yields no guaranteed offer (`offer: undefined`, state unchanged) instead of failing. `balanceTransaction` builds the balanced tx from just the fallible offers in that case. `makeTransfer` / `initSwap` are unaffected — they already feed the offer through `Transaction.fromParts`, which accepts `undefined`.

## Test

Adds `balances a transaction whose only imbalance is in the fallible section`, which fails on `main` for the expected reason and passes with the fix.
