### PR TITLE
fix(testkit): republish wallet-sdk-testkit to drop leaked workspace: deps

### DIFF
--- a/.changeset/fix-testkit-workspace-protocol-leak.md
+++ b/.changeset/fix-testkit-workspace-protocol-leak.md
@@ -1,0 +1,11 @@
+---
+'@midnightntwrk/wallet-sdk-testkit': patch
+---
+
+Fix uninstallable `wallet-sdk-testkit@0.2.0`. That release shipped its internal
+`wallet-sdk-*` dependencies (and the `wallet-sdk-utilities` peer) as the
+monorepo-only `workspace:^` specifier, which leaked into the published tarball on
+both the `@midnightntwrk` and `@midnight-ntwrk` scopes. External installs failed
+(`npm` → `EUNSUPPORTEDPROTOCOL: Unsupported URL Type "workspace:"`, `yarn` classic
+→ "Couldn't find any versions ... that matches workspace:^"). This release
+publishes those dependencies with concrete versions, restoring installability.


### PR DESCRIPTION
## Problem

`wallet-sdk-testkit@0.2.0` is uninstallable for external consumers. The publish shipped its internal `wallet-sdk-*` dependencies (and the `wallet-sdk-utilities` peer) as the monorepo-only `workspace:^` specifier, which leaked verbatim into the published tarball — confirmed on **both** the `@midnightntwrk` and `@midnight-ntwrk` scopes, and it is the `latest` dist-tag on each.

Reproduction:
- `npm install @midnight-ntwrk/wallet-sdk-testkit@0.2.0` → `EUNSUPPORTEDPROTOCOL: Unsupported URL Type "workspace:"`
- yarn 1.x → `Couldn't find any versions for "@midnight-ntwrk/wallet-sdk-dust-wallet" that matches "workspace:^"`

`npm pack`-ing the published `0.2.0` shows `workspace:^` present 11× in `package.json` (9 internal deps + the utilities peer + a devDep).

## Fix

Source deps are already concrete (#527), and the canary/beta lines publish correctly via `changeset publish` (which rewrites `workspace:`). `0.2.0` leaked because it was published outside that flow. npm immutability means `0.2.0` can't be overwritten, so this changeset cuts a corrected **`0.2.1`** whose changelog documents the uninstallable-`0.2.0` fix. When the release PR merges, the gated stable publish republishes `0.2.1` on `@midnightntwrk` and mirrors `@midnight-ntwrk` via `publish-alias.mjs`, superseding the broken `latest`.

Only `wallet-sdk-testkit` bumps — it's a leaf; no publishable package depends on it, so nothing cascades (the barrel `@midnightntwrk/wallet-sdk` is unaffected).

## Notes

- The pending `pin-internal-deps-exact.md` changeset also bumps testkit to `0.2.1`; both aggregate into a single `0.2.1` with both changelog bullets.
- Optional follow-up (registry action, not in this PR): `npm deprecate` `0.2.0` on both scopes so pinned consumers get a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)