### PR TITLE
docs(release-notes): restructure v1.2.0 to RN template v6

### DIFF
--- a/release-notes/v1.2.0.md
+++ b/release-notes/v1.2.0.md
@@ -1,15 +1,26 @@
-### Version 1.2.0
+# `wallet-sdk 1.2.0`
 
-**Version:** 1.2.0 **Date:** 2026-06-19 **Environment:** Mainnet, Preprod, Preview
+## Metadata
+
+> **Bundle pointer is mandatory.** The bundle fields below pin this release to its bundle. The bundle RN's dependency
+> matrix is the canonical source of truth for cross-component interop — these are pointers, do not duplicate matrix rows
+> here.
+
+- **Release type**: minor
+- **Date**: 2026-06-19
+- **Ships in bundle**: `N/A`
+- **Environment**: Mainnet, Preprod, Preview
+- **Released artifact(s)**: npm packages under the `@midnightntwrk/*` scope (see **Artifacts** below)
+- **Upgrade scope**: binary only
+- **Reset required**: No
+- **Governance action required**: No
 
 > **Required:** the npm scope has changed from `@midnight-ntwrk` to **`@midnightntwrk`** (no dash). New installs should
 > depend on `@midnightntwrk/*`. The old `@midnight-ntwrk/*` packages continue to be published as a transitional alias
 > during the migration window, so existing consumers keep working, but the dashed scope is deprecated — migrate import
 > paths at your convenience. See [ADR-0007](../docs/decisions/0007-npmjs-trusted-publishing-and-scope-rename.md).
 
----
-
-### High-level summary
+## High-level summary
 
 A maintenance release centred on the npm scope migration plus a batch of correctness and resource-leak fixes. Packages
 now publish under the canonical `@midnightntwrk` scope (with `@midnight-ntwrk` kept alive as a transitional alias), via
@@ -20,11 +31,10 @@ stream no longer pins past state (and the wasm resources it holds); the prover c
 key derivation reports out-of-bounds paths cleanly. This release also introduces a new publishable end-to-end test
 harness, `@midnightntwrk/wallet-sdk-testkit`.
 
----
+## Audience
 
-### Audience
-
-This release is relevant for developers who:
+These release notes are scoped to the audiences relevant to an SDK release — primarily **External integrators** and
+**Shielded Technologies** engineering teams. Specifically, developers who:
 
 - Build wallets for the Midnight network
 - Integrate Midnight token transfers into their DApps
@@ -32,96 +42,36 @@ This release is relevant for developers who:
 - Implement atomic swaps between parties
 - Maintain long-lived indexer subscriptions or run the SDK's e2e harness against their own infrastructure
 
----
+## Dependencies
 
-### What changed (Summary of updates)
+**Pointer-only.** The full cross-component matrix lives in the bundle RN linked from Metadata above. Hard,
+component-local items a reader must see without clicking through:
 
-- **Scope migration:** packages now publish as `@midnightntwrk/*` (canonical), with `@midnight-ntwrk/*` dual-published
-  as a transitional, deprecated alias. Publishing moves to npmjs Trusted Publishing (OIDC + provenance).
-- **New package** `@midnightntwrk/wallet-sdk-testkit` — a publishable wallet e2e harness so downstream consumers can
-  share it instead of vendoring copies.
-- Fix dust registration for fee payment racing into a `BalanceCheckOverspend` rejection; add
-  `WalletFacade.waitForGeneratedDust(...)` to defer registration until enough dust accrues.
-- Fix shielded `balanceTransaction` failing when the only imbalance is in a fallible segment.
-- Fix a fiber/memory leak in the indexer-client WebSocket subscription stream under sustained push load.
-- Fix the runtime state-changes stream retaining every published state (and its wasm resources) for the lifetime of any
-  subscriber.
-- Fix prover-client requests failing with `invalid content-length header` under undici `>= 8.2.0`.
-- Fix HD `deriveKeyAt` / `deriveKeysAt` leaking a low-level `invalid child index` error for out-of-bounds BIP32 paths.
-- Declare node-client's `./testing` runtime dependencies as optional peer dependencies.
+- `@midnightntwrk/wallet-sdk-node-client`'s `./testing` export requires `@midnight-ntwrk/ledger-v8` and
+  `@midnightntwrk/wallet-sdk-prover-client` — these are now declared as **optional peer dependencies** and must be
+  installed by consumers of that export (see **Breaking changes** below).
+- Upstream, non-SDK dependencies remain on the dashed `@midnight-ntwrk` scope (`@midnight-ntwrk/ledger-v8`,
+  `wallet-api`, `zkir-v2`, `midnight-js-network-id`) — they are not part of this rename.
 
