### PR TITLE
fix(ci): restore GitHub Releases + tags on v2 publish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -189,13 +189,28 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Build, publish (both scopes), and tag
-        # Both scopes publish via OIDC + provenance (see scripts/publish.mjs).
-        run: |
-          yarn changeset:publish
-          git push origin --tags
+      - name: Build packages
+        run: yarn dist:publish
+
+      # Publish the canonical @midnightntwrk scope via changesets. The action
+      # runs `changeset publish` (OIDC Trusted Publishing — no token; provenance
+      # via NPM_CONFIG_PROVENANCE), then pushes the release tags and creates one
+      # GitHub Release per package from its CHANGELOG. This restores the Releases
+      # that the action created before publishing was hand-rolled into a script.
+      - name: Publish @midnightntwrk + GitHub Releases
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        with:
+          publish: yarn changeset publish
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ env.MIDNIGHT_GH_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
+
+      # Mirror the transitional @midnight-ntwrk alias (dashed scope). The
+      # canonical scope is already live from the step above; this only stages
+      # and publishes the alias, so it can never lead the canonical scope.
+      - name: Publish @midnight-ntwrk alias
+        run: node scripts/publish-alias.mjs
 
   canary:
     name: Canary (snapshot publish)
@@ -241,6 +256,7 @@ jobs:
       - name: Snapshot version + publish canary
         env:
           GITHUB_TOKEN: ${{ env.MIDNIGHT_GH_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
         run: |
           set -euo pipefail
 
@@ -292,14 +308,21 @@ jobs:
           yarn dist:publish
 
           # Publish under a branch-specific dist-tag: "canary" on main,
-          # "canary-<branch>" elsewhere. Uses the npm CLI (OIDC + provenance)
-          # via scripts/publish.mjs, which forwards --tag to `npm publish`.
+          # "canary-<branch>" elsewhere.
           if [ "${{ github.ref_name }}" = "main" ]; then
             CANARY_TAG="canary"
           else
             CANARY_TAG="canary-${{ github.ref_name }}"
           fi
-          node scripts/publish.mjs --tag "$CANARY_TAG"
+
+          # Canonical @midnightntwrk scope: `changeset publish` (OIDC +
+          # provenance via NPM_CONFIG_PROVENANCE), the same mechanism the stable
+          # job uses. --no-git-tag so canary snapshots leave no git tags (and
+          # no GitHub Releases — that is the action's job, not the CLI's).
+          yarn changeset publish --tag "$CANARY_TAG" --no-git-tag
+
+          # Dashed @midnight-ntwrk alias: mirrored afterwards from the workspace.
+          node scripts/publish-alias.mjs --tag "$CANARY_TAG"
 
       - name: Cleanup (always)
         if: always()

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "dist": "turbo run dist",
     "watch": "turbo watch dist",
     "dist:publish": "turbo run dist:publish",
-    "changeset:publish": "yarn dist:publish && node scripts/publish.mjs && yarn changeset tag",
     "changeset:version": "yarn changeset version && yarn install --mode=update-lockfile",
     "changeset:check": "yarn changeset status --verbose",
     "clean": "turbo run clean"

--- a/scripts/publish-alias.mjs
+++ b/scripts/publish-alias.mjs
@@ -12,19 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Publishes non-private workspace packages to npmjs under TWO scopes during the
-// org migration from `@midnight-ntwrk` to `@midnightntwrk`, both via npm Trusted
-// Publishing (OIDC) + `--provenance` (no tokens):
+// Publishes the transitional `@midnight-ntwrk/*` (dashed) alias to npmjs during
+// the org migration to `@midnightntwrk`, via npm Trusted Publishing (OIDC) +
+// `--provenance` (no tokens). For each non-private workspace package it stages a
+// copy in a temp dir, rewrites the scope in package.json, the README, and the
+// compiled `dist/**`, then publishes it under the dashed scope with a migration
+// banner pointing at the `@midnightntwrk` equivalent.
 //
-//   1. Primary `@midnightntwrk/*` — published as-is from the workspace.
-//   2. Alias `@midnight-ntwrk/*` — transitional, so dashed-scope consumers keep
-//      resolving; staged in a temp dir with the scope rewritten, then published.
+// The canonical `@midnightntwrk` scope is NOT published here — `changeset
+// publish` owns it (see .github/workflows/cd.yml): via changesets/action for
+// stable releases (which also creates the GitHub Releases), and via a
+// `--no-git-tag` snapshot publish for canaries. This script runs afterwards and
+// only mirrors the alias, so it never leads the canonical scope.
 //
 // Versions already on the registry are skipped so re-runs are idempotent.
 //
 // Usage:
-//   node scripts/publish.mjs              # dist-tag from changesets pre mode, else `latest`
-//   node scripts/publish.mjs --tag canary # force the `canary` dist-tag
+//   node scripts/publish-alias.mjs              # dist-tag from changesets pre mode, else `latest`
+//   node scripts/publish-alias.mjs --tag canary # force the `canary` dist-tag
 
 import { execFileSync } from 'node:child_process';
 import { cpSync, existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -98,8 +103,8 @@ if (publishable.length === 0) {
   process.exit(0);
 }
 
-console.log(`Publishing ${publishable.length} package(s)${distTag ? ` (dist-tag: ${distTag})` : ''}:`);
-publishable.forEach((ws) => console.log(`  - ${ws.pkg.name}@${ws.pkg.version} (+ alias ${toAlias(ws.pkg.name)})`));
+console.log(`Publishing ${publishable.length} alias package(s)${distTag ? ` (dist-tag: ${distTag})` : ''}:`);
+publishable.forEach((ws) => console.log(`  - ${toAlias(ws.pkg.name)}@${ws.pkg.version}`));
 
 const isAlreadyPublished = (name, version) => {
   try {
@@ -172,29 +177,9 @@ const publishAlias = (ws) => {
   }
 };
 
-// Publish the primary @midnightntwrk scope via OIDC + provenance.
-const publishPrimary = (ws) => {
-  const { name, version } = ws.pkg;
-  if (isAlreadyPublished(name, version)) {
-    console.log(`\nSkip ${name}@${version}: already published.`);
-    return { name, version, status: 'skipped' };
-  }
-
-  console.log(`\nPublishing ${name}@${version} (OIDC + provenance)...`);
-  try {
-    execFileSync('npm', ['publish', '--provenance', '--access', 'public', ...tagArgs], {
-      cwd: ws.location,
-      stdio: 'inherit',
-    });
-    return { name, version, status: 'published' };
-  } catch (err) {
-    return { name, version, status: 'failed', error: err.message };
-  }
-};
-
 const results = publishable.flatMap((ws) => {
   // Under any non-`latest` dist-tag (a canary snapshot or a changesets pre/beta
-  // release), only publish prerelease-versioned packages. A prerelease version
+  // release), only mirror prerelease-versioned packages. A prerelease version
   // always carries a semver "-"; a canonical version (no "-") must never sit
   // under a prerelease dist-tag. Plain `latest` releases resolve no dist-tag
   // (distTag undefined), so this never affects them.
@@ -202,16 +187,10 @@ const results = publishable.flatMap((ws) => {
     console.log(`Skip ${ws.pkg.name}@${ws.pkg.version}: not a prerelease version for --tag ${distTag}.`);
     return [];
   }
-  const primary = publishPrimary(ws);
-  // Only mirror to the dashed alias once the primary scope is in good shape
-  // (published or already present). If the primary publish failed, skip the
-  // alias so the transitional scope never leads the @midnightntwrk one.
-  if (primary.status === 'failed') {
-    const aliasName = toAlias(ws.pkg.name);
-    console.error(`Skip alias ${aliasName}@${ws.pkg.version}: primary publish failed.`);
-    return [primary];
-  }
-  return [primary, publishAlias(ws)];
+  // The canonical @midnightntwrk publish ran first via `changeset publish`
+  // (see cd.yml); step ordering means it is already live, so mirroring the
+  // dashed alias here can never let the alias lead the canonical scope.
+  return [publishAlias(ws)];
 });
 
 const counts = results.reduce((acc, r) => ({ ...acc, [r.status]: (acc[r.status] ?? 0) + 1 }), {});

--- a/scripts/write-canary-changeset.mjs
+++ b/scripts/write-canary-changeset.mjs
@@ -29,8 +29,8 @@ import { resolve } from 'node:path';
 const config = JSON.parse(readFileSync('.changeset/config.json', 'utf8'));
 const ignore = new Set(config.ignore ?? []);
 
-// Same publishable set as scripts/publish.mjs (non-private workspaces), minus
-// changeset-ignored names so `changeset version` doesn't choke on them.
+// Same publishable set as scripts/publish-alias.mjs (non-private workspaces),
+// minus changeset-ignored names so `changeset version` doesn't choke on them.
 const names = execFileSync('yarn', ['workspaces', 'list', '--json'], { encoding: 'utf8' })
   .trim()
   .split('\n')


### PR DESCRIPTION
## What

Ports the main publish fix (#522) to the **v2** release line: the canonical `@midnightntwrk` scope is published via `changeset publish` everywhere.

- **`publish-stable`** → `changesets/action` runs `changeset publish` (OIDC + provenance), pushes the release tags, and **creates one GitHub Release per package** from its CHANGELOG.
- **`canary`** → `changeset publish --tag <canary> --no-git-tag` (tag-less snapshot).
- `scripts/publish.mjs` is now single-purpose and renamed `scripts/publish-alias.mjs` — it only mirrors the transitional dashed `@midnight-ntwrk` alias, running after the canonical publish.

## Why

v2 still ran the hand-rolled `yarn changeset:publish` (`publish.mjs` + `changeset tag`), which publishes to npm but **never creates GitHub Releases**. That is exactly the gap that left `2.0.0-beta.0` (and, on the v1 line, `1.2.0`) published to npmjs with no Releases — both had to be backfilled by hand. With this change the next v2 publish creates the tags and Releases automatically.

## Effect

- Beta versions (any version containing `-`) are auto-marked as **prereleases**, so they never displace the stable "Latest".
- `cd.yml` here is now identical to `main`'s; the only files touched are the CI publish flow.

## Files

- `.github/workflows/cd.yml` — publish flow
- `scripts/publish.mjs` → `scripts/publish-alias.mjs` — single-purpose alias mirror
- `scripts/write-canary-changeset.mjs` — comment update
- `package.json` — removed the now-dead `changeset:publish` script
