### PR TITLE
chore(ci): one-time token bootstrap for the @midnightntwrk scope

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,15 @@ env:
 
 on:
   workflow_dispatch:
+    inputs:
+      bootstrap-primary-scope:
+        description: >-
+          One-time migration bootstrap. Publishes the @midnightntwrk scope with a token (provenance disabled) to seed
+          the new package names on npmjs. A trusted publisher can only be attached to a package that already exists, so
+          OIDC cannot perform the first publish. Run once, attach the trusted publishers on npmjs, then leave this off
+          so publishes use OIDC.
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -272,3 +281,57 @@ jobs:
         run: |
           git reset --hard
           git clean -fd
+
+  # One-time migration bootstrap (manual dispatch only, opt-in checkbox). The
+  # first publish of each new @midnightntwrk package cannot use OIDC — a trusted
+  # publisher can only be attached to a package that already exists on npmjs. So
+  # this job seeds the new package names by publishing the current versions
+  # under the `latest` dist-tag with the MIDNIGHTBOT token (scripts/publish.mjs
+  # sees it as NPM_PRIMARY_TOKEN and skips provenance). After running once and
+  # attaching trusted publishers on npmjs, this job and its dispatch input can
+  # be removed and publishing reverts to OIDC.
+  bootstrap-primary-scope:
+    name: Bootstrap @midnightntwrk (one-time, token)
+    if: ${{ inputs.bootstrap-primary-scope }}
+    runs-on: ubuntu-latest-8-core-x64
+    # Reuse the stable environment so the bootstrap publish goes through the
+    # same reviewer gate; token auth ignores the per-environment OIDC publisher.
+    environment: npm-publish-stable
+    permissions:
+      contents: read
+    concurrency:
+      group: bootstrap-primary-scope-${{ github.ref_name }}
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@midnightntwrk'
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Configure yarn (install-time auth for GH Packages)
+        run: |
+          yarn config set 'npmScopes.midnight-ntwrk.npmAuthToken' "${{ env.MIDNIGHT_GH_TOKEN }}"
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build
+        run: yarn dist:publish
+
+      - name: Publish both scopes with tokens (seed @midnightntwrk under latest)
+        run: node scripts/publish.mjs
+        env:
+          # Token-publish the primary @midnightntwrk scope (provenance disabled)
+          # to create the package names; the @midnight-ntwrk alias uses the
+          # legacy token as usual. Both are token publishes here — no OIDC.
+          NPM_PRIMARY_TOKEN: ${{ secrets.MIDNIGHTBOT_PACKAGES_WRITE }}
+          NPM_LEGACY_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -7,6 +7,13 @@
 //      scope is already `@midnightntwrk`. No token: npm authenticates via
 //      OIDC against the trusted publisher configured on npmjs.
 //
+//      Bootstrap exception: a trusted publisher can only be attached to a
+//      package that already exists on npmjs, so OIDC cannot perform the FIRST
+//      publish of a new package name. When NPM_PRIMARY_TOKEN is set, the
+//      primary scope is published with that token instead (provenance off) to
+//      seed the new names. Run once, attach the trusted publishers on npmjs,
+//      then drop NPM_PRIMARY_TOKEN so subsequent publishes use OIDC.
+//
 //   2. Alias — `@midnight-ntwrk/*`, transitional, so existing consumers of
 //      the dashed scope keep resolving during the migration window. The
 //      package is staged in a temp dir with its name, internal SDK deps, and
@@ -72,8 +79,14 @@ if (publishable.length === 0) {
 }
 
 const legacyToken = process.env.NPM_LEGACY_TOKEN;
+// Bootstrap-only: when set, the primary @midnightntwrk scope is published with
+// this token instead of via OIDC (provenance off). See the header note.
+const primaryToken = process.env.NPM_PRIMARY_TOKEN;
 console.log(`Publishing ${publishable.length} package(s)${values.tag ? ` (dist-tag: ${values.tag})` : ''}:`);
 publishable.forEach((ws) => console.log(`  - ${ws.pkg.name}@${ws.pkg.version} (+ alias ${toAlias(ws.pkg.name)})`));
+if (primaryToken) {
+  console.log('\n⚠ NPM_PRIMARY_TOKEN set — publishing @midnightntwrk with a token (bootstrap, no provenance).');
+}
 if (!legacyToken) {
   console.log('\n⚠ NPM_LEGACY_TOKEN not set — skipping the @midnight-ntwrk alias publish.');
 }
@@ -150,8 +163,11 @@ const publishAlias = (ws) => {
   }
 };
 