----
+For all other interop questions, see the bundle dependency matrix.
 
-### New features
+**Downstream impact (cascading effects).**
 
-**New package: `@midnightntwrk/wallet-sdk-testkit`**
+- Consumers depending on `@midnight-ntwrk/wallet-sdk*` keep working unchanged via the transitional alias — no lockstep
+  upgrade is forced. Import paths should be migrated to `@midnightntwrk/*` before the alias is eventually retired.
 
-**Description:** Extracts the reusable wallet end-to-end harness — environment provisioning, wallet bootstrapping, sync
-waiters, and tx-history assertions — into a publishable package so downstream consumers can depend on it rather than
-copying it. Endpoints are injected via a `WalletTestEnvironment` config (`createRemoteEnvironment` /
-`createTestContainersEnvironment`) instead of being read from `process.env`. Shared healthcheck scenarios are
-single-sourced via `registerDustHealthchecks` and `registerTokenTransferHealthchecks`.
+## Deployment information
 
----
+> **Mandatory.** Operational triage — what it actually takes to deploy this release.
 
-**`WalletFacade.waitForGeneratedDust(utxos, requiredAmount, opts?)`**
+- **Upgrade scope**: binary only — consumers bump npm package versions; no coordinated on-chain runtime upgrade.
+- **Reset required**: No — no state-wipe, re-sync, or re-index is needed to adopt this release.
+- **Governance action required**: No — no on-chain proposal, SPO vote, or config ratification is needed.
+- **Downtime / coordination**: None — package upgrades are independent; consumers adopt at their own pace.
 
-**Description:** Lets callers defer dust registration until enough dust has accrued on the chosen Night UTxOs. Pair it
-with `estimateRegistration` to pick the threshold, so the subsequent registration can cover its own fee. Part of the
-dust-registration fee-coverage fix below.
+## Artifacts
 
----
-
-### New features requiring configuration updates
-
-N/A
-
----
-
-### Improvements
-
-- Indexer-client `ClientError` now preserves the full GraphQL error array as `cause` and joins all error messages,
-  instead of surfacing only the first.
-- Publishing moves to npmjs Trusted Publishing: primary `@midnightntwrk` publishes are tokenless (OIDC) and carry
-  provenance attestations; the `@midnight-ntwrk` alias is generated at publish time from identical bytes.
-
----
-
-### Deprecations
-
-- **The `@midnight-ntwrk/*` scope is deprecated.** It remains published as a transitional alias during the migration
-  window for backward compatibility. New code should depend on `@midnightntwrk/*`.
-
----
-
-### Breaking changes or required actions for developers
-
-**npm scope renamed to `@midnightntwrk` (all packages)**
-
-The canonical scope is now `@midnightntwrk` (no dash). Existing consumers depending on `@midnight-ntwrk/*` continue to
-work because the dashed scope is dual-published as an alias, but it is deprecated. To migrate, update your dependency
-names and import specifiers from `@midnight-ntwrk/wallet-sdk*` to `@midnightntwrk/wallet-sdk*`. Note that upstream,
-non-SDK dependencies (`@midnight-ntwrk/ledger-v8`, `wallet-api`, `zkir-v2`, `midnight-js-network-id`) keep the dashed
-scope — they are not part of this rename. See
-[ADR-0007](../docs/decisions/0007-npmjs-trusted-publishing-and-scope-rename.md).
-
----
-
-**node-client `./testing` runtime dependencies are now optional peer dependencies**
-
-`@midnightntwrk/wallet-sdk-node-client` declares `@midnight-ntwrk/ledger-v8` and
-`@midnightntwrk/wallet-sdk-prover-client` as optional peer dependencies. They are used at runtime by the `./testing`
-export, so consumers of that export must ensure both are installed.
-
----
-
-### Known issues
-
-N/A
-
----
-
-### Packages
+Published as npm packages at the `1.2.0` release tag.
 
 | Package                                       | Version | Description                                                                                                         |
 | --------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
@@ -141,45 +91,141 @@ N/A
 | `@midnightntwrk/wallet-sdk-unshielded-wallet` | 3.1.0   | Unchanged.                                                                                                          |
 | `@midnightntwrk/wallet-sdk-utilities`         | 1.2.0   | Unchanged.                                                                                                          |
 
----
+## What changed
 
