### PR TITLE
fix(ci): canary publishes a coherent all-package OIDC snapshot, gated on package-bumping changesets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,15 +24,14 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      # 'false' only on the push that merges the release PR (no changesets
-      # left) — the signal publish-stable uses to publish. Every other PR
-      # carries a changeset (enforced by changeset:check), so this stays
-      # 'true' until a real release lands and never triggers a spurious gate.
-      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
-      # 'true' when at least one pending changeset actually bumps a package —
-      # the signal canary uses to publish. Empty (docs/CI) changesets bump
-      # nothing, so this is 'false' for them and canary correctly skips.
-      hasReleases: ${{ steps.releases.outputs.hasReleases }}
+      # Single publish-mode signal the downstream jobs gate on, so at most one
+      # can ever fire. Resolved by the "Resolve publish mode" step from two
+      # internal signals (hasChangesets from changesets/action, hasReleases from
+      # the detect step below):
+      #   'stable' → release PR merged: no changesets left → publish canonical
+      #   'canary' → pending package-bumping changeset(s) → publish snapshot
+      #   'none'   → docs/CI-only (empty changeset): publish nothing
+      mode: ${{ steps.mode.outputs.mode }}
     concurrency:
       group: version-${{ github.ref_name }}
       cancel-in-progress: false
@@ -40,13 +39,13 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # No registry-url/scope here: this job only opens the release PR, it never
+      # runs `npm publish` (those are set on the publish-stable/canary jobs).
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
           cache-dependency-path: 'yarn.lock'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@midnightntwrk'
 
       - name: Enable corepack
         run: corepack enable
@@ -80,7 +79,7 @@ jobs:
       # changesets in the workspace. `releases` in the status JSON lists only
       # packages that would actually be bumped (empty changesets contribute
       # nothing), so its length is the precise "is there a real change to
-      # snapshot" signal canary gates on.
+      # snapshot" signal that resolves `mode` to 'canary'.
       - name: Detect package-bumping changesets
         id: releases
         run: |
@@ -113,6 +112,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ env.MIDNIGHT_GH_TOKEN }}
 
+      # Collapse the two signals into one mutually-exclusive mode (see the
+      # `mode` job output above). hasChangesets == 'false' wins as 'stable':
+      # when the release PR merges there are no changesets left, so hasReleases
+      # is 'false' too and there is no ambiguity.
+      - name: Resolve publish mode
+        id: mode
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.changesets.outputs.hasChangesets }}" = "false" ]; then
+            MODE=stable
+          elif [ "${{ steps.releases.outputs.hasReleases }}" = "true" ]; then
+            MODE=canary
+          else
+            MODE=none
+          fi
+          echo "Resolved publish mode: ${MODE}"
+          echo "mode=${MODE}" >> "$GITHUB_OUTPUT"
+
   # Publishes stable packages (primary @midnightntwrk + @midnight-ntwrk alias).
   # Runs only on the push that merged the release PR (no changesets left) and
   # is gated by the npm-publish-stable environment. Independent of canary, so
@@ -120,7 +137,7 @@ jobs:
   publish-stable:
     name: Publish (stable)
     needs: [version]
-    if: needs.version.outputs.hasChangesets == 'false'
+    if: needs.version.outputs.mode == 'stable'
     runs-on: ubuntu-latest-8-core-x64
     # Human gate: this environment must require reviewer approval before the
     # job can run. Configure required reviewers in repo
@@ -188,10 +205,10 @@ jobs:
     name: Canary (snapshot publish)
     needs: [version]
     # Publish a snapshot only when there are pending package-bumping changesets
-    # (real unreleased changes). Mutually exclusive with publish-stable, which
-    # runs on hasChangesets == 'false'. `version` is ungated, so this dependency
-    # adds no reviewer gate — it just provides the signal.
-    if: needs.version.outputs.hasReleases == 'true'
+    # (real unreleased changes). Mutually exclusive with publish-stable by
+    # construction (see the `mode` output). `version` is ungated, so this
+    # dependency adds no reviewer gate — it just provides the signal.
+    if: needs.version.outputs.mode == 'canary'
     runs-on: ubuntu-latest-8-core-x64
     # Canary has its own environment only to scope the npmjs Trusted Publisher
     # per release type — no required reviewers here, so snapshot publishing is
@@ -216,7 +233,7 @@ jobs:
           scope: '@midnightntwrk'
 
       - name: Upgrade npm to a Trusted Publishing-capable version
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.17.0
 
       - name: Enable corepack
         run: corepack enable

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,28 +4,8 @@ env:
   MIDNIGHT_GH_USER: ${{ secrets.GH_USERNAME }}
   MIDNIGHT_GH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
   MIDNIGHTCI_GPG_PRIVATE_KEY: ${{ secrets.MIDNIGHTCI_GPG_PRIVATE_KEY }}
-  # Packages publish to npmjs under TWO scopes during the org migration:
-  #   • @midnightntwrk/* (primary) via npm Trusted Publishing (OIDC) — no
-  #     long-lived token. Each package needs a Trusted Publisher on npmjs:
-  #       repo: <owner>/<this-repo>
-  #       workflow: .github/workflows/cd.yml
-  #       environment: npm-publish-stable (publish-stable) or npm-publish-canary
-  #   • @midnight-ntwrk/* (transitional alias) authenticated with the dashed
-  #     org's npmjs token MIDNIGHTCI_NPMJS_TOKEN, surfaced to scripts/publish.mjs
-  #     as NPM_LEGACY_TOKEN. Drop this once consumers have moved to the new scope.
-  # Docs: https://docs.npmjs.com/trusted-publishers
 
 on:
-  workflow_dispatch:
-    inputs:
-      bootstrap-primary-scope:
-        description: >-
-          One-time migration bootstrap. Publishes the @midnightntwrk scope with a token (provenance disabled) to seed
-          the new package names on npmjs. A trusted publisher can only be attached to a package that already exists, so
-          OIDC cannot perform the first publish. Run once, attach the trusted publishers on npmjs, then leave this off
-          so publishes use OIDC.
-        type: boolean
-        default: false
   push:
     branches:
       - main
@@ -49,6 +29,10 @@ jobs:
       # carries a changeset (enforced by changeset:check), so this stays
       # 'true' until a real release lands and never triggers a spurious gate.
       hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
+      # 'true' when at least one pending changeset actually bumps a package —
+      # the signal canary uses to publish. Empty (docs/CI) changesets bump
+      # nothing, so this is 'false' for them and canary correctly skips.
+      hasReleases: ${{ steps.releases.outputs.hasReleases }}
     concurrency:
       group: version-${{ github.ref_name }}
       cancel-in-progress: false
@@ -91,6 +75,32 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --immutable
+
+      # Must run BEFORE the changesets action: `changeset version` consumes the
+      # changesets in the workspace. `releases` in the status JSON lists only
+      # packages that would actually be bumped (empty changesets contribute
+      # nothing), so its length is the precise "is there a real change to
+      # snapshot" signal canary gates on.
+      - name: Detect package-bumping changesets
+        id: releases
+        run: |
+          set -uo pipefail   # no -e: we handle status's exit code ourselves
+          rm -f changeset-status.json
+          # status exits 1 if packages changed without a changeset (possible on
+          # v2 where the diff vs main is non-empty); treat any failure / missing
+          # output as "no releasing changesets".
+          yarn changeset status --output=changeset-status.json || true
+          if [ -f changeset-status.json ]; then
+            COUNT=$(node -p "require('./changeset-status.json').releases.length" 2>/dev/null || echo 0)
+          else
+            COUNT=0
+          fi
+          rm -f changeset-status.json
+          if [ "${COUNT:-0}" -gt 0 ]; then
+            echo "hasReleases=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "hasReleases=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create / update Release Pull Request
         id: changesets
@@ -167,25 +177,25 @@ jobs:
         run: yarn install --immutable
 
       - name: Build, publish (both scopes), and tag
+        # Both scopes publish via OIDC + provenance (see scripts/publish.mjs).
         run: |
           yarn changeset:publish
           git push origin --tags
         env:
           GITHUB_TOKEN: ${{ env.MIDNIGHT_GH_TOKEN }}
-          # Primary @midnightntwrk publishes via OIDC — scripts/publish.mjs
-          # blanks NODE_AUTH_TOKEN so npm uses Trusted Publishing + provenance.
-          # NPM_LEGACY_TOKEN authenticates the transitional @midnight-ntwrk
-          # alias publish only; the primary stays OIDC-only.
-          NPM_LEGACY_TOKEN: ${{ secrets.MIDNIGHTCI_NPMJS_TOKEN }}
 
   canary:
     name: Canary (snapshot publish)
+    needs: [version]
+    # Publish a snapshot only when there are pending package-bumping changesets
+    # (real unreleased changes). Mutually exclusive with publish-stable, which
+    # runs on hasChangesets == 'false'. `version` is ungated, so this dependency
+    # adds no reviewer gate — it just provides the signal.
+    if: needs.version.outputs.hasReleases == 'true'
     runs-on: ubuntu-latest-8-core-x64
-    # Intentionally independent of the stable jobs: canary must publish
-    # automatically on every main push, so it must not be gated by (or depend
-    # on) the reviewer-gated publish-stable job. Its own environment exists
-    # only to scope the npmjs Trusted Publisher per release type — no required
-    # reviewers here.
+    # Canary has its own environment only to scope the npmjs Trusted Publisher
+    # per release type — no required reviewers here, so snapshot publishing is
+    # never blocked on approval.
     environment: npm-publish-canary
     permissions:
       contents: read
@@ -221,9 +231,6 @@ jobs:
       - name: Snapshot version + publish canary
         env:
           GITHUB_TOKEN: ${{ env.MIDNIGHT_GH_TOKEN }}