-// Publish the primary @midnightntwrk scope via OIDC + provenance. NODE_AUTH_TOKEN
-// is blanked so npm falls back to Trusted Publishing instead of token auth.
+// Publish the primary @midnightntwrk scope. Normally via OIDC + provenance,
+// with NODE_AUTH_TOKEN blanked so npm performs the Trusted Publishing token
+// exchange instead of using the setup-node .npmrc placeholder token. During
+// the migration bootstrap (NPM_PRIMARY_TOKEN set), publishes with that token
+// and no provenance, to seed new package names that OIDC cannot create.
 const publishPrimary = (ws) => {
   const { name, version } = ws.pkg;
   if (isAlreadyPublished(name, version)) {
@@ -159,12 +175,13 @@ const publishPrimary = (ws) => {
     return { name, version, status: 'skipped' };
   }
 
-  console.log(`\nPublishing ${name}@${version} (OIDC + provenance)...`);
+  const provenanceArgs = primaryToken ? [] : ['--provenance'];
+  console.log(`\nPublishing ${name}@${version} (${primaryToken ? 'token bootstrap' : 'OIDC + provenance'})...`);
   try {
-    execFileSync('npm', ['publish', '--provenance', '--access', 'public', ...tagArgs], {
+    execFileSync('npm', ['publish', ...provenanceArgs, '--access', 'public', ...tagArgs], {
       cwd: ws.location,
       stdio: 'inherit',
-      env: { ...process.env, NODE_AUTH_TOKEN: '' },
+      env: { ...process.env, NODE_AUTH_TOKEN: primaryToken ?? '' },
     });
     return { name, version, status: 'published' };
   } catch (err) {


### PR DESCRIPTION
## Why

The first CD run after #479 merged failed: the `canary` job's primary publish errored with `ENEEDAUTH` on every package.

Root cause is the npm Trusted Publishing **bootstrap problem**, not a workflow bug:

- The new `@midnightntwrk/*` packages don't exist on npmjs yet — this run was their first-ever publish (all `404`).
- A trusted publisher can only be attached to a package that **already exists** on npmjs (it's configured on the package's settings page). So OIDC cannot perform the *first* publish of a new package name — npm attempts the token exchange, npmjs has no matching publisher, no token is issued, and the publish falls through to `ENEEDAUTH`.

So each new package needs a one-time token seed; after that, SRE attaches the trusted publisher and OIDC + provenance works for every subsequent publish.

## What

- **`scripts/publish.mjs`**: `publishPrimary` now honours `NPM_PRIMARY_TOKEN`. When set, the primary `@midnightntwrk` scope is published with that token and **without** `--provenance` (token publishes can't emit attestations). When unset, behaviour is unchanged — OIDC + provenance. The `@midnight-ntwrk` alias path is untouched.
- **`.github/workflows/cd.yml`**:
  - New `workflow_dispatch` checkbox input `bootstrap-primary-scope` (default off).
  - New `bootstrap-primary-scope` job, gated `if: ${{ inputs.bootstrap-primary-scope }}` (manual dispatch only — never runs on push). It builds and runs `scripts/publish.mjs` under the default `latest` dist-tag with `NPM_PRIMARY_TOKEN` = `MIDNIGHTBOT_PACKAGES_WRITE` (seeds the new scope) and `NPM_LEGACY_TOKEN` = `MIDNIGHTCI_PACKAGES_WRITE` (alias, as usual). It runs in the `npm-publish-stable` environment so the seed publish goes through the same reviewer gate.

## Rollout

1. Merge this PR.
2. Run **CD** via *Actions → Run workflow* on `main` with **bootstrap-primary-scope ✔**. This token-publishes all `@midnightntwrk/*` packages at their current versions under `latest`, creating the names on npmjs.
3. SRE attaches a Trusted Publisher to each new `@midnightntwrk/*` package (repo `midnightntwrk/midnight-wallet`, workflow `.github/workflows/cd.yml`, environments `npm-publish-stable` and `npm-publish-canary`).
4. Confirm a normal canary run (push to `main`) now publishes via OIDC + provenance.
5. Once confirmed, remove the bootstrap job + dispatch input + the `NPM_PRIMARY_TOKEN` branch in `publish.mjs` (the transitional machinery).

> Note: the alias stays coupled to the primary (a primary failure still skips the `@midnight-ntwrk` alias), so until the bootstrap + trusted-publisher steps are done, normal pushes will not publish either scope. Steps 2–3 should be done promptly after merge.

Relates to the migration in #479 / ADR-0007.