-### Links and references
-
-- ADR-0007:
-  [npmjs Trusted Publishing and scope rename](../docs/decisions/0007-npmjs-trusted-publishing-and-scope-rename.md)
-- Examples: [`packages/docs-snippets`](../packages/docs-snippets)
-- GitHub Repository: [midnightntwrk/midnight-wallet](https://github.com/midnightntwrk/midnight-wallet)
-- DApp Connector API:
-  [midnightntwrk/midnight-dapp-connector-api](https://github.com/midnightntwrk/midnight-dapp-connector-api)
-
----
-
-### Fixed defect list
-
-- Dust registration for fee payment (`WalletFacade.registerNightUtxosForDustGeneration`) could build a registration
-  whose `allow_fee_payment` was below its own fee, causing the chain to reject submission with `BalanceCheckOverspend`.
-  The wallet now estimates the fee at build time, reverts the booking, and throws before submission. A new
-  `WalletFacade.waitForGeneratedDust(utxos, requiredAmount, opts?)` lets callers defer registration until enough dust
-  has accrued (pair with `estimateRegistration` to pick the threshold).
-- Shielded `balanceTransaction` failed with "Could not create a valid guaranteed offer" when a transaction's only
-  imbalance was in a fallible segment. The guaranteed section is now skipped when already balanced instead of attempting
-  to build an empty guaranteed offer.
-- Fiber/memory leak in the indexer-client WebSocket subscription stream. At the indexer's sustained ~1k msg/sec push
-  rate, `Stream.async` forked a top-level fiber per emit (via `Runtime.runPromiseExit`) and accumulated them in Effect's
-  `Global.roots`. Switched to `Stream.asyncPush`, which writes straight to an internal queue and ties teardown to the
-  surrounding scope via `Effect.acquireRelease`. `ClientError` now also preserves the full GraphQL error array as
-  `cause` and joins all error messages instead of dropping all but the first.
-- Runtime state-changes stream retained every published state for the lifetime of any subscriber. The shared
-  unbounded-with-replay PubSub appended every published value to a shared linked list whose head a subscription's replay
-  window never released, so a long-lived subscriber pinned every state published during its lifetime (and the wasm
-  resources those states hold). Replaced with per-subscriber `SubscriptionRef.changes` decoupled by a sliding buffer of
-  capacity 1 — latest-value semantics, memory bounded to the current state plus at most one buffered state per
+- **Scope migration:** packages now publish as `@midnightntwrk/*` (canonical), with `@midnight-ntwrk/*` dual-published
+  as a transitional, deprecated alias. Publishing moves to npmjs Trusted Publishing (OIDC + provenance).
+- **New package** `@midnightntwrk/wallet-sdk-testkit` — a publishable wallet e2e harness so downstream consumers can
+  share it instead of vendoring copies.
+- Fix dust registration for fee payment racing into a `BalanceCheckOverspend` rejection; add
+  `WalletFacade.waitForGeneratedDust(...)` to defer registration until enough dust accrues.
+- Fix shielded `balanceTransaction` failing when the only imbalance is in a fallible segment.
+- Fix a fiber/memory leak in the indexer-client WebSocket subscription stream under sustained push load.
+- Fix the runtime state-changes stream retaining every published state (and its wasm resources) for the lifetime of any
   subscriber.
-- Prover-client requests failed with `invalid content-length header` when undici `>= 8.2.0` was the process-wide fetch
-  dispatcher (pulled in transitively by importing e.g. testcontainers or `@effect/platform-node`). The HTTP prover
-  client no longer sets an explicit `content-length` header and lets `fetch` derive it from the body.
-- HD `deriveKeyAt` / `deriveKeysAt` leaked the underlying `invalid child index` error from `@scure/bip32` for invalid
-  BIP32 path components. They now return `keyOutOfBounds` for non-integer, negative, or `>= 2^31` account/role/index
-  values.
-- `@midnightntwrk/wallet-sdk-node-client` did not declare the runtime dependencies of its `./testing` export. It now
-  declares `@midnight-ntwrk/ledger-v8` and `@midnightntwrk/wallet-sdk-prover-client` as optional peer dependencies.
+- Fix prover-client requests failing with `invalid content-length header` under undici `>= 8.2.0`.
+- Fix HD `deriveKeyAt` / `deriveKeysAt` leaking a low-level `invalid child index` error for out-of-bounds BIP32 paths.
+- Declare node-client's `./testing` runtime dependencies as optional peer dependencies.
+
+## New features
+
+### Feature `@midnightntwrk/wallet-sdk-testkit` (new package)
+
+**Description:** Extracts the reusable wallet end-to-end harness — environment provisioning, wallet bootstrapping, sync
+waiters, and tx-history assertions — into a publishable package so downstream consumers can depend on it rather than
+copying it. Endpoints are injected via a `WalletTestEnvironment` config (`createRemoteEnvironment` /
+`createTestContainersEnvironment`) instead of being read from `process.env`. Shared healthcheck scenarios are
+single-sourced via `registerDustHealthchecks` and `registerTokenTransferHealthchecks`.
+
+### Feature `WalletFacade.waitForGeneratedDust(utxos, requiredAmount, opts?)`
+
+**Description:** Lets callers defer dust registration until enough dust has accrued on the chosen Night UTxOs. Pair it
+with `estimateRegistration` to pick the threshold, so the subsequent registration can cover its own fee. Part of the
+dust-registration fee-coverage fix below.
+
+## New features requiring configuration updates
+
+None.
+
+## Improvements
+
+**Improvement:** Indexer-client error reporting
+
+**Description:** `ClientError` now preserves the full GraphQL error array as `cause` and joins all error messages,
+instead of surfacing only the first.
+
+**Improvement:** npmjs Trusted Publishing with provenance
+
+**Description:** Primary `@midnightntwrk` publishes are tokenless (OIDC) and carry provenance attestations; the
+`@midnight-ntwrk` alias is generated at publish time from identical bytes.
+
+## Deprecations
+
+**Deprecated item:** the `@midnight-ntwrk/*` npm scope (SDK packages)
+
+**Starts:** 1.2.0 (2026-06-19) **Full removal:** `TODO — end of migration window (date not yet set)` **Replacement:**
+`@midnightntwrk/*` **Migration steps:** Update dependency names and import specifiers from `@midnight-ntwrk/wallet-sdk*`
+to `@midnightntwrk/wallet-sdk*`. The dashed scope remains published as a transitional alias during the migration window
+for backward compatibility, so existing consumers keep working in the meantime.
+
+## Breaking changes
+
+### Breaking change `npm scope renamed to @midnightntwrk (all packages)`
+
+**What changed:** The canonical scope is now `@midnightntwrk` (no dash). `@midnight-ntwrk/*` is dual-published as a
+deprecated transitional alias.
+
+**What breaks:** Nothing immediately — existing consumers depending on `@midnight-ntwrk/*` continue to work because the
+dashed scope is dual-published as an alias. The dashed scope is, however, deprecated.
+
+**Required actions:**
+
+- Update your dependency names from `@midnight-ntwrk/wallet-sdk*` to `@midnightntwrk/wallet-sdk*`.
+- Update import specifiers in source to the new scope.
+- Leave upstream, non-SDK dependencies (`@midnight-ntwrk/ledger-v8`, `wallet-api`, `zkir-v2`, `midnight-js-network-id`)
+  unchanged — they keep the dashed scope and are not part of this rename.
+
+**Code example:**
+
+```diff
+- import { WalletBuilder } from '@midnight-ntwrk/wallet-sdk-facade';
++ import { WalletBuilder } from '@midnightntwrk/wallet-sdk-facade';
+```
+
+```diff
+  // package.json
+- "@midnight-ntwrk/wallet-sdk-facade": "^4.1.0"
++ "@midnightntwrk/wallet-sdk-facade": "^4.1.0"
+```
+
+See [ADR-0007](../docs/decisions/0007-npmjs-trusted-publishing-and-scope-rename.md).
+
+### Breaking change `node-client ./testing runtime dependencies are now optional peer dependencies`
+
+**What changed:** `@midnightntwrk/wallet-sdk-node-client` declares `@midnight-ntwrk/ledger-v8` and
+`@midnightntwrk/wallet-sdk-prover-client` as optional peer dependencies.
+
+**What breaks:** These are used at runtime by the `./testing` export, so consumers of that export must ensure both are
+installed.
+
+**Required actions:**
+
+- If you import from `@midnightntwrk/wallet-sdk-node-client/testing`, install both peers explicitly.
+
+**Code example:**
+
+```
+yarn add @midnight-ntwrk/ledger-v8 @midnightntwrk/wallet-sdk-prover-client
+```
+
+## Known issues
+
+None.
+
+## Links and references
+
+- **QA test coverage / test evidence**: `@midnightntwrk/wallet-sdk-testkit` (publishable e2e harness)
+- **PRs**: [Milestone v1.2.0](https://github.com/midnightntwrk/midnight-wallet/milestone/4)
+- **Engineering docs**:
+  [ADR-0007 — npmjs Trusted Publishing and scope rename](../docs/decisions/0007-npmjs-trusted-publishing-and-scope-rename.md)
+- **Migration guides**: —
+- **SDK docs**: [`packages/docs-snippets`](../packages/docs-snippets)
+- **Known issues board**: —
+- **Public schema**: —
+- **API documentation**:
+  [midnightntwrk/midnight-dapp-connector-api](https://github.com/midnightntwrk/midnight-dapp-connector-api)
+- **GitHub Repository**: [midnightntwrk/midnight-wallet](https://github.com/midnightntwrk/midnight-wallet)
+
+## Fixed defect list
+
+The following defects were fixed in `1.2.0`.
+
+| Defect number | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| —             | Dust registration for fee payment (`WalletFacade.registerNightUtxosForDustGeneration`) could build a registration whose `allow_fee_payment` was below its own fee, causing the chain to reject submission with `BalanceCheckOverspend`. The wallet now estimates the fee at build time, reverts the booking, and throws before submission. A new `WalletFacade.waitForGeneratedDust(utxos, requiredAmount, opts?)` lets callers defer registration until enough dust has accrued (pair with `estimateRegistration` to pick the threshold).                                                        |
+| —             | Shielded `balanceTransaction` failed with "Could not create a valid guaranteed offer" when a transaction's only imbalance was in a fallible segment. The guaranteed section is now skipped when already balanced instead of attempting to build an empty guaranteed offer.                                                                                                                                                                                                                                                                                                                        |
+| —             | Fiber/memory leak in the indexer-client WebSocket subscription stream. At the indexer's sustained ~1k msg/sec push rate, `Stream.async` forked a top-level fiber per emit (via `Runtime.runPromiseExit`) and accumulated them in Effect's `Global.roots`. Switched to `Stream.asyncPush`, which writes straight to an internal queue and ties teardown to the surrounding scope via `Effect.acquireRelease`. `ClientError` now also preserves the full GraphQL error array as `cause` and joins all error messages instead of dropping all but the first.                                         |
+| —             | Runtime state-changes stream retained every published state for the lifetime of any subscriber. The shared unbounded-with-replay PubSub appended every published value to a shared linked list whose head a subscription's replay window never released, so a long-lived subscriber pinned every state published during its lifetime (and the wasm resources those states hold). Replaced with per-subscriber `SubscriptionRef.changes` decoupled by a sliding buffer of capacity 1 — latest-value semantics, memory bounded to the current state plus at most one buffered state per subscriber. |
+| —             | Prover-client requests failed with `invalid content-length header` when undici `>= 8.2.0` was the process-wide fetch dispatcher (pulled in transitively by importing e.g. testcontainers or `@effect/platform-node`). The HTTP prover client no longer sets an explicit `content-length` header and lets `fetch` derive it from the body.                                                                                                                                                                                                                                                         |
+| —             | HD `deriveKeyAt` / `deriveKeysAt` leaked the underlying `invalid child index` error from `@scure/bip32` for invalid BIP32 path components. They now return `keyOutOfBounds` for non-integer, negative, or `>= 2^31` account/role/index values.                                                                                                                                                                                                                                                                                                                                                    |
+| —             | `@midnightntwrk/wallet-sdk-node-client` did not declare the runtime dependencies of its `./testing` export. It now declares `@midnight-ntwrk/ledger-v8` and `@midnightntwrk/wallet-sdk-prover-client` as optional peer dependencies.                                                                                                                                                                                                                                                                                                                                                              |


### PR DESCRIPTION
Reformats `release-notes/v1.2.0.md` to follow the v6 component release-note template.

## What changed
- Added `Metadata` (with mandatory `Release type: minor`), `Dependencies`, `Deployment information`, and `Artifacts` sections.
- Reorganized `New features`, `Improvements`, `Deprecations`, `Breaking changes`, and `Known issues` into the template's headings and field conventions.
- Converted the fixed-defect list into the template's table format.
- Pointed the **PRs** link at [milestone v1.2.0](https://github.com/midnightntwrk/midnight-wallet/milestone/4); left **Migration guides** unlinked.

## Notes / TODO
- `Ships in bundle` is set to `N/A` — update if a bundle pointer applies.
- Deprecation **Full removal** date for the `@midnight-ntwrk` alias is a `TODO` (migration-window end not yet set).

Prettier passes clean; no other repo-enforced markdown lint applies.