### PR TITLE
chore(ci): use MIDNIGHTCI_NPMJS_TOKEN for the @midnightntwrk bootstrap

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -286,7 +286,7 @@ jobs:
   # first publish of each new @midnightntwrk package cannot use OIDC — a trusted
   # publisher can only be attached to a package that already exists on npmjs. So
   # this job seeds the new package names by publishing the current versions
-  # under the `latest` dist-tag with the MIDNIGHTBOT token (scripts/publish.mjs
+  # under the `latest` dist-tag with the MIDNIGHTCI npmjs token (publish.mjs
   # sees it as NPM_PRIMARY_TOKEN and skips provenance). After running once and
   # attaching trusted publishers on npmjs, this job and its dispatch input can
   # be removed and publishing reverts to OIDC.
@@ -333,5 +333,5 @@ jobs:
           # Token-publish the primary @midnightntwrk scope (provenance disabled)
           # to create the package names; the @midnight-ntwrk alias uses the
           # legacy token as usual. Both are token publishes here — no OIDC.
-          NPM_PRIMARY_TOKEN: ${{ secrets.MIDNIGHTBOT_PACKAGES_WRITE }}
+          NPM_PRIMARY_TOKEN: ${{ secrets.MIDNIGHTCI_NPMJS_TOKEN }}
           NPM_LEGACY_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}


### PR DESCRIPTION
## Why

The bootstrap run failed with `E404` on every `PUT` to npmjs:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@midnightntwrk%2fwallet-sdk-testkit
npm error 404  '@midnightntwrk/wallet-sdk-testkit@0.2.0' is not in this registry.
```

Auth succeeded (no `ENEEDAUTH`), but `MIDNIGHTBOT_PACKAGES_WRITE` is not authorized to publish to the `@midnightntwrk` scope — npm returns 404 on publish when the account lacks write access to the org/scope. The token that *does* have `midnightntwrk` org access is `MIDNIGHTCI_NPMJS_TOKEN`.

## What

Switch the bootstrap job's `NPM_PRIMARY_TOKEN` from `MIDNIGHTBOT_PACKAGES_WRITE` to `MIDNIGHTCI_NPMJS_TOKEN`. Nothing else changes — still a one-time, manual-dispatch, opt-in (`bootstrap-primary-scope` checkbox) job that token-publishes the new scope under `latest` with provenance disabled.

## Rollout

After merge, re-dispatch **CD** on `main` with **bootstrap-primary-scope ✔**. Once the `@midnightntwrk` names exist on npmjs, SRE attaches trusted publishers (both environments), then the bootstrap machinery can be removed and publishing reverts to OIDC.