### PR TITLE
fix(facade): build both legs of a mixed shielded/unshielded swap in initSwap (#554)

### DIFF
--- a/.changeset/fix-291-initswap-partial-tx.md
+++ b/.changeset/fix-291-initswap-partial-tx.md
@@ -1,0 +1,10 @@
+---
+'@midnightntwrk/wallet-sdk-facade': patch
+---
+
+fix(facade): build both legs of a mixed shielded/unshielded swap in `initSwap` (#291, #554)
+
+`WalletFacade.initSwap` only built the leg matching the *input* kind, so a mixed swap (e.g. shielded input →
+unshielded output) silently dropped the counter-leg's requested output and returned a one-legged transaction that
+still signed, proved, balanced and submitted. Each leg is now built whenever its part is present — a leg may be all
+give (inputs) or all want (outputs) — so mixed swaps carry both the give and want sides.

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -1246,15 +1246,17 @@ export class WalletFacade {
       throw Error('At least one shielded or unshielded swap is required.');
     }
 
-    const shieldedTx =
-      hasShieldedPart && shieldedInputs !== undefined
-        ? await this.shielded.initSwap(shieldedSecretKeys, shieldedInputs, shieldedOutputs)
-        : undefined;
+    // Build each leg whenever its part is present — a leg may be all give (inputs, no outputs) or all
+    // want (outputs, no inputs). Gating on inputs alone dropped the want-only counter-leg of a mixed
+    // swap, silently returning a one-legged transaction (issue #291 / #554). The underlying initSwaps
+    // accept an empty input set and build an output-only offer.
+    const shieldedTx = hasShieldedPart
+      ? await this.shielded.initSwap(shieldedSecretKeys, shieldedInputs ?? {}, shieldedOutputs)
+      : undefined;
 
-    const unshieldedTx =
-      hasUnshieldedPart && unshieldedInputs !== undefined
-        ? await this.unshielded.initSwap(unshieldedInputs, unshieldedOutputs, ttl)
-        : undefined;
+    const unshieldedTx = hasUnshieldedPart
+      ? await this.unshielded.initSwap(unshieldedInputs ?? {}, unshieldedOutputs, ttl)
+      : undefined;
 
     const combinedTx = this.mergeUnprovenTransactions(shieldedTx, unshieldedTx);
 

--- a/packages/facade/test/initSwap.test.ts
+++ b/packages/facade/test/initSwap.test.ts
@@ -1,0 +1,154 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * Mixed shielded/unshielded swaps must build BOTH legs (issue #291 / #554).
+ *
+ * `initSwap` used to build only the leg matching the input kind and silently drop the counter-leg's requested output,
+ * returning a one-legged transaction. These tests assert the transaction returned by `initSwap` carries both legs: the
+ * give side (the spent input kind) and the want side (the requested output of the opposite kind). They run in
+ * simulation mode — the maker's give side needs real coins to select, but the transaction is intentionally imbalanced
+ * (no taker, no fees), so no submission is needed.
+ */
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Simulator, immediateBlockProducer, type GenesisMint } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { Effect } from 'effect';
+import { describe, expect, it, vi } from 'vitest';
+import { type CombinedSwapInputs, type CombinedSwapOutputs, type WalletFacade } from '../src/index.js';
+import {
+  createSimulatorWalletFactories,
+  deriveWalletKeys,
+  makeSimulatorFacade,
+  tokenValue,
+  waitForShieldedCoins,
+  waitForUnshieldedBalance,
+  type SimulatorConfig,
+} from './utils/index.js';
+
+vi.setConfig({ testTimeout: 60_000 });
+
+const NETWORK_ID = NetworkId.NetworkId.Undeployed;
+const SEED = '0000000000000000000000000000000000000000000000000000000000000001';
+
+const shieldedTokenType = ledger.shieldedToken().raw;
+const nightTokenType = ledger.nativeToken().raw;
+
+/**
+ * Boots a simulator with the given genesis funds, starts a maker facade, and runs `assert` against it. The facade is
+ * torn down when the scope closes.
+ */
+const runWithMaker = (
+  genesisMints: [GenesisMint, ...GenesisMint[]],
+  assert: (facade: WalletFacade, keys: ReturnType<typeof deriveWalletKeys>) => Promise<void>,
+) =>
+  Effect.gen(function* () {
+    const keys = deriveWalletKeys(SEED, NETWORK_ID);
+    const simulator = yield* Simulator.init({ genesisMints, blockProducer: immediateBlockProducer() });
+    const config: SimulatorConfig = { simulator, networkId: NETWORK_ID, costParameters: { feeBlocksMargin: 5 } };
+    const factories = createSimulatorWalletFactories(config);
+    const facade = yield* makeSimulatorFacade(config, keys, factories);
+    yield* Effect.promise(() => assert(facade, keys));
+  }).pipe(Effect.scoped, Effect.runPromise);
+
+describe('WalletFacade.initSwap builds both legs of a mixed swap', () => {
+  it('shielded give -> unshielded want: keeps the unshielded want output', async () =>
+    runWithMaker(
+      [
+        {
+          type: 'shielded',
+          tokenType: shieldedTokenType,
+          amount: tokenValue(10n),
+          recipient: deriveWalletKeys(SEED, NETWORK_ID).shieldedKeys,
+        },
+      ],
+      async (facade, keys) => {
+        await waitForShieldedCoins(facade).pipe(Effect.runPromise);
+
+        const ttl = new Date(Date.now() + 60 * 60 * 1000);
+        const wantAmount = tokenValue(1n);
+        const unshieldedAddress = await facade.unshielded.getAddress();
+
+        const desiredInputs: CombinedSwapInputs = { shielded: { [shieldedTokenType]: tokenValue(1n) } };
+        const desiredOutputs: CombinedSwapOutputs[] = [
+          {
+            type: 'unshielded',
+            outputs: [{ type: nightTokenType, amount: wantAmount, receiverAddress: unshieldedAddress }],
+          },
+        ];
+
+        const recipe = await facade.initSwap(
+          desiredInputs,
+          desiredOutputs,
+          { shieldedSecretKeys: keys.shieldedKeys, dustSecretKey: keys.dustKey },
+          { ttl },
+        );
+        const tx = recipe.transaction;
+
+        // Give side (shielded input) is represented.
+        expect(tx.guaranteedOffer).toBeDefined();
+        expect(tx.guaranteedOffer!.inputs.length).toBeGreaterThan(0);
+
+        // Want side: the requested unshielded output must be present with the exact amount and token.
+        const wantOutputs = [...(tx.intents?.values() ?? [])]
+          .flatMap((intent) => [
+            ...(intent.guaranteedUnshieldedOffer?.outputs ?? []),
+            ...(intent.fallibleUnshieldedOffer?.outputs ?? []),
+          ])
+          .filter((output) => output.type === nightTokenType && output.value === wantAmount);
+        expect(wantOutputs).toHaveLength(1);
+      },
+    ));
+
+  it('unshielded give -> shielded want: keeps the shielded want output', async () =>
+    runWithMaker(
+      [
+        {
+          type: 'unshielded',
+          tokenType: nightTokenType,
+          amount: tokenValue(100n),
+          recipient: deriveWalletKeys(SEED, NETWORK_ID).userAddress,
+          verifyingKey: deriveWalletKeys(SEED, NETWORK_ID).signatureVerifyingKey,
+        },
+      ],
+      async (facade, keys) => {
+        await waitForUnshieldedBalance(facade, nightTokenType, tokenValue(1n)).pipe(Effect.runPromise);
+
+        const ttl = new Date(Date.now() + 60 * 60 * 1000);
+        const wantAmount = tokenValue(1n);
+        const shieldedAddress = await facade.shielded.getAddress();
+
+        const desiredInputs: CombinedSwapInputs = { unshielded: { [nightTokenType]: tokenValue(1n) } };
+        const desiredOutputs: CombinedSwapOutputs[] = [
+          {
+            type: 'shielded',
+            outputs: [{ type: shieldedTokenType, amount: wantAmount, receiverAddress: shieldedAddress }],
+          },
+        ];
+
+        const recipe = await facade.initSwap(
+          desiredInputs,
+          desiredOutputs,
+          { shieldedSecretKeys: keys.shieldedKeys, dustSecretKey: keys.dustKey },
+          { ttl },
+        );
+        const tx = recipe.transaction;
+
+        // Give side (unshielded input) is represented.
+        expect(tx.intents?.size ?? 0).toBeGreaterThan(0);
+
+        // Want side: the requested shielded output must be present.
+        expect(tx.guaranteedOffer).toBeDefined();
+        expect(tx.guaranteedOffer!.outputs.length).toBeGreaterThan(0);
+      },
+    ));
+});


### PR DESCRIPTION
# Description

Fixes #554 — `WalletFacade.initSwap` returned partial transactions for mixed shielded/unshielded swaps.

Each leg was only built when the *inputs* key for that kind was present, so a cross-kind swap — shielded input →
unshielded output, or the reverse — silently dropped the counter-leg's requested output. The one-legged transaction
signed, proved, balanced and submitted with no error, so the give side moved on chain while the want side never
existed.

# Proposed Solution

Build each leg whenever *its part* is present, rather than only when it has inputs. A swap leg may be all give
(inputs, no outputs) or all want (outputs, no inputs); the underlying `shielded.initSwap` / `unshielded.initSwap`
already accept an empty input set and build an output-only offer, so a mixed swap now carries both the give and the
want sides.

# Important Changes Introduced

- `WalletFacade.initSwap` now builds both legs of a mixed shielded/unshielded swap instead of dropping the counter-leg.

# Testing

- New unit tests (`packages/facade/test/initSwap.test.ts`), both directions (shielded→unshielded and
  unshielded→shielded), assert the transaction returned by `initSwap` carries both legs — the give-side input and the
  exact requested want-side output. Written test-first: they failed on the old code (leg missing) and pass on the fix.
- They run in simulation mode (no Docker): the maker's give side needs real coins to select, but the swap transaction
  is intentionally imbalanced, so no taker/submission is required.
- `yarn test:unit`, `yarn typecheck`, `yarn lint`, `yarn format:check` (facade) all pass.

> Note: full on-chain settlement of a mixed swap (maker → taker → submit → balance deltas) is **not** covered here.
> The sibling `it.skip('can perform an unshielded swap')` e2e is already disabled for a pre-existing
> `FeeCalculation(OutsideTimeToDismiss)` issue, which any full-settlement mixed-swap test would also hit. That is
> independent of this fix and out of scope.
