### PR TITLE
test(capabilities): prove ledger-v8 / ledger-v9 WASM coexistence (fork-simulation spike)

### DIFF
--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -67,7 +67,8 @@
     "@effect/platform-node": "0.107.0",
     "@effect/rpc": "0.75.1",
     "@effect/sql": "0.51.1",
-    "@effect/workflow": "0.18.2"
+    "@effect/workflow": "0.18.2",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0"
   },
   "scripts": {
     "typecheck": "tsc -b ./tsconfig.json --noEmit --force",

--- a/packages/capabilities/src/simulation/test/dualLedger.test.ts
+++ b/packages/capabilities/src/simulation/test/dualLedger.test.ts
@@ -1,0 +1,100 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Dual-ledger coexistence spike.
+ *
+ * Hard-fork support requires ledger-v8 (pre-fork) and ledger-v9 (post-fork) WASM modules to be loaded and used side by
+ * side in a single process. This test pins that assumption: each ledger must construct, serialize, and deserialize its
+ * own objects correctly while the other is loaded and in active use.
+ *
+ * Deliberately NOT asserted here: any cross-version compatibility (v9 reading v8 bytes, equal commitments/token types
+ * across versions). Those are separate, open questions.
+ */
+
+import * as v8 from '@midnight-ntwrk/ledger-v8';
+import * as v9 from '@midnightntwrk/ledger-v9';
+import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { describe, expect, it } from 'vitest';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+
+const seed = (fill: number): Buffer => Buffer.alloc(32, fill);
+
+describe('dual-ledger WASM coexistence', () => {
+  it('constructs a blank LedgerState from each ledger in the same process', () => {
+    const v8State = v8.LedgerState.blank(networkId);
+    const v9State = v9.LedgerState.blank(networkId);
+
+    expect(v8State).toBeInstanceOf(v8.LedgerState);
+    expect(v9State).toBeInstanceOf(v9.LedgerState);
+    // The two modules must be genuinely distinct — no shared class identity.
+    expect(v8State).not.toBeInstanceOf(v9.LedgerState);
+    expect(v9State).not.toBeInstanceOf(v8.LedgerState);
+  });
+
+  it('round-trips v8 LedgerState serialization with the other ledger loaded', () => {
+    const original = v8.LedgerState.blank(networkId);
+    const bytes = original.serialize();
+    const restored = v8.LedgerState.deserialize(bytes);
+
+    expect(restored).toBeInstanceOf(v8.LedgerState);
+    expect(restored.serialize()).toEqual(bytes);
+  });
+
+  it('round-trips v9 LedgerState serialization with the other ledger loaded', () => {
+    const original = v9.LedgerState.blank(networkId);
+    const bytes = original.serialize();
+    const restored = v9.LedgerState.deserialize(bytes);
+
+    expect(restored).toBeInstanceOf(v9.LedgerState);
+    expect(restored.serialize()).toEqual(bytes);
+  });
+
+  it('interleaves key derivation, coin creation, and hashing across both ledgers without clashes', () => {
+    // Alternate between the two modules on every step so any shared global WASM state would surface.
+    const v8Keys = v8.ZswapSecretKeys.fromSeed(seed(1));
+    const v9Keys = v9.ZswapSecretKeys.fromSeed(seed(1));
+
+    const v8Coin = v8.createShieldedCoinInfo(v8.shieldedToken().raw, 100n);
+    const v9Coin = v9.createShieldedCoinInfo(v9.shieldedToken().raw, 100n);
+
+    const v8Commitment = v8.coinCommitment(v8Coin, v8Keys.coinPublicKey);
+    const v9Commitment = v9.coinCommitment(v9Coin, v9Keys.coinPublicKey);
+
+    expect(v8Commitment).toMatch(/^[0-9a-f]+$/);
+    expect(v9Commitment).toMatch(/^[0-9a-f]+$/);
+
+    // Each module keeps working after the other was exercised.
+    const v8Again = v8.coinCommitment(v8Coin, v8Keys.coinPublicKey);
+    const v9Again = v9.coinCommitment(v9Coin, v9Keys.coinPublicKey);
+    expect(v8Again).toEqual(v8Commitment);
+    expect(v9Again).toEqual(v9Commitment);
+  });
+
+  it('keeps ledger state usable after heavy interleaved use of the other module', () => {
+    const v8State = v8.LedgerState.blank(networkId);
+    const v9State = v9.LedgerState.blank(networkId);
+
+    // Exercise v9 between v8 operations and vice versa.
+    const v8BytesFirst = v8State.serialize();
+    const v9BytesFirst = v9State.serialize();
+    const v9Keys = v9.ZswapSecretKeys.fromSeed(seed(7));
+    const v8Keys = v8.ZswapSecretKeys.fromSeed(seed(7));
+    expect(v9Keys.coinPublicKey).toBeDefined();
+    expect(v8Keys.coinPublicKey).toBeDefined();
+
+    expect(v8State.serialize()).toEqual(v8BytesFirst);
+    expect(v9State.serialize()).toEqual(v9BytesFirst);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2516,6 +2516,7 @@ __metadata:
     "@effect/rpc": "npm:0.75.1"
     "@effect/sql": "npm:0.51.1"
     "@effect/workflow": "npm:0.18.2"
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@midnight-ntwrk/zkir-v2": "npm:^2.1.0"
     "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.3"
     "@midnightntwrk/wallet-sdk-abstractions": "npm:3.0.0-beta.0"


### PR DESCRIPTION
> **Stacked on #628** (`hard-fork-support`). Base is that branch, so this PR's diff is only the spike commit. Merge #628
> first, or retarget this to `v2` after it lands.

## What

De-risking spike for byte-faithful hard-fork simulation: proves that the ledger-v8 and ledger-v9 WASM modules can be
loaded and used side by side in a single process.

This gates the whole approach. The planned fork harness runs a v8-typed simulator to produce pre-fork blocks and hands
over to the v9 simulator at the fork block, so both WASM modules are live in one vitest process. If that didn't work, the
approach would need rethinking before anything gets built on it. It works.

## Tests

Five tests in `packages/capabilities/src/simulation/test/dualLedger.test.ts` (unit tier, no Docker):

1. blank `LedgerState` constructed from each module in the same process, asserting genuinely distinct class identity —
   a v8 state is not an instance of `v9.LedgerState` and vice versa
2. v8 `LedgerState` serialize → deserialize → serialize round-trip with the other ledger loaded
3. the same for v9
4. interleaved `ZswapSecretKeys.fromSeed` / `createShieldedCoinInfo` / `coinCommitment` alternating between modules on
   every step, so any shared global WASM state would surface; each module still produces its original commitment after
   the other was exercised
5. both `LedgerState`s still serialize to their original bytes after heavy interleaved use of the other module

All 5 pass.

**Deliberately not asserted:** any cross-version compatibility — v9 deserializing v8 bytes, or commitments/token types
matching across versions. Those are separate open questions for the ledger team, and the spike would be misleading if it
implied an answer.

## Dependency scoping

`@midnight-ntwrk/ledger-v8@^8.1.0` is added as a **devDependency** of `capabilities`, not a dependency. `capabilities` is
published, and the only importer of v8 today is this test — consumers should not be made to install a second WASM blob
for code that doesn't exist yet. It gets promoted to a real dependency when the vendored v8 simulator lands in `src/`, at
which point the published-bundle-size question becomes real and worth a browser check.

Note the two ledger packages live under different npm scopes (`@midnight-ntwrk` for v8, `@midnightntwrk` for v9), which
is what makes coexistence possible at the package-manager level in the first place.

## Verification

`yarn test:unit --force --filter=@midnightntwrk/wallet-sdk-capabilities` (5/5), plus `typecheck`, `lint`, `format:check`
and `changeset:check` clean. No changeset needed: test + devDependency only, no published behavior change.
