### PR TITLE
fix(e2e): repair flaky/stale e2e tests and add StageNet support

### DIFF
--- a/.changeset/e2e-test-fixes-and-stagenet.md
+++ b/.changeset/e2e-test-fixes-and-stagenet.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(e2e): repair flaky/stale e2e tests and add StageNet network support (test/CI/infra only, no package release)

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,6 +21,7 @@ on:
           - qanet
           - preview
           - prepod
+          - stagenet
       seed:
         type: string
         description: Seed of a funded wallet (leave empty to use secret default)

--- a/packages/abstractions/src/NetworkId.ts
+++ b/packages/abstractions/src/NetworkId.ts
@@ -18,6 +18,7 @@ export const NetworkId = {
   Undeployed: 'undeployed',
   Preview: 'preview',
   PreProd: 'preprod',
+  StageNet: 'stagenet',
 } as const;
 
 export type WellKnownNetworkId = (typeof NetworkId)[keyof typeof NetworkId];

--- a/packages/e2e-tests/src/tests/emptyWallet.universal.test.ts
+++ b/packages/e2e-tests/src/tests/emptyWallet.universal.test.ts
@@ -167,7 +167,8 @@ describe('Fresh wallet with empty state', () => {
       const serialized = await unshieldedWallet.serializeState();
       const stateObject = JSON.parse(serialized);
       logger.info(`Serialized unshielded wallet state: ${inspect(stateObject)}`);
-      expect(stateObject.publicKey.publicKey).toHaveLength(64);
+      expect(stateObject.publicKey.publicKey.tag).toBe('schnorr');
+      expect(stateObject.publicKey.publicKey.value).toHaveLength(64);
       expect(stateObject.publicKey.addressHex).toHaveLength(64);
       const restoredWallet = Unshielded.restore(serialized);
       const newState = await firstValueFrom(restoredWallet.state);

--- a/packages/e2e-tests/src/tests/fundedWallet.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/fundedWallet.undeployed.test.ts
@@ -182,9 +182,18 @@ describe('Funded wallet', () => {
     'Shielded transaction history entries contain receivedCoins and spentCoins',
     async () => {
       await funded.wallet.waitForSyncedState();
-      const txHistory = await funded.wallet.getAllFromTxHistory();
-      const shieldedEntries = txHistory.filter((e) => e.shielded !== undefined);
-      expect(shieldedEntries.length).toBeGreaterThan(0);
+      // Shielded tx-history is populated in a detached fiber after state sync (it needs an extra
+      // TransactionHistoryDetail indexer query the shielded subscription doesn't provide), so it is
+      // eventually consistent and not covered by waitForSyncedState(). Poll until it lands.
+      const shieldedEntries = await vi.waitFor(
+        async () => {
+          const txHistory = await funded.wallet.getAllFromTxHistory();
+          const entries = txHistory.filter((e) => e.shielded !== undefined);
+          expect(entries.length).toBeGreaterThan(0);
+          return entries;
+        },
+        { timeout: 30_000, interval: 1_000 },
+      );
       shieldedEntries.forEach((entry) => utils.expectValidShieldedTxHistoryEntry(entry));
       // At least one entry should have receivedCoins (from genesis funding)
       const entryWithReceived = shieldedEntries.find((e) => e.shielded!.receivedCoins.length > 0);

--- a/packages/e2e-tests/src/tests/helpers/network.ts
+++ b/packages/e2e-tests/src/tests/helpers/network.ts
@@ -14,7 +14,7 @@ import { logger } from '../logger.js';
 import { BlockHash } from '@midnightntwrk/wallet-sdk-indexer-client';
 import { QueryRunner } from '@midnightntwrk/wallet-sdk-indexer-client/effect';
 
-export type MidnightNetwork = 'undeployed' | 'qanet' | 'devnet' | 'preview' | 'preprod';
+export type MidnightNetwork = 'undeployed' | 'qanet' | 'devnet' | 'preview' | 'preprod' | 'stagenet';
 
 export const sleep = (secs: number): Promise<void> => {
   return new Promise((resolve) => setTimeout(resolve, secs * 1000));

--- a/packages/e2e-tests/src/tests/test-fixture.ts
+++ b/packages/e2e-tests/src/tests/test-fixture.ts
@@ -58,7 +58,8 @@ export function useTestContainersFixture() {
       case 'devnet':
       case 'qanet':
       case 'preview':
-      case 'preprod': {
+      case 'preprod':
+      case 'stagenet': {
         const environmentVars = buildTestEnvironmentVariables(envVarsToPass, {
           additionalVars: {
             TESTCONTAINERS_UID: uid,
@@ -147,6 +148,9 @@ export class TestContainersFixture {
       case 'preprod': {
         return 'https://indexer.preprod.midnight.network/api/v4/graphql';
       }
+      case 'stagenet': {
+        return 'https://indexer.stagenet.midnight.network/api/v4/graphql';
+      }
       case 'undeployed': {
         const indexerPort = this.getIndexerPort();
         return `http://localhost:${indexerPort}/api/v3/graphql`;
@@ -170,6 +174,9 @@ export class TestContainersFixture {
       }
       case 'preprod': {
         return 'wss://indexer.preprod.midnight.network/api/v4/graphql/ws';
+      }
+      case 'stagenet': {
+        return 'wss://indexer.stagenet.midnight.network/api/v4/graphql/ws';
       }
       case 'undeployed': {
         const indexerPort = this.getIndexerPort();
@@ -195,6 +202,9 @@ export class TestContainersFixture {
       case 'preprod': {
         return 'wss://rpc.preprod.midnight.network';
       }
+      case 'stagenet': {
+        return 'wss://rpc.stagenet.midnight.network';
+      }
       case 'undeployed': {
         const nodePortRpc = this.getNodeContainer().getMappedPort(TestContainersFixture.NODE_PORT_RPC);
         return `ws://localhost:${nodePortRpc}`;
@@ -217,6 +227,8 @@ export class TestContainersFixture {
         return NetworkId.NetworkId.Preview;
       case 'preprod':
         return NetworkId.NetworkId.PreProd;
+      case 'stagenet':
+        return NetworkId.NetworkId.StageNet;
       default:
         throw new Error(`Unrecognized network: ${String(TestContainersFixture.network)}`);
     }

--- a/packages/e2e-tests/src/tests/test-fixture.ts
+++ b/packages/e2e-tests/src/tests/test-fixture.ts
@@ -149,7 +149,7 @@ export class TestContainersFixture {
         return 'https://indexer.preprod.midnight.network/api/v4/graphql';
       }
       case 'stagenet': {
-        return 'https://indexer.stagenet.midnight.network/api/v4/graphql';
+        return 'https://indexer.stagenet.shielded.tools/api/v4/graphql';
       }
       case 'undeployed': {
         const indexerPort = this.getIndexerPort();
@@ -176,7 +176,7 @@ export class TestContainersFixture {
         return 'wss://indexer.preprod.midnight.network/api/v4/graphql/ws';
       }
       case 'stagenet': {
-        return 'wss://indexer.stagenet.midnight.network/api/v4/graphql/ws';
+        return 'wss://indexer.stagenet.shielded.tools/api/v4/graphql/ws';
       }
       case 'undeployed': {
         const indexerPort = this.getIndexerPort();
@@ -203,7 +203,7 @@ export class TestContainersFixture {
         return 'wss://rpc.preprod.midnight.network';
       }
       case 'stagenet': {
-        return 'wss://rpc.stagenet.midnight.network';
+        return 'wss://rpc.stagenet.shielded.tools';
       }
       case 'undeployed': {
         const nodePortRpc = this.getNodeContainer().getMappedPort(TestContainersFixture.NODE_PORT_RPC);

--- a/packages/wallet-sdk-testkit/src/environment.ts
+++ b/packages/wallet-sdk-testkit/src/environment.ts
@@ -56,9 +56,9 @@ export const NETWORK_PRESETS: Record<RemoteNetwork, RemoteNetworkPreset> = {
   },
   stagenet: {
     networkId: NetworkId.NetworkId.StageNet,
-    indexerHttpUrl: 'https://indexer.stagenet.midnight.network/api/v4/graphql',
-    indexerWsUrl: 'wss://indexer.stagenet.midnight.network/api/v4/graphql/ws',
-    nodeUrl: 'wss://rpc.stagenet.midnight.network',
+    indexerHttpUrl: 'https://indexer.stagenet.shielded.tools/api/v4/graphql',
+    indexerWsUrl: 'wss://indexer.stagenet.shielded.tools/api/v4/graphql/ws',
+    nodeUrl: 'wss://rpc.stagenet.shielded.tools',
   },
 };
 

--- a/packages/wallet-sdk-testkit/src/environment.ts
+++ b/packages/wallet-sdk-testkit/src/environment.ts
@@ -54,6 +54,12 @@ export const NETWORK_PRESETS: Record<RemoteNetwork, RemoteNetworkPreset> = {
     indexerWsUrl: 'wss://indexer.preprod.midnight.network/api/v4/graphql/ws',
     nodeUrl: 'wss://rpc.preprod.midnight.network',
   },
+  stagenet: {
+    networkId: NetworkId.NetworkId.StageNet,
+    indexerHttpUrl: 'https://indexer.stagenet.midnight.network/api/v4/graphql',
+    indexerWsUrl: 'wss://indexer.stagenet.midnight.network/api/v4/graphql/ws',
+    nodeUrl: 'wss://rpc.stagenet.midnight.network',
+  },
 };
 
 /**

--- a/packages/wallet-sdk-testkit/src/types.ts
+++ b/packages/wallet-sdk-testkit/src/types.ts
@@ -17,7 +17,7 @@ import { type DefaultProvingConfiguration } from '@midnightntwrk/wallet-sdk-capa
 import { type DefaultSubmissionConfiguration } from '@midnightntwrk/wallet-sdk-capabilities/submission';
 
 /** Networks a wallet test environment can target. */
-export type MidnightNetwork = 'undeployed' | 'qanet' | 'devnet' | 'preview' | 'preprod';
+export type MidnightNetwork = 'undeployed' | 'qanet' | 'devnet' | 'preview' | 'preprod' | 'stagenet';
 
 /** A remote (already-running) network — anything other than the local testcontainers stack. */
 export type RemoteNetwork = Exclude<MidnightNetwork, 'undeployed'>;


### PR DESCRIPTION
## Summary

Two unrelated-but-bundled sets of changes to the e2e/testkit layer.

### 1. E2E test fixes (verified against real infra)

**`emptyWallet.universal.test.ts` — stale assertion (not a regression).**
The ECDSA work (#483) intentionally changed the serialized unshielded verifying key from a plain 64-char hex string to a tagged union `{ tag: 'schnorr' | 'ecdsa', value: '<hex>' }` (see `unshielded-wallet/src/v1/Serialization.ts` and the passing unit test in `serialization.test.ts`). The e2e test still asserted the old shape. Updated to assert the tagged form.

**`fundedWallet.undeployed.test.ts` — race in the test (not a functional regression; assertion unchanged).**
Shielded tx-history is written in a detached `forkScoped` fiber *after* state sync and requires an extra `TransactionHistoryDetail` indexer round-trip (the shielded subscription, unlike the unshielded one, doesn't return `block.timestamp`). It is therefore eventually consistent and **not** gated by `waitForSyncedState()`. The single immediate read was racy — confirmed by polling:

```
poll 0 (right after waitForSyncedState): total=5 shielded=0
poll 1 (~1s later):                      total=6 shielded=1  → entry present, with receivedCoins
```

Replaced the single read with `vi.waitFor`. The assertion itself is unchanged (not weakened) — genesis funding genuinely produces a received shielded coin.

> Latent concern worth a separate discussion: `getAllFromTxHistory()` is eventually consistent and not covered by `waitForSyncedState()`. The test fix is correct, but if the SDK intends history to be readable synchronously after sync, that's an API-design question.

### 2. StageNet network support

- Add `StageNet` to the `NetworkId` enum.
- Wire stagenet indexer (HTTP + WS) and node RPC endpoints into the e2e `TestContainersFixture` and the `wallet-sdk-testkit` remote presets.
- Add the `stagenet` `MidnightNetwork` variant in e2e + testkit type unions and the fixture switch.
- Offer `stagenet` as a target in the `e2e-tests` workflow dispatch.

## Test plan

- [x] `fundedWallet.undeployed.test.ts` "Shielded transaction history…" passes under the `undeployed` project (~1.5s; entry lands ~1s post-sync).
- [x] `emptyWallet.universal.test.ts` "Unshielded wallet state can be serialized and then restored" passes under the `undeployed` project.
- [x] Both files green together in one undeployed run (4 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)