### PR TITLE
chore(deps): set Renovate minimumReleaseAge to 7 days

### DIFF
--- a/.changeset/renovate-minimum-release-age.md
+++ b/.changeset/renovate-minimum-release-age.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(deps): set Renovate minimumReleaseAge to 7 days (#611)

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "dependencyDashboard": true,
   "semanticCommits": "enabled",
   "rebaseWhen": "conflicted",
+  "minimumReleaseAge": "7 days",
   "hostRules": [
     {
       "hostType": "npm",


### PR DESCRIPTION
# Description

Adds a top-level `"minimumReleaseAge": "7 days"` to `renovate.json` so Renovate does not
open (or rebase) a dependency bump until the release is at least 7 days old.

Refs #611

# Proposed Solution

Our Yarn config (`.yarnrc.yml`) sets `npmMinimalAgeGate: "1w"` — it refuses to install any
package version younger than 7 days as a supply-chain safeguard. Renovate, however,
inherits only a **3-day** minimum age from `security:minimumReleaseAgeNpm` (bundled inside
`config:best-practices`). The gates disagree: Renovate opens a PR at day 3, but Yarn
quarantines the install until day 7, leaving the PR **red from day 3 to day 7**.

This bit PR #610: `prettier@3.9.6` was 6 days old — past Renovate's 3-day gate, short of
Yarn's 7-day gate — so `yarn install --immutable` failed with `YN0016: … are quarantined`,
cascading into Build, Tests, and `renovate/artifacts` failures.

Setting Renovate's `minimumReleaseAge` to `7 days` makes both gates agree, so Renovate
never proposes a version Yarn will reject.

**Alternative considered:** lower both gates to 3 days (drop Yarn's `npmMinimalAgeGate` to
`3d`, no `renovate.json` change) — rejected; we keep the more conservative 7-day buffer.

# Important Changes Introduced

- `renovate.json`: `"minimumReleaseAge": "7 days"` (overrides the preset's 3-day default).
- `.yarnrc.yml` `npmMinimalAgeGate: "1w"` intentionally left unchanged.
- Config-only; no runtime behaviour affected. Empty changeset added (non-release).

# Testing

A subsequent Renovate PR should not open until its updates are ≥7 days old, and should pass
CI on first run instead of failing the `npmMinimalAgeGate` quarantine.
