### PR TITLE
feat(runtime): variant activation hook and registration-derived activation range

### DIFF
--- a/.changeset/runtime-variant-activation-hook.md
+++ b/.changeset/runtime-variant-activation-hook.md
@@ -1,0 +1,22 @@
+---
+'@midnightntwrk/wallet-sdk-runtime': minor
+---
+
+Add the runtime machinery a hard-fork variant handoff needs: a variant-activation hook and a registration-derived
+activation range on the variant start context.
+
+`Runtime.onVariantActivation(impl)` registers a poly-function watcher that is notified with the running variant that
+became current after a migration — and never for the variant the runtime started with. It exists so work that lives
+outside the runtime state, most importantly background synchronization started with the application's secret keys, can
+be re-established on the newly activated variant instead of leaving it idle. The returned effect completes only once the
+watcher is subscribed, so an activation triggered immediately afterwards cannot be missed; a failing watcher neither
+affects the runtime nor unsubscribes itself.
+
+`Variant.VariantContext` gains a required `activationRange: ProtocolVersion.Range` — the half-open
+`[sinceVersion, nextVariantSinceVersion)` window the runtime already derives from `withVariant` registration, now handed
+to the variant so migration boundaries and any version-boundary logic inside a variant cannot disagree with
+registration. This is a breaking change only for code that constructs a `VariantContext` and calls `Variant.start`
+directly, which is not part of the normal wallet lifecycle.
+
+`Variant.migrateState` may now fail with `WalletRuntimeError` (the error channel was `never`); such a failure already
+surfaced on the state stream at runtime, and the contract now says so. Existing implementations remain valid.

--- a/packages/dust-wallet/src/v1/test/runningV1Variant.test.ts
+++ b/packages/dust-wallet/src/v1/test/runningV1Variant.test.ts
@@ -16,7 +16,7 @@ import {
   type FinalizedTransaction,
   LedgerParameters,
 } from '@midnightntwrk/ledger-v9';
