### PR TITLE
fix: treat bridge claim tx as implicitly successful

### DIFF
--- a/.changeset/clever-states-move.md
+++ b/.changeset/clever-states-move.md
@@ -1,0 +1,5 @@
+---
+'@midnightntwrk/wallet-sdk-unshielded-wallet': major
+---
+
+fix: treat BridgeClaimTransaction as successful implicitly

--- a/packages/unshielded-wallet/src/v1/SyncSchema.ts
+++ b/packages/unshielded-wallet/src/v1/SyncSchema.ts
@@ -130,10 +130,10 @@ export const UnshieldedUpdateSchema = Schema.transform(
   {
     strict: true,
     decode: (wire) => {
-      const isSystemTransaction = wire.transaction.type === 'SystemTransaction';
+      const isStatusImplicitlySuccess = ['SystemTransaction', 'BridgeClaimTransaction'].includes(wire.transaction.type);
       return {
         ...wire,
-        status: isSystemTransaction ? 'SUCCESS' : wire.transaction.transactionResult!.status,
+        status: isStatusImplicitlySuccess ? 'SUCCESS' : wire.transaction.transactionResult!.status,
       };
     },
     encode: ({ status: _status, ...rest }) => rest,


### PR DESCRIPTION
# Description

Treat bridge claim tx as implicitly successful in the unshielded wallet
