### PR TITLE
chore: upgrade ledger to 1.0.0-rc.3

### DIFF
--- a/.changeset/ledger-rc3-upgrade.md
+++ b/.changeset/ledger-rc3-upgrade.md
@@ -1,0 +1,14 @@
+---
+'@midnightntwrk/wallet-sdk-testkit': patch
+'@midnightntwrk/wallet-sdk-unshielded-wallet': patch
+'@midnightntwrk/wallet-sdk-shielded': patch
+'@midnightntwrk/wallet-sdk-address-format': patch
+'@midnightntwrk/wallet-sdk-prover-client': patch
+'@midnightntwrk/wallet-sdk-capabilities': patch
+'@midnightntwrk/wallet-sdk-dust-wallet': patch
+'@midnightntwrk/wallet-sdk-node-client': patch
+'@midnightntwrk/wallet-sdk-facade': patch
+'@midnightntwrk/wallet-sdk': patch
+---
+
+chore: upgrade ledger to 1.0.0-rc.3

--- a/packages/address-format/package.json
+++ b/packages/address-format/package.json
@@ -26,7 +26,7 @@
     }
   },
   "dependencies": {
-    "@midnightntwrk/ledger-v9": "1.0.0-rc.2",
+    "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
     "@scure/base": "^2.0.0",
     "@subsquid/scale-codec": "^4.0.1"
   },

--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@midnight-ntwrk/zkir-v2": "^2.1.0",
-    "@midnightntwrk/ledger-v9": "1.0.0-rc.2",
+    "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
     "@midnightntwrk/wallet-sdk-abstractions": "3.0.0-beta.0",
     "@midnightntwrk/wallet-sdk-indexer-client": "1.3.0-beta.1",
     "@midnightntwrk/wallet-sdk-node-client": "2.0.0-beta.1",

--- a/packages/docs-snippets/src/utils.ts
+++ b/packages/docs-snippets/src/utils.ts
@@ -101,4 +101,7 @@ export const aFakeProvingProvider: ledger.ProvingProvider = {
   prove(_serializedPreimage: Uint8Array, _keyLocation: string, _overwriteBindingInput?: bigint): Promise<Uint8Array> {
     return Promise.resolve(new Uint8Array(0));
   },
+  lookupKey(_keyLocation: string): Promise<ledger.ProvingKeyMaterial | undefined> {
+    return Promise.resolve(undefined);
+  },
 };