-import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Duration, Effect, Exit, Ref, Scope, Stream, SubscriptionRef, TestClock, TestContext } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { chooseCoin, makeDefaultCoinsAndBalancesCapability } from '../CoinsAndBalances.js';
@@ -134,7 +134,13 @@ describe('RunningV1Variant.startSync tx-history fan-out', () => {
       const scope = yield* Scope.make();
       const variant = new RunningV1Variant(
         scope,
-        { stateRef },
+        {
+          stateRef,
+          activationRange: ProtocolVersion.makeRange(
+            ProtocolVersion.MinSupportedVersion,
+            ProtocolVersion.MaxSupportedVersion,
+          ),
+        },
         variantContextOf(batches, trackingHistoryService(counters)),
       );
 

--- a/packages/dust-wallet/test/DustWallet.test.ts
+++ b/packages/dust-wallet/test/DustWallet.test.ts
@@ -49,7 +49,7 @@ import {
   DustTransactionHistoryEntrySchema,
   makeSimulatorTransactionHistoryService,
 } from '../src/v1/TransactionHistory.js';
-import { InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import { InMemoryTransactionHistoryStorage, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { createUnshieldedKeystore, type UnshieldedKeystore } from './UnshieldedKeyStore.js';
 import { getDustSeed, sumUtxos } from './utils.js';
 
@@ -219,7 +219,15 @@ describe('DustWallet', () => {
 
       const initialState = CoreWallet.initEmpty(dustParameters, dustSecretKey, NETWORK);
       stateRef = yield* SubscriptionRef.make(initialState);
-      wallet = yield* walletVariant.start({ stateRef }).pipe(Effect.provideService(Scope.Scope, scope));
+      wallet = yield* walletVariant
+        .start({
+          stateRef,
+          activationRange: ProtocolVersion.makeRange(
+            ProtocolVersion.MinSupportedVersion,
+            ProtocolVersion.MaxSupportedVersion,
+          ),
+        })
+        .pipe(Effect.provideService(Scope.Scope, scope));
       yield* wallet.startSyncInBackground(dustSecretKey);
 
       submissionService = Submission.makeSimulatorSubmissionService<ProofErasedTransaction>('InBlock')({ simulator });

--- a/packages/runtime/src/Runtime.ts
+++ b/packages/runtime/src/Runtime.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { Effect, Either, Exit, Option, Scope, Stream, SubscriptionRef, SynchronizedRef } from 'effect';
+import { Effect, Either, Exit, Option, PubSub, Scope, Stream, SubscriptionRef, SynchronizedRef } from 'effect';
 import { type ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { StateChange, type Variant, VersionChangeType, WalletRuntimeError } from './abstractions/index.js';
 import { EitherOps, HList, Poly } from '@midnightntwrk/wallet-sdk-utilities';
@@ -29,6 +29,23 @@ export interface Runtime<Variants extends Variant.AnyVersionedVariantArray> {
   dispatch<TResult, E = never>(
     impl: Poly.PolyFunction<Variant.RunningVariantOf<HList.Each<Variants>>, Effect.Effect<TResult, E>>,
   ): Effect.Effect<TResult, WalletRuntimeError | E>;
+
+  /**
+   * Registers a watcher that is notified whenever a migration activates a new variant, with the running variant that
+   * became current.
+   *
+   * @remarks
+   *   The watcher is _not_ invoked for the variant the runtime started with — only for activations caused by a protocol
+   *   version change. It is meant for work that has to be re-established on the new variant, e.g. restarting background
+   *   synchronization with the keys the application passed to `start`.
+   *
+   *   The returned effect completes only once the watcher is subscribed, so an activation triggered right after it
+   *   resolves cannot be missed. A watcher that fails does not affect the runtime, nor other watchers, and stays
+   *   subscribed for subsequent activations.
+   */
+  onVariantActivation<E = never>(
+    impl: Poly.PolyFunction<Variant.RunningVariantOf<HList.Each<Variants>>, Effect.Effect<void, E>>,
+  ): Effect.Effect<void>;
 }
 
 export type RunningVariant<
@@ -93,6 +110,12 @@ export const init = <Variants extends Variant.AnyVersionedVariantArray, InitTag 
       ),
     ),
     Effect.bind('progressRef', () => SynchronizedRef.make<Progress>({ applyGap: 0n, sourceGap: 0n })),
+    // The scope the whole runtime lives in — activation watchers registered later are forked into it,
+    // so they are torn down exactly when the runtime is.
+    Effect.bind('runtimeScope', () => Effect.scope),
+    Effect.bind('activations', () =>
+      Effect.acquireRelease(PubSub.unbounded<EachRunningVariant<Variants>>(), (pubsub) => PubSub.shutdown(pubsub)),
+    ),
     Effect.bind('currentVariantRef', ({ initiatedFirstVariant }) =>
       Effect.acquireRelease(SynchronizedRef.make<EachRunningVariant<Variants>>(initiatedFirstVariant), (ref, exit) =>
         Effect.gen(function* () {
@@ -103,15 +126,24 @@ export const init = <Variants extends Variant.AnyVersionedVariantArray, InitTag 
         }),
       ),
     ),
-    Effect.bind('runningStream', ({ initiatedFirstVariant, currentStateRef, progressRef, currentVariantRef }) => {
-      return runVariantStream(initiatedFirstVariant, currentStateRef, progressRef, currentVariantRef).pipe(
-        Effect.catchAll((error: WalletRuntimeError) => {
-          return SubscriptionRef.set(currentStateRef, Either.left(error));
-        }),
-        Effect.forkScoped,
-      );
-    }),
-    Effect.map(({ currentStateRef, progressRef, currentVariantRef }): Runtime<Variants> => {
+    Effect.bind(
+      'runningStream',
+      ({ initiatedFirstVariant, currentStateRef, progressRef, currentVariantRef, activations }) => {
+        return runVariantStream(
+          initiatedFirstVariant,
+          currentStateRef,
+          progressRef,
+          currentVariantRef,
+          activations,
+        ).pipe(
+          Effect.catchAll((error: WalletRuntimeError) => {
+            return SubscriptionRef.set(currentStateRef, Either.left(error));
+          }),
+          Effect.forkScoped,
+        );
+      },
+    ),
+    Effect.map(({ currentStateRef, progressRef, currentVariantRef, activations, runtimeScope }): Runtime<Variants> => {
       // Latest-value semantics with bounded memory: each subscriber gets the current state on
       // subscription (SubscriptionRef.changes emits it atomically with subsequent changes) and
       // may skip intermediate states when it lags behind the producer — the sliding buffer of
@@ -133,6 +165,24 @@ export const init = <Variants extends Variant.AnyVersionedVariantArray, InitTag 
         dispatch: <TResult, E = never>(
           impl: Poly.PolyFunction<Variant.RunningVariantOf<HList.Each<Variants>>, Effect.Effect<TResult, E>>,
         ): Effect.Effect<TResult, WalletRuntimeError | E> => dispatch(runtime, impl),
+        onVariantActivation: <E = never>(
+          impl: Poly.PolyFunction<Variant.RunningVariantOf<HList.Each<Variants>>, Effect.Effect<void, E>>,
+        ): Effect.Effect<void> =>
+          Effect.gen(function* () {
+            // Subscribing before forking the consumer is what makes the returned effect a
+            // "watcher is live" guarantee: an activation published right after this resolves is
+            // already enqueued for this subscription.
+            const subscription = yield* Scope.extend(PubSub.subscribe(activations), runtimeScope);
+            const consumer = Stream.fromQueue(subscription).pipe(
+              Stream.runForEach((activated) =>
+                // A failing watcher must neither stop the runtime nor unsubscribe itself.
+                Poly.dispatch(activated.runningVariant as Variant.RunningVariantOf<HList.Each<Variants>>, impl).pipe(
+                  Effect.ignoreLogged,
+                ),
+              ),
+            );
+            yield* Effect.forkIn(consumer, runtimeScope);
+          }),
       };
 
       return runtime;
@@ -223,7 +273,7 @@ const initHeadVariant = <Variants extends Variant.AnyVersionedVariantArray>(
     const stateRef = yield* SubscriptionRef.make(init.state);
     const variantScope = yield* Scope.make();
     const runningVariant = yield* headVersionedVariant.variant
-      .start({ stateRef })
+      .start({ stateRef, activationRange: validVersionRange })
       .pipe(Effect.provideService(Scope.Scope, variantScope)) as Effect.Effect<
       Variant.RunningVariantOf<HList.Head<Variants>>,
       WalletRuntimeError
@@ -253,6 +303,7 @@ const runVariantStream = <Variants extends Variant.AnyVersionedVariantArray>(
   >,
   progressRef: SynchronizedRef.SynchronizedRef<Progress>,
   currentVariantRef: SynchronizedRef.SynchronizedRef<EachRunningVariant<Variants>>,
+  activations: PubSub.PubSub<EachRunningVariant<Variants>>,
 ): Effect.Effect<void, WalletRuntimeError> => {
   type Accumulator = {
     protocolVersion: ProtocolVersion.ProtocolVersion;
@@ -304,7 +355,16 @@ const runVariantStream = <Variants extends Variant.AnyVersionedVariantArray>(
                   initProtocolVersion: newProtocolVersion,
                 });
                 yield* SynchronizedRef.set(currentVariantRef, newInitiatedVariant);
-                return yield* runVariantStream(newInitiatedVariant, stateRef, progressRef, currentVariantRef);
+                // Published before handing control to the new variant's stream, so watchers can
+                // re-establish their work (e.g. background sync) on it right away.
+                yield* PubSub.publish(activations, newInitiatedVariant);
+                return yield* runVariantStream(
+                  newInitiatedVariant,
+                  stateRef,
+                  progressRef,
+                  currentVariantRef,
+                  activations,
+                );
               }),
             });
           } else {

--- a/packages/runtime/src/abstractions/Variant.ts
+++ b/packages/runtime/src/abstractions/Variant.ts
@@ -21,6 +21,16 @@ import type * as StateChange from './StateChange.js';
 
 export interface VariantContext<TState> {
   stateRef: SubscriptionRef.SubscriptionRef<TState>;
+  /**
+   * The half-open protocol version range `[sinceVersion, nextVariantSinceVersion)` the variant is active for, derived
+   * from the registration order of the variants.
+   *
+   * @remarks
+   *   A variant uses it to recognize data that belongs to another variant: observing a protocol version outside of this
+   *   range is what makes it emit a {@link StateChange.VersionChange}, so the runtime can migrate to the variant that
+   *   owns that version.
+   */
+  activationRange: ProtocolVersion.ProtocolVersion.Range;
 }
 
 /**
@@ -38,7 +48,7 @@ export type Variant<
 > = Poly.WithTag<TTag> & {
   start(context: VariantContext<TState>): Effect<TRunning, WalletRuntimeError, Scope.Scope>;
 
-  migrateState(previousState: TPreviousState): Effect<TState>;
+  migrateState(previousState: TPreviousState): Effect<TState, WalletRuntimeError>;
 };
 
 export type RunningVariant<TTag extends symbol | string, TState> = Poly.WithTag<TTag> & {

--- a/packages/runtime/src/abstractions/Variant.ts
+++ b/packages/runtime/src/abstractions/Variant.ts
@@ -29,6 +29,12 @@ export interface VariantContext<TState> {
    *   A variant uses it to recognize data that belongs to another variant: observing a protocol version outside of this
    *   range is what makes it emit a {@link StateChange.VersionChange}, so the runtime can migrate to the variant that
    *   owns that version.
+   *
+   *   The runtime keeps the same range on its own `RunningVariant` record, but that record is built _from_ the result of
+   *   {@link Variant.start} and a variant holds no back-reference to the runtime, so it is unreachable from inside a
+   *   starting variant. Handing it over through the context keeps `withVariant(sinceVersion)` the single source of
+   *   truth, so the migration boundary the runtime enforces and the boundary a variant splits its sync batches on
+   *   cannot drift apart.
    */
   activationRange: ProtocolVersion.ProtocolVersion.Range;
 }
@@ -48,6 +54,20 @@ export type Variant<
 > = Poly.WithTag<TTag> & {
   start(context: VariantContext<TState>): Effect<TRunning, WalletRuntimeError, Scope.Scope>;
 
+  /**
+   * Produces this variant's initial state from the previous variant's state, at the protocol version boundary.
+   *
+   * @remarks
+   *   An implementation is expected to be written so that it succeeds: a migration that fails leaves the wallet unable to
+   *   follow the chain past the fork, so re-shaping state must not be able to reject state a previous variant
+   *   considered valid.
+   *
+   *   The error channel is not an invitation to weaken that; it exists because part of the migration is not the variant's
+   *   own code. The v8-to-v9 state translation is a ledger-side tool reached across a WASM boundary
+   *   (`LedgerStateTranslator` in `capabilities`): it is loaded at that moment, run to completion, and signals failure
+   *   by throwing. A typed failure surfaces that on the state stream — which is what already happened at runtime before
+   *   this signature said so — instead of turning it into a defect that tears the runtime down with no diagnosis.
+   */
   migrateState(previousState: TPreviousState): Effect<TState, WalletRuntimeError>;
 };
 

--- a/packages/runtime/src/test/runtime.test.ts
+++ b/packages/runtime/src/test/runtime.test.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { type ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Deferred, Effect, Ref } from 'effect';
+import { Deferred, Effect, Either, Option, Ref } from 'effect';
 import * as rx from 'rxjs';
 import { describe, expect, it } from 'vitest';
 import { StateChange, VersionChangeType, WalletRuntimeError } from '../abstractions/index.js';
@@ -363,6 +363,18 @@ describe('Variant activation and context', () => {
   const First = 'first' as const;
   const Second = 'second' as const;
 
+  /** Awaits the first state emission matching `predicate` (any emission by default) as an effect. */
+  const firstStateWhere = <TState>(
+    states: rx.Observable<ProtocolState.ProtocolState<TState>>,
+    predicate: (state: ProtocolState.ProtocolState<TState>) => boolean = () => true,
+  ): Effect.Effect<ProtocolState.ProtocolState<TState>> =>
+    Effect.promise(() => rx.firstValueFrom(states.pipe(rx.filter(predicate))));
+
+  const atVersion =
+    (version: ProtocolVersion.ProtocolVersion) =>
+    ({ version: emitted }: ProtocolState.ProtocolState<unknown>): boolean =>
+      emitted === version;
+
   const makeTwoVariantWallet = (secondBuilder?: InterceptingVariantBuilder<typeof Second, number>) => {
     const firstBuilder = new InterceptingVariantBuilder<typeof First, number>(First);
     const Wallet = WalletBuilder.init()
@@ -375,87 +387,88 @@ describe('Variant activation and context', () => {
     return { Wallet, firstBuilder };
   };
 
-  it('invokes onVariantActivation exactly once, with the newly activated variant, after a migration', async () => {
-    const { Wallet } = makeTwoVariantWallet();
-    const wallet = Wallet.startEmpty(Wallet);
-    const recorder = await Effect.runPromise(makeActivationRecorder(1));
+  /** Starts a two-variant wallet, stopping it when the surrounding scope closes. */
+  const startTwoVariantWallet = (secondBuilder?: InterceptingVariantBuilder<typeof Second, number>) => {
+    const { Wallet } = makeTwoVariantWallet(secondBuilder);
+    return Effect.acquireRelease(
+      Effect.sync(() => Wallet.startEmpty(Wallet)),
+      (wallet) => Effect.promise(() => wallet.stop()),
+    );
+  };
 
-    await wallet.runtime
-      .onVariantActivation({
+  it('invokes onVariantActivation exactly once, with the newly activated variant, after a migration', () =>
+    Effect.gen(function* () {
+      const wallet = yield* startTwoVariantWallet();
+      const recorder = yield* makeActivationRecorder(1);
+
+      yield* wallet.runtime.onVariantActivation({
         [First]: () => recorder.record(First),
         [Second]: () => recorder.record(Second),
-      })
-      .pipe(Effect.runPromise);
+      });
 
-    // Wait for the first variant to be initiated before driving it
-    await rx.firstValueFrom(wallet.rawState);
+      // Wait for the first variant to be initiated before driving it
+      yield* firstStateWhere(wallet.rawState);
 
-    await wallet.runtime
-      .dispatch({
+      yield* wallet.runtime.dispatch({
         [First]: (variant: InterceptingRunningVariant<typeof First, number>) =>
           variant.emitProtocolVersionChange(
             VersionChangeType.Version({ version: ProtocolVersion.ProtocolVersion(100n) }),
           ),
         [Second]: () => Effect.void,
-      })
-      .pipe(Effect.runPromise);
+      });
 
-    await Effect.runPromise(recorder.done);
-    // Exactly one activation — for the migration target, never for the initially started variant
-    expect(await Effect.runPromise(recorder.tags)).toEqual([Second]);
+      yield* recorder.done;
+      // Exactly one activation — for the migration target, never for the initially started variant
+      expect(yield* recorder.tags).toEqual([Second]);
 
-    // Sanity: dispatch reaches the migrated-to variant
-    const nowSecond = await wallet.runtime
-      .dispatch({ [First]: () => Effect.succeed(false), [Second]: () => Effect.succeed(true) })
-      .pipe(Effect.runPromise);
-    expect(nowSecond).toBe(true);
+      // Sanity: dispatch reaches the migrated-to variant
+      const nowSecond = yield* wallet.runtime.dispatch({
+        [First]: () => Effect.succeed(false),
+        [Second]: () => Effect.succeed(true),
+      });
+      expect(nowSecond).toBe(true);
+    }).pipe(Effect.scoped, Effect.runPromise));
 
-    await wallet.stop();
-  });
+  it('does not invoke onVariantActivation when no migration occurs', () =>
+    Effect.gen(function* () {
+      const wallet = yield* startTwoVariantWallet();
+      const recorder = yield* makeActivationRecorder(1);
 
-  it('does not invoke onVariantActivation when no migration occurs', async () => {
-    const { Wallet } = makeTwoVariantWallet();
-    const wallet = Wallet.startEmpty(Wallet);
-    const recorder = await Effect.runPromise(makeActivationRecorder(1));
-
-    await wallet.runtime
-      .onVariantActivation({
+      yield* wallet.runtime.onVariantActivation({
         [First]: () => recorder.record(First),
         [Second]: () => recorder.record(Second),
-      })
-      .pipe(Effect.runPromise);
+      });
 
-    await rx.firstValueFrom(wallet.rawState);
+      yield* firstStateWhere(wallet.rawState);
 
-    // Plain state emission — no version change, no migration
-    await wallet.runtime
-      .dispatch({
+      // Plain state emission — no version change, no migration
+      yield* wallet.runtime.dispatch({
         [First]: (variant: InterceptingRunningVariant<typeof First, number>) =>
           variant.emit(StateChange.State({ state: 42 })),
         [Second]: () => Effect.void,
-      })
-      .pipe(Effect.runPromise);
-    await rx.firstValueFrom(wallet.rawState.pipe(rx.filter(({ state }) => state === 42)));
+      });
+      yield* firstStateWhere(wallet.rawState, ({ state }) => state === 42);
 
-    expect(await Effect.runPromise(recorder.tags)).toEqual([]);
+      expect(yield* recorder.tags).toEqual([]);
+    }).pipe(Effect.scoped, Effect.runPromise));
 
-    await wallet.stop();
-  });
+  it('observes every migration of a chain in order, surviving a failing handler', () =>
+    Effect.gen(function* () {
+      const A = 'a' as const;
+      const B = 'b' as const;
+      const C = 'c' as const;
+      const Wallet = WalletBuilder.init()
+        .withVariant(ProtocolVersion.MinSupportedVersion, new InterceptingVariantBuilder<typeof A, number>(A))
+        .withVariant(ProtocolVersion.ProtocolVersion(50n), new InterceptingVariantBuilder<typeof B, number>(B))
+        .withVariant(ProtocolVersion.ProtocolVersion(100n), new InterceptingVariantBuilder<typeof C, number>(C))
+        .build();
+      const wallet = yield* Effect.acquireRelease(
+        Effect.sync(() => Wallet.startEmpty(Wallet)),
+        (started) => Effect.promise(() => started.stop()),
+      );
+      const recorder = yield* makeActivationRecorder(2);
 
-  it('observes every migration of a chain in order, surviving a failing handler', async () => {
-    const A = 'a' as const;
-    const B = 'b' as const;
-    const C = 'c' as const;
-    const Wallet = WalletBuilder.init()
-      .withVariant(ProtocolVersion.MinSupportedVersion, new InterceptingVariantBuilder<typeof A, number>(A))
-      .withVariant(ProtocolVersion.ProtocolVersion(50n), new InterceptingVariantBuilder<typeof B, number>(B))
-      .withVariant(ProtocolVersion.ProtocolVersion(100n), new InterceptingVariantBuilder<typeof C, number>(C))
-      .build();
-    const wallet = Wallet.startEmpty(Wallet);
-    const recorder = await Effect.runPromise(makeActivationRecorder(2));
-
-    await wallet.runtime
-      .onVariantActivation({
+      yield* wallet.runtime.onVariantActivation({
         [A]: () => recorder.record(A),
         // The first activation handler fails AFTER recording — the subscription must survive
         // and still observe the second migration.
@@ -464,158 +477,131 @@ describe('Variant activation and context', () => {
             .record(B)
             .pipe(Effect.flatMap(() => Effect.fail(new WalletRuntimeError({ message: 'handler boom' })))),
         [C]: () => recorder.record(C),
-      })
-      .pipe(Effect.runPromise);
+      });
 
-    await rx.firstValueFrom(wallet.rawState);
+      yield* firstStateWhere(wallet.rawState);
 
-    await wallet.runtime
-      .dispatch({
+      yield* wallet.runtime.dispatch({
         [A]: (variant: InterceptingRunningVariant<typeof A, number>) =>
           variant.emitProtocolVersionChange(
             VersionChangeType.Version({ version: ProtocolVersion.ProtocolVersion(50n) }),
           ),
         [B]: () => Effect.void,
         [C]: () => Effect.void,
-      })
-      .pipe(Effect.runPromise);
+      });
 
-    // Wait until the second variant is live (its start() re-publishes the migrated state at version 50n)
-    await rx.firstValueFrom(
-      wallet.rawState.pipe(rx.filter(({ version }) => version === ProtocolVersion.ProtocolVersion(50n))),
-    );
+      // Wait until the second variant is live (its start() re-publishes the migrated state at version 50n)
+      yield* firstStateWhere(wallet.rawState, atVersion(ProtocolVersion.ProtocolVersion(50n)));
 
-    await wallet.runtime
-      .dispatch({
+      yield* wallet.runtime.dispatch({
         [A]: () => Effect.void,
         [B]: (variant: InterceptingRunningVariant<typeof B, number>) =>
           variant.emitProtocolVersionChange(
             VersionChangeType.Version({ version: ProtocolVersion.ProtocolVersion(100n) }),
           ),
         [C]: () => Effect.void,
-      })
-      .pipe(Effect.runPromise);
+      });
 
-    await Effect.runPromise(recorder.done);
-    expect(await Effect.runPromise(recorder.tags)).toEqual([B, C]);
+      yield* recorder.done;
+      expect(yield* recorder.tags).toEqual([B, C]);
+    }).pipe(Effect.scoped, Effect.runPromise));
 
-    await wallet.stop();
-  });
+  it('has the activation subscription live as soon as onVariantActivation resolves', () =>
+    Effect.gen(function* () {
+      const wallet = yield* startTwoVariantWallet();
+      const recorder = yield* makeActivationRecorder(1);
 
-  it('has the activation subscription live as soon as onVariantActivation resolves', async () => {
-    const { Wallet } = makeTwoVariantWallet();
-    const wallet = Wallet.startEmpty(Wallet);
-    const recorder = await Effect.runPromise(makeActivationRecorder(1));
-
-    await wallet.runtime
-      .onVariantActivation({
+      yield* wallet.runtime.onVariantActivation({
         [First]: () => recorder.record(First),
         [Second]: () => recorder.record(Second),
-      })
-      .pipe(Effect.runPromise);
+      });
 
-    // Trigger the migration immediately after registration returns — no other synchronization.
-    // If the subscription were established lazily, this activation could be missed.
-    await wallet.runtime
-      .dispatch({
+      // Trigger the migration immediately after registration returns — no other synchronization.
+      // If the subscription were established lazily, this activation could be missed.
+      yield* wallet.runtime.dispatch({
         [First]: (variant: InterceptingRunningVariant<typeof First, number>) =>
           variant.emitProtocolVersionChange(
             VersionChangeType.Version({ version: ProtocolVersion.ProtocolVersion(100n) }),
           ),
         [Second]: () => Effect.void,
-      })
-      .pipe(Effect.runPromise);
+      });
 
-    await Effect.runPromise(recorder.done);
-    expect(await Effect.runPromise(recorder.tags)).toEqual([Second]);
+      yield* recorder.done;
+      expect(yield* recorder.tags).toEqual([Second]);
+    }).pipe(Effect.scoped, Effect.runPromise));
 
-    await wallet.stop();
-  });
+  it('passes the activation range derived from registration into each variant start context', () =>
+    Effect.gen(function* () {
+      const A = 'a' as const;
+      const B = 'b' as const;
+      const C = 'c' as const;
+      const builderA = new InterceptingVariantBuilder<typeof A, number>(A);
+      const builderB = new InterceptingVariantBuilder<typeof B, number>(B);
+      const builderC = new InterceptingVariantBuilder<typeof C, number>(C);
+      const Wallet = WalletBuilder.init()
+        .withVariant(ProtocolVersion.MinSupportedVersion, builderA)
+        .withVariant(ProtocolVersion.ProtocolVersion(50n), builderB)
+        .withVariant(ProtocolVersion.ProtocolVersion(100n), builderC)
+        .build();
+      const wallet = yield* Effect.acquireRelease(
+        Effect.sync(() => Wallet.startEmpty(Wallet)),
+        (started) => Effect.promise(() => started.stop()),
+      );
 
-  it('passes the activation range derived from registration into each variant start context', async () => {
-    const A = 'a' as const;
-    const B = 'b' as const;
-    const C = 'c' as const;
-    const builderA = new InterceptingVariantBuilder<typeof A, number>(A);
-    const builderB = new InterceptingVariantBuilder<typeof B, number>(B);
-    const builderC = new InterceptingVariantBuilder<typeof C, number>(C);
-    const Wallet = WalletBuilder.init()
-      .withVariant(ProtocolVersion.MinSupportedVersion, builderA)
-      .withVariant(ProtocolVersion.ProtocolVersion(50n), builderB)
-      .withVariant(ProtocolVersion.ProtocolVersion(100n), builderC)
-      .build();
-    const wallet = Wallet.startEmpty(Wallet);
-
-    await rx.firstValueFrom(wallet.rawState);
-    await wallet.runtime
-      .dispatch({
+      yield* firstStateWhere(wallet.rawState);
+      yield* wallet.runtime.dispatch({
         [A]: (variant: InterceptingRunningVariant<typeof A, number>) =>
           variant.emitProtocolVersionChange(
             VersionChangeType.Version({ version: ProtocolVersion.ProtocolVersion(50n) }),
           ),
         [B]: () => Effect.void,
         [C]: () => Effect.void,
-      })
-      .pipe(Effect.runPromise);
-    await rx.firstValueFrom(
-      wallet.rawState.pipe(rx.filter(({ version }) => version === ProtocolVersion.ProtocolVersion(50n))),
-    );
-    await wallet.runtime
-      .dispatch({
+      });
+      yield* firstStateWhere(wallet.rawState, atVersion(ProtocolVersion.ProtocolVersion(50n)));
+      yield* wallet.runtime.dispatch({
         [A]: () => Effect.void,
         [B]: (variant: InterceptingRunningVariant<typeof B, number>) =>
           variant.emitProtocolVersionChange(
             VersionChangeType.Version({ version: ProtocolVersion.ProtocolVersion(100n) }),
           ),
         [C]: () => Effect.void,
-      })
-      .pipe(Effect.runPromise);
-    await rx.firstValueFrom(
-      wallet.rawState.pipe(rx.filter(({ version }) => version === ProtocolVersion.ProtocolVersion(100n))),
-    );
+      });
+      yield* firstStateWhere(wallet.rawState, atVersion(ProtocolVersion.ProtocolVersion(100n)));
 
-    // Each variant's half-open range [sinceVersion_N, sinceVersion_N+1) — the last one is
-    // open-ended up to MaxSupportedVersion. Derived from registration, delivered via context.
-    expect(builderA.built[0]?.receivedContext).toMatchObject({
-      activationRange: [ProtocolVersion.MinSupportedVersion, ProtocolVersion.ProtocolVersion(50n)],
-    });
-    expect(builderB.built[0]?.receivedContext).toMatchObject({
-      activationRange: [ProtocolVersion.ProtocolVersion(50n), ProtocolVersion.ProtocolVersion(100n)],
-    });
-    expect(builderC.built[0]?.receivedContext).toMatchObject({
-      activationRange: [ProtocolVersion.ProtocolVersion(100n), ProtocolVersion.MaxSupportedVersion],
-    });
+      // Each variant's half-open range [sinceVersion_N, sinceVersion_N+1) — the last one is
+      // open-ended up to MaxSupportedVersion. Derived from registration, delivered via context.
+      expect(builderA.built[0]?.receivedContext).toMatchObject({
+        activationRange: [ProtocolVersion.MinSupportedVersion, ProtocolVersion.ProtocolVersion(50n)],
+      });
+      expect(builderB.built[0]?.receivedContext).toMatchObject({
+        activationRange: [ProtocolVersion.ProtocolVersion(50n), ProtocolVersion.ProtocolVersion(100n)],
+      });
+      expect(builderC.built[0]?.receivedContext).toMatchObject({
+        activationRange: [ProtocolVersion.ProtocolVersion(100n), ProtocolVersion.MaxSupportedVersion],
+      });
+    }).pipe(Effect.scoped, Effect.runPromise));
 
-    await wallet.stop();
-  });
+  it('surfaces a migrateState failure as a WalletRuntimeError on the state stream', () =>
+    Effect.gen(function* () {
+      const failingSecond = new InterceptingVariantBuilder<typeof Second, number>(Second, {
+        migrateState: () => Effect.fail(new WalletRuntimeError({ message: 'migration boom' })),
+      });
+      const wallet = yield* startTwoVariantWallet(failingSecond);
 
-  it('surfaces a migrateState failure as a WalletRuntimeError on the state stream', async () => {
-    const failingSecond = new InterceptingVariantBuilder<typeof Second, number>(Second, {
-      migrateState: () => Effect.fail(new WalletRuntimeError({ message: 'migration boom' })),
-    });
-    const { Wallet } = makeTwoVariantWallet(failingSecond);
-    const wallet = Wallet.startEmpty(Wallet);
+      // Subscribed here, before the migration is triggered, so the terminal failure cannot be missed
+      const terminalOutcome = rx.lastValueFrom(wallet.rawState).then(Either.right, Either.left);
 
-    const terminalOutcome = rx.lastValueFrom(wallet.rawState).then(
-      (value) => ({ kind: 'completed' as const, value }),
-      (error: unknown) => ({ kind: 'errored' as const, error }),
-    );
-
-    await rx.firstValueFrom(wallet.rawState);
-    await wallet.runtime
-      .dispatch({
+      yield* firstStateWhere(wallet.rawState);
+      yield* wallet.runtime.dispatch({
         [First]: (variant: InterceptingRunningVariant<typeof First, number>) =>
           variant.emitProtocolVersionChange(
             VersionChangeType.Version({ version: ProtocolVersion.ProtocolVersion(100n) }),
           ),
         [Second]: () => Effect.void,
-      })
-      .pipe(Effect.runPromise);
+      });
 
-    const outcome = await terminalOutcome;
-    expect(outcome.kind).toBe('errored');
-    expect((outcome as { kind: 'errored'; error: unknown }).error).toBeInstanceOf(WalletRuntimeError);
-
-    await wallet.stop();
-  });
+      const outcome = yield* Effect.promise(() => terminalOutcome);
+      expect(Either.isLeft(outcome)).toBe(true);
+      expect(Either.getLeft(outcome)).toEqual(Option.some(expect.any(WalletRuntimeError)));
+    }).pipe(Effect.scoped, Effect.runPromise));
 });

--- a/packages/runtime/src/test/runtime.test.ts
+++ b/packages/runtime/src/test/runtime.test.ts
@@ -27,16 +27,6 @@ import {
 import { WalletBuilder } from '../WalletBuilder.js';
 
 /**
- * Typed probe for the `Runtime.onVariantActivation` API introduced by the hard-fork foundation work — these tests are
- * the RED phase driving its implementation. Once the method lands on the `Runtime` interface, this probe is replaced by
- * direct typed calls and deleted.
- */
-const onVariantActivation = <TImpl extends object>(runtime: object, impl: TImpl): Effect.Effect<void> =>
-  // Type cast required because: onVariantActivation is the API under test (TDD red phase) and is
-  // not on the Runtime interface until the implementation lands.
-  (runtime as { onVariantActivation: (impl: TImpl) => Effect.Effect<void> }).onVariantActivation(impl);
-
-/**
  * Records variant-activation notifications: `record(tag)` appends the tag and completes `done` once `expectedCount`
  * activations have been observed.
  */
@@ -390,10 +380,12 @@ describe('Variant activation and context', () => {
     const wallet = Wallet.startEmpty(Wallet);
     const recorder = await Effect.runPromise(makeActivationRecorder(1));
 
-    await onVariantActivation(wallet.runtime, {
-      [First]: () => recorder.record(First),
-      [Second]: () => recorder.record(Second),
-    }).pipe(Effect.runPromise);
+    await wallet.runtime
+      .onVariantActivation({
+        [First]: () => recorder.record(First),
+        [Second]: () => recorder.record(Second),
+      })
+      .pipe(Effect.runPromise);
 
     // Wait for the first variant to be initiated before driving it
     await rx.firstValueFrom(wallet.rawState);
@@ -426,10 +418,12 @@ describe('Variant activation and context', () => {
     const wallet = Wallet.startEmpty(Wallet);
     const recorder = await Effect.runPromise(makeActivationRecorder(1));
 
-    await onVariantActivation(wallet.runtime, {
-      [First]: () => recorder.record(First),
-      [Second]: () => recorder.record(Second),
-    }).pipe(Effect.runPromise);
+    await wallet.runtime
+      .onVariantActivation({
+        [First]: () => recorder.record(First),
+        [Second]: () => recorder.record(Second),
+      })
+      .pipe(Effect.runPromise);
 
     await rx.firstValueFrom(wallet.rawState);
 
@@ -460,14 +454,18 @@ describe('Variant activation and context', () => {
     const wallet = Wallet.startEmpty(Wallet);
     const recorder = await Effect.runPromise(makeActivationRecorder(2));
 
-    await onVariantActivation(wallet.runtime, {
-      [A]: () => recorder.record(A),
-      // The first activation handler fails AFTER recording — the subscription must survive
-      // and still observe the second migration.
-      [B]: () =>
-        recorder.record(B).pipe(Effect.flatMap(() => Effect.fail(new WalletRuntimeError({ message: 'handler boom' })))),
-      [C]: () => recorder.record(C),
-    }).pipe(Effect.runPromise);
+    await wallet.runtime
+      .onVariantActivation({
+        [A]: () => recorder.record(A),
+        // The first activation handler fails AFTER recording — the subscription must survive
+        // and still observe the second migration.
+        [B]: () =>
+          recorder
+            .record(B)
+            .pipe(Effect.flatMap(() => Effect.fail(new WalletRuntimeError({ message: 'handler boom' })))),
+        [C]: () => recorder.record(C),
+      })
+      .pipe(Effect.runPromise);
 
     await rx.firstValueFrom(wallet.rawState);
 
@@ -509,10 +507,12 @@ describe('Variant activation and context', () => {
     const wallet = Wallet.startEmpty(Wallet);
     const recorder = await Effect.runPromise(makeActivationRecorder(1));
 
-    await onVariantActivation(wallet.runtime, {
-      [First]: () => recorder.record(First),
-      [Second]: () => recorder.record(Second),
-    }).pipe(Effect.runPromise);
+    await wallet.runtime
+      .onVariantActivation({
+        [First]: () => recorder.record(First),
+        [Second]: () => recorder.record(Second),
+      })
+      .pipe(Effect.runPromise);
 
     // Trigger the migration immediately after registration returns — no other synchronization.
     // If the subscription were established lazily, this activation could be missed.

--- a/packages/runtime/src/test/runtime.test.ts
+++ b/packages/runtime/src/test/runtime.test.ts
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { type ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Effect } from 'effect';
+import { Deferred, Effect, Ref } from 'effect';
 import * as rx from 'rxjs';
 import { describe, expect, it } from 'vitest';
-import { StateChange, VersionChangeType } from '../abstractions/index.js';
+import { StateChange, VersionChangeType, WalletRuntimeError } from '../abstractions/index.js';
 import { isOrderedSubsequenceOf, protocolStateEquals, toProtocolStateArray } from '../testing/utils.js';
 import {
   type InterceptingRunningVariant,
@@ -25,6 +25,38 @@ import {
   NumericRangeMultiplierBuilder,
 } from '../testing/variants.js';
 import { WalletBuilder } from '../WalletBuilder.js';
+
+/**
+ * Typed probe for the `Runtime.onVariantActivation` API introduced by the hard-fork foundation work — these tests are
+ * the RED phase driving its implementation. Once the method lands on the `Runtime` interface, this probe is replaced by
+ * direct typed calls and deleted.
+ */
+const onVariantActivation = <TImpl extends object>(runtime: object, impl: TImpl): Effect.Effect<void> =>
+  // Type cast required because: onVariantActivation is the API under test (TDD red phase) and is
+  // not on the Runtime interface until the implementation lands.
+  (runtime as { onVariantActivation: (impl: TImpl) => Effect.Effect<void> }).onVariantActivation(impl);
+
+/**
+ * Records variant-activation notifications: `record(tag)` appends the tag and completes `done` once `expectedCount`
+ * activations have been observed.
+ */
+const makeActivationRecorder = (expectedCount: number) =>
+  Effect.gen(function* () {
+    const tagsRef = yield* Ref.make<readonly string[]>([]);
+    const doneSignal = yield* Deferred.make<void>();
+    const record = (tag: string): Effect.Effect<void> =>
+      Ref.updateAndGet(tagsRef, (tags) => [...tags, tag]).pipe(
+        Effect.flatMap((tags) =>
+          tags.length >= expectedCount ? Deferred.succeed(doneSignal, void 0) : Effect.succeed(false),
+        ),
+        Effect.asVoid,
+      );
+    return {
+      tags: Ref.get(tagsRef),
+      done: Deferred.await(doneSignal).pipe(Effect.timeout('2 seconds')),
+      record,
+    };
+  });
 
 describe('Wallet runtime', () => {
   it('allows to dispatch a poly function on a running variant', async () => {
@@ -332,6 +364,257 @@ describe('Wallet runtime', () => {
       })
       .pipe(Effect.runPromise);
     expect(stillSoleVariant).toBe(true);
+
+    await wallet.stop();
+  });
+});
+
+describe('Variant activation and context', () => {
+  const First = 'first' as const;
+  const Second = 'second' as const;
+
+  const makeTwoVariantWallet = (secondBuilder?: InterceptingVariantBuilder<typeof Second, number>) => {
+    const firstBuilder = new InterceptingVariantBuilder<typeof First, number>(First);
+    const Wallet = WalletBuilder.init()
+      .withVariant(ProtocolVersion.MinSupportedVersion, firstBuilder)
+      .withVariant(
+        ProtocolVersion.ProtocolVersion(100n),
+        secondBuilder ?? new InterceptingVariantBuilder<typeof Second, number>(Second),
+      )
+      .build();
+    return { Wallet, firstBuilder };
+  };
+
+  it('invokes onVariantActivation exactly once, with the newly activated variant, after a migration', async () => {
+    const { Wallet } = makeTwoVariantWallet();
+    const wallet = Wallet.startEmpty(Wallet);
+    const recorder = await Effect.runPromise(makeActivationRecorder(1));
+
+    await onVariantActivation(wallet.runtime, {
+      [First]: () => recorder.record(First),
+      [Second]: () => recorder.record(Second),
+    }).pipe(Effect.runPromise);
+
+    // Wait for the first variant to be initiated before driving it
+    await rx.firstValueFrom(wallet.rawState);
+
+    await wallet.runtime
+      .dispatch({
+        [First]: (variant: InterceptingRunningVariant<typeof First, number>) =>
+          variant.emitProtocolVersionChange(
+            VersionChangeType.Version({ version: ProtocolVersion.ProtocolVersion(100n) }),
+          ),
+        [Second]: () => Effect.void,
+      })
+      .pipe(Effect.runPromise);
+
+    await Effect.runPromise(recorder.done);
+    // Exactly one activation — for the migration target, never for the initially started variant
+    expect(await Effect.runPromise(recorder.tags)).toEqual([Second]);
+
+    // Sanity: dispatch reaches the migrated-to variant
+    const nowSecond = await wallet.runtime
+      .dispatch({ [First]: () => Effect.succeed(false), [Second]: () => Effect.succeed(true) })
+      .pipe(Effect.runPromise);
+    expect(nowSecond).toBe(true);
+
+    await wallet.stop();
+  });
+
+  it('does not invoke onVariantActivation when no migration occurs', async () => {
+    const { Wallet } = makeTwoVariantWallet();
+    const wallet = Wallet.startEmpty(Wallet);
+    const recorder = await Effect.runPromise(makeActivationRecorder(1));
+
+    await onVariantActivation(wallet.runtime, {
+      [First]: () => recorder.record(First),
+      [Second]: () => recorder.record(Second),
+    }).pipe(Effect.runPromise);
+
+    await rx.firstValueFrom(wallet.rawState);
+
+    // Plain state emission — no version change, no migration
+    await wallet.runtime
+      .dispatch({
+        [First]: (variant: InterceptingRunningVariant<typeof First, number>) =>
+          variant.emit(StateChange.State({ state: 42 })),
+        [Second]: () => Effect.void,
+      })
+      .pipe(Effect.runPromise);
+    await rx.firstValueFrom(wallet.rawState.pipe(rx.filter(({ state }) => state === 42)));
+
+    expect(await Effect.runPromise(recorder.tags)).toEqual([]);
+
+    await wallet.stop();
+  });
+
+  it('observes every migration of a chain in order, surviving a failing handler', async () => {
+    const A = 'a' as const;
+    const B = 'b' as const;
+    const C = 'c' as const;
+    const Wallet = WalletBuilder.init()
+      .withVariant(ProtocolVersion.MinSupportedVersion, new InterceptingVariantBuilder<typeof A, number>(A))
+      .withVariant(ProtocolVersion.ProtocolVersion(50n), new InterceptingVariantBuilder<typeof B, number>(B))
+      .withVariant(ProtocolVersion.ProtocolVersion(100n), new InterceptingVariantBuilder<typeof C, number>(C))
+      .build();
+    const wallet = Wallet.startEmpty(Wallet);
+    const recorder = await Effect.runPromise(makeActivationRecorder(2));
+
+    await onVariantActivation(wallet.runtime, {
+      [A]: () => recorder.record(A),
+      // The first activation handler fails AFTER recording — the subscription must survive
+      // and still observe the second migration.
+      [B]: () =>
+        recorder.record(B).pipe(Effect.flatMap(() => Effect.fail(new WalletRuntimeError({ message: 'handler boom' })))),
+      [C]: () => recorder.record(C),
+    }).pipe(Effect.runPromise);
+
+    await rx.firstValueFrom(wallet.rawState);
+
+    await wallet.runtime
+      .dispatch({
+        [A]: (variant: InterceptingRunningVariant<typeof A, number>) =>
+          variant.emitProtocolVersionChange(
+            VersionChangeType.Version({ version: ProtocolVersion.ProtocolVersion(50n) }),
+          ),
+        [B]: () => Effect.void,
+        [C]: () => Effect.void,
+      })
+      .pipe(Effect.runPromise);
+
+    // Wait until the second variant is live (its start() re-publishes the migrated state at version 50n)
+    await rx.firstValueFrom(
+      wallet.rawState.pipe(rx.filter(({ version }) => version === ProtocolVersion.ProtocolVersion(50n))),
+    );
+
+    await wallet.runtime
+      .dispatch({
+        [A]: () => Effect.void,
+        [B]: (variant: InterceptingRunningVariant<typeof B, number>) =>
+          variant.emitProtocolVersionChange(
+            VersionChangeType.Version({ version: ProtocolVersion.ProtocolVersion(100n) }),
+          ),
+        [C]: () => Effect.void,
+      })
+      .pipe(Effect.runPromise);
+
+    await Effect.runPromise(recorder.done);
+    expect(await Effect.runPromise(recorder.tags)).toEqual([B, C]);
+
+    await wallet.stop();
+  });
+
+  it('has the activation subscription live as soon as onVariantActivation resolves', async () => {
+    const { Wallet } = makeTwoVariantWallet();
+    const wallet = Wallet.startEmpty(Wallet);
+    const recorder = await Effect.runPromise(makeActivationRecorder(1));
+
+    await onVariantActivation(wallet.runtime, {
+      [First]: () => recorder.record(First),
+      [Second]: () => recorder.record(Second),
+    }).pipe(Effect.runPromise);
+
+    // Trigger the migration immediately after registration returns — no other synchronization.
+    // If the subscription were established lazily, this activation could be missed.
+    await wallet.runtime
+      .dispatch({
+        [First]: (variant: InterceptingRunningVariant<typeof First, number>) =>
+          variant.emitProtocolVersionChange(
+            VersionChangeType.Version({ version: ProtocolVersion.ProtocolVersion(100n) }),
+          ),
+        [Second]: () => Effect.void,
+      })
+      .pipe(Effect.runPromise);
+
+    await Effect.runPromise(recorder.done);
+    expect(await Effect.runPromise(recorder.tags)).toEqual([Second]);
+
+    await wallet.stop();
+  });
+
+  it('passes the activation range derived from registration into each variant start context', async () => {
+    const A = 'a' as const;
+    const B = 'b' as const;
+    const C = 'c' as const;
+    const builderA = new InterceptingVariantBuilder<typeof A, number>(A);
+    const builderB = new InterceptingVariantBuilder<typeof B, number>(B);
+    const builderC = new InterceptingVariantBuilder<typeof C, number>(C);
+    const Wallet = WalletBuilder.init()
+      .withVariant(ProtocolVersion.MinSupportedVersion, builderA)
+      .withVariant(ProtocolVersion.ProtocolVersion(50n), builderB)
+      .withVariant(ProtocolVersion.ProtocolVersion(100n), builderC)
+      .build();
+    const wallet = Wallet.startEmpty(Wallet);
+
+    await rx.firstValueFrom(wallet.rawState);
+    await wallet.runtime
+      .dispatch({
+        [A]: (variant: InterceptingRunningVariant<typeof A, number>) =>
+          variant.emitProtocolVersionChange(
+            VersionChangeType.Version({ version: ProtocolVersion.ProtocolVersion(50n) }),
+          ),
+        [B]: () => Effect.void,
+        [C]: () => Effect.void,
+      })
+      .pipe(Effect.runPromise);
+    await rx.firstValueFrom(
+      wallet.rawState.pipe(rx.filter(({ version }) => version === ProtocolVersion.ProtocolVersion(50n))),
+    );
+    await wallet.runtime
+      .dispatch({
+        [A]: () => Effect.void,
+        [B]: (variant: InterceptingRunningVariant<typeof B, number>) =>
+          variant.emitProtocolVersionChange(
+            VersionChangeType.Version({ version: ProtocolVersion.ProtocolVersion(100n) }),
+          ),
+        [C]: () => Effect.void,
+      })
+      .pipe(Effect.runPromise);
+    await rx.firstValueFrom(
+      wallet.rawState.pipe(rx.filter(({ version }) => version === ProtocolVersion.ProtocolVersion(100n))),
+    );
+
+    // Each variant's half-open range [sinceVersion_N, sinceVersion_N+1) — the last one is
+    // open-ended up to MaxSupportedVersion. Derived from registration, delivered via context.
+    expect(builderA.built[0]?.receivedContext).toMatchObject({
+      activationRange: [ProtocolVersion.MinSupportedVersion, ProtocolVersion.ProtocolVersion(50n)],
+    });
+    expect(builderB.built[0]?.receivedContext).toMatchObject({
+      activationRange: [ProtocolVersion.ProtocolVersion(50n), ProtocolVersion.ProtocolVersion(100n)],
+    });
+    expect(builderC.built[0]?.receivedContext).toMatchObject({
+      activationRange: [ProtocolVersion.ProtocolVersion(100n), ProtocolVersion.MaxSupportedVersion],
+    });
+
+    await wallet.stop();
+  });
+
+  it('surfaces a migrateState failure as a WalletRuntimeError on the state stream', async () => {
+    const failingSecond = new InterceptingVariantBuilder<typeof Second, number>(Second, {
+      migrateState: () => Effect.fail(new WalletRuntimeError({ message: 'migration boom' })),
+    });
+    const { Wallet } = makeTwoVariantWallet(failingSecond);
+    const wallet = Wallet.startEmpty(Wallet);
+
+    const terminalOutcome = rx.lastValueFrom(wallet.rawState).then(
+      (value) => ({ kind: 'completed' as const, value }),
+      (error: unknown) => ({ kind: 'errored' as const, error }),
+    );
+
+    await rx.firstValueFrom(wallet.rawState);
+    await wallet.runtime
+      .dispatch({
+        [First]: (variant: InterceptingRunningVariant<typeof First, number>) =>
+          variant.emitProtocolVersionChange(
+            VersionChangeType.Version({ version: ProtocolVersion.ProtocolVersion(100n) }),
+          ),
+        [Second]: () => Effect.void,
+      })
+      .pipe(Effect.runPromise);
+
+    const outcome = await terminalOutcome;
+    expect(outcome.kind).toBe('errored');
+    expect((outcome as { kind: 'errored'; error: unknown }).error).toBeInstanceOf(WalletRuntimeError);
 
     await wallet.stop();
   });

--- a/packages/runtime/src/testing/variants.ts
+++ b/packages/runtime/src/testing/variants.ts
@@ -167,6 +167,10 @@ export type InterceptingRunningVariant<TTag extends string | symbol, TState> = V
   emitProtocolVersionChange: (change: VersionChangeType.VersionChangeType) => Effect.Effect<void>;
   emit: (change: StateChange.StateChange<TState>) => Effect.Effect<void>;
 };
+export type InterceptingVariantOptions<TState> = {
+  /** Replaces the default identity migration, e.g. to simulate a failing state migration. */
+  migrateState?: (previousState: TState) => Effect.Effect<TState, WalletRuntimeError>;
+};
 export class InterceptingVariant<TTag extends string | symbol, TState> implements Variant.Variant<
   TTag,
   TState,
@@ -174,16 +178,27 @@ export class InterceptingVariant<TTag extends string | symbol, TState> implement
   InterceptingRunningVariant<TTag, TState>
 > {
   __polyTag__: TTag;
-  constructor(tag: TTag) {
+  /** The context the runtime handed to {@link start} — recorded for test assertions. */
+  receivedContext: Variant.VariantContext<TState> | undefined;
+  readonly #options: InterceptingVariantOptions<TState>;
+
+  constructor(tag: TTag, options: InterceptingVariantOptions<TState> = {}) {
     this.__polyTag__ = tag;
+    this.#options = options;
   }
 
   migrateState(previousState: TState): Effect.Effect<TState> {
-    return Effect.succeed(previousState);
+    const override = this.#options.migrateState;
+    // Type cast required because: Variant.migrateState still declares a `never` error channel;
+    // the hard-fork foundation work widens it to WalletRuntimeError, at which point this cast
+    // disappears. Effect error channels are type-level only, so the failure injected by the
+    // override still propagates at runtime — which is exactly what the RED test observes.
+    return override === undefined ? Effect.succeed(previousState) : (override(previousState) as Effect.Effect<TState>);
   }
   start(
     context: Variant.VariantContext<TState>,
   ): Effect.Effect<InterceptingRunningVariant<TTag, TState>, WalletRuntimeError, Scope.Scope> {
+    this.receivedContext = context;
     const tag = this.__polyTag__;
     return Effect.gen(this, function* () {
       const pubsub = yield* PubSub.bounded<StateChange.StateChange<TState>>({
@@ -216,10 +231,17 @@ export class InterceptingVariantBuilder<TTag extends string | symbol, TState> im
   object
 > {
   tag: TTag;
-  constructor(tag: TTag) {
+  /** Every variant instance produced by {@link build} — lets tests inspect recorded contexts. */
+  readonly built: InterceptingVariant<TTag, TState>[] = [];
+  readonly #options: InterceptingVariantOptions<TState>;
+  constructor(tag: TTag, options: InterceptingVariantOptions<TState> = {}) {
     this.tag = tag;
+    this.#options = options;
   }
   build(): InterceptingVariant<TTag, TState> {
-    return new InterceptingVariant(this.tag);
+    const variant = new InterceptingVariant(this.tag, this.#options);
+    // Test-harness bookkeeping: mutation is confined to test tooling by design.
+    this.built.push(variant);
+    return variant;
   }
 }

--- a/packages/runtime/src/testing/variants.ts
+++ b/packages/runtime/src/testing/variants.ts
@@ -187,14 +187,11 @@ export class InterceptingVariant<TTag extends string | symbol, TState> implement
     this.#options = options;
   }
 
-  migrateState(previousState: TState): Effect.Effect<TState> {
+  migrateState(previousState: TState): Effect.Effect<TState, WalletRuntimeError> {
     const override = this.#options.migrateState;
-    // Type cast required because: Variant.migrateState still declares a `never` error channel;
-    // the hard-fork foundation work widens it to WalletRuntimeError, at which point this cast
-    // disappears. Effect error channels are type-level only, so the failure injected by the
-    // override still propagates at runtime — which is exactly what the RED test observes.
-    return override === undefined ? Effect.succeed(previousState) : (override(previousState) as Effect.Effect<TState>);
+    return override === undefined ? Effect.succeed(previousState) : override(previousState);
   }
+
   start(
     context: Variant.VariantContext<TState>,
   ): Effect.Effect<InterceptingRunningVariant<TTag, TState>, WalletRuntimeError, Scope.Scope> {

--- a/packages/shielded-wallet/src/v1/test/runningV1Variant.test.ts
+++ b/packages/shielded-wallet/src/v1/test/runningV1Variant.test.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Duration, Effect, Exit, Ref, Scope, Stream, SubscriptionRef, TestClock, TestContext } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { makeDefaultCoinsAndBalancesCapability } from '../CoinsAndBalances.js';
@@ -118,7 +118,13 @@ describe('RunningV1Variant.startSync tx-history fan-out', () => {
       const scope = yield* Scope.make();
       const variant = new RunningV1Variant(
         scope,
-        { stateRef },
+        {
+          stateRef,
+          activationRange: ProtocolVersion.makeRange(
+            ProtocolVersion.MinSupportedVersion,
+            ProtocolVersion.MaxSupportedVersion,
+          ),
+        },
         variantContextOf(batches, trackingHistoryService(counters)),
       );
 


### PR DESCRIPTION
## What

First work package of the hard-fork foundation milestone: the `packages/runtime` machinery a variant handoff needs at a
protocol fork. No behavior changes for a single-variant wallet — this is additive runtime API plus one new field on the
variant start context.

Mainnet will hard-fork from ledger-v8 to ledger-v9, and one SDK release has to run v8 behavior pre-fork and v9 post-fork,
switching automatically mid-sync. The variant architecture was built for that, but two runtime gaps meant the handoff
could never complete:

- **Gap 1 (restart)**: after a migration, `initHeadVariant` only calls `variant.start(...)`. Nothing re-invokes
  `startSyncInBackground`, so the newly activated variant sits idle.
- **Gap 2 (keys)**: the secret keys sync needs arrive as the `startAux` of `startSyncInBackground` — they are not in
  state and not serialized, so they are unavailable at `migrateState`/`start(context)`.

## Changes

**`Runtime.onVariantActivation<E>(impl)`** — registers a poly-function watcher notified with the running variant that
became current after a migration, and never for the variant the runtime started with. This is the seam the per-wallet
work uses to re-dispatch `startSyncInBackground` with keys the wallet class retains in memory, so keys never have to
enter serialized state (Gaps 1+2).

Implementation notes:
- Unbounded activation `PubSub`, acquired with `Effect.acquireRelease` under the runtime scope captured via
  `Effect.scope`. Unbounded because a bounded pubsub would let a slow watcher block the publish inside the migration's
  `followEffect` and stall the migration itself; dropping when nobody is subscribed is the desired semantics.
- Published after `SynchronizedRef.set(currentVariantRef, …)` and before control passes to the new variant's stream.
- Registration does `Scope.extend(PubSub.subscribe(…), runtimeScope)` and only then `Effect.forkIn(consumer, …)`, so an
  activation triggered immediately after the effect resolves cannot be missed.
- Each notification is `Poly.dispatch(…).pipe(Effect.ignoreLogged)`: a failing watcher neither fails the runtime nor
  unsubscribes itself.

**`VariantContext.activationRange: ProtocolVersion.Range`** — the half-open `[sinceVersion, nextSinceVersion)` window the
runtime already derived from `withVariant` registration (`validVersionRange`) is now handed to the variant at `start`.
The upcoming per-wallet work needs it inside the pure sync capability to split a batch that straddles the fork (apply the
prefix, stop at the boundary, annotate the out-of-range version so the runtime migrates) and for the restore-healing
emission. The value existed but wasn't reachable from inside a starting variant: the `RunningVariant` record that holds
it is built *from* the result of `start`, and a variant has no back-reference to the runtime. Threading it through the
context makes `withVariant(sinceVersion)` the single source of truth, so the migration boundary and the sync split point
cannot drift apart — and keeps the not-yet-final fork version out of the code entirely.

**`Variant.migrateState` error channel widened** to `WalletRuntimeError`. Such a failure already surfaced on the state
stream at runtime; now the contract says so. Existing implementations remain valid, since `Effect<TState>` is assignable
to `Effect<TState, WalletRuntimeError>`.

## Compatibility

`runtime` **minor** (changeset included). `onVariantActivation` is additive. `VariantContext.activationRange` is breaking
only for code that constructs a `VariantContext` and calls `Variant.start` (or a `RunningVariant` constructor) directly,
which is not part of the normal wallet lifecycle. All three such call sites in this repo are test stubs and are updated
here: `packages/dust-wallet/test/DustWallet.test.ts`, plus `runningV1Variant.test.ts` in `shielded-wallet` and in
`dust-wallet` — the latter two drive sync fan-out on a single variant and never cross a version boundary, so they get the
widest range (`MinSupportedVersion` to `MaxSupportedVersion`).

## Testing

TDD per CLAUDE.md — red tests are the first commit (`dbae745b`), reviewed before the implementation commit
(`9604ffe4`). Six new tests in `packages/runtime/src/test/runtime.test.ts`, driven by the synthetic
`InterceptingVariant` harness:

1. `onVariantActivation` fires exactly once after a migration, with the newly activated variant
2. it does not fire when no migration occurs
3. it observes every migration of a 3-variant chain in order, surviving a handler that fails
4. the subscription is live as soon as `onVariantActivation` resolves (register → immediately trigger → observed)
5. each variant receives its registration-derived `activationRange`: `[0n,50n)`, `[50n,100n)`, `[100n, Max)`
6. a `migrateState` failure surfaces as `WalletRuntimeError` on the state stream

Each of the six is a single effect — one `Effect.gen` ending in `.pipe(Effect.scoped, Effect.runPromise)` — with wallet
startup as an `Effect.acquireRelease`, so `stop()` also runs when a test fails mid-way.

Verified on the branch tip: repo-wide `typecheck` (35 tasks), `lint` (55) and `format:check` (21) clean, and `test:unit`
green across all 50 tasks (runtime 41/41, dust-wallet and shielded-wallet included). Effect diagnostics on the touched
files report only two pre-existing hits on the untouched `'No variant to init'` lines — nothing on the PubSub/watcher
forks or the reworked tests.

## Review follow-ups (in `d9eb2d7c` and `d8cdad9c`)

- The activation/context tests were rewritten from sequences of awaited `Effect.runPromise` calls into one effect per
  test, per review.
- The two design points raised in review are now documented where they apply rather than only here: `migrateState`
  carries the invariant that an implementation is expected to be written so that it succeeds, and states that the error
  channel exists for the part of the migration that is not the variant's own code — the v8-to-v9 translation is a
  ledger-side tool across a WASM boundary that signals failure by throwing, so typing it as infallible would only turn a
  diagnosable stream failure into a defect. `activationRange` documents why it is handed through the context even though
  the runtime keeps the same range on its `RunningVariant` record.
- Two variant-context stubs missed by the original commit (`runningV1Variant.test.ts` in shielded-wallet and
  dust-wallet) broke `typecheck`, which skipped format/lint/barrel-export and left every test stage skipped. Fixed; CI's
  `General Checks` is green again.

## Follow-ups (same milestone, not in this PR)

Per-wallet work for shielded / unshielded / dust: write the indexer-reported `protocolVersion` into state (the version
signal itself — today `ProtocolState.version` pins at `0n`, so fork detection cannot fire), boundary splitting in
`applyUpdate`, the `migrateState` strategy seam, the restore-healing emission, and `start()` retaining its aux plus
registering the activation watcher. The handoff tests that prove the full transition land with those.
