### PR TITLE
chore(deps): group renovate PRs by update type

### DIFF
--- a/.changeset/group-renovate-prs.md
+++ b/.changeset/group-renovate-prs.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(deps): group renovate PRs by update type (#608)

--- a/renovate.json
+++ b/renovate.json
@@ -16,17 +16,16 @@
   ],
   "packageRules": [
     {
-      "matchManagers": ["npm"],
-      "enabled": true
+      "groupName": "All dependencies (non-major)",
+      "matchUpdateTypes": ["patch", "minor"]
+    },
+    {
+      "groupName": "All dependencies (major)",
+      "matchUpdateTypes": ["major"]
     },
     {
       "groupName": "Midnight libraries and docker images",
       "matchPackageNames": ["@midnight-ntwrk/**", "ghcr.io/midnight-ntwrk/**"]
-    },
-    {
-      "groupName": "devDependencies (non-major)",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch", "minor"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,7 @@
     },
     {
       "groupName": "Midnight libraries and docker images",
-      "matchPackageNames": ["@midnight-ntwrk/**", "ghcr.io/midnight-ntwrk/**"]
+      "matchPackageNames": ["@midnightntwrk/**", "@midnight-ntwrk/**", "ghcr.io/midnight-ntwrk/**"]
     }
   ]
 }


### PR DESCRIPTION
# Description

Restructures `renovate.json` `packageRules` so Renovate opens a small, predictable set of
grouped PRs each week instead of one PR per dependency (~21 open today → ~3–4 expected).

Refs #608

# Proposed Solution

Group **by update type** rather than by package manager:

- **All non-major** (patch + minor) → one PR, spanning npm, GitHub Actions, and Docker
- **All majors** → one PR
- **All Midnight packages/images** (`@midnight-ntwrk/**`, `ghcr.io/midnight-ntwrk/**`) → one PR

The Midnight rule is placed **last** because Renovate's last matching `groupName` wins, so
Midnight bumps always group together and never leak into the generic non-major/major buckets.

Also removed the redundant `{ "matchManagers": ["npm"], "enabled": true }` rule — npm is
already enabled by default via `config:best-practices`, so it was a no-op.

**Trade-off (accepted):** collapsing all majors into one PR means that PR will sometimes be
red — a breaking major blocks the others behind it until fixed or split out. For a
low-traffic SDK repo this is an acceptable cost for the reduced noise.

# Important Changes Introduced

Config-only change; no code or runtime behaviour affected. Empty changeset added (non-release).

# Testing

After merge, verify against the Dependency Dashboard that open PRs collapse to the expected
groups.