### PR TITLE
fix(ci): deduplicate integration-test check names (#520)

### DIFF
--- a/.changeset/fix-520-integration-check-names.md
+++ b/.changeset/fix-520-integration-check-names.md
@@ -1,0 +1,9 @@
+---
+---
+
+ci: fix duplicated and mislabeled integration-test check names (#520)
+
+Drops the redundant `Integration Tests:` prefix from the matrix job name (GitHub
+already nests it under the `Integration Tests` caller job) and switches the JUnit
+reporter to `annotate_only`, so it no longer spawns detached check-runs that were
+mis-grouped under the unrelated "Check for Changeset" suite.

--- a/.changeset/fix-520-integration-check-names.md
+++ b/.changeset/fix-520-integration-check-names.md
@@ -1,9 +1,10 @@
 ---
 ---
 
-ci: fix duplicated and mislabeled integration-test check names (#520)
+ci: fix duplicated and mislabeled test check names (#520)
 
 Drops the redundant `Integration Tests:` prefix from the matrix job name (GitHub
-already nests it under the `Integration Tests` caller job) and switches the JUnit
-reporter to `annotate_only`, so it no longer spawns detached check-runs that were
-mis-grouped under the unrelated "Check for Changeset" suite.
+already nests it under the `Integration Tests` caller job) and switches both the
+integration and unit JUnit reporters to `annotate_only`, so they no longer spawn
+detached check-runs that were mis-grouped under the unrelated "Check for
+Changeset" suite.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,11 +205,16 @@ jobs:
       - name: Run unit tests
         run: yarn test:unit
 
+      # annotate_only: this job's own status already reports unit pass/fail, so we
+      # only want failure annotations on the diff. A check_name here would spawn a
+      # detached check-run (owned by the generic "GitHub Actions" app) that GitHub
+      # mis-groups under an unrelated suite ("Check for Changeset") — same root
+      # cause as the integration reporter, see #520.
       - name: Publish Unit Test Report
         uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6
         if: success() || failure()
         with:
-          check_name: 'Unit Test Results Wallet SDK'
+          annotate_only: true
           report_paths: |
             **/test-report*.xml
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,7 +45,11 @@ jobs:
           echo "files=$files" >> "$GITHUB_OUTPUT"
 
   test-integration:
-    name: 'Integration Tests: ${{ matrix.test-file }}'
+    # Just the file path here. ci.yml already invokes this reusable workflow as a
+    # caller job named "Integration Tests", and GitHub composes the check name as
+    # `CI / <caller-job> / <matrix-job>`. Prefixing here too would double the words
+    # ("Integration Tests / Integration Tests: …") — see #520.
+    name: '${{ matrix.test-file }}'
     needs: [discover-integration]
     runs-on: ubuntu-latest-8-core-x64
     # Per-file guard (each matrix job is one file). Slowest healthy file is ~12 min,
@@ -120,10 +124,15 @@ jobs:
           echo "Running ${base} in ${pkg_dir}"
           yarn turbo run test:integration --filter="./${pkg_dir}" -- "${base}"
 
+      # annotate_only: the matrix job's own status already reports pass/fail per file,
+      # so we only want failure annotations on the diff — not a separate check-run.
+      # A check_name here would spawn a detached check-run (owned by the generic
+      # "GitHub Actions" app) that GitHub mis-groups under an unrelated suite
+      # ("Check for Changeset") and duplicates the job status — see #520.
       - name: Publish Integration Test Report
         uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6
         if: success() || failure()
         with:
-          check_name: 'Integration Tests: ${{ matrix.test-file }}'
+          annotate_only: true
           report_paths: |
             **/test-report*.xml


### PR DESCRIPTION
Fixes #520

## Problem

On PR pages the test checks rendered with confusing, duplicated, and mis-grouped names:

1. **Doubled label** — `CI / Integration Tests / Integration Tests: packages/…` (the words "Integration Tests" appeared twice).
2. **Phantom grouping (integration)** — duplicate `Integration Tests: packages/…` check-runs nested under the unrelated **`Check for Changeset`** workflow.
3. **Phantom grouping (unit)** — the unit reporter's `Unit Test Results Wallet SDK` check-run is *also* mis-grouped under **`Check for Changeset`** (same root cause; the issue's original claim that it "doesn't exhibit this" was wrong).

## Changes

`.github/workflows/integration.yml`:

1. **Drop the redundant prefix** from the matrix job name: `'Integration Tests: ${{ matrix.test-file }}'` → `'${{ matrix.test-file }}'`. `ci.yml` already invokes this reusable workflow as a caller job named `Integration Tests`, and GitHub composes the check name as `CI / <caller-job> / <matrix-job>` — so the prefix was doubling the words. Result: `CI / Integration Tests / packages/…`.
2. **Switch the integration JUnit reporter to `annotate_only: true`** (removing the per-file `check_name`).

`.github/workflows/ci.yml`:

3. **Switch the unit JUnit reporter to `annotate_only: true`** (removing `check_name: 'Unit Test Results Wallet SDK'`).

### Why `annotate_only`

Any check-run published via `action-junit-report`'s `check_name` is a **detached** Checks-API run (owned by the generic "GitHub Actions" app), not bound to the CI workflow run — so GitHub orphan-groups it under an arbitrary suite and it merely duplicates the job's own pass/fail status. There's no option to fix the grouping; not creating the detached run is the fix. With `annotate_only`, test **failures still surface as annotations on the diff**, and gating is unchanged (the test step's exit code drives the job → caller → aggregate `Tests` status).

Includes a no-bump changeset (CI-only change).

## Verification

Once CI runs on this PR:

- Integration checks read cleanly as `CI / Integration Tests / packages/…` (no doubled prefix).
- **No** check-runs appear under `Check for Changeset` for either `Integration Tests: …` or `Unit Test Results Wallet SDK`.
- Failing tests still annotate the diff.