### PR TITLE
fix(ci): make the @midnight-ntwrk alias publish to npmjs (registry + token)

### DIFF
--- a/.changeset/testkit-alias-npmjs-publish.md
+++ b/.changeset/testkit-alias-npmjs-publish.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(ci): publish the wallet-sdk-testkit package and the @midnight-ntwrk alias to npmjs (registry + dashed-org token)

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,9 +10,9 @@ env:
   #       repo: <owner>/<this-repo>
   #       workflow: .github/workflows/cd.yml
   #       environment: npm-publish-stable (publish-stable) or npm-publish-canary
-  #   • @midnight-ntwrk/* (transitional alias) authenticated with the legacy
-  #     MIDNIGHTCI_PACKAGES_WRITE token, surfaced to scripts/publish.mjs as
-  #     NPM_LEGACY_TOKEN. Drop this once consumers have moved to the new scope.
+  #   • @midnight-ntwrk/* (transitional alias) authenticated with the dashed
+  #     org's npmjs token MIDNIGHTCI_NPM_TOKEN, surfaced to scripts/publish.mjs
+  #     as NPM_LEGACY_TOKEN. Drop this once consumers have moved to the new scope.
   # Docs: https://docs.npmjs.com/trusted-publishers
 
 on:
@@ -176,7 +176,7 @@ jobs:
           # blanks NODE_AUTH_TOKEN so npm uses Trusted Publishing + provenance.
           # NPM_LEGACY_TOKEN authenticates the transitional @midnight-ntwrk
           # alias publish only; the primary stays OIDC-only.
-          NPM_LEGACY_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+          NPM_LEGACY_TOKEN: ${{ secrets.MIDNIGHTCI_NPM_TOKEN }}
 
   canary:
     name: Canary (snapshot publish)
@@ -223,7 +223,7 @@ jobs:
           GITHUB_TOKEN: ${{ env.MIDNIGHT_GH_TOKEN }}
           # Authenticates the transitional @midnight-ntwrk alias publish; the
           # primary @midnightntwrk publish stays OIDC-only (see release job).
-          NPM_LEGACY_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+          NPM_LEGACY_TOKEN: ${{ secrets.MIDNIGHTCI_NPM_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -334,4 +334,4 @@ jobs:
           # to create the package names; the @midnight-ntwrk alias uses the
           # legacy token as usual. Both are token publishes here — no OIDC.
           NPM_PRIMARY_TOKEN: ${{ secrets.MIDNIGHTCI_NPMJS_TOKEN }}
-          NPM_LEGACY_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+          NPM_LEGACY_TOKEN: ${{ secrets.MIDNIGHTCI_NPM_TOKEN }}

--- a/packages/wallet-sdk-testkit/package.json
+++ b/packages/wallet-sdk-testkit/package.json
@@ -9,7 +9,8 @@
   "author": "Midnight Foundation",
   "license": "Apache-2.0",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "files": [
     "dist/"


### PR DESCRIPTION
## Why

The `@midnightntwrk` bootstrap run published all 15 primary packages fine, but every `@midnight-ntwrk` alias publish failed — for two distinct reasons:

1. **`@midnight-ntwrk/wallet-sdk-testkit` hit `ENEEDAUTH` against `https://npm.pkg.github.com/`.** `packages/wallet-sdk-testkit/package.json` still had `publishConfig.registry: https://npm.pkg.github.com/` (leftover from #441) while every other package was migrated to npmjs. The primary publish reached npmjs only because the `@midnightntwrk:registry` scope config (set by setup-node) overrides `publishConfig.registry`; the dashed alias has no such override, so it fell through to GitHub Packages.
2. **The other alias publishes hit `E404` on the npmjs `PUT`.** `NPM_LEGACY_TOKEN` was wired to `MIDNIGHTCI_PACKAGES_WRITE`, which is a GitHub token (also used for `MIDNIGHT_GH_TOKEN` and the changesets API), not an npmjs token with publish rights to the dashed scope.

## What

- **`packages/wallet-sdk-testkit/package.json`** — point `publishConfig` at npmjs with public access, matching every other package.
- **`.github/workflows/cd.yml`** — switch `NPM_LEGACY_TOKEN` (alias auth, all three jobs: canary, publish-stable, bootstrap) from `MIDNIGHTCI_PACKAGES_WRITE` to **`MIDNIGHTCI_NPM_TOKEN`**, the npmjs token for the dashed `midnight-ntwrk` org. `MIDNIGHT_GH_TOKEN` (line 5) is unchanged — it's correctly the GitHub token.

Token map after this change:
| Scope | Token | Auth |
|---|---|---|
| `@midnightntwrk/*` (primary) | OIDC; `MIDNIGHTCI_NPMJS_TOKEN` for the one-time bootstrap | Trusted Publishing / token |
| `@midnight-ntwrk/*` (alias) | `MIDNIGHTCI_NPM_TOKEN` | token |
| GitHub Packages install + changesets API | `MIDNIGHTCI_PACKAGES_WRITE` | GitHub PAT |