### PR TITLE
docs(release): v1.2.0 release notes

### DIFF
--- a/.changeset/barrel-republish-v1-2-0.md
+++ b/.changeset/barrel-republish-v1-2-0.md
@@ -1,0 +1,8 @@
+---
+'@midnightntwrk/wallet-sdk': minor
+---
+
+Republish the barrel package to track the latest sibling versions shipped in this release
+(facade, dust-wallet, shielded, indexer-client, prover-client, node-client, runtime, hd, and the
+new testkit). No API changes to the barrel itself — the version bump keeps the
+`@midnightntwrk/wallet-sdk` release line aligned with the underlying packages it re-exports.

--- a/release-notes/v1.2.0.md
+++ b/release-notes/v1.2.0.md
@@ -1,0 +1,185 @@
+### Version 1.2.0
+
+**Version:** 1.2.0 **Date:** 2026-06-19 **Environment:** Mainnet, Preprod, Preview
+
+> **Required:** the npm scope has changed from `@midnight-ntwrk` to **`@midnightntwrk`** (no dash). New installs should
+> depend on `@midnightntwrk/*`. The old `@midnight-ntwrk/*` packages continue to be published as a transitional alias
+> during the migration window, so existing consumers keep working, but the dashed scope is deprecated — migrate import
+> paths at your convenience. See [ADR-0007](../docs/decisions/0007-npmjs-trusted-publishing-and-scope-rename.md).
+
+---
+
+### High-level summary
+
+A maintenance release centred on the npm scope migration plus a batch of correctness and resource-leak fixes. Packages
+now publish under the canonical `@midnightntwrk` scope (with `@midnight-ntwrk` kept alive as a transitional alias), via
+npmjs Trusted Publishing with provenance. Functionally: dust registration for fee payment no longer risks a
+`BalanceCheckOverspend` rejection and gains a `waitForGeneratedDust` helper; shielded balancing handles fallible-only
+imbalances; the indexer WebSocket subscription no longer leaks fibers under sustained load; the runtime state-changes
+stream no longer pins past state (and the wasm resources it holds); the prover client works under newer undici; and HD
+key derivation reports out-of-bounds paths cleanly. This release also introduces a new publishable end-to-end test
+harness, `@midnightntwrk/wallet-sdk-testkit`.
+
+---
+
+### Audience
+
+This release is relevant for developers who:
+
+- Build wallets for the Midnight network
+- Integrate Midnight token transfers into their DApps
+- Need to manage shielded (private) and unshielded token balances
+- Implement atomic swaps between parties
+- Maintain long-lived indexer subscriptions or run the SDK's e2e harness against their own infrastructure
+
+---
+
+### What changed (Summary of updates)
+
+- **Scope migration:** packages now publish as `@midnightntwrk/*` (canonical), with `@midnight-ntwrk/*` dual-published
+  as a transitional, deprecated alias. Publishing moves to npmjs Trusted Publishing (OIDC + provenance).
+- **New package** `@midnightntwrk/wallet-sdk-testkit` — a publishable wallet e2e harness so downstream consumers can
+  share it instead of vendoring copies.
+- Fix dust registration for fee payment racing into a `BalanceCheckOverspend` rejection; add
+  `WalletFacade.waitForGeneratedDust(...)` to defer registration until enough dust accrues.
+- Fix shielded `balanceTransaction` failing when the only imbalance is in a fallible segment.
+- Fix a fiber/memory leak in the indexer-client WebSocket subscription stream under sustained push load.
+- Fix the runtime state-changes stream retaining every published state (and its wasm resources) for the lifetime of any
+  subscriber.
+- Fix prover-client requests failing with `invalid content-length header` under undici `>= 8.2.0`.
+- Fix HD `deriveKeyAt` / `deriveKeysAt` leaking a low-level `invalid child index` error for out-of-bounds BIP32 paths.
+- Declare node-client's `./testing` runtime dependencies as optional peer dependencies.
+
+---
+
+### New features
+
+**New package: `@midnightntwrk/wallet-sdk-testkit`**
+
+**Description:** Extracts the reusable wallet end-to-end harness — environment provisioning, wallet bootstrapping, sync
+waiters, and tx-history assertions — into a publishable package so downstream consumers can depend on it rather than
+copying it. Endpoints are injected via a `WalletTestEnvironment` config (`createRemoteEnvironment` /
+`createTestContainersEnvironment`) instead of being read from `process.env`. Shared healthcheck scenarios are
+single-sourced via `registerDustHealthchecks` and `registerTokenTransferHealthchecks`.
+
+---
+
+**`WalletFacade.waitForGeneratedDust(utxos, requiredAmount, opts?)`**
+
+**Description:** Lets callers defer dust registration until enough dust has accrued on the chosen Night UTxOs. Pair it
+with `estimateRegistration` to pick the threshold, so the subsequent registration can cover its own fee. Part of the
+dust-registration fee-coverage fix below.
+
+---
+
+### New features requiring configuration updates
+
+N/A
+
+---
+
+### Improvements
+
+- Indexer-client `ClientError` now preserves the full GraphQL error array as `cause` and joins all error messages,
+  instead of surfacing only the first.
+- Publishing moves to npmjs Trusted Publishing: primary `@midnightntwrk` publishes are tokenless (OIDC) and carry
+  provenance attestations; the `@midnight-ntwrk` alias is generated at publish time from identical bytes.
+
+---
+
+### Deprecations
+
+- **The `@midnight-ntwrk/*` scope is deprecated.** It remains published as a transitional alias during the migration
+  window for backward compatibility. New code should depend on `@midnightntwrk/*`.
+
+---
+
+### Breaking changes or required actions for developers
+
+**npm scope renamed to `@midnightntwrk` (all packages)**
+
+The canonical scope is now `@midnightntwrk` (no dash). Existing consumers depending on `@midnight-ntwrk/*` continue to
+work because the dashed scope is dual-published as an alias, but it is deprecated. To migrate, update your dependency
+names and import specifiers from `@midnight-ntwrk/wallet-sdk*` to `@midnightntwrk/wallet-sdk*`. Note that upstream,
+non-SDK dependencies (`@midnight-ntwrk/ledger-v8`, `wallet-api`, `zkir-v2`, `midnight-js-network-id`) keep the dashed
+scope — they are not part of this rename. See
+[ADR-0007](../docs/decisions/0007-npmjs-trusted-publishing-and-scope-rename.md).
+
+---
+
+**node-client `./testing` runtime dependencies are now optional peer dependencies**
+
+`@midnightntwrk/wallet-sdk-node-client` declares `@midnight-ntwrk/ledger-v8` and
+`@midnightntwrk/wallet-sdk-prover-client` as optional peer dependencies. They are used at runtime by the `./testing`
+export, so consumers of that export must ensure both are installed.
+
+---
+
+### Known issues
+
+N/A
+
+---
+
+### Packages
+
+| Package                                       | Version | Description                                                                                                         |
+| --------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
+| `@midnightntwrk/wallet-sdk`                   | 1.2.0   | Barrel republished to track the latest sibling versions and the new `@midnightntwrk` scope. No API changes.         |
+| `@midnightntwrk/wallet-sdk-facade`            | 4.1.0   | Dust-registration fee-coverage fix; new `waitForGeneratedDust`.                                                     |
+| `@midnightntwrk/wallet-sdk-dust-wallet`       | 4.2.0   | Dust-registration fee-coverage fix (estimate at build time, revert booking, throw before submission).               |
+| `@midnightntwrk/wallet-sdk-shielded`          | 3.0.2   | `balanceTransaction` handles fallible-only imbalances (skips an already-balanced guaranteed section).               |
+| `@midnightntwrk/wallet-sdk-indexer-client`    | 1.2.3   | WebSocket subscription fiber/memory-leak fix (`Stream.asyncPush`); preserves full GraphQL error array.              |
+| `@midnightntwrk/wallet-sdk-prover-client`     | 1.2.3   | No longer sends an explicit `content-length` header; fixes `invalid content-length header` under undici `>= 8.2.0`. |
+| `@midnightntwrk/wallet-sdk-node-client`       | 1.1.3   | Declares `ledger-v8` and `prover-client` as optional peer deps for the `./testing` export.                          |
+| `@midnightntwrk/wallet-sdk-runtime`           | 1.0.5   | State-changes stream no longer pins past states (per-subscriber sliding buffer; latest-value semantics).            |
+| `@midnightntwrk/wallet-sdk-hd`                | 3.0.3   | `deriveKeyAt` / `deriveKeysAt` return `keyOutOfBounds` for invalid BIP32 path components.                           |
+| `@midnightntwrk/wallet-sdk-testkit`           | 0.2.0   | **New** publishable wallet e2e harness (env provisioning, bootstrapping, sync waiters, tx-history assertions).      |
+| `@midnightntwrk/wallet-sdk-capabilities`      | 3.3.1   | Unchanged.                                                                                                          |
+| `@midnightntwrk/wallet-sdk-abstractions`      | 2.1.0   | Unchanged.                                                                                                          |
+| `@midnightntwrk/wallet-sdk-address-format`    | 3.1.2   | Unchanged.                                                                                                          |
+| `@midnightntwrk/wallet-sdk-unshielded-wallet` | 3.1.0   | Unchanged.                                                                                                          |
+| `@midnightntwrk/wallet-sdk-utilities`         | 1.2.0   | Unchanged.                                                                                                          |
+
+---
+
+### Links and references
+
+- ADR-0007:
+  [npmjs Trusted Publishing and scope rename](../docs/decisions/0007-npmjs-trusted-publishing-and-scope-rename.md)
+- Examples: [`packages/docs-snippets`](../packages/docs-snippets)
+- GitHub Repository: [midnightntwrk/midnight-wallet](https://github.com/midnightntwrk/midnight-wallet)
+- DApp Connector API:
+  [midnightntwrk/midnight-dapp-connector-api](https://github.com/midnightntwrk/midnight-dapp-connector-api)
+
+---
+
+### Fixed defect list
+
+- Dust registration for fee payment (`WalletFacade.registerNightUtxosForDustGeneration`) could build a registration
+  whose `allow_fee_payment` was below its own fee, causing the chain to reject submission with `BalanceCheckOverspend`.
+  The wallet now estimates the fee at build time, reverts the booking, and throws before submission. A new
+  `WalletFacade.waitForGeneratedDust(utxos, requiredAmount, opts?)` lets callers defer registration until enough dust
+  has accrued (pair with `estimateRegistration` to pick the threshold).
+- Shielded `balanceTransaction` failed with "Could not create a valid guaranteed offer" when a transaction's only
+  imbalance was in a fallible segment. The guaranteed section is now skipped when already balanced instead of attempting
+  to build an empty guaranteed offer.
+- Fiber/memory leak in the indexer-client WebSocket subscription stream. At the indexer's sustained ~1k msg/sec push
+  rate, `Stream.async` forked a top-level fiber per emit (via `Runtime.runPromiseExit`) and accumulated them in Effect's
+  `Global.roots`. Switched to `Stream.asyncPush`, which writes straight to an internal queue and ties teardown to the
+  surrounding scope via `Effect.acquireRelease`. `ClientError` now also preserves the full GraphQL error array as
+  `cause` and joins all error messages instead of dropping all but the first.
+- Runtime state-changes stream retained every published state for the lifetime of any subscriber. The shared
+  unbounded-with-replay PubSub appended every published value to a shared linked list whose head a subscription's replay
+  window never released, so a long-lived subscriber pinned every state published during its lifetime (and the wasm
+  resources those states hold). Replaced with per-subscriber `SubscriptionRef.changes` decoupled by a sliding buffer of
+  capacity 1 — latest-value semantics, memory bounded to the current state plus at most one buffered state per
+  subscriber.
+- Prover-client requests failed with `invalid content-length header` when undici `>= 8.2.0` was the process-wide fetch
+  dispatcher (pulled in transitively by importing e.g. testcontainers or `@effect/platform-node`). The HTTP prover
+  client no longer sets an explicit `content-length` header and lets `fetch` derive it from the body.
+- HD `deriveKeyAt` / `deriveKeysAt` leaked the underlying `invalid child index` error from `@scure/bip32` for invalid
+  BIP32 path components. They now return `keyOutOfBounds` for non-integer, negative, or `>= 2^31` account/role/index
+  values.
+- `@midnightntwrk/wallet-sdk-node-client` did not declare the runtime dependencies of its `./testing` export. It now
+  declares `@midnight-ntwrk/ledger-v8` and `@midnightntwrk/wallet-sdk-prover-client` as optional peer dependencies.


### PR DESCRIPTION
Adds `release-notes/v1.2.0.md` and a `minor` changeset for `@midnightntwrk/wallet-sdk` so the barrel republishes as 1.2.0 (the version the release-notes filename tracks).