--- a/packages/dust-wallet/package.json
+++ b/packages/dust-wallet/package.json
@@ -30,7 +30,7 @@
     }
   },
   "dependencies": {
-    "@midnightntwrk/ledger-v9": "1.0.0-rc.2",
+    "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
     "@midnightntwrk/wallet-sdk-abstractions": "3.0.0-beta.0",
     "@midnightntwrk/wallet-sdk-address-format": "4.0.0-beta.1",
     "@midnightntwrk/wallet-sdk-capabilities": "4.0.0-beta.1",

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@cardano-sdk/key-management": "0.29.13",
-    "@midnightntwrk/ledger-v9": "1.0.0-rc.2",
+    "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
     "@midnightntwrk/wallet-sdk-abstractions": "workspace:*",
     "@midnightntwrk/wallet-sdk-address-format": "workspace:*",
     "@midnightntwrk/wallet-sdk-capabilities": "workspace:^",

--- a/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
@@ -330,6 +330,7 @@ describe('Optional Balancing', () => {
             {
               check: () => Promise.resolve([]),
               prove: () => Promise.resolve(tx.mockProve().guaranteedOffer!.outputs.at(0)!.proof.serialize()),
+              lookupKey: () => Promise.resolve(undefined),
             },
             ledger.LedgerParameters.initialParameters().transactionCostModel.runtimeCostModel,
           ),

--- a/packages/facade/package.json
+++ b/packages/facade/package.json
@@ -26,7 +26,7 @@
     }
   },
   "dependencies": {
-    "@midnightntwrk/ledger-v9": "1.0.0-rc.2",
+    "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
     "@midnightntwrk/wallet-sdk-abstractions": "3.0.0-beta.0",
     "@midnightntwrk/wallet-sdk-address-format": "4.0.0-beta.1",
     "@midnightntwrk/wallet-sdk-capabilities": "4.0.0-beta.1",

--- a/packages/node-client/package.json
+++ b/packages/node-client/package.json
@@ -43,7 +43,7 @@
     "effect": "^3.19.19"
   },
   "peerDependencies": {
-    "@midnightntwrk/ledger-v9": "1.0.0-rc.2",
+    "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
     "@midnightntwrk/wallet-sdk-prover-client": "2.0.0-beta.1"
   },
   "peerDependenciesMeta": {
@@ -62,7 +62,7 @@
     "@effect/rpc": "0.75.1",
     "@effect/sql": "0.51.1",
     "@effect/workflow": "0.18.2",
-    "@midnightntwrk/ledger-v9": "1.0.0-rc.2",
+    "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
     "@midnightntwrk/wallet-sdk-prover-client": "^2.0.0-beta.1",
     "@types/tar-stream": "3.1.4",
     "tar-stream": "3.2.0",

--- a/packages/prover-client/package.json
+++ b/packages/prover-client/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@effect/platform": "^0.96.0",
     "@midnight-ntwrk/zkir-v2": "^2.1.0",
-    "@midnightntwrk/ledger-v9": "1.0.0-rc.2",
+    "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
     "@midnightntwrk/wallet-sdk-utilities": "1.2.0",
     "effect": "^3.19.19",
     "web-worker": "^1.5.0"

--- a/packages/prover-client/src/effect/HttpProverClient.ts
+++ b/packages/prover-client/src/effect/HttpProverClient.ts
@@ -144,6 +144,9 @@ class HttpProverClientImpl implements Context.Tag.Service<ProverClient> {
         Effect.flatMap((tx) => this.request(PROVE_TX_PATH, tx, 'Failed to prove')),
         Effect.runPromise,
       ),
+    // The proof server holds its own key material and resolves circuits from the
+    // preimage's key location, so there is never local key material to provide.
+    lookupKey: (_keyLocation: string): Promise<ledger.ProvingKeyMaterial | undefined> => Promise.resolve(undefined),
   });
 
   proveTransaction<S extends ledger.Signaturish, B extends ledger.Bindingish>(

--- a/packages/prover-client/src/effect/WasmProver.ts
+++ b/packages/prover-client/src/effect/WasmProver.ts
@@ -167,6 +167,8 @@ class WasmProverImpl implements Context.Tag.Service<ProverClient> {
         op: 'prove',
         args: [serializedPreimage, overwriteBindingInput],
       }),