-          # Authenticates the transitional @midnight-ntwrk alias publish; the
-          # primary @midnightntwrk publish stays OIDC-only (see release job).
-          NPM_LEGACY_TOKEN: ${{ secrets.MIDNIGHTCI_NPMJS_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -257,6 +264,14 @@ jobs:
             fs.writeFileSync(path, JSON.stringify(config, null, 2) + "\n");
           '
 
+          # Snapshot the ENTIRE SDK as one coherent set from this commit:
+          # `changeset version --snapshot` only versions packages named in a
+          # changeset (+ dependents), so without this the canary dist-tag would
+          # be inconsistent across packages. This writes a temporary changeset
+          # patch-bumping every publishable package (discarded by Cleanup); real
+          # changesets still win with their minor/major bumps.
+          node scripts/write-canary-changeset.mjs
+
           # Apply snapshot versions
           yarn changeset version --snapshot canary.${TIMESTAMP}-${SHORT_SHA}
 
@@ -281,57 +296,3 @@ jobs:
         run: |
           git reset --hard
           git clean -fd
-
-  # One-time migration bootstrap (manual dispatch only, opt-in checkbox). The
-  # first publish of each new @midnightntwrk package cannot use OIDC — a trusted
-  # publisher can only be attached to a package that already exists on npmjs. So
-  # this job seeds the new package names by publishing the current versions
-  # under the `latest` dist-tag with the MIDNIGHTCI npmjs token (publish.mjs
-  # sees it as NPM_PRIMARY_TOKEN and skips provenance). After running once and
-  # attaching trusted publishers on npmjs, this job and its dispatch input can
-  # be removed and publishing reverts to OIDC.
-  bootstrap-primary-scope:
-    name: Bootstrap @midnightntwrk (one-time, token)
-    if: ${{ inputs.bootstrap-primary-scope }}
-    runs-on: ubuntu-latest-8-core-x64
-    # Reuse the stable environment so the bootstrap publish goes through the
-    # same reviewer gate; token auth ignores the per-environment OIDC publisher.
-    environment: npm-publish-stable
-    permissions:
-      contents: read
-    concurrency:
-      group: bootstrap-primary-scope-${{ github.ref_name }}
-      cancel-in-progress: false
-
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-          cache-dependency-path: 'yarn.lock'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@midnightntwrk'
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Configure yarn (install-time auth for GH Packages)
-        run: |
-          yarn config set 'npmScopes.midnight-ntwrk.npmAuthToken' "${{ env.MIDNIGHT_GH_TOKEN }}"
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Build
-        run: yarn dist:publish
-
-      - name: Publish both scopes with tokens (seed @midnightntwrk under latest)
-        run: node scripts/publish.mjs
-        env:
-          # Token-publish the primary @midnightntwrk scope (provenance disabled)
-          # to create the package names; the @midnight-ntwrk alias uses the
-          # legacy token as usual. Both are token publishes here — no OIDC.
-          NPM_PRIMARY_TOKEN: ${{ secrets.MIDNIGHTCI_NPMJS_TOKEN }}
-          NPM_LEGACY_TOKEN: ${{ secrets.MIDNIGHTCI_NPMJS_TOKEN }}

--- a/docs/decisions/0007-npmjs-trusted-publishing-and-scope-rename.md
+++ b/docs/decisions/0007-npmjs-trusted-publishing-and-scope-rename.md
@@ -45,21 +45,25 @@ publish time. Both scopes publish via OIDC + provenance — there are no long-li
 
 `.github/workflows/cd.yml` runs three jobs on every push to `main`/`v2`:
 
-- **`version`** (ungated) — runs `changesets/action` to create/update the "Version Packages" PR. Exposes two outputs the
-  publish jobs gate on: `hasChangesets` (any changeset files present) and `hasReleases` (any pending changeset actually
-  bumps a package, via `changeset status --output`).
+- **`version`** (ungated) — runs `changesets/action` to create/update the "Version Packages" PR, then resolves a single
+  `mode` output the publish jobs gate on. `mode` is derived from two internal signals: `hasChangesets` (any changeset
+  files present, from the action) and `hasReleases` (any pending changeset actually bumps a package, via
+  `changeset status --output`). It is `stable` when no changesets remain, `canary` when a package-bumping changeset is
+  pending, and `none` otherwise.
 - **`publish-stable`** (gated by the `npm-publish-stable` environment, with required reviewers) — `needs: [version]`,
-  runs when `hasChangesets == 'false'`. Publishes canonical versions of both scopes and pushes git tags.
+  runs when `mode == 'stable'`. Publishes canonical versions of both scopes and pushes git tags.
 - **`canary`** (environment `npm-publish-canary`, no required reviewers) — `needs: [version]`, runs when
-  `hasReleases == 'true'`. Publishes a snapshot of both scopes under the `canary` dist-tag.
+  `mode == 'canary'`. Publishes a snapshot of both scopes under the `canary` dist-tag.
 
-The two `if` conditions are mutually exclusive, so a push triggers **exactly one** publishing scenario, or neither:
+A single `mode` output drives both publish jobs, so a push triggers **exactly one** publishing scenario, or neither
+(`mode == 'stable'` wins whenever no changesets remain, which also implies `hasReleases` is `false`, so the two can
+never collide):
 
-| Push                           | `hasChangesets` | `hasReleases` | Result                       |
-| ------------------------------ | --------------- | ------------- | ---------------------------- |
-| "Version Packages" PR merged   | `false`         | `false`       | `publish-stable` → canonical |
-| Pending package-bumping change | `true`          | `true`        | `canary` → snapshot          |
-| Docs/CI-only (empty changeset) | `true`          | `false`       | neither                      |
+| Push                           | `hasChangesets` | `hasReleases` | `mode`   | Result                       |
+| ------------------------------ | --------------- | ------------- | -------- | ---------------------------- |
+| "Version Packages" PR merged   | `false`         | `false`       | `stable` | `publish-stable` → canonical |
+| Pending package-bumping change | `true`          | `true`        | `canary` | `canary` → snapshot          |
+| Docs/CI-only (empty changeset) | `true`          | `false`       | `none`   | neither                      |
 
 ### Canary publishes all packages as one coherent set
 

--- a/docs/decisions/0007-npmjs-trusted-publishing-and-scope-rename.md
+++ b/docs/decisions/0007-npmjs-trusted-publishing-and-scope-rename.md
@@ -6,6 +6,14 @@
 
 Technical Story: migrate CD off GitHub Packages and onto the `@midnightntwrk` npm org.
 
+> **Update (2026-06-22):** Trusted Publishing was subsequently configured on npmjs for the dashed `@midnight-ntwrk`
+> scope too, so the transitional alias now publishes via **OIDC + `--provenance`** as well — the token-based alias auth
+> (`NPM_LEGACY_TOKEN`) and the one-time bootstrap job have been removed, and both scopes now publish identically and
+> tokenlessly. The "Auth differs per scope" specifics and the related negative consequences below are kept for history
+> but no longer reflect the implementation. CD topology is now three jobs — `version` (ungated, manages the release PR),
+> `publish-stable` (gated, runs when the release PR merges), and `canary` (snapshot). Canary publishes only when there
+> are pending package-bumping changesets and snapshots **all** publishable packages as one coherent set from the commit.
+
 ## Context and Problem Statement
 
 The Wallet SDK has historically published under the `@midnight-ntwrk` scope to GitHub Packages, authenticated with a

--- a/docs/decisions/0007-npmjs-trusted-publishing-and-scope-rename.md
+++ b/docs/decisions/0007-npmjs-trusted-publishing-and-scope-rename.md
@@ -2,123 +2,87 @@
 
 - Status: accepted
 - Deciders: Agron Murtezi, SRE team
-- Date: 2026-06-18
+- Date: 2026-06-18 (updated 2026-06-22)
 
 Technical Story: migrate CD off GitHub Packages and onto the `@midnightntwrk` npm org.
 
-> **Update (2026-06-22):** Trusted Publishing was subsequently configured on npmjs for the dashed `@midnight-ntwrk`
-> scope too, so the transitional alias now publishes via **OIDC + `--provenance`** as well — the token-based alias auth
-> (`NPM_LEGACY_TOKEN`) and the one-time bootstrap job have been removed, and both scopes now publish identically and
-> tokenlessly. The "Auth differs per scope" specifics and the related negative consequences below are kept for history
-> but no longer reflect the implementation. CD topology is now three jobs — `version` (ungated, manages the release PR),
-> `publish-stable` (gated, runs when the release PR merges), and `canary` (snapshot). Canary publishes only when there
-> are pending package-bumping changesets and snapshots **all** publishable packages as one coherent set from the commit.
-
 ## Context and Problem Statement
 
-The Wallet SDK has historically published under the `@midnight-ntwrk` scope to GitHub Packages, authenticated with a
-long-lived PAT. Two things need to change at once:
+The Wallet SDK historically published under the `@midnight-ntwrk` scope to GitHub Packages, authenticated with a
+long-lived PAT. Two things needed to change at once:
 
 - **Registry & auth:** move to npmjs with [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) so
   publishes are tokenless and carry provenance attestations, gated behind environments with human review for stable
   releases.
-- **Scope:** the new npm org is `midnightntwrk` (no dash), so packages must publish under `@midnightntwrk/*` rather than
+- **Scope:** the new npm org is `midnightntwrk` (no dash), so packages publish under `@midnightntwrk/*` rather than
   `@midnight-ntwrk/*`.
 
-A hard cut-over would break every existing consumer that depends on `@midnight-ntwrk/*`. How do we change registry,
-auth, and scope without breaking downstream consumers, and without standing up throwaway infrastructure for a temporary
-state?
+A hard cut-over would break every existing consumer of `@midnight-ntwrk/*`, so the dashed scope is kept alive as a
+transitional alias during the migration window.
 
-## Decision Drivers
+## Decision
 
-- Do not break existing consumers of `@midnight-ntwrk/*` during the migration window.
-- Prefer tokenless, attestable publishing (OIDC + provenance) for the canonical packages.
-- Keep the build graph and developer workflow stable — a scope rename must not destabilise local dev or CI.
-- Avoid building the monorepo twice or shipping non-identical bytes under the two scopes.
-- Keep the transitional machinery cheap to remove, since it is temporary by design.
-- Upstream `@midnight-ntwrk/*` dependencies (`ledger-v8`, `wallet-api`, `zkir-v2`, `midnight-js-network-id`) are not
-  ours and continue to live on GitHub Packages — they must remain dashed everywhere.
+Dual-publish both scopes from npmjs, with `@midnightntwrk` canonical in source and `@midnight-ntwrk` generated at
+publish time. Both scopes publish via OIDC + provenance — there are no long-lived publish tokens.
 
-## Considered Options
+### Scopes
 
-1. **Hard cut-over** to `@midnightntwrk` only.
-2. **Dual-publish** both scopes during a migration window, with `@midnightntwrk` as the canonical scope in source and
-   `@midnight-ntwrk` generated as a transitional alias.
-3. **Dual-publish with the alias as the source scope** — keep `@midnight-ntwrk` in source and generate `@midnightntwrk`
-   at publish time.
+- **Source tree uses `@midnightntwrk`.** Package names, internal SDK dependency ranges, source imports, changesets, and
+  the lockfile are all on the dashless scope.
+- **`@midnight-ntwrk` is a publish-time alias.** `scripts/publish.mjs` stages a copy of each package in a temp dir and
+  rewrites the name, internal SDK deps, and compiled `dist/**` import specifiers back to the dashed scope, then
+  publishes it. The working tree stays pristine (so `changeset tag` tags the canonical scope). The alias README carries
+  a migration banner pointing at the `@midnightntwrk` equivalent.
+- **Both scopes publish via OIDC + `npm publish --provenance`** — no token in the environment, so npm performs the
+  Trusted Publishing token exchange. Each package, **under both scopes**, needs a Trusted Publisher configured on npmjs:
+  - repo: `<owner>/<this-repo>`
+  - workflow: `.github/workflows/cd.yml`
+  - environment: `npm-publish-stable` or `npm-publish-canary`
+- **Upstream dashed dependencies** (`ledger-v8`, `wallet-api`, `zkir-v2`, `midnight-js-network-id`) are not ours and
+  remain on GitHub Packages — install-time auth uses a read PAT; they stay dashed everywhere.
 
-For the dual-publish mechanics, two sub-questions:
+### CD topology and publishing scenarios
 
-- **Where the alias rename lives:** publish-time-only (leave source on `@midnight-ntwrk`) vs. rename the source tree to
-  `@midnightntwrk` and rewrite back to dashed at publish time.
-- **Job topology:** one job publishing both scopes vs. a separate job per scope.
+`.github/workflows/cd.yml` runs three jobs on every push to `main`/`v2`:
 
-## Decision Outcome
+- **`version`** (ungated) — runs `changesets/action` to create/update the "Version Packages" PR. Exposes two outputs the
+  publish jobs gate on: `hasChangesets` (any changeset files present) and `hasReleases` (any pending changeset actually
+  bumps a package, via `changeset status --output`).
+- **`publish-stable`** (gated by the `npm-publish-stable` environment, with required reviewers) — `needs: [version]`,
+  runs when `hasChangesets == 'false'`. Publishes canonical versions of both scopes and pushes git tags.
+- **`canary`** (environment `npm-publish-canary`, no required reviewers) — `needs: [version]`, runs when
+  `hasReleases == 'true'`. Publishes a snapshot of both scopes under the `canary` dist-tag.
 
-Chosen: **option 2 — dual-publish with `@midnightntwrk` canonical in source**, with these specifics:
+The two `if` conditions are mutually exclusive, so a push triggers **exactly one** publishing scenario, or neither:
 
-- **Source tree uses `@midnightntwrk`.** The rename touches package names, internal SDK dependency ranges, ~172 source
-  import references, changesets, and the lockfile. Upstream dashed deps are left untouched.
-- **The `@midnight-ntwrk` alias is generated at publish time.** `scripts/publish.mjs` stages a copy of each package in a
-  temp dir and rewrites the name, internal SDK deps, and compiled `dist/**` import specifiers back to the dashed scope.
-  The working tree stays pristine (so `changeset tag` tags the canonical scope).
-- **Auth differs per scope.** Primary `@midnightntwrk` publishes via OIDC with `npm publish --provenance` (no token).
-  The alias publishes with the legacy `MIDNIGHTCI_PACKAGES_WRITE` token (surfaced as `NPM_LEGACY_TOKEN`), without
-  provenance — token publishes cannot emit OIDC attestations. The script blanks `NODE_AUTH_TOKEN` for the primary
-  publish so npm falls back to OIDC.
-- **One job per release type publishes both scopes.** The two CD jobs (`release` stable + gated, `canary` snapshot) each
-  invoke the single dual-publishing script. Both scopes ship from the same checkout and the same built `dist/`.
-- **The alias README carries a migration banner** pointing consumers at the `@midnightntwrk` equivalent.
+| Push                           | `hasChangesets` | `hasReleases` | Result                       |
+| ------------------------------ | --------------- | ------------- | ---------------------------- |
+| "Version Packages" PR merged   | `false`         | `false`       | `publish-stable` → canonical |
+| Pending package-bumping change | `true`          | `true`        | `canary` → snapshot          |
+| Docs/CI-only (empty changeset) | `true`          | `false`       | neither                      |
 
-The alias is removed (script branch + `NPM_LEGACY_TOKEN` + token rotation) once consumers have migrated.
+### Canary publishes all packages as one coherent set
 
-### Positive Consequences
+`changeset version --snapshot` only versions packages named in a changeset (plus their dependents), which would leave
+the `canary` dist-tag inconsistent across packages. Before snapshotting, the canary job runs
+`scripts/write-canary-changeset.mjs`, which writes a temporary changeset patch-bumping **every** publishable package, so
+the whole SDK at `@canary` is a coherent set from a single commit. Real pending changesets are kept, so their
+minor/major bumps still win. As defence-in-depth, `scripts/publish.mjs` skips any package whose version lacks a snapshot
+prerelease (`-`) when publishing under a `--tag`, so a canonical version can never reach a `canary*` tag.
+
+## Consequences
 
 - Existing `@midnight-ntwrk` consumers keep resolving throughout the migration.
-- Canonical `@midnightntwrk` packages are tokenless and provenance-attested.
+- Both scopes are tokenless and provenance-attested; there is no long-lived publish token to rotate or leak.
 - Identical content under both scopes is guaranteed by a single build per run.
-- The transitional code is isolated to `publish.mjs` and a single workflow env var, so teardown is a small, reviewable
-  change.
+- Stable releases require human approval (the `npm-publish-stable` environment); canary never blocks on approval.
+- The scope rename was a large mechanical diff, and `publish.mjs` carries temp-dir staging + dist-specifier rewriting
+  for the duration of the migration window.
 
-### Negative Consequences
-
-- The scope rename is a large mechanical diff.
-- `publish.mjs` carries non-trivial logic (temp-dir staging, dist-specifier rewriting) for the duration of the window.
-- The alias publish has no provenance.
-- The job that runs OIDC also has the legacy token present in its environment (mitigated: the token is never _used_ for
-  the primary publish — `NODE_AUTH_TOKEN` is blanked there).
-
-## Pros and Cons of the Options
-
-### Hard cut-over
-
-- Good, because simplest possible publish flow.
-- Bad, because it immediately breaks every `@midnight-ntwrk` consumer — unacceptable.
-
-### Dual-publish, `@midnightntwrk` canonical in source (chosen)
-
-- Good, because the canonical scope is the one that gets OIDC + provenance and the one developers see everywhere.
-- Good, because the dashed alias is purely a publish-time artifact, easy to delete later.
-- Bad, because it requires a large source rename and dist-specifier rewriting for the alias.
-
-### Dual-publish, `@midnight-ntwrk` canonical in source
-
-- Good, because no source rename — smallest diff.
-- Bad, because the canonical scope going forward (`@midnightntwrk`) would be the _rewritten_ one, so provenance/source
-  identity would lag the scope we actually want to be primary.
-
-### Job topology: one job vs. separate jobs
-
-One job per release type was chosen.
-
-- Good (one job), because the monorepo builds once and both scopes ship identical bytes; the canary job's snapshot
-  versioning is computed a single time.
-- Good (one job), because idempotent skip-on-already-published makes whole-run retries safe.
-- Bad (one job), because the OIDC job also has the legacy token in its environment.
-- Separate jobs would isolate the token but require building twice or passing build artifacts between jobs, and would
-  duplicate the canary snapshot setup — not worth it for a temporary alias.
+The alias is removed (the alias branch in `scripts/publish.mjs` + the migration banner) once consumers have migrated to
+`@midnightntwrk`.
 
 ## Links
 
 - [npm Trusted Publishers](https://docs.npmjs.com/trusted-publishers)
-- Implemented by `scripts/publish.mjs` and `.github/workflows/cd.yml`
+- Implemented by `scripts/publish.mjs`, `scripts/write-canary-changeset.mjs`, and `.github/workflows/cd.yml`

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -1,4 +1,17 @@
 #!/usr/bin/env node
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Publishes non-private workspace packages to npmjs under TWO scopes during the
 // org migration from `@midnight-ntwrk` to `@midnightntwrk`, both via npm Trusted
 // Publishing (OIDC) + `--provenance` (no tokens):

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -1,28 +1,11 @@
 #!/usr/bin/env node
-// Publishes non-private workspace packages to npmjs under TWO scopes during
-// the org migration from `@midnight-ntwrk` to `@midnightntwrk`:
+// Publishes non-private workspace packages to npmjs under TWO scopes during the
+// org migration from `@midnight-ntwrk` to `@midnightntwrk`, both via npm Trusted
+// Publishing (OIDC) + `--provenance` (no tokens):
 //
-//   1. Primary — `@midnightntwrk/*` via npm Trusted Publishing (OIDC) +
-//      `--provenance`. Published as-is from the workspace, since the source
-//      scope is already `@midnightntwrk`. No token: npm authenticates via
-//      OIDC against the trusted publisher configured on npmjs.
-//
-//      Bootstrap exception: a trusted publisher can only be attached to a
-//      package that already exists on npmjs, so OIDC cannot perform the FIRST
-//      publish of a new package name. When NPM_PRIMARY_TOKEN is set, the
-//      primary scope is published with that token instead (provenance off) to
-//      seed the new names. Run once, attach the trusted publishers on npmjs,
-//      then drop NPM_PRIMARY_TOKEN so subsequent publishes use OIDC.
-//
-//   2. Alias — `@midnight-ntwrk/*`, transitional, so existing consumers of
-//      the dashed scope keep resolving during the migration window. The
-//      package is staged in a temp dir with its name, internal SDK deps, and
-//      compiled `dist/**` import specifiers rewritten back to the dashed
-//      scope, then published with the legacy npm token (NPM_LEGACY_TOKEN).
-//      No provenance — token publishes cannot emit OIDC attestations.
-//
-// The alias publish is skipped (with a warning) when NPM_LEGACY_TOKEN is
-// absent, so local runs and the OIDC-only path still work.
+//   1. Primary `@midnightntwrk/*` — published as-is from the workspace.
+//   2. Alias `@midnight-ntwrk/*` — transitional, so dashed-scope consumers keep
+//      resolving; staged in a temp dir with the scope rewritten, then published.
 //
 // Versions already on the registry are skipped so re-runs are idempotent.
 //
@@ -78,18 +61,8 @@ if (publishable.length === 0) {
   process.exit(0);
 }
 
-const legacyToken = process.env.NPM_LEGACY_TOKEN;
-// Bootstrap-only: when set, the primary @midnightntwrk scope is published with
-// this token instead of via OIDC (provenance off). See the header note.
-const primaryToken = process.env.NPM_PRIMARY_TOKEN;
 console.log(`Publishing ${publishable.length} package(s)${values.tag ? ` (dist-tag: ${values.tag})` : ''}:`);
 publishable.forEach((ws) => console.log(`  - ${ws.pkg.name}@${ws.pkg.version} (+ alias ${toAlias(ws.pkg.name)})`));
-if (primaryToken) {
-  console.log('\n⚠ NPM_PRIMARY_TOKEN set — publishing @midnightntwrk with a token (bootstrap, no provenance).');
-}
-if (!legacyToken) {
-  console.log('\n⚠ NPM_LEGACY_TOKEN not set — skipping the @midnight-ntwrk alias publish.');
-}
 
 const isAlreadyPublished = (name, version) => {
   try {
@@ -121,8 +94,8 @@ const rewriteScopeInTree = (dir) => {
   });
 };
 
-// Stage a dashed-scope copy of the package in a temp dir and publish it with
-// the legacy token. Returns the publish status.
+// Stage a dashed-scope copy of the package in a temp dir and publish it via
+// OIDC + provenance. Returns the publish status.
 const publishAlias = (ws) => {
   const aliasName = toAlias(ws.pkg.name);
   if (isAlreadyPublished(aliasName, ws.pkg.version)) {
@@ -149,11 +122,10 @@ const publishAlias = (ws) => {
     const readmeBody = existsSync(readmePath) ? toAlias(readFileSync(readmePath, 'utf8')) : '';
     writeFileSync(readmePath, migrationBanner(ws.pkg.name) + readmeBody);
 
-    console.log(`\nPublishing ${aliasName}@${ws.pkg.version} (alias, token auth)...`);
-    execFileSync('npm', ['publish', '--access', 'public', ...tagArgs], {
+    console.log(`\nPublishing ${aliasName}@${ws.pkg.version} (alias, OIDC + provenance)...`);
+    execFileSync('npm', ['publish', '--provenance', '--access', 'public', ...tagArgs], {
       cwd: stage,
       stdio: 'inherit',
-      env: { ...process.env, NODE_AUTH_TOKEN: legacyToken },
     });
     return { name: aliasName, version: ws.pkg.version, status: 'published' };
   } catch (err) {
@@ -163,11 +135,7 @@ const publishAlias = (ws) => {
   }
 };
 
-// Publish the primary @midnightntwrk scope. Normally via OIDC + provenance,
-// with NODE_AUTH_TOKEN blanked so npm performs the Trusted Publishing token
-// exchange instead of using the setup-node .npmrc placeholder token. During
-// the migration bootstrap (NPM_PRIMARY_TOKEN set), publishes with that token
-// and no provenance, to seed new package names that OIDC cannot create.
+// Publish the primary @midnightntwrk scope via OIDC + provenance.
 const publishPrimary = (ws) => {
   const { name, version } = ws.pkg;
   if (isAlreadyPublished(name, version)) {
@@ -175,13 +143,11 @@ const publishPrimary = (ws) => {
     return { name, version, status: 'skipped' };
   }
 
-  const provenanceArgs = primaryToken ? [] : ['--provenance'];
-  console.log(`\nPublishing ${name}@${version} (${primaryToken ? 'token bootstrap' : 'OIDC + provenance'})...`);
+  console.log(`\nPublishing ${name}@${version} (OIDC + provenance)...`);
   try {
-    execFileSync('npm', ['publish', ...provenanceArgs, '--access', 'public', ...tagArgs], {
+    execFileSync('npm', ['publish', '--provenance', '--access', 'public', ...tagArgs], {
       cwd: ws.location,
       stdio: 'inherit',
-      env: { ...process.env, NODE_AUTH_TOKEN: primaryToken ?? '' },
     });
     return { name, version, status: 'published' };
   } catch (err) {
@@ -190,6 +156,14 @@ const publishPrimary = (ws) => {
 };
 
 const results = publishable.flatMap((ws) => {
+  // In prerelease/canary mode (--tag set), only publish packages that received
+  // a snapshot version. A snapshot version always carries a semver prerelease
+  // "-"; a canonical version (no "-") must never be published under a canary
+  // dist-tag. Stable publishes pass no --tag, so this never affects releases.
+  if (values.tag && !ws.pkg.version.includes('-')) {
+    console.log(`Skip ${ws.pkg.name}@${ws.pkg.version}: no snapshot version for --tag ${values.tag}.`);
+    return [];
+  }
   const primary = publishPrimary(ws);
   // Only mirror to the dashed alias once the primary scope is in good shape
   // (published or already present). If the primary publish failed, skip the
@@ -199,8 +173,7 @@ const results = publishable.flatMap((ws) => {
     console.error(`Skip alias ${aliasName}@${ws.pkg.version}: primary publish failed.`);
     return [primary];
   }
-  const alias = legacyToken ? [publishAlias(ws)] : [];
-  return [primary, ...alias];
+  return [primary, publishAlias(ws)];
 });
 
 const counts = results.reduce((acc, r) => ({ ...acc, [r.status]: (acc[r.status] ?? 0) + 1 }), {});

--- a/scripts/write-canary-changeset.mjs
+++ b/scripts/write-canary-changeset.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// Writes a temporary changeset that patch-bumps EVERY publishable package so a
+// canary snapshot covers the whole SDK as one coherent set from a single commit.
+// `changeset version --snapshot` otherwise versions only packages named in a
+// changeset (plus their dependents), which would leave the `canary` dist-tag
+// inconsistent across packages.
+//
+// Run ONLY in the canary CD job; the checkout is discarded afterwards. Existing
+// real changesets are left in place — their semver bump (minor/major) still
+// wins over this patch.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const config = JSON.parse(readFileSync('.changeset/config.json', 'utf8'));
+const ignore = new Set(config.ignore ?? []);
+
+// Same publishable set as scripts/publish.mjs (non-private workspaces), minus
+// changeset-ignored names so `changeset version` doesn't choke on them.
+const names = execFileSync('yarn', ['workspaces', 'list', '--json'], { encoding: 'utf8' })
+  .trim()
+  .split('\n')
+  .map((line) => JSON.parse(line))
+  .filter((ws) => ws.location !== '.')
+  .flatMap((ws) => {
+    const pkg = JSON.parse(readFileSync(resolve(ws.location, 'package.json'), 'utf8'));
+    return pkg.private || ignore.has(pkg.name) ? [] : [pkg.name];
+  });
+
+if (names.length === 0) {
+  console.log('No publishable packages found — not writing a canary changeset.');
+  process.exit(0);
+}
+
+const frontmatter = names.map((name) => `'${name}': patch`).join('\n');
+writeFileSync(
+  '.changeset/zzz-canary-all-packages.md',
+  `---\n${frontmatter}\n---\n\nCanary snapshot of all packages.\n`,
+);
+console.log(`Wrote canary changeset covering ${names.length} package(s).`);

--- a/scripts/write-canary-changeset.mjs
+++ b/scripts/write-canary-changeset.mjs
@@ -1,4 +1,17 @@
 #!/usr/bin/env node
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Writes a temporary changeset that patch-bumps EVERY publishable package so a
 // canary snapshot covers the whole SDK as one coherent set from a single commit.
 // `changeset version --snapshot` otherwise versions only packages named in a


### PR DESCRIPTION
## Why

A CD run showed the **canary** job publishing **canonical** versions (e.g. `@midnight-ntwrk/wallet-sdk@1.2.0`) under the `canary` dist-tag instead of snapshots.

**Root cause:** `changeset version --snapshot` only bumps packages named in a *pending* changeset (+ dependents). Between releases the only pending changesets are often the **empty** ones added by convention for docs/CI PRs — so nothing gets bumped, every package keeps its canonical version, and `publish.mjs --tag canary` ships those canonical versions under `canary`.

Trusted Publishing is now configured on npmjs for **both** scopes, so the migration's publish tokens are no longer needed either.

## What changed

`cd.yml` runs `version` first, which resolves a single **`mode`** output that gates exactly one publish job (or neither):

| Push | `mode` | Result |
|---|---|---|
| Release PR merged (no changesets) | `stable` | `publish-stable` → canonical, both scopes |
| Pending package-bumping changeset | `canary` | `canary` → snapshot, both scopes |
| Docs/CI-only (empty changeset) | `none` | publish nothing |

- **Canary publishes ALL packages as one coherent set:** new `scripts/write-canary-changeset.mjs` writes a temporary all-package changeset before `--snapshot`, so the `@canary` dist-tag is never inconsistent across packages. Real changesets still win with their minor/major bumps.
- **`publish.mjs`:** both scopes publish via **OIDC + `--provenance`** (tokenless) — dropped the legacy publish-token / `NODE_AUTH_TOKEN` overrides and the one-time bootstrap job + `workflow_dispatch` trigger. Added a defense-in-depth guard: in `--tag` mode, skip any package whose version lacks a snapshot `-`, so a canonical version can never reach a `canary*` tag.
- **Hardening:** pinned canary's npm to `^11.17.0` (matches `publish-stable`; was the non-deterministic `@latest`), and dropped the unused `registry-url`/`scope` from the `version` job (it only opens the release PR, never publishes).
- **License headers** added to `publish.mjs` and `write-canary-changeset.mjs`.
- **ADR 0007** rewritten to document the OIDC dual-publish + canary model.

## Verification

- `node --check` both scripts; prettier clean; `cd.yml` parses to `version` / `publish-stable` / `canary` with the single `mode` gate.
- Dry-ran `write-canary-changeset.mjs` → 15-package (all non-private) changeset; `changeset status` then reports all of them in `releases` (the 4 changeset-`ignore`d test/docs packages are private and excluded by `publish.mjs`).
- `changeset status --since=origin/main` exits 0 (no package source touched → `check-changeset` passes without a changeset).
