### PR TITLE
Fast-sync review fixes: nullifier matching, foreign spends, schema nullability

### DIFF
--- a/packages/dust-wallet/src/v1/CoreWallet.ts
+++ b/packages/dust-wallet/src/v1/CoreWallet.ts
@@ -33,6 +33,7 @@ import {
   type CollapsedMerkleTree,
   type NewDustGeneration,
   type DustGenerationDtimUpdate,
+  type DustUtxoEntry,
   type DustUtxoMap,
 } from './SyncSchema.js';
 
@@ -121,29 +122,32 @@ export const CoreWallet = {
     newGenerations: ReadonlyArray<NewDustGeneration>,
     generationDtimeUpdates: ReadonlyArray<DustGenerationDtimUpdate>,
   ): CoreWallet {
-    let updatedState = wallet.state;
+    // apply snapshot updates covering (lastIndex, nextGenerationIndex) — the gap before the next own generation,
+    // or every remaining update when there is no next generation
+    const applySnapshotGap = (state: DustLocalState, lastIndex: number, nextGenerationIndex?: number): DustLocalState =>
+      dustCollapsedGenTreeSnapshot
+        .filter(
+          ({ startIndex, endIndex }) =>
+            startIndex > lastIndex && (nextGenerationIndex === undefined || endIndex < nextGenerationIndex),
+        )
+        .reduce((current, update) => current.applyGenerationCollapsedUpdate(update.update), state);
 
-    let lastUpdatedIndex = -1;
-    for (const { generationMtIndex, genInfo, qdo } of newGenerations) {
-      // apply updates prior to the current generation index
-      updatedState = dustCollapsedGenTreeSnapshot
-        .filter(({ startIndex, endIndex }) => startIndex > lastUpdatedIndex && endIndex < generationMtIndex)
-        .reduce((state, update) => state.applyGenerationCollapsedUpdate(update.update), updatedState);
+    const { state: stateWithGenerations, lastIndex } = newGenerations.reduce(
+      (acc, { generationMtIndex, genInfo, qdo }) => ({
+        state: applySnapshotGap(acc.state, acc.lastIndex, generationMtIndex).insertGenerationInfo(
+          BigInt(generationMtIndex),
+          genInfo,
+          qdo.backingNight,
+        ),
+        lastIndex: generationMtIndex,
+      }),
+      { state: wallet.state, lastIndex: -1 },
+    );
 
-      // now, insert the generation info
-      updatedState = updatedState.insertGenerationInfo(BigInt(generationMtIndex), genInfo, qdo.backingNight);
-      lastUpdatedIndex = generationMtIndex;
-    }
-
-    // apply the rest of the updates
-    updatedState = dustCollapsedGenTreeSnapshot
-      .filter(({ startIndex }) => startIndex > lastUpdatedIndex)
-      .reduce((state, update) => state.applyGenerationCollapsedUpdate(update.update), updatedState);
-
-    // apply dtime updates
-    updatedState = generationDtimeUpdates.reduce(
+    // apply the rest of the updates, then the dtime updates
+    const updatedState = generationDtimeUpdates.reduce(
       (state, update) => state.updateGenerationTreeFromEvidence(update.treeInsertionPath),
-      updatedState,
+      applySnapshotGap(stateWithGenerations, lastIndex),
     );
 
     return {
@@ -167,41 +171,28 @@ export const CoreWallet = {
     newDustUtxos: Readonly<DustUtxoMap>,
     collapsedCommitments: ReadonlyArray<CollapsedMerkleTree>,
   ): CoreWallet {
-    let updatedState = wallet.state;
     const newUtxos = [...HashMap.values(newDustUtxos)].toSorted((a, b) => Number(a.qdo.mtIndex - b.qdo.mtIndex));
-    for (const { startIndex, update } of collapsedCommitments) {
-      // apply utxos going before the current index
+
+    const insertCommitments = (state: DustLocalState, utxos: ReadonlyArray<DustUtxoEntry>): DustLocalState =>
+      utxos.reduce((current, utxoInfo) => current.insertCommitment(utxoInfo.qdo.mtIndex, utxoInfo.qdo, true), state);
+
+    const stateAfterCollapsed = collapsedCommitments.reduce((state, { startIndex, update }) => {
+      // apply utxos going before the current index, then the current update
       const priorUtxos = newUtxos.filter(
         (utxoInfo) =>
-          Number(utxoInfo.qdo.mtIndex) < startIndex && utxoInfo.qdo.mtIndex >= updatedState.commitmentTreeFirstFree,
+          Number(utxoInfo.qdo.mtIndex) < startIndex && utxoInfo.qdo.mtIndex >= state.commitmentTreeFirstFree,
       );
-      updatedState = priorUtxos.reduce(
-        (state, utxoInfo) => state.insertCommitment(utxoInfo.qdo.mtIndex, utxoInfo.qdo, true),
-        updatedState,
-      );
-      // apply current update
-      updatedState = updatedState.applyCommitmentCollapsedUpdate(update);
-    }
+      return insertCommitments(state, priorUtxos).applyCommitmentCollapsedUpdate(update);
+    }, wallet.state);
 
-    // check utxos after the last index
+    // insert the utxos after the last collapsed update — all of them when there were no collapsed updates
     const lastCollapsedIndex = collapsedCommitments.at(-1);
-    if (lastCollapsedIndex !== undefined) {
-      const utxosAfterLastIndex = newUtxos.filter(
-        (utxoInfo) => Number(utxoInfo.qdo.mtIndex) > lastCollapsedIndex.endIndex,
-      );
-      updatedState = utxosAfterLastIndex.reduce(
-        (state, utxoInfo) => state.insertCommitment(utxoInfo.qdo.mtIndex, utxoInfo.qdo, true),
-        updatedState,
-      );
-    }
-
-    // edge-case: no collapsed commitments but new utxos
-    if (!collapsedCommitments.length && newUtxos.length) {
-      updatedState = newUtxos.reduce(
-        (state, utxoInfo) => state.insertCommitment(utxoInfo.qdo.mtIndex, utxoInfo.qdo, true),
-        updatedState,
-      );
-    }
+    const updatedState = insertCommitments(
+      stateAfterCollapsed,
+      lastCollapsedIndex !== undefined
+        ? newUtxos.filter((utxoInfo) => Number(utxoInfo.qdo.mtIndex) > lastCollapsedIndex.endIndex)
+        : newUtxos,
+    );
 
     return { ...wallet, state: updatedState };
   },

--- a/packages/dust-wallet/src/v1/Sync.ts
+++ b/packages/dust-wallet/src/v1/Sync.ts
@@ -83,7 +83,14 @@ import {
   StateUpdate,
   isProgressUpdate,
 } from './SyncSchema.js';
-import { calculatePrefixLength, hashMapGroupBy, leBigintToHex, uniqueArray } from './Utils.js';
+import {
+  bigintToLeHex,
+  calculatePrefixLength,
+  gapRanges,
+  hashMapGroupBy,
+  leBigintToHex,
+  uniqueArray,
+} from './Utils.js';
 import { type Dust } from './types/index.js';
 
 export interface SyncService<TState, TStartAux, TUpdate> {
@@ -231,36 +238,32 @@ const loadCollapsedCommitments = (
     .toSorted((a, b) => Number(a[1].qdo.mtIndex - b[1].qdo.mtIndex))
     .map(([_, u]) => Number(u.qdo.mtIndex)); // e.g. 43, 67, 68, 75
 
-  // 1: split into groups
-  const groups = [];
-  const firstSkipIndex = skipMtIndexes.at(0);
+  // 1: split into the ranges not covered by the wallet's own utxo indexes
+  const groups = gapRanges(lastAppliedIndex, maxIndex, skipMtIndexes);
 
-  const startIndex = lastAppliedIndex + 1;
-  if (firstSkipIndex !== undefined && startIndex < firstSkipIndex) {
-    groups.push({ start: startIndex, end: firstSkipIndex - 1 });
-  } else if (firstSkipIndex === undefined) {
-    groups.push({ start: startIndex, end: maxIndex });
-  }
-
-  skipMtIndexes.forEach((skipMtIndex, i) => {
-    const start = skipMtIndex + 1;
-    const next = skipMtIndexes.at(i + 1);
-    // skip consecutive indices e.g., 67, 68
-    if (next !== undefined && next - start > 0) {
-      groups.push({ start, end: next - 1 });
-    } else if (next === undefined && start <= maxIndex) {
-      groups.push({ start, end: maxIndex });
-    }
-  });
-
-  // 2: Query all groups in parallel
+  // 2: query all groups
   return pipe(
     groups.map(({ start, end }) => indexerSyncService.dustCommitmentMerkleTreeUpdate(start, end)),
     Effect.all,
   );
 };
 
-const NULLIFIER_LENGTH = 64;
+const NULLIFIER_BYTE_LENGTH = 32;
+const NULLIFIER_LENGTH = NULLIFIER_BYTE_LENGTH * 2;
+
+// Progress through the nullifier-resolution phase, in commitment-index units: a nullifier with no further spends
+// counts as a full scan of the commitment space; a still-live chain counts up to the merkle index of its freshest
+// successor. Bounded by totalNullifiers * maxCommitmentEndIndex (the phase ceiling).
+export const nullifierPhaseProgress = (
+  mtIndicesSum: bigint,
+  totalNullifiers: number,
+  freshCount: number,
+  maxCommitmentEndIndex: number,
+): number =>
+  Math.min(
+    Number(mtIndicesSum) + (totalNullifiers - freshCount) * maxCommitmentEndIndex,
+    totalNullifiers * maxCommitmentEndIndex,
+  );
 
 const resolveNullifierSpends = (
   initialNullifiers: DustNullifier[],
@@ -281,7 +284,6 @@ const resolveNullifierSpends = (
   Scope.Scope | SubscriptionClient
 > => {
   const maxCommitmentEndIndex = latestBlock.dustCommitmentEndIndex - 1;
-  const commitmentIndicesSum = initialNullifiers.length * maxCommitmentEndIndex;
   const initialSpentUtxos: DustUtxoMap = HashMap.empty();
   return pipe(
     Stream.unfoldEffect(
@@ -316,14 +318,15 @@ const resolveNullifierSpends = (
           if (freshUtxos.length > 0) {
             const mtIndicesSum = freshUtxos.reduce((partialSum, a) => partialSum + a.qdo.mtIndex, 0n);
             const generationEndIndex = latestBlock.dustGenerationEndIndex - 1;
-            const progress =
-              Number(mtIndicesSum) +
-              ((initialNullifiers.length - freshUtxos.length) * maxCommitmentEndIndex) / commitmentIndicesSum;
+            const progress = nullifierPhaseProgress(
+              mtIndicesSum,
+              initialNullifiers.length,
+              freshUtxos.length,
+              maxCommitmentEndIndex,
+            );
 
             // NOTE: since this process goes after the generation updates, we need to add the generationEndIndex to the progress
-            yield* Effect.promise(() =>
-              emit.single(ProgressUpdate({ appliedIndex: Math.floor(progress) + generationEndIndex })),
-            );
+            yield* Effect.promise(() => emit.single(ProgressUpdate({ appliedIndex: progress + generationEndIndex })));
           }
 
           const { nextUtxos, nextSpentUtxos } = accumulateUtxoUpdates(dustUtxoUpdates, newUtxos, spentUtxos);
@@ -465,7 +468,7 @@ export const makeEventLessSyncService = (
         doEventlessSync(state, secretKey, anonymityLevel, indexerSyncService),
         Stream.provideSomeLayer(Layer.merge(indexerSyncService.connectionLayer(), indexerSyncService.queryClient())),
       ),
-    blockData: (): Effect.Effect<BlockData, WalletError> => defaultSyncService.blockData(),
+    blockData: defaultSyncService.blockData,
   };
 };
 
@@ -595,7 +598,8 @@ export const makeIndexerSyncService = (config: DefaultSyncConfiguration): Indexe
       toBlock: number | null,
       prefixLength: number,
     ): Stream.Stream<DustNullifierTransactionsSubscription, WalletError, Scope.Scope | SubscriptionClient> {
-      const hexedNullifiers = HashSet.fromIterable(dustNullifiers.map((n) => leBigintToHex(n, true)));
+      // fixed 32-byte little-endian form — the encoding nullifierLeBytes uses on the wire
+      const hexedNullifiers = HashSet.fromIterable(dustNullifiers.map((n) => bigintToLeHex(n, NULLIFIER_BYTE_LENGTH)));
       return pipe(
         DustNullifierTransactions.run({
           nullifierLeBytesPrefixes: uniqueArray([...hexedNullifiers].map((n) => n.substring(0, prefixLength))),
@@ -787,13 +791,16 @@ const createUtxoUpdatesFromSpend = (
   generationDtimeUpdates: ReadonlyArray<DustGenerationDtimUpdate>,
   transaction: NullifierRegularTransaction,
   dustSpend: DustSpendProcessedEvent,
-): Effect.Effect<[DustUtxoUpdate, DustUtxoUpdate], SyncWalletError> =>
+): Effect.Effect<Option.Option<[DustUtxoUpdate, DustUtxoUpdate]>, SyncWalletError> =>
   Effect.gen(function* () {
     const { nullifier, vFee, commitmentIndex, declaredTime } = dustSpend;
     const knownUtxo = Option.getOrUndefined(HashMap.get(knownUtxos, nullifier));
     const qdo = knownUtxo?.qdo ?? pendingDust.get(nullifier) ?? dustState.findUtxoByNullifier(nullifier);
     if (!qdo) {
-      return yield* new SyncWalletError({ message: `Failed to find qdo by nullifier: ${nullifier}` });
+      // A matched transaction carries every dust spend it contains, including other parties' (e.g. the counterparty
+      // of a multi-intent transaction paying its own fees). Those nullifiers can never resolve locally — skip them.
+      yield* Effect.logDebug(`Skipping dust spend of a nullifier not owned by this wallet: ${nullifier}`);
+      return Option.none();
     }
     const genInfo = knownUtxo?.genInfo ?? dustState.generationInfo(qdo);
     if (!genInfo) {
@@ -818,10 +825,10 @@ const createUtxoUpdatesFromSpend = (
       isSpent: false,
       ...txMeta,
     };
-    return [spentUtxoUpdate, newUtxoUpdate];
+    return Option.some<[DustUtxoUpdate, DustUtxoUpdate]>([spentUtxoUpdate, newUtxoUpdate]);
   });
 
-const createDustUtxoUpdates = (
+export const createDustUtxoUpdates = (
   dustState: DustLocalState,
   nullifierTransactions: ReadonlyArray<DustNullifierTransactionsSubscription>,
   secretKey: DustSecretKey,
@@ -854,6 +861,7 @@ const createDustUtxoUpdates = (
       ),
     ),
     Effect.all,
+    Effect.map(Arr.getSomes),
     Effect.map(Arr.flatten),
   );
 

--- a/packages/dust-wallet/src/v1/SyncSchema.ts
+++ b/packages/dust-wallet/src/v1/SyncSchema.ts
@@ -415,15 +415,14 @@ export const WalletSyncUpdate = {
   },
 };
 
-export type DustUtxoMap = HashMap.HashMap<
-  DustNullifier,
-  {
-    qdo: QualifiedDustOutput;
-    transactionId: number;
-    transactionHash: string;
-    genInfo: DustGenerationInfo;
-  }
->;
+export type DustUtxoEntry = {
+  qdo: QualifiedDustOutput;
+  transactionId: number;
+  transactionHash: string;
+  genInfo: DustGenerationInfo;
+};
+
+export type DustUtxoMap = HashMap.HashMap<DustNullifier, DustUtxoEntry>;
 
 export const DustUtxoMap = {
   create: (generations: ReadonlyArray<NewDustGeneration>): DustUtxoMap =>
@@ -465,8 +464,9 @@ export const WireBlockDataSchema = Schema.Struct({
   zswapEndIndex: Schema.Number,
   dustCommitmentEndIndex: Schema.Number,
   dustGenerationEndIndex: Schema.Number,
-  dustCommitmentMerkleTreeRoot: Schema.String,
-  dustGenerationMerkleTreeRoot: Schema.String,
+  // nullable in the indexer schema: a block may carry no dust state
+  dustCommitmentMerkleTreeRoot: Schema.NullOr(Schema.String),
+  dustGenerationMerkleTreeRoot: Schema.NullOr(Schema.String),
 });
 
 export const BlockDataSchema = Schema.transform(
@@ -490,11 +490,18 @@ export const BlockDataSchema = Schema.transform(
       return {
         ...wire,
         timestamp: new Date(wire.timestamp),
+        // '' is the local encoding for "no root" — it matches the wallet-side encoding of an empty tree
+        dustCommitmentMerkleTreeRoot: wire.dustCommitmentMerkleTreeRoot ?? '',
+        dustGenerationMerkleTreeRoot: wire.dustGenerationMerkleTreeRoot ?? '',
       };
     },
     encode: (domain) => ({
       ...domain,
-      timestamp: Math.floor(domain.timestamp.getTime() * 1000),
+      timestamp: domain.timestamp.getTime(),
+      dustCommitmentMerkleTreeRoot:
+        domain.dustCommitmentMerkleTreeRoot === '' ? null : domain.dustCommitmentMerkleTreeRoot,
+      dustGenerationMerkleTreeRoot:
+        domain.dustGenerationMerkleTreeRoot === '' ? null : domain.dustGenerationMerkleTreeRoot,
     }),
   },
 );

--- a/packages/dust-wallet/src/v1/Utils.ts
+++ b/packages/dust-wallet/src/v1/Utils.ts
@@ -44,25 +44,40 @@ export const hashMapGroupBy = <K, V>(arr: ReadonlyArray<V>, keyFn: (v: V) => K):
   }, HashMap.empty<K, V[]>());
 
 export const leBigintToHex = (n: bigint, dropLengthPrefix: boolean = false): string => {
-  let bytes = Buffer.from(ScaleBigInt.encode(n));
-  if (dropLengthPrefix) {
-    bytes = bytes.subarray(1); // drop the 0x73 prefix byte
-  }
-  const str = bytes.toString('hex');
-  return str.length % 2 === 0 ? str : '0' + str;
+  const encoded = Buffer.from(ScaleBigInt.encode(n));
+  const bytes = dropLengthPrefix ? encoded.subarray(1) : encoded; // drop the SCALE compact length-prefix byte
+  return bytes.toString('hex');
 };
+
+// fixed-width little-endian hex, as the indexer encodes nullifiers and commitments ("32-byte little-endian form").
+// SCALE compact encoding (leBigintToHex) is minimal-length and drops most-significant zero bytes, so it cannot be
+// compared against the indexer's fixed-width values directly.
+export const bigintToLeHex = (n: bigint, byteLength: number): string =>
+  Array.from({ length: byteLength }, (_, i) =>
+    Number((n >> BigInt(8 * i)) & 0xffn)
+      .toString(16)
+      .padStart(2, '0'),
+  ).join('');
 
 export const uniqueArray = <T>(arr: ReadonlyArray<T>): T[] => Array.from(HashSet.fromIterable(arr));
 
 export const calculatePrefixLength = (anonymityLevel: number, totalItems: number, maxLength: number): number => {
   const itemPower = totalItems <= 0 ? 1 : Math.round(Math.log2(totalItems));
-  let prefixLength = Math.max(0, itemPower - anonymityLevel);
+  const rawLength = Math.max(0, itemPower - anonymityLevel);
 
   // as we work with hex values, we need to ensure the length is even
-  prefixLength = prefixLength % 2 === 1 ? prefixLength - 1 : prefixLength;
+  const evenLength = rawLength % 2 === 1 ? rawLength - 1 : rawLength;
 
   // force it to be between 2 (indexer's min length) and maxLength
-  prefixLength = Math.min(maxLength, Math.max(2, prefixLength));
-
-  return prefixLength;
+  return Math.min(maxLength, Math.max(2, evenLength));
 };
+
+// The index ranges of [lastAppliedIndex + 1, maxIndex] left uncovered by the (sorted, ascending) skipIndexes.
+export const gapRanges = (
+  lastAppliedIndex: number,
+  maxIndex: number,
+  skipIndexes: ReadonlyArray<number>,
+): { start: number; end: number }[] =>
+  [lastAppliedIndex, ...skipIndexes]
+    .map((boundary, i) => ({ start: boundary + 1, end: (skipIndexes.at(i) ?? maxIndex + 1) - 1 }))
+    .filter(({ start, end }) => start <= end);

--- a/packages/dust-wallet/src/v1/test/coreWallet.test.ts
+++ b/packages/dust-wallet/src/v1/test/coreWallet.test.ts
@@ -1,0 +1,74 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { DustSecretKey, dustFirstNonce, dustNullifier, LedgerParameters } from '@midnight-ntwrk/ledger-v8';
+import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { describe, expect, it } from 'vitest';
+import { CoreWallet } from '../CoreWallet.js';
+import { type NewDustGeneration, DustUtxoMap } from '../SyncSchema.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+const dustParameters = LedgerParameters.initialParameters().dust;
+const seedHex = '0000000000000000000000000000000000000000000000000000000000000001';
+
+// Characterization coverage for the pure state-apply functions used by the projections sync capability. The
+// collapsed-update paths need indexer-produced merkle payloads and stay covered by the projections e2e suite.
+describe('CoreWallet dust apply functions', () => {
+  const secretKey = DustSecretKey.fromSeed(Buffer.from(seedHex, 'hex'));
+
+  const generation = (backingNightByte: string, mtIndex: bigint, generationMtIndex: number): NewDustGeneration => {
+    const backingNight = backingNightByte.repeat(32);
+    const qdo = {
+      initialValue: 1_000_000_000n,
+      owner: secretKey.publicKey,
+      nonce: dustFirstNonce(backingNight, secretKey.publicKey),
+      seq: 0,
+      ctime: new Date(1_000_000),
+      backingNight,
+      mtIndex,
+    };
+    return {
+      dustNullifier: dustNullifier(qdo, secretKey),
+      genInfo: { value: 5_000_000_000n, owner: secretKey.publicKey, nonce: backingNight, dtime: undefined },
+      generationMtIndex,
+      qdo,
+      transactionId: 7,
+      transactionHash: 'cd'.repeat(32),
+    };
+  };
+
+  it('applies new utxos and their commitments, then removes spent nullifiers', () => {
+    const state = CoreWallet.initEmpty(dustParameters, secretKey, networkId);
+    const generations = [generation('ab', 0n, 0), generation('ba', 1n, 1)];
+    const utxoMap = DustUtxoMap.create(generations);
+
+    const withUtxos = CoreWallet.applyNewDustUtxos(state, utxoMap);
+    const withCommitments = CoreWallet.applyDustCommitments(withUtxos, utxoMap, []);
+
+    expect(withCommitments.state.utxos).toHaveLength(2);
+    expect(withCommitments.state.commitmentTreeFirstFree).toBe(2n);
+
+    const afterSpend = CoreWallet.applySpentNullifiers(withCommitments, [generations[0].dustNullifier]);
+    expect(afterSpend.state.utxos).toHaveLength(1);
+    expect(afterSpend.state.utxos[0].backingNight).toBe(generations[1].qdo.backingNight);
+  });
+
+  it('inserts generation info for new generations', () => {
+    const state = CoreWallet.initEmpty(dustParameters, secretKey, networkId);
+    const generations = [generation('ab', 0n, 0), generation('ba', 1n, 1)];
+
+    const withGenerations = CoreWallet.applyDustGenerations(state, [], generations, []);
+
+    expect(withGenerations.state.generatingTreeFirstFree).toBe(2n);
+    expect(state.state.generatingTreeFirstFree).toBe(0n);
+  });
+});

--- a/packages/dust-wallet/src/v1/test/sync.test.ts
+++ b/packages/dust-wallet/src/v1/test/sync.test.ts
@@ -22,7 +22,6 @@ import { DustLedgerEvents, DustNullifierTransactions } from '@midnightntwrk/wall
 import type {
   DustLedgerEventsSubscription,
   DustLedgerEventsSubscriptionVariables,
-  DustNullifierTransactionsSubscription as WireDustNullifierTransactionsSubscription,
   DustNullifierTransactionsSubscriptionVariables,
 } from '@midnightntwrk/wallet-sdk-indexer-client';
 import { type SubscriptionClient } from '@midnightntwrk/wallet-sdk-indexer-client/effect';
@@ -198,7 +197,7 @@ describe('V1 projections nullifier subscription', () => {
       recorded.value = variables;
       return Stream.fromIterable(
         [topByteSetHex, decoyHex, topByteZeroHex].map((hex) => ({ dustNullifierTransactions: wireRecord(hex) })),
-      ) as Stream.Stream<WireDustNullifierTransactionsSubscription, ClientError | ServerError, SubscriptionClient>;
+      );
     };
 
     const service = makeIndexerSyncService({

--- a/packages/dust-wallet/src/v1/test/sync.test.ts
+++ b/packages/dust-wallet/src/v1/test/sync.test.ts
@@ -10,20 +10,39 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { DustSecretKey, LedgerParameters } from '@midnight-ntwrk/ledger-v8';
+import {
+  DustSecretKey,
+  dustFirstNonce,
+  dustNullifier,
+  type Event as LedgerEvent,
+  LedgerParameters,
+} from '@midnight-ntwrk/ledger-v8';
 import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
-import { DustLedgerEvents } from '@midnightntwrk/wallet-sdk-indexer-client';
+import { DustLedgerEvents, DustNullifierTransactions } from '@midnightntwrk/wallet-sdk-indexer-client';
 import type {
   DustLedgerEventsSubscription,
   DustLedgerEventsSubscriptionVariables,
+  DustNullifierTransactionsSubscription as WireDustNullifierTransactionsSubscription,
+  DustNullifierTransactionsSubscriptionVariables,
 } from '@midnightntwrk/wallet-sdk-indexer-client';
 import { type SubscriptionClient } from '@midnightntwrk/wallet-sdk-indexer-client/effect';
 import { type ClientError, type ServerError } from '@midnightntwrk/wallet-sdk-utilities/networking';
-import { Effect, Stream } from 'effect';
+import { Chunk, Effect, Stream } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { CoreWallet } from '../CoreWallet.js';
-import { makeDefaultSyncService, makeEventLessSyncCapability } from '../Sync.js';
-import { DustUtxoMap, StateUpdate } from '../SyncSchema.js';
+import {
+  createDustUtxoUpdates,
+  makeDefaultSyncService,
+  makeEventLessSyncCapability,
+  makeIndexerSyncService,
+  nullifierPhaseProgress,
+} from '../Sync.js';
+import {
+  type DustNullifierTransactionsSubscription,
+  type DustSpendProcessedEvent,
+  DustUtxoMap,
+  StateUpdate,
+} from '../SyncSchema.js';
 
 const networkId = NetworkId.NetworkId.Undeployed;
 const dustParameters = LedgerParameters.initialParameters().dust;
@@ -149,5 +168,180 @@ describe('V1 projections sync capability', () => {
     expect(state.state.syncTime).toEqual(inputSyncTime);
     expect(state.state.serialize()).toEqual(serializedInput);
     expect(state.progress).toBe(inputProgress);
+  });
+});
+
+describe('V1 projections nullifier subscription', () => {
+  const ledgerParametersHex = Buffer.from(LedgerParameters.initialParameters().serialize()).toString('hex');
+
+  const wireRecord = (nullifierLeBytes: string) => ({
+    nullifierLeBytes,
+    commitmentLeBytes: '00'.repeat(32),
+    transactionId: 1,
+    transactionHash: 'ff'.repeat(32),
+    blockHeight: 10,
+    blockHash: 'ee'.repeat(32),
+    transaction: { __typename: 'SystemTransaction', block: { ledgerParameters: ledgerParametersHex } } as const,
+  });
+
+  it('keeps exact matches in fixed-width LE form, including nullifiers with a zero top byte', async () => {
+    // topByteSet survives minimal-length (SCALE) encoding unchanged; topByteZero loses its final byte there,
+    // while the indexer always reports the fixed 32-byte little-endian form.
+    const topByteSet = (0x44n << 248n) | 0x12n;
+    const topByteZero = (1n << 240n) | 0x0cn;
+    const topByteSetHex = '12' + '00'.repeat(30) + '44';
+    const topByteZeroHex = '0c' + '00'.repeat(29) + '01' + '00';
+    const decoyHex = '12' + 'ff'.repeat(30) + '44'; // anonymity-set member sharing topByteSet's prefix
+
+    const recorded: { value?: DustNullifierTransactionsSubscriptionVariables } = {};
+    const stub = (variables: DustNullifierTransactionsSubscriptionVariables) => {
+      recorded.value = variables;
+      return Stream.fromIterable(
+        [topByteSetHex, decoyHex, topByteZeroHex].map((hex) => ({ dustNullifierTransactions: wireRecord(hex) })),
+      ) as Stream.Stream<WireDustNullifierTransactionsSubscription, ClientError | ServerError, SubscriptionClient>;
+    };
+
+    const service = makeIndexerSyncService({
+      indexerClientConnection: {
+        indexerHttpUrl: 'http://localhost:8088/api/v4/graphql',
+        indexerWsUrl: 'ws://localhost:8088/api/v4/graphql/ws',
+      },
+      networkId,
+    });
+
+    const records = await service
+      .subscribeDustNullifierTransactions([topByteSet, topByteZero], 100, 2)
+      .pipe(
+        Stream.runCollect,
+        Effect.map(Chunk.toArray),
+        Effect.provideService(DustNullifierTransactions.tag, stub),
+        Effect.provide(service.connectionLayer()),
+        Effect.scoped,
+        Effect.runPromise,
+      );
+
+    expect(records.map((r) => r.nullifierLeBytes)).toEqual([topByteSetHex, topByteZeroHex]);
+    expect(recorded.value?.fromBlock).toBe(0);
+    expect(recorded.value?.toBlock).toBe(100);
+    expect(recorded.value?.nullifierLeBytesPrefixes).toHaveLength(2);
+    expect(recorded.value?.nullifierLeBytesPrefixes).toEqual(expect.arrayContaining(['12', '0c']));
+  });
+});
+
+describe('V1 projections dust spend resolution', () => {
+  const initialParameters = LedgerParameters.initialParameters();
+
+  const spendEvent = (content: DustSpendProcessedEvent) => ({
+    id: 1,
+    maxId: 1,
+    protocolVersion: 1,
+    // Type cast required because: constructing a real ledger Event needs a serialized on-chain event; the code
+    // under test only reads `raw.content`, so a structural fake keeps this test free of live infrastructure.
+    raw: { content } as unknown as LedgerEvent,
+  });
+
+  const transactionWithSpends = (events: ReturnType<typeof spendEvent>[]): DustNullifierTransactionsSubscription => ({
+    nullifierLeBytes: '00'.repeat(32),
+    commitmentLeBytes: '00'.repeat(32),
+    transactionId: 42,
+    transactionHash: 'ee'.repeat(32),
+    blockHeight: 10,
+    blockHash: 'dd'.repeat(32),
+    transaction: {
+      __typename: 'RegularTransaction',
+      block: { ledgerParameters: initialParameters },
+      id: 42,
+      hash: 'ee'.repeat(32),
+      dustLedgerEvents: events,
+      zswapLedgerEvents: [],
+    },
+  });
+
+  const dustSpend = (nullifier: bigint): DustSpendProcessedEvent => ({
+    tag: 'dustSpendProcessed',
+    commitment: 1n,
+    commitmentIndex: 9n,
+    nullifier,
+    vFee: 100n,
+    declaredTime: new Date(2_000_000),
+    blockTime: new Date(2_000_000),
+  });
+
+  it("skips dust spends whose nullifier is not this wallet's (multi-party transactions)", async () => {
+    const secretKey = DustSecretKey.fromSeed(Buffer.from(seedHex, 'hex'));
+    const state = CoreWallet.initEmpty(dustParameters, secretKey, networkId);
+    const foreignNullifier = 123456789n;
+
+    const updates = await Effect.runPromise(
+      createDustUtxoUpdates(
+        state.state,
+        [transactionWithSpends([spendEvent(dustSpend(foreignNullifier))])],
+        secretKey,
+        DustUtxoMap.create([]),
+        new Map(),
+        [],
+      ),
+    );
+
+    expect(updates).toEqual([]);
+  });
+
+  it('resolves an owned spend into a spent update and its successor', async () => {
+    const secretKey = DustSecretKey.fromSeed(Buffer.from(seedHex, 'hex'));
+    const state = CoreWallet.initEmpty(dustParameters, secretKey, networkId);
+    const backingNight = 'ab'.repeat(32);
+    const qdo = {
+      initialValue: 1_000_000_000n,
+      owner: secretKey.publicKey,
+      nonce: dustFirstNonce(backingNight, secretKey.publicKey),
+      seq: 0,
+      ctime: new Date(1_000_000),
+      backingNight,
+      mtIndex: 4n,
+    };
+    const nullifier = dustNullifier(qdo, secretKey);
+    const knownUtxos = DustUtxoMap.create([
+      {
+        dustNullifier: nullifier,
+        genInfo: { value: 5_000_000_000n, owner: secretKey.publicKey, nonce: backingNight, dtime: undefined },
+        generationMtIndex: 0,
+        qdo,
+        transactionId: 7,
+        transactionHash: 'cd'.repeat(32),
+      },
+    ]);
+
+    const updates = await Effect.runPromise(
+      createDustUtxoUpdates(
+        state.state,
+        [transactionWithSpends([spendEvent(dustSpend(nullifier))])],
+        secretKey,
+        knownUtxos,
+        new Map(),
+        [],
+      ),
+    );
+
+    expect(updates).toHaveLength(2);
+    const [spent, successor] = updates;
+    expect(spent.isSpent).toBe(true);
+    expect(spent.dustNullifier).toBe(nullifier);
+    expect(successor.isSpent).toBe(false);
+    expect(successor.qdo.seq).toBe(1);
+    expect(successor.qdo.mtIndex).toBe(9n);
+  });
+});
+
+describe('nullifierPhaseProgress', () => {
+  it('counts settled nullifiers as a full commitment-space scan', () => {
+    expect(nullifierPhaseProgress(0n, 5, 0, 100)).toBe(500);
+  });
+
+  it('adds the merkle indices of still-live chains to the settled portion', () => {
+    expect(nullifierPhaseProgress(100n, 5, 2, 100)).toBe(400);
+  });
+
+  it('never exceeds the phase ceiling', () => {
+    expect(nullifierPhaseProgress(600n, 5, 2, 100)).toBe(500);
   });
 });

--- a/packages/dust-wallet/src/v1/test/syncSchema.test.ts
+++ b/packages/dust-wallet/src/v1/test/syncSchema.test.ts
@@ -1,0 +1,56 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { LedgerParameters } from '@midnight-ntwrk/ledger-v8';
+import { Schema } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { BlockDataSchema } from '../SyncSchema.js';
+
+describe('BlockDataSchema', () => {
+  const ledgerParametersHex = Buffer.from(LedgerParameters.initialParameters().serialize()).toString('hex');
+  const wireBlock = {
+    height: 7,
+    hash: '00'.repeat(32),
+    ledgerParameters: ledgerParametersHex,
+    timestamp: 1752487200000,
+    zswapEndIndex: 3,
+    dustCommitmentEndIndex: 5,
+    dustGenerationEndIndex: 4,
+    dustCommitmentMerkleTreeRoot: 'aa'.repeat(32),
+    dustGenerationMerkleTreeRoot: 'bb'.repeat(32),
+  };
+
+  it('decodes the timestamp as UNIX milliseconds', () => {
+    const decoded = Schema.decodeUnknownSync(BlockDataSchema)(wireBlock);
+    expect(decoded.timestamp).toEqual(new Date(1752487200000));
+  });
+
+  it('round-trips through encode without changing the timestamp', () => {
+    const decoded = Schema.decodeUnknownSync(BlockDataSchema)(wireBlock);
+    const encoded = Schema.encodeSync(BlockDataSchema)(decoded);
+    expect(encoded).toEqual(wireBlock);
+  });
+
+  it('decodes null merkle tree roots (block without dust state) to the empty-tree encoding', () => {
+    const decoded = Schema.decodeUnknownSync(BlockDataSchema)({
+      ...wireBlock,
+      dustCommitmentMerkleTreeRoot: null,
+      dustGenerationMerkleTreeRoot: null,
+    });
+    expect(decoded.dustCommitmentMerkleTreeRoot).toBe('');
+    expect(decoded.dustGenerationMerkleTreeRoot).toBe('');
+
+    const encoded = Schema.encodeSync(BlockDataSchema)(decoded);
+    expect(encoded.dustCommitmentMerkleTreeRoot).toBeNull();
+    expect(encoded.dustGenerationMerkleTreeRoot).toBeNull();
+  });
+});

--- a/packages/dust-wallet/test/Utils.test.ts
+++ b/packages/dust-wallet/test/Utils.test.ts
@@ -13,7 +13,7 @@
 
 import { describe, it } from '@vitest/runner';
 import { expect } from 'vitest';
-import { calculatePrefixLength } from '../src/v1/Utils.js';
+import { bigintToLeHex, calculatePrefixLength, gapRanges, leBigintToHex } from '../src/v1/Utils.js';
 import { LedgerOps } from '@midnightntwrk/wallet-sdk-utilities';
 
 describe('Utils', () => {
@@ -30,5 +30,58 @@ describe('Utils', () => {
     expect(nullifier.substring(0, calculatePrefixLength(5, 1000, maxLength)).length).toBe(4);
     expect(nullifier.substring(0, calculatePrefixLength(6, 1000, maxLength)).length).toBe(4);
     expect(nullifier.substring(0, calculatePrefixLength(7, 1000, maxLength)).length).toBe(2);
+  });
+
+  describe('bigintToLeHex()', () => {
+    it('encodes little-endian at a fixed width', () => {
+      expect(bigintToLeHex(1n, 32)).toBe('01' + '00'.repeat(31));
+      expect(bigintToLeHex(0n, 4)).toBe('00000000');
+      expect(bigintToLeHex(0x0102n, 4)).toBe('02010000');
+    });
+
+    it('keeps the full width when the most significant byte is zero', () => {
+      // A value < 2^248 loses its top byte under minimal-length (SCALE) encoding.
+      // The indexer's nullifierLeBytes is fixed 32-byte LE, so the width must be preserved.
+      const topByteZero = (1n << 240n) | 0xabn;
+      const hex = bigintToLeHex(topByteZero, 32);
+      expect(hex).toHaveLength(64);
+      expect(hex.endsWith('0100')).toBe(true);
+      expect(hex.startsWith('ab')).toBe(true);
+      // the SCALE-based encoding drops the zero top byte for the same value
+      expect(leBigintToHex(topByteZero, true)).toHaveLength(62);
+    });
+
+    it('matches the SCALE-based encoding, padded to full width', () => {
+      const nullifier = BigInt('0x12bdf27706a2994ad7f214d5653bb44546afe1fedadda5219c8ba4fe90f23f44');
+      expect(bigintToLeHex(nullifier, 32)).toBe(leBigintToHex(nullifier, true).padEnd(64, '0'));
+    });
+  });
+
+  describe('gapRanges()', () => {
+    it('covers the whole span when there is nothing to skip', () => {
+      expect(gapRanges(42, 100, [])).toEqual([{ start: 43, end: 100 }]);
+    });
+
+    it('splits around skipped indexes, dropping empty ranges for consecutive skips', () => {
+      // mirrors the worked example in loadCollapsedCommitments: skips at 43, 67, 68, 75
+      expect(gapRanges(-1, 80, [43, 67, 68, 75])).toEqual([
+        { start: 0, end: 42 },
+        { start: 44, end: 66 },
+        { start: 69, end: 74 },
+        { start: 76, end: 80 },
+      ]);
+    });
+
+    it('omits the leading range when the first skip is at the start', () => {
+      expect(gapRanges(42, 100, [43])).toEqual([{ start: 44, end: 100 }]);
+    });
+
+    it('omits the trailing range when the last skip is at the end', () => {
+      expect(gapRanges(-1, 100, [100])).toEqual([{ start: 0, end: 99 }]);
+    });
+
+    it('returns nothing when skips cover the whole span', () => {
+      expect(gapRanges(41, 43, [42, 43])).toEqual([]);
+    });
   });
 });

--- a/packages/e2e-tests/src/tests/projectionsBasedSync.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/projectionsBasedSync.undeployed.test.ts
@@ -123,8 +123,8 @@ describe('Projections-based synchronisation model', () => {
     const receiverStateEventsSynced = await receiverEventsSynced.wallet.waitForSyncedState();
 
     // Projections-based sync
-    await funded.wallet.doSync(funded.shieldedSecretKeys, funded.dustSecretKey);
-    await receiver.wallet.doSync(receiver.shieldedSecretKeys, receiver.dustSecretKey);
+    await funded.wallet.doSync(funded.dustSecretKey);
+    await receiver.wallet.doSync(receiver.dustSecretKey);
 
     const fundedState = await funded.wallet.waitForSyncedState();
     const receiverState = await receiver.wallet.waitForSyncedState();
@@ -185,8 +185,8 @@ describe('Projections-based synchronisation model', () => {
 
     await utils.waitForBlockAdvancement(fixture.getIndexerUri());
 
-    await funded.wallet.doSync(funded.shieldedSecretKeys, funded.dustSecretKey);
-    await receiver.wallet.doSync(receiver.shieldedSecretKeys, receiver.dustSecretKey);
+    await funded.wallet.doSync(funded.dustSecretKey);
+    await receiver.wallet.doSync(receiver.dustSecretKey);
 
     const ttl = new Date(Date.now() + 30 * 60 * 1000);
     const txRecipe = await funded.wallet.transferTransaction(
@@ -244,7 +244,7 @@ describe('Projections-based synchronisation model', () => {
     logger.info(`Dust registration tx id: ${dustRegistrationTxid}`);
 
     await utils.waitForBlockAdvancement(fixture.getIndexerUri());
-    await receiver.wallet.doSync(receiver.shieldedSecretKeys, receiver.dustSecretKey);
+    await receiver.wallet.doSync(receiver.dustSecretKey);
 
     const receiverStateAfterRegistration = await utils.waitForStateAfterDustRegistration(
       receiver.wallet,
@@ -295,7 +295,7 @@ describe('Projections-based synchronisation model', () => {
         expect(deepestDustChain).toBeGreaterThanOrEqual(expectedChainDepth);
       }
 
-      await funded.wallet.doSync(funded.shieldedSecretKeys, funded.dustSecretKey);
+      await funded.wallet.doSync(funded.dustSecretKey);
 
       const eventsState = await fundedEventsSynced.wallet.waitForSyncedState();
       const projectionsState = await funded.wallet.waitForSyncedState();
@@ -310,7 +310,7 @@ describe('Projections-based synchronisation model', () => {
       // receiver starts on a fresh blockchain with no prior UTXOs — the projection snapshot is
       // empty, so the sync should be purely a roundtrip to the indexer with no heavy computation.
       const start = Date.now();
-      await receiver.wallet.doSync(receiver.shieldedSecretKeys, receiver.dustSecretKey);
+      await receiver.wallet.doSync(receiver.dustSecretKey);
       const elapsedMs = Date.now() - start;
 
       const state = await receiver.wallet.waitForSyncedState();
@@ -326,7 +326,7 @@ describe('Projections-based synchronisation model', () => {
     'Incremental projections-based sync after new blocks is near-instant',
     async () => {
       // Establish a clean baseline state for receiver (empty wallet).
-      await receiver.wallet.doSync(receiver.shieldedSecretKeys, receiver.dustSecretKey);
+      await receiver.wallet.doSync(receiver.dustSecretKey);
       await receiver.wallet.waitForSyncedState();
 
       // Advance the chain without involving the receiver wallet.
@@ -336,7 +336,7 @@ describe('Projections-based synchronisation model', () => {
       await utils.waitForBlockAdvancement(fixture.getIndexerUri());
 
       const start = Date.now();
-      await receiver.wallet.doSync(receiver.shieldedSecretKeys, receiver.dustSecretKey);
+      await receiver.wallet.doSync(receiver.dustSecretKey);
       const elapsedMs = Date.now() - start;
 
       const state = await receiver.wallet.waitForSyncedState();

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -1366,6 +1366,15 @@ export class WalletFacade {
     });
   }
 
+  /**
+   * Starts the wallets and their background synchronization.
+   *
+   * @param shieldedSecretKeys - Secret keys for the shielded wallet
+   * @param dustSecretKey - Secret key for the dust wallet
+   * @param manualSync - When true, the dust wallet is not started in the background; drive it explicitly with
+   *   {@link doSync} instead (requires a dust wallet built with the projections sync service, see
+   *   `makeEventLessSyncService`)
+   */
   async start(
     shieldedSecretKeys: ledger.ZswapSecretKeys,
     dustSecretKey: ledger.DustSecretKey,
@@ -1379,11 +1388,14 @@ export class WalletFacade {
     ]);
   }
 
-  async doSync(shieldedSecretKeys: ledger.ZswapSecretKeys, dustSecretKey: ledger.DustSecretKey): Promise<void> {
-    await Promise.all([
-      // this.shielded.stepSync(shieldedSecretKeys),
-      this.dust.stepSync(dustSecretKey),
-    ]);
+  /**
+   * Runs a single dust synchronization pass and resolves when it completes. Only the dust wallet supports manual sync;
+   * the shielded and unshielded wallets keep syncing in the background via {@link start}.
+   *
+   * @param dustSecretKey - Secret key for the dust wallet
+   */
+  async doSync(dustSecretKey: ledger.DustSecretKey): Promise<void> {
+    await this.dust.stepSync(dustSecretKey);
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
Fixes for the 12 findings from the review of the fast-sync branch (7 correctness/API issues, 5 immutability-rule violations). Targets the feature branch (`js/fast-sync`, checked out locally as `js/fast-sync-v1`), not `main`.

## Correctness fixes

1. **Fixed-width nullifier matching** (`Sync.ts`, `Utils.ts`) — `leBigintToHex` produces SCALE-compact *minimal-length* bytes, while the indexer's `nullifierLeBytes` is documented as fixed *"32-byte little-endian form"*. Any nullifier with a zero top byte (~1/256 of them) never matched its own spend record, silently leaving the UTXO unspent locally and losing the successor (fee-change) UTXO. New `bigintToLeHex(n, byteLength)` produces the fixed-width form; the exact-match filter now uses it.
2. **Foreign dust spends no longer kill sync** (`Sync.ts`) — a matched transaction carries *every* dust spend it contains, including other parties' (multi-intent transactions, e.g. swaps). Unresolvable nullifiers previously raised `SyncWalletError`, permanently blocking sync on an on-chain transaction; they are now skipped with a debug log. A missing `genInfo` for an *owned* qdo still fails hard.
3. **Nullable merkle roots** (`SyncSchema.ts`) — `dustCommitmentMerkleTreeRoot`/`dustGenerationMerkleTreeRoot` are nullable in the indexer schema (generated type `string | null`); decoding now maps null to `''`, which matches the wallet-side encoding of an empty tree in the root check (and encodes back to null).
4. **BlockData timestamp encode** (`SyncSchema.ts`) — encode emitted `getTime() * 1000`; decode/encode now round-trips (unit-tested).
5. **Progress formula** (`Sync.ts`) — a misplaced parenthesis divided the settled-nullifier term by the phase ceiling, making it inert. Extracted as `nullifierPhaseProgress` with an explicit clamp to the phase ceiling.
6. **`blockData(height)` forwarding** — `makeEventLessSyncService` now passes the delegate function through instead of wrapping it and dropping the argument.
7. **`WalletFacade.doSync`** — dropped the unused `shieldedSecretKeys` parameter and the commented-out shielded call; added JSDoc for `start`/`doSync`; updated the e2e call sites.

## Immutability-rule fixes (CLAUDE.md hard requirements)

8–9. `CoreWallet.applyDustGenerations` / `applyDustCommitments` — `let` + `for` loops converted to folds; the no-collapsed-updates edge case collapses into the trailing insert.
10. Collapsed-commitment range grouping — `groups.push(...)` across if/else + `forEach` replaced by pure `gapRanges(lastAppliedIndex, maxIndex, skipIndexes)` (table-tested against the old implementation's outputs, including consecutive-skip and boundary cases).
11. `leBigintToHex` — `let` reassignment replaced with a const ternary; removed the dead odd-length guard (`Buffer.toString('hex')` is always even-length, and prepending `'0'` to LE hex would corrupt the value if it could ever fire).
12. `calculatePrefixLength` — `let` pipeline replaced with consts (existing test unchanged and green).

## Tests

- TDD per repo policy: the two key behavior tests were verified **red against the original code** (only those two fail, and the owned-spend positive control passes both before and after) before the fixes were finalized.
- New: fixed-width LE hex vectors incl. the zero-top-byte case; `gapRanges` table tests; `BlockDataSchema` round-trip + null-root decoding; a stubbed-subscription test proving exact-match filtering keeps zero-top-byte nullifiers and drops anonymity-set decoys; `createDustUtxoUpdates` foreign-spend skip + owned-spend resolution (spent + successor); `nullifierPhaseProgress` bounds; CoreWallet characterization tests (written against the loop implementation, green after the fold refactor).
- `yarn test:unit` for dust-wallet (58) and facade (32), `typecheck` (incl. e2e-tests), `lint`, and Effect LS diagnostics all pass.

## Decisions taken (flagged in the review as needing confirmation)

- **Null root ⇔ empty local tree compare equal** (both encode to `''`). If you'd rather fail sync when the indexer has no root but the local tree is non-empty, that needs its own error path.
- **Foreign spends: skip + `Effect.logDebug`** rather than surfacing a warning-level state.
- **Progress formula intent**: settled nullifiers count as a full commitment-space scan, live chains contribute their freshest successor's mt-index — my reconstruction; the unit tests encode it, adjust if the intent differed.