+    lookupKey: (keyLocation: string): Promise<ProvingKeyMaterial | undefined> =>
+      (keyMaterialProvider ?? this.keyMaterialProvider).lookupKey(keyLocation),
   });
 
   proveTransaction<S extends ledger.Signaturish, B extends ledger.Bindingish>(

--- a/packages/shielded-wallet/package.json
+++ b/packages/shielded-wallet/package.json
@@ -30,7 +30,7 @@
     }
   },
   "dependencies": {
-    "@midnightntwrk/ledger-v9": "1.0.0-rc.2",
+    "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
     "@midnightntwrk/wallet-sdk-abstractions": "3.0.0-beta.0",
     "@midnightntwrk/wallet-sdk-address-format": "4.0.0-beta.1",
     "@midnightntwrk/wallet-sdk-capabilities": "4.0.0-beta.1",

--- a/packages/unshielded-wallet/package.json
+++ b/packages/unshielded-wallet/package.json
@@ -30,7 +30,7 @@
     }
   },
   "dependencies": {
-    "@midnightntwrk/ledger-v9": "1.0.0-rc.2",
+    "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
     "@midnightntwrk/wallet-sdk-abstractions": "3.0.0-beta.0",
     "@midnightntwrk/wallet-sdk-address-format": "4.0.0-beta.1",
     "@midnightntwrk/wallet-sdk-capabilities": "4.0.0-beta.1",

--- a/packages/unshielded-wallet/src/v1/test/signingSchemeMismatch.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/signingSchemeMismatch.test.ts
@@ -118,6 +118,7 @@ describe('signing rejects a scheme mismatch (ECDSA-MM-03/04/05/07/08)', () => {
       {
         prove: () => Promise.resolve(Buffer.from([42])),
         check: () => Promise.resolve([]),
+        lookupKey: () => Promise.resolve(undefined),
       },
       ledger.LedgerParameters.initialParameters().transactionCostModel.runtimeCostModel,
     );

--- a/packages/unshielded-wallet/src/v1/test/transacting.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/transacting.test.ts
@@ -293,6 +293,9 @@ describe('Unshielded wallet transacting', () => {
           check(): Promise<(bigint | undefined)[]> {
             return Promise.resolve([]);
           },
+          lookupKey(): Promise<ledger.ProvingKeyMaterial | undefined> {
+            return Promise.resolve(undefined);
+          },
         },
         ledger.LedgerParameters.initialParameters().transactionCostModel.runtimeCostModel,
       );

--- a/packages/wallet-integration-tests/package.json
+++ b/packages/wallet-integration-tests/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@midnightntwrk/ledger-v9": "1.0.0-rc.2",
+    "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
     "@midnightntwrk/wallet-sdk-abstractions": "^3.0.0-beta.0",
     "@midnightntwrk/wallet-sdk-address-format": "^4.0.0-beta.1",
     "@midnightntwrk/wallet-sdk-capabilities": "^4.0.0-beta.1",

--- a/packages/wallet-sdk-testkit/package.json
+++ b/packages/wallet-sdk-testkit/package.json
@@ -39,7 +39,7 @@
     }
   },
   "dependencies": {
-    "@midnightntwrk/ledger-v9": "1.0.0-rc.2",
+    "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
     "@midnightntwrk/wallet-sdk-abstractions": "3.0.0-beta.0",
     "@midnightntwrk/wallet-sdk-address-format": "4.0.0-beta.1",
     "@midnightntwrk/wallet-sdk-capabilities": "4.0.0-beta.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2414,7 +2414,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/wallet-integration-tests@workspace:packages/wallet-integration-tests"
   dependencies:
-    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.2"
+    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.3"
     "@midnightntwrk/wallet-sdk-abstractions": "npm:^3.0.0-beta.0"
     "@midnightntwrk/wallet-sdk-address-format": "npm:^4.0.0-beta.1"
     "@midnightntwrk/wallet-sdk-capabilities": "npm:^4.0.0-beta.1"
@@ -2462,7 +2462,7 @@ __metadata:
   resolution: "@midnight/wallet-e2e-tests@workspace:packages/e2e-tests"
   dependencies:
     "@cardano-sdk/key-management": "npm:0.29.13"
-    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.2"
+    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.3"
     "@midnightntwrk/wallet-sdk-abstractions": "workspace:*"
     "@midnightntwrk/wallet-sdk-address-format": "workspace:*"
     "@midnightntwrk/wallet-sdk-capabilities": "workspace:^"
@@ -2487,10 +2487,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@midnightntwrk/ledger-v9@npm:1.0.0-rc.2":
-  version: 1.0.0-rc.2
-  resolution: "@midnightntwrk/ledger-v9@npm:1.0.0-rc.2"
-  checksum: 10c0/7b0e8436074b1d8caeb8e378be2646d31c74e4ba285292e06bdec45503e765aea30f12b920dfdfc47777a14fa1b98cf2bfbe16730cc554c27e828c2f558d73ca
+"@midnightntwrk/ledger-v9@npm:1.0.0-rc.3":
+  version: 1.0.0-rc.3
+  resolution: "@midnightntwrk/ledger-v9@npm:1.0.0-rc.3"
+  checksum: 10c0/6fb6a2afa8d058994dc75f7165755106e7e70d2887806af669b0bf1b31e2b197f1d004651b8fba9811cb80d44523f3ce76f6bbb318fde9adf5a13dd244de3106
   languageName: node
   linkType: hard
 
@@ -2506,7 +2506,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnightntwrk/wallet-sdk-address-format@workspace:packages/address-format"
   dependencies:
-    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.2"
+    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.3"
     "@scure/base": "npm:^2.0.0"
     "@subsquid/scale-codec": "npm:^4.0.1"
   languageName: unknown
@@ -2524,7 +2524,7 @@ __metadata:
     "@effect/sql": "npm:0.51.1"
     "@effect/workflow": "npm:0.18.2"
     "@midnight-ntwrk/zkir-v2": "npm:^2.1.0"
-    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.2"
+    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.3"
     "@midnightntwrk/wallet-sdk-abstractions": "npm:3.0.0-beta.0"
     "@midnightntwrk/wallet-sdk-indexer-client": "npm:1.3.0-beta.1"
     "@midnightntwrk/wallet-sdk-node-client": "npm:2.0.0-beta.1"
@@ -2551,7 +2551,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnightntwrk/wallet-sdk-dust-wallet@workspace:packages/dust-wallet"
   dependencies:
-    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.2"
+    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.3"
     "@midnightntwrk/wallet-sdk-abstractions": "npm:3.0.0-beta.0"
     "@midnightntwrk/wallet-sdk-address-format": "npm:4.0.0-beta.1"
     "@midnightntwrk/wallet-sdk-capabilities": "npm:4.0.0-beta.1"
@@ -2568,7 +2568,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnightntwrk/wallet-sdk-facade@workspace:packages/facade"
   dependencies:
-    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.2"
+    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.3"
     "@midnightntwrk/wallet-sdk-abstractions": "npm:3.0.0-beta.0"
     "@midnightntwrk/wallet-sdk-address-format": "npm:4.0.0-beta.1"
     "@midnightntwrk/wallet-sdk-capabilities": "npm:4.0.0-beta.1"
@@ -2650,7 +2650,7 @@ __metadata:
     "@effect/rpc": "npm:0.75.1"
     "@effect/sql": "npm:0.51.1"
     "@effect/workflow": "npm:0.18.2"
-    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.2"
+    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.3"
     "@midnightntwrk/wallet-sdk-abstractions": "npm:3.0.0-beta.0"
     "@midnightntwrk/wallet-sdk-prover-client": "npm:^2.0.0-beta.1"
     "@midnightntwrk/wallet-sdk-utilities": "npm:1.2.0"
@@ -2664,7 +2664,7 @@ __metadata:
     tar-stream: "npm:3.2.0"
     tsx: "npm:4.22.4"
   peerDependencies:
-    "@midnightntwrk/ledger-v9": 1.0.0-rc.2
+    "@midnightntwrk/ledger-v9": 1.0.0-rc.3
     "@midnightntwrk/wallet-sdk-prover-client": 2.0.0-beta.1
   peerDependenciesMeta:
     "@midnightntwrk/ledger-v9":
@@ -2680,7 +2680,7 @@ __metadata:
   dependencies:
     "@effect/platform": "npm:^0.96.0"
     "@midnight-ntwrk/zkir-v2": "npm:^2.1.0"
-    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.2"
+    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.3"
     "@midnightntwrk/wallet-sdk-utilities": "npm:1.2.0"
     effect: "npm:^3.19.19"
     web-worker: "npm:^1.5.0"
@@ -2702,7 +2702,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnightntwrk/wallet-sdk-shielded@workspace:packages/shielded-wallet"
   dependencies:
-    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.2"
+    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.3"
     "@midnightntwrk/wallet-sdk-abstractions": "npm:3.0.0-beta.0"
     "@midnightntwrk/wallet-sdk-address-format": "npm:4.0.0-beta.1"
     "@midnightntwrk/wallet-sdk-capabilities": "npm:4.0.0-beta.1"
@@ -2718,7 +2718,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnightntwrk/wallet-sdk-testkit@workspace:packages/wallet-sdk-testkit"
   dependencies:
-    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.2"
+    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.3"
     "@midnightntwrk/wallet-sdk-abstractions": "npm:3.0.0-beta.0"
     "@midnightntwrk/wallet-sdk-address-format": "npm:4.0.0-beta.1"
     "@midnightntwrk/wallet-sdk-capabilities": "npm:4.0.0-beta.1"
@@ -2752,7 +2752,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnightntwrk/wallet-sdk-unshielded-wallet@workspace:packages/unshielded-wallet"
   dependencies:
-    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.2"
+    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.3"
     "@midnightntwrk/wallet-sdk-abstractions": "npm:3.0.0-beta.0"
     "@midnightntwrk/wallet-sdk-address-format": "npm:4.0.0-beta.1"
     "@midnightntwrk/wallet-sdk-capabilities": "npm:4.0.0-beta.1"


### PR DESCRIPTION
Upgrades `@midnightntwrk/ledger-v9` from 1.0.0-rc.2 to 1.0.0-rc.3 across all packages.

rc.3 adds a required `lookupKey` method to `ProvingProvider`:
- `WasmProver` delegates to its `KeyMaterialProvider`
- `HttpProverClient` returns `undefined` (proof server holds its own key material)
- test/doc fakes return `undefined`

Typecheck, lint, Effect diagnostics, and unit tests pass.