### PR TITLE
feat(indexer-client): adopt indexer graphql-transport-ws+deflate subscription compression

### DIFF
--- a/.changeset/indexer-ws-deflate-compression.md
+++ b/.changeset/indexer-ws-deflate-compression.md
@@ -1,0 +1,14 @@
+---
+'@midnightntwrk/wallet-sdk-indexer-client': minor
+---
+
+feat(indexer-client): adopt the indexer's `graphql-transport-ws+deflate` subscription compression (#462)
+
+Subscriptions now negotiate the indexer's deflate subprotocol (indexer >= 4.4.0), so payloads at or above the server's
+256 B threshold arrive as zlib binary frames and are inflated client-side. Compression is always on with no public
+configuration; against an indexer that predates the subprotocol the client silently falls back to standard
+`graphql-transport-ws`.
+
+The WebSocket connection is also now held open for the client's entire lifetime (`lazy: false`), so backpressure
+pause/resume cycles reuse a single physical connection instead of reconnecting each time, and disposing the client
+leaves nothing pending — no timers survive to delay the exit of a short-lived process.

--- a/infra/compose/docker-compose-dynamic.yml
+++ b/infra/compose/docker-compose-dynamic.yml
@@ -19,7 +19,11 @@ services:
       start_period: 10s
 
   indexer:
-    image: 'ghcr.io/midnight-ntwrk/indexer-standalone:4.3.2'
+    # 4.4.0 is the first indexer offering the graphql-transport-ws+deflate subprotocol; only rc
+    # images exist so far and they are amd64-only, hence the platform pin (emulated on arm64
+    # hosts). Move to the stable multi-arch 4.4.0 tag and drop the platform pin once it ships.
+    image: 'ghcr.io/midnight-ntwrk/indexer-standalone:4.4.0-rc.1'
+    platform: linux/amd64
     container_name: indexer_$TESTCONTAINERS_UID
     cap_drop:
       - ALL

--- a/infra/compose/docker-compose.ws-no-deflate.yml
+++ b/infra/compose/docker-compose.ws-no-deflate.yml
@@ -1,0 +1,8 @@
+# Override for the WebSocket deflate-compression *fallback* integration test: it freezes the last
+# pre-deflate indexer (4.3.x) so the test always exercises negotiation against a server that does
+# not know the graphql-transport-ws+deflate subprotocol, regardless of what the compose default
+# moves to. Delete this file (and the fallback test it serves) only when support for pre-deflate
+# indexers is deliberately dropped.
+services:
+  indexer:
+    image: 'ghcr.io/midnight-ntwrk/indexer-standalone:4.3.2'

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -1,6 +1,10 @@
 services:
   indexer:
-    image: 'ghcr.io/midnight-ntwrk/indexer-standalone:4.3.2'
+    # 4.4.0 is the first indexer offering the graphql-transport-ws+deflate subprotocol; only rc
+    # images exist so far and they are amd64-only, hence the platform pin (emulated on arm64
+    # hosts). Move to the stable multi-arch 4.4.0 tag and drop the platform pin once it ships.
+    image: 'ghcr.io/midnight-ntwrk/indexer-standalone:4.4.0-rc.1'
+    platform: linux/amd64
     container_name: indexer_$TESTCONTAINERS_UID
     cap_drop:
       - ALL

--- a/packages/capabilities/src/pendingTransactions/pendingTransactionsService.ts
+++ b/packages/capabilities/src/pendingTransactions/pendingTransactionsService.ts
@@ -263,7 +263,11 @@ export class PendingTransactionsServiceEffectImpl<
       return pipe(
         result.transactions,
         Iterable.filterMap((res): Option.Option<PendingTransactions.TransactionResult> => {
-          if (res.__typename == 'SystemTransaction') {
+          // Only RegularTransaction carries the identifiers and transactionResult this matching
+          // needs — and wallet-submitted transactions are always regular. Narrowing to it (rather
+          // than excluding known other variants) keeps future schema variants ignored instead of
+          // breaking compilation, as BridgeClaimTransaction (indexer 4.4.0) once did.
+          if (res.__typename != 'RegularTransaction') {
             return Option.none();
           }
 

--- a/packages/indexer-client/indexer.gql
+++ b/packages/indexer-client/indexer.gql
@@ -2,78 +2,344 @@
 # @generated indexer GraphQL schema — DO NOT EDIT BY HAND
 # Update with: yarn schema:sync --filter=@midnightntwrk/wallet-sdk-indexer-client -- --update
 # source:  midnightntwrk/midnight-indexer
-# tag:     v4.3.2
+# tag:     v4.4.0-rc.1
 # path:    indexer-api/graphql/schema-v4.graphql
-# commit:  7b6d40e0a31bb94656e2757cafb6ebbad0463a66
-# sha256:  ee13e3f7d73c50934c2bff8771afb4f87a4a91e01567f6595b39af6c142f5bef
+# commit:  668ed0258ac92bb25ed02cabe6075274d8fbaac8
+# sha256:  6c3058d26bcfd8d77cba59e54af73595d8cf888ea0187d6dd72a42f75f62ea20
 # ─────────────────────────────────────────────────────────────
+
+"""
+Tagged-union helper for fields like `Either<ZswapCoinPublicKey, ContractAddress>`
+used in standard unshielded events.
+
+Exactly one of `userAddress` or `contractAddress` is non-null; the `kind`
+discriminator says which.
+"""
+type AddressOrContract @beta {
+  """
+  Which of the two address fields is populated.
+  """
+  kind: AddressOrContractKind!
+  """
+  The hex-encoded user address; populated when kind is USER.
+  """
+  userAddress: HexEncoded
+  """
+  The hex-encoded contract address; populated when kind is CONTRACT.
+  """
+  contractAddress: HexEncoded
+}
+
+"""
+Discriminator for `AddressOrContract`.
+"""
+enum AddressOrContractKind {
+  """
+  The address is a user (zswap coin public key) address.
+  """
+  USER
+  """
+  The address is a contract address.
+  """
+  CONTRACT
+}
 
 """
 A block with its relevant data.
 """
 type Block {
-	"""
-	The block hash.
-	"""
-	hash: HexEncoded!
-	"""
-	The block height.
-	"""
-	height: Int!
-	"""
-	The protocol version.
-	"""
-	protocolVersion: Int!
-	"""
-	The UNIX timestamp.
-	"""
-	timestamp: Int!
-	"""
-	The hex-encoded block author.
-	"""
-	author: HexEncoded
-	"""
-	The hex-encoded serialized zswap state Merkle tree root.
-	"""
-	zswapMerkleTreeRoot: HexEncoded!
-	"""
-	The hex-encoded ledger parameters for this block.
-	"""
-	ledgerParameters: HexEncoded!
-	"""
-	The parent of this block.
-	"""
-	parent: Block
-	"""
-	The transactions within this block.
-	"""
-	transactions: [Transaction!]!
-	"""
-	The system parameters (governance) at this block height.
-	"""
-	systemParameters: SystemParameters!
-	"""
-	The hex-encoded dust commitment Merkle tree root at the latest indexed state.
-	"""
-	dustCommitmentMerkleTreeRoot: HexEncoded
-	"""
-	The hex-encoded dust generation Merkle tree root at the latest indexed state.
-	"""
-	dustGenerationMerkleTreeRoot: HexEncoded
+  """
+  The block hash.
+  """
+  hash: HexEncoded!
+  """
+  The block height.
+  """
+  height: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The UNIX timestamp.
+  """
+  timestamp: Int!
+  """
+  The hex-encoded block author.
+  """
+  author: HexEncoded
+  """
+  The hex-encoded serialized zswap state Merkle tree root.
+  """
+  zswapMerkleTreeRoot: HexEncoded!
+  """
+  The hex-encoded ledger parameters for this block.
+  """
+  ledgerParameters: HexEncoded!
+  """
+  The zswap commitment tree end index at this block; exclusive, i.e. the next free index.
+  """
+  zswapEndIndex: Int!
+  """
+  The dust commitment tree end index at this block; exclusive, i.e. the next free index.
+  """
+  dustCommitmentEndIndex: Int! @beta
+  """
+  The dust generation tree end index at this block; exclusive, i.e. the next free index.
+  """
+  dustGenerationEndIndex: Int! @beta
+  """
+  The hex-encoded dust commitment Merkle tree root at this block.
+  """
+  dustCommitmentMerkleTreeRoot: HexEncoded @beta
+  """
+  The hex-encoded dust generation Merkle tree root at this block.
+  """
+  dustGenerationMerkleTreeRoot: HexEncoded @beta
+  """
+  The parent of this block.
+  """
+  parent: Block
+  """
+  The transactions within this block.
+  """
+  transactions: [Transaction!]!
+  """
+  The system parameters (governance) at this block height.
+  """
+  systemParameters: SystemParameters!
+  """
+  The zswap commitment tree filtered to the given contract address, resolved from this
+  block's ledger state; null if the contract does not exist at this block. Hex-encoded.
+  For building transactions, compose with `ledgerParameters` and `contract { state }` in
+  one request, anchored to the same block; use the latest block: older trees age out of
+  the ledger's root window, and blocks beyond the chain-indexer's ledger state retention
+  window no longer have a loadable ledger state and yield an error.
+  """
+  contractZswapState(address: HexEncoded!): HexEncoded @beta
 }
 
 """
 Either a block hash or a block height.
 """
 input BlockOffset @oneOf {
-	"""
-	A hex-encoded block hash.
-	"""
-	hash: HexEncoded
-	"""
-	A block height.
-	"""
-	height: Int
+  """
+  A hex-encoded block hash.
+  """
+  hash: HexEncoded
+  """
+  A block height.
+  """
+  height: Int
+}
+
+"""
+Per-address bridge balance.
+"""
+type BridgeBalance @beta {
+  """
+  Sum of UserTransfer amounts for this address, gross/pre-fee (16-byte big-endian u128).
+  """
+  deposited: HexEncoded!
+  """
+  Sum of bridge claim amounts for this address, net/post-fee (16-byte big-endian u128).
+  """
+  claimed: HexEncoded!
+  """
+  Remaining claimable, read from the ledger's `bridge_receiving` map (net, zero once fully
+  claimed). 16-byte big-endian u128.
+  """
+  balance: HexEncoded!
+}
+
+"""
+A claim of bridged NIGHT: a regular `ClaimRewards` transaction whose `ClaimKind` is
+`CardanoBridge`. Structurally a regular transaction, surfaced as its own type so consumers can
+tell it apart and read the bridged `recipient` and `amount` directly.
+"""
+type BridgeClaimTransaction implements Transaction @beta {
+  """
+  The transaction ID.
+  """
+  id: Int!
+  """
+  The hex-encoded transaction hash.
+  """
+  hash: HexEncoded!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The hex-encoded serialized transaction content.
+  """
+  raw: HexEncoded!
+  """
+  The Midnight address the bridged NIGHT is claimed to.
+  """
+  recipient: HexEncoded!
+  """
+  The claimed amount as 16-byte big-endian u128.
+  """
+  amount: HexEncoded!
+  """
+  The block for this transaction.
+  """
+  block: Block!
+  """
+  The contract actions for this transaction.
+  """
+  contractActions: [ContractAction!]!
+  """
+  Unshielded UTXOs created by this transaction.
+  """
+  unshieldedCreatedOutputs: [UnshieldedUtxo!]!
+  """
+  Unshielded UTXOs spent (consumed) by this transaction.
+  """
+  unshieldedSpentOutputs: [UnshieldedUtxo!]!
+  """
+  Zswap ledger events of this transaction.
+  """
+  zswapLedgerEvents: [ZswapLedgerEvent!]!
+  """
+  Dust ledger events of this transaction.
+  """
+  dustLedgerEvents: [DustLedgerEvent!]!
+}
+
+"""
+Polymorphic c2m-bridge event. Each concrete variant exposes its own additional fields.
+"""
+interface BridgeEvent {
+  id: Int!
+  blockHeight: Int!
+  midnightTxHash: HexEncoded!
+}
+
+"""
+GraphQL discriminator for bridge events.
+"""
+enum BridgeEventVariant {
+  USER_TRANSFER
+  RESERVE_TRANSFER
+  INVALID_TRANSFER
+  UNAPPROVED_TRANSFER
+  SUBMINIMAL_FLUSH_TRANSFER
+}
+
+"""
+Malformed bridge metadata. NIGHT redirected to treasury.
+"""
+type BridgeInvalidTransfer implements BridgeEvent @beta {
+  id: Int!
+  blockHeight: Int!
+  midnightTxHash: HexEncoded!
+  cardanoTxHash: HexEncoded!
+  amount: HexEncoded!
+}
+
+"""
+Aggregate bridge inflows snapshot.
+"""
+type BridgePoolSummary @beta {
+  """
+  Cumulative ReserveTransfer amount (16-byte big-endian u128).
+  """
+  reserveTotal: HexEncoded!
+  treasuryByReason: [BridgeTreasuryAggregate!]!
+  """
+  Sum of `count` from SubminimalFlushTransfer events.
+  """
+  subminimumTxCount: Int!
+  lastEventBlockHeight: Int
+}
+
+"""
+Pair of latest bridge event and refreshed pool summary, emitted by `bridgePoolUpdates`.
+"""
+type BridgePoolUpdate @beta {
+  """
+  The triggering event, or None for the initial snapshot on subscribe.
+  """
+  newEvent: BridgeEvent
+  pool: BridgePoolSummary!
+}
+
+"""
+Reserve top-up. NIGHT credited to the protocol Reserve pool.
+"""
+type BridgeReserveTransfer implements BridgeEvent @beta {
+  id: Int!
+  blockHeight: Int!
+  midnightTxHash: HexEncoded!
+  cardanoTxHash: HexEncoded!
+  amount: HexEncoded!
+}
+
+"""
+Aggregated subminimum transfers flushed to treasury.
+"""
+type BridgeSubminimalFlushTransfer implements BridgeEvent @beta {
+  id: Int!
+  blockHeight: Int!
+  midnightTxHash: HexEncoded!
+  amount: HexEncoded!
+  """
+  Number of subminimum Cardano txs aggregated into this flush.
+  """
+  count: Int!
+}
+
+"""
+Treasury inflow aggregate by reason.
+"""
+type BridgeTreasuryAggregate @beta {
+  reason: BridgeTreasuryReason!
+  """
+  Cumulative amount (16-byte big-endian u128).
+  """
+  total: HexEncoded!
+  count: Int!
+}
+
+"""
+GraphQL discriminator for treasury redirection reasons.
+"""
+enum BridgeTreasuryReason {
+  INVALID
+  UNAPPROVED
+  SUBMINIMAL_FLUSH
+}
+
+"""
+User deposit not in `ApprovedTransactions` at observation time. NIGHT redirected to treasury.
+"""
+type BridgeUnapprovedTransfer implements BridgeEvent @beta {
+  id: Int!
+  blockHeight: Int!
+  midnightTxHash: HexEncoded!
+  cardanoTxHash: HexEncoded!
+  amount: HexEncoded!
+  """
+  The recipient parsed from metadata (would have received NIGHT if approved).
+  """
+  recipient: HexEncoded!
+}
+
+"""
+Approved user deposit. NIGHT credited to `recipient`.
+"""
+type BridgeUserTransfer implements BridgeEvent @beta {
+  id: Int!
+  blockHeight: Int!
+  midnightTxHash: HexEncoded!
+  cardanoTxHash: HexEncoded!
+  """
+  Amount as 8-byte big-endian u64 NIGHT (in stars).
+  """
+  amount: HexEncoded!
+  recipient: HexEncoded!
 }
 
 scalar CardanoRewardAddress
@@ -82,70 +348,105 @@ scalar CardanoRewardAddress
 A Merkle tree collapsed update between two indices.
 """
 type CollapsedMerkleTree {
-	"""
-	The start index.
-	"""
-	startIndex: Int!
-	"""
-	The end index.
-	"""
-	endIndex: Int!
-	"""
-	The hex-encoded value.
-	"""
-	update: HexEncoded!
-	"""
-	The protocol version.
-	"""
-	protocolVersion: Int!
+  """
+  The start index.
+  """
+  startIndex: Int!
+  """
+  The end index.
+  """
+  endIndex: Int!
+  """
+  The hex-encoded value.
+  """
+  update: HexEncoded!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
 }
 
 """
 Committee member for an epoch.
 """
 type CommitteeMember {
-	epochNo: Int!
-	position: Int!
-	sidechainPubkeyHex: String!
-	expectedSlots: Int!
-	auraPubkeyHex: String
-	poolIdHex: String
-	spoSkHex: String
+  epochNo: Int!
+  position: Int!
+  sidechainPubkeyHex: String!
+  expectedSlots: Int!
+  auraPubkeyHex: String
+  poolIdHex: String
+  spoSkHex: String
 }
 
 """
 Options for the connect mutation.
 """
 input ConnectOptions {
-	"""
-	Transaction index to start searching for relevant transactions (inclusive).
-	"""
-	startIndex: Int
+  """
+  Transaction index to start searching for relevant transactions (inclusive).
+  """
+  startIndex: Int
+}
+
+"""
+A contract, identified by address, resolved as of a given block (or the latest state if no
+offset is given). The topmost contract concept; its actions are a sub-query.
+"""
+type Contract @beta {
+  """
+  The hex-encoded contract address.
+  """
+  address: HexEncoded!
+  """
+  The hex-encoded serialized contract state as of the queried block (the latest contract
+  action at or before it).
+  """
+  state: HexEncoded!
+  """
+  The contract's maintenance authority as of the queried block.
+  """
+  maintenanceAuthority: ContractMaintenanceAuthority! @beta
+  """
+  Recent contract actions for this contract, newest first, optionally filtered by type;
+  `limit` defaults to 100 and is capped at 500. Use the `contractActions` subscription to
+  enumerate all actions.
+  """
+  actions(limit: Int, type: ContractActionType): [ContractAction!]! @beta
 }
 
 """
 A contract action.
 """
 interface ContractAction {
-	address: HexEncoded!
-	state: HexEncoded!
-	zswapState: HexEncoded!
-	transaction: Transaction!
-	unshieldedBalances: [ContractBalance!]!
+  address: HexEncoded!
+  state: HexEncoded!
+  zswapState: HexEncoded!
+  transaction: Transaction!
+  unshieldedBalances: [ContractBalance!]!
 }
 
 """
 Either a block offset or a transaction offset.
 """
 input ContractActionOffset @oneOf {
-	"""
-	Either a block hash or a block height.
-	"""
-	blockOffset: BlockOffset
-	"""
-	Either a transaction hash or a transaction identifier.
-	"""
-	transactionOffset: TransactionOffset
+  """
+  Either a block hash or a block height.
+  """
+  blockOffset: BlockOffset
+  """
+  Either a transaction hash or a transaction identifier.
+  """
+  transactionOffset: TransactionOffset
+}
+
+"""
+Contract action variant, used to filter `Contract.actions`.
+"""
+enum ContractActionType {
+  DEPLOY
+  CALL
+  UPDATE
 }
 
 """
@@ -154,254 +455,405 @@ This type is exposed through the GraphQL API to allow clients to query
 unshielded token balances for any contract action (Deploy, Call, Update).
 """
 type ContractBalance {
-	"""
-	Hex-encoded token type identifier.
-	"""
-	tokenType: HexEncoded!
-	"""
-	Balance amount as string to support larger integer values (up to 16 bytes).
-	"""
-	amount: String!
+  """
+  Hex-encoded token type identifier.
+  """
+  tokenType: HexEncoded!
+  """
+  Balance amount as string to support larger integer values (up to 16 bytes).
+  """
+  amount: String!
 }
 
 """
 A contract call.
 """
 type ContractCall implements ContractAction {
-	"""
-	The hex-encoded serialized address.
-	"""
-	address: HexEncoded!
-	"""
-	The hex-encoded serialized state.
-	"""
-	state: HexEncoded!
-	"""
-	The hex-encoded serialized contract-specific zswap state.
-	"""
-	zswapState: HexEncoded!
-	"""
-	The entry point.
-	"""
-	entryPoint: String!
-	"""
-	Transaction for this contract call.
-	"""
-	transaction: Transaction!
-	"""
-	Contract deploy for this contract call.
-	"""
-	deploy: ContractDeploy!
-	"""
-	Unshielded token balances held by this contract.
-	"""
-	unshieldedBalances: [ContractBalance!]!
+  """
+  The hex-encoded serialized address.
+  """
+  address: HexEncoded!
+  """
+  The hex-encoded serialized state.
+  """
+  state: HexEncoded!
+  """
+  The hex-encoded serialized contract-specific zswap state.
+  """
+  zswapState: HexEncoded!
+  """
+  The entry point.
+  """
+  entryPoint: String!
+  """
+  Transaction for this contract call.
+  """
+  transaction: Transaction!
+  """
+  Contract deploy for this contract call.
+  """
+  deploy: ContractDeploy!
+  """
+  Unshielded token balances held by this contract.
+  """
+  unshieldedBalances: [ContractBalance!]!
+  """
+  Contract events emitted by this contract call.
+
+  Only `ContractCall` exposes this field — `ContractDeploy` and
+  `ContractUpdate` don't execute circuits with the `emit` expression.
+
+  Events are attributed to a call by matching contract address and entry
+  point within the transaction; if several calls in one transaction share
+  both, their events are not attributed here and remain reachable via the
+  top-level `contractEvents` query.
+  """
+  contractEvents: [ContractEvent!]! @beta
 }
 
 """
 A contract deployment.
 """
 type ContractDeploy implements ContractAction {
-	"""
-	The hex-encoded serialized address.
-	"""
-	address: HexEncoded!
-	"""
-	The hex-encoded serialized state.
-	"""
-	state: HexEncoded!
-	"""
-	The hex-encoded serialized contract-specific zswap state.
-	"""
-	zswapState: HexEncoded!
-	"""
-	Transaction for this contract deploy.
-	"""
-	transaction: Transaction!
-	"""
-	Unshielded token balances held by this contract.
-	"""
-	unshieldedBalances: [ContractBalance!]!
+  """
+  The hex-encoded serialized address.
+  """
+  address: HexEncoded!
+  """
+  The hex-encoded serialized state.
+  """
+  state: HexEncoded!
+  """
+  The hex-encoded serialized contract-specific zswap state.
+  """
+  zswapState: HexEncoded!
+  """
+  Transaction for this contract deploy.
+  """
+  transaction: Transaction!
+  """
+  Unshielded token balances held by this contract.
+  """
+  unshieldedBalances: [ContractBalance!]!
+}
+
+"""
+Common interface implemented by every concrete contract event type.
+"""
+interface ContractEvent {
+  id: Int!
+  raw: HexEncoded!
+  maxId: Int!
+  protocolVersion: Int!
+  version: Int!
+  contractAddress: HexEncoded!
+  transactionId: Int!
+  transaction: Transaction!
+}
+
+"""
+Filter for contract events queries and subscriptions; block-range bounds live here so the
+same shape works for both.
+"""
+input ContractEventFilter {
+  """
+  The hex-encoded contract address to filter events for.
+  """
+  contractAddress: HexEncoded!
+  """
+  Event types to narrow to; must be non-empty when given.
+  """
+  types: [ContractEventType!]
+  """
+  Prefix matches on indexed event fields, combined with AND semantics; standard events
+  only.
+  """
+  fieldPrefixes: [FieldPrefixFilter!]
+  """
+  Lower bound on the block height an event was emitted in; on subscription this acts as
+  a starting cursor alongside `id`.
+  """
+  fromBlock: Int
+  """
+  Upper bound on the block height an event was emitted in; on subscription, the stream
+  completes once the chain has reached this block.
+  """
+  toBlock: Int
+  """
+  The hex-encoded transaction hash to narrow to events emitted by that transaction.
+  """
+  transactionHash: HexEncoded
+}
+
+"""
+Closed enum of contract event types the indexer surfaces. Used in filter
+input only, response discrimination is via `__typename`.
+"""
+enum ContractEventType {
+  """
+  A contract spends a shielded coin.
+  """
+  SHIELDED_SPEND
+  """
+  A contract or user receives a shielded coin.
+  """
+  SHIELDED_RECEIVE
+  """
+  A contract mints a shielded coin.
+  """
+  SHIELDED_MINT
+  """
+  A contract burns a shielded coin.
+  """
+  SHIELDED_BURN
+  """
+  A contract spends an unshielded coin.
+  """
+  UNSHIELDED_SPEND
+  """
+  A contract or user receives an unshielded coin.
+  """
+  UNSHIELDED_RECEIVE
+  """
+  A contract mints an unshielded coin.
+  """
+  UNSHIELDED_MINT
+  """
+  A contract burns an unshielded coin.
+  """
+  UNSHIELDED_BURN
+  """
+  A contract is paused.
+  """
+  PAUSED
+  """
+  A contract is unpaused.
+  """
+  UNPAUSED
+  """
+  A custom event emitted by a contract.
+  """
+  MISC
+}
+
+"""
+The maintenance authority of a contract.
+"""
+type ContractMaintenanceAuthority @beta {
+  """
+  The committee of verifying keys authorised to maintain the contract.
+  """
+  committee: [ContractMaintenanceVerifyingKey!]!
+  """
+  The number of committee signatures required to authorise maintenance.
+  """
+  threshold: Int!
+  """
+  Monotonic counter guarding against replay of maintenance operations.
+  """
+  counter: Int!
+}
+
+"""
+A verifying key in a contract maintenance authority committee.
+"""
+type ContractMaintenanceVerifyingKey @beta {
+  """
+  The signature scheme of the key.
+  """
+  kind: ContractMaintenanceVerifyingKeyKind!
+  """
+  The hex-encoded tagged-serialized verifying key.
+  """
+  key: HexEncoded!
+}
+
+"""
+The signature scheme of a maintenance authority verifying key.
+"""
+enum ContractMaintenanceVerifyingKeyKind {
+  SCHNORR
+  ECDSA
 }
 
 """
 A contract update.
 """
 type ContractUpdate implements ContractAction {
-	"""
-	The hex-encoded serialized address.
-	"""
-	address: HexEncoded!
-	"""
-	The hex-encoded serialized state.
-	"""
-	state: HexEncoded!
-	"""
-	The hex-encoded serialized contract-specific zswap state.
-	"""
-	zswapState: HexEncoded!
-	"""
-	Transaction for this contract update.
-	"""
-	transaction: Transaction!
-	"""
-	Unshielded token balances held by this contract after the update.
-	"""
-	unshieldedBalances: [ContractBalance!]!
+  """
+  The hex-encoded serialized address.
+  """
+  address: HexEncoded!
+  """
+  The hex-encoded serialized state.
+  """
+  state: HexEncoded!
+  """
+  The hex-encoded serialized contract-specific zswap state.
+  """
+  zswapState: HexEncoded!
+  """
+  Transaction for this contract update.
+  """
+  transaction: Transaction!
+  """
+  Unshielded token balances held by this contract after the update.
+  """
+  unshieldedBalances: [ContractBalance!]!
 }
 
 """
 The D-parameter controlling validator committee composition.
 """
 type DParameter {
-	"""
-	Number of permissioned candidates.
-	"""
-	numPermissionedCandidates: Int!
-	"""
-	Number of registered candidates.
-	"""
-	numRegisteredCandidates: Int!
+  """
+  Number of permissioned candidates.
+  """
+  numPermissionedCandidates: Int!
+  """
+  Number of registered candidates.
+  """
+  numRegisteredCandidates: Int!
 }
 
 """
 D-parameter change record for history queries.
 """
 type DParameterChange {
-	"""
-	The block height where this parameter became effective.
-	"""
-	blockHeight: Int!
-	"""
-	The hex-encoded block hash where this parameter became effective.
-	"""
-	blockHash: HexEncoded!
-	"""
-	The UNIX timestamp when this parameter became effective.
-	"""
-	timestamp: Int!
-	"""
-	Number of permissioned candidates.
-	"""
-	numPermissionedCandidates: Int!
-	"""
-	Number of registered candidates.
-	"""
-	numRegisteredCandidates: Int!
+  """
+  The block height where this parameter became effective.
+  """
+  blockHeight: Int!
+  """
+  The hex-encoded block hash where this parameter became effective.
+  """
+  blockHash: HexEncoded!
+  """
+  The UNIX timestamp when this parameter became effective.
+  """
+  timestamp: Int!
+  """
+  Number of permissioned candidates.
+  """
+  numPermissionedCandidates: Int!
+  """
+  Number of registered candidates.
+  """
+  numRegisteredCandidates: Int!
 }
 
 scalar DustAddress
 
 type DustGenerationDtimeUpdate implements DustLedgerEvent {
-	"""
-	The ID of this dust ledger event.
-	"""
-	id: Int!
-	"""
-	The hex-encoded serialized event.
-	"""
-	raw: HexEncoded!
-	"""
-	The maximum ID of all dust ledger events.
-	"""
-	maxId: Int!
-	"""
-	The protocol version.
-	"""
-	protocolVersion: Int!
+  """
+  The ID of this dust ledger event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all dust ledger events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
 }
 
 """
 A dust generation dtime update emitted when the backing Night UTXO is
 spent and the entry's decay time is set.
 """
-type DustGenerationDtimeUpdateItem {
-	"""
-	Generation-tree index of the entry whose dtime changed.
-	"""
-	generationMtIndex: Int!
-	"""
-	The hex-encoded owner (dust address).
-	"""
-	owner: HexEncoded!
-	"""
-	Hex-encoded hash of the NIGHT UTXO that backs this dust output.
-	"""
-	nightUtxoHash: HexEncoded!
-	"""
-	The decay time as observed in this ledger event.
-	"""
-	newDtime: Int!
-	"""
-	The originating transaction ID (indexer-internal BIGSERIAL).
-	"""
-	transactionId: Int!
-	"""
-	The hex-encoded originating transaction hash (32-byte chain identifier).
-	"""
-	transactionHash: HexEncoded!
-	"""
-	Hex-encoded tagged-serialised `TreeInsertionPath<DustGenerationInfo>`
-	from the originating ledger event. Wallets deserialise this and hand
-	it to `generating_tree.update_from_evidence(...)`.
-	"""
-	treeInsertionPath: HexEncoded!
+type DustGenerationDtimeUpdateItem @beta {
+  """
+  Generation-tree index of the entry whose dtime changed.
+  """
+  generationMtIndex: Int!
+  """
+  The hex-encoded owner (dust address).
+  """
+  owner: HexEncoded!
+  """
+  Hex-encoded hash of the NIGHT UTXO that backs this dust output.
+  """
+  nightUtxoHash: HexEncoded!
+  """
+  The decay time as observed in this ledger event.
+  """
+  newDtime: Int!
+  """
+  The originating transaction ID (indexer-internal BIGSERIAL).
+  """
+  transactionId: Int!
+  """
+  The hex-encoded originating transaction hash (32-byte chain identifier).
+  """
+  transactionHash: HexEncoded!
+  """
+  Hex-encoded tagged-serialised `TreeInsertionPath<DustGenerationInfo>`
+  from the originating ledger event. Wallets deserialise this and hand
+  it to `generating_tree.update_from_evidence(...)`.
+  """
+  treeInsertionPath: HexEncoded!
 }
 
 """
 DUST generation status for a specific Cardano reward address.
 """
 type DustGenerationStatus {
-	"""
-	The Bech32-encoded Cardano reward address (e.g., stake_test1... or stake1...).
-	"""
-	cardanoRewardAddress: CardanoRewardAddress!
-	"""
-	The Bech32m-encoded associated DUST address if registered.
-	"""
-	dustAddress: DustAddress
-	"""
-	Whether this reward address is registered.
-	"""
-	registered: Boolean!
-	"""
-	NIGHT balance backing generation in STAR.
-	"""
-	nightBalance: String!
-	"""
-	DUST generation rate in SPECK per second.
-	"""
-	generationRate: String!
-	"""
-	Maximum DUST capacity in SPECK.
-	"""
-	maxCapacity: String!
-	"""
-	Current generated DUST capacity in SPECK.
-	"""
-	currentCapacity: String!
-	"""
-	Cardano UTXO transaction hash for update/unregister operations.
-	"""
-	utxoTxHash: HexEncoded
-	"""
-	Cardano UTXO output index for update/unregister operations.
-	"""
-	utxoOutputIndex: Int
+  """
+  The Bech32-encoded Cardano reward address (e.g., stake_test1... or stake1...).
+  """
+  cardanoRewardAddress: CardanoRewardAddress!
+  """
+  The Bech32m-encoded associated DUST address if registered.
+  """
+  dustAddress: DustAddress
+  """
+  Whether this reward address is registered.
+  """
+  registered: Boolean!
+  """
+  NIGHT balance backing generation in STAR.
+  """
+  nightBalance: String!
+  """
+  DUST generation rate in SPECK per second.
+  """
+  generationRate: String!
+  """
+  Maximum DUST capacity in SPECK.
+  """
+  maxCapacity: String!
+  """
+  Current generated DUST capacity in SPECK.
+  """
+  currentCapacity: String!
+  """
+  Cardano UTXO transaction hash for update/unregister operations.
+  """
+  utxoTxHash: HexEncoded
+  """
+  Cardano UTXO output index for update/unregister operations.
+  """
+  utxoOutputIndex: Int
 }
 
 """
 Dust generations for a Cardano reward address.
 """
 type DustGenerations {
-	"""
-	The Bech32-encoded Cardano reward address.
-	"""
-	cardanoRewardAddress: CardanoRewardAddress!
-	"""
-	All active registrations with aggregated generation stats.
-	"""
-	registrations: [DustRegistration!]!
+  """
+  The Bech32-encoded Cardano reward address.
+  """
+  cardanoRewardAddress: CardanoRewardAddress!
+  """
+  All active registrations with aggregated generation stats.
+  """
+  registrations: [DustRegistration!]!
 }
 
 """
@@ -412,222 +864,242 @@ union DustGenerationsEvent = DustGenerationsItem | DustGenerationsProgress | Dus
 """
 A dust generations item with optional collapsed Merkle tree update.
 """
-type DustGenerationsItem {
-	"""
-	Index of this output in the dust commitment Merkle tree.
-	"""
-	commitmentMtIndex: Int!
-	"""
-	Index of this output in the dust generation Merkle tree.
-	"""
-	generationMtIndex: Int!
-	"""
-	The hex-encoded owner (dust address).
-	"""
-	owner: HexEncoded!
-	"""
-	The NIGHT value backing this output, in STAR.
-	"""
-	value: String!
-	"""
-	The DUST value at creation, in SPECK.
-	"""
-	initialValue: String!
-	"""
-	Hex-encoded hash of the NIGHT UTXO that backs this dust output.
-	"""
-	backingNight: HexEncoded!
-	"""
-	The creation timestamp.
-	"""
-	ctime: Int!
-	"""
-	The originating transaction ID (indexer-internal BIGSERIAL).
-	"""
-	transactionId: Int!
-	"""
-	The hex-encoded originating transaction hash (32-byte chain identifier).
-	"""
-	transactionHash: HexEncoded!
-	"""
-	Collapsed Merkle tree update filling the gap before this entry.
-	"""
-	collapsedMerkleTree: MerkleTreeCollapsedUpdate
+type DustGenerationsItem @beta {
+  """
+  Index of this output in the dust commitment Merkle tree.
+  """
+  commitmentMtIndex: Int!
+  """
+  Index of this output in the dust generation Merkle tree.
+  """
+  generationMtIndex: Int!
+  """
+  The hex-encoded owner (dust address).
+  """
+  owner: HexEncoded!
+  """
+  The NIGHT value backing this output, in STAR.
+  """
+  value: String!
+  """
+  The DUST value at creation, in SPECK.
+  """
+  initialValue: String!
+  """
+  Hex-encoded hash of the NIGHT UTXO that backs this dust output.
+  """
+  backingNight: HexEncoded!
+  """
+  The creation timestamp.
+  """
+  ctime: Int!
+  """
+  The originating transaction ID (indexer-internal BIGSERIAL).
+  """
+  transactionId: Int!
+  """
+  The hex-encoded originating transaction hash (32-byte chain identifier).
+  """
+  transactionHash: HexEncoded!
+  """
+  Collapsed Merkle tree update filling the gap before this entry.
+  """
+  collapsedMerkleTree: MerkleTreeCollapsedUpdate
 }
 
 """
 Progress indicator for dust generations subscription (includes final collapsed update).
 """
-type DustGenerationsProgress {
-	"""
-	The highest index processed so far.
-	"""
-	highestIndex: Int!
-	"""
-	Final collapsed Merkle tree update covering remaining range.
-	"""
-	collapsedMerkleTree: MerkleTreeCollapsedUpdate
+type DustGenerationsProgress @beta {
+  """
+  The highest index processed so far.
+  """
+  highestIndex: Int!
+  """
+  Final collapsed Merkle tree update covering remaining range.
+  """
+  collapsedMerkleTree: MerkleTreeCollapsedUpdate
 }
 
 type DustInitialUtxo implements DustLedgerEvent {
-	"""
-	The ID of this dust ledger event.
-	"""
-	id: Int!
-	"""
-	The hex-encoded serialized event.
-	"""
-	raw: HexEncoded!
-	"""
-	The maximum ID of all dust ledger events.
-	"""
-	maxId: Int!
-	"""
-	The protocol version.
-	"""
-	protocolVersion: Int!
-	"""
-	The dust output.
-	"""
-	output: DustOutput!
+  """
+  The ID of this dust ledger event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all dust ledger events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The dust output.
+  """
+  output: DustOutput!
 }
 
 """
 A dust related ledger event.
 """
 interface DustLedgerEvent {
-	id: Int!
-	raw: HexEncoded!
-	maxId: Int!
-	protocolVersion: Int!
+  id: Int!
+  raw: HexEncoded!
+  maxId: Int!
+  protocolVersion: Int!
 }
 
 """
 A transaction containing a dust nullifier match with block context.
 """
 type DustNullifierTransaction {
-	"""
-	The hex-encoded matched nullifier.
-	"""
-	nullifier: HexEncoded!
-	"""
-	The hex-encoded commitment.
-	"""
-	commitment: HexEncoded!
-	"""
-	The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
-	"""
-	transactionId: Int!
-	"""
-	The hex-encoded transaction hash (32-byte chain identifier).
-	"""
-	transactionHash: HexEncoded!
-	"""
-	The block height containing this transaction.
-	"""
-	blockHeight: Int!
-	"""
-	The hex-encoded block hash (use to query block with ledger parameters).
-	"""
-	blockHash: HexEncoded!
+  """
+  The hex-encoded matched nullifier, in 32-byte little-endian form.
+  """
+  nullifierLeBytes: HexEncoded! @beta
+  """
+  The hex-encoded commitment, in 32-byte little-endian form.
+  """
+  commitmentLeBytes: HexEncoded! @beta
+  """
+  The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
+  """
+  transactionId: Int!
+  """
+  The hex-encoded transaction hash (32-byte chain identifier).
+  """
+  transactionHash: HexEncoded!
+  """
+  The block height containing this transaction.
+  """
+  blockHeight: Int!
+  """
+  The hex-encoded block hash (use to query block with ledger parameters).
+  """
+  blockHash: HexEncoded!
+  """
+  The transaction containing this nullifier match.
+  """
+  transaction: Transaction! @beta
 }
 
 """
 A dust output.
 """
 type DustOutput {
-	"""
-	The hex-encoded 32-byte nonce.
-	"""
-	nonce: HexEncoded!
+  """
+  The hex-encoded 32-byte nonce.
+  """
+  nonce: HexEncoded!
 }
 
 """
 A single dust registration with aggregated generation stats.
 """
 type DustRegistration {
-	"""
-	The Bech32m-encoded DUST address.
-	"""
-	dustAddress: DustAddress!
-	"""
-	Whether this registration is valid.
-	"""
-	valid: Boolean!
-	"""
-	NIGHT balance backing generation in STAR.
-	"""
-	nightBalance: String!
-	"""
-	DUST generation rate in SPECK per second.
-	"""
-	generationRate: String!
-	"""
-	Maximum DUST capacity in SPECK.
-	"""
-	maxCapacity: String!
-	"""
-	Current generated DUST capacity in SPECK.
-	"""
-	currentCapacity: String!
-	"""
-	Cardano UTXO transaction hash.
-	"""
-	utxoTxHash: HexEncoded
-	"""
-	Cardano UTXO output index.
-	"""
-	utxoOutputIndex: Int
+  """
+  The Bech32m-encoded DUST address.
+  """
+  dustAddress: DustAddress!
+  """
+  Whether this registration is valid.
+  """
+  valid: Boolean!
+  """
+  NIGHT balance backing generation in STAR.
+  """
+  nightBalance: String!
+  """
+  DUST generation rate in SPECK per second.
+  """
+  generationRate: String!
+  """
+  Maximum DUST capacity in SPECK.
+  """
+  maxCapacity: String!
+  """
+  Current generated DUST capacity in SPECK.
+  """
+  currentCapacity: String!
+  """
+  Cardano UTXO transaction hash.
+  """
+  utxoTxHash: HexEncoded
+  """
+  Cardano UTXO output index.
+  """
+  utxoOutputIndex: Int
 }
 
 type DustSpendProcessed implements DustLedgerEvent {
-	"""
-	The ID of this dust ledger event.
-	"""
-	id: Int!
-	"""
-	The hex-encoded serialized event.
-	"""
-	raw: HexEncoded!
-	"""
-	The maximum ID of all dust ledger events.
-	"""
-	maxId: Int!
-	"""
-	The protocol version.
-	"""
-	protocolVersion: Int!
+  """
+  The ID of this dust ledger event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all dust ledger events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
 }
 
 """
 Current epoch information.
 """
 type EpochInfo {
-	epochNo: Int!
-	durationSeconds: Int!
-	elapsedSeconds: Int!
+  epochNo: Int!
+  durationSeconds: Int!
+  elapsedSeconds: Int!
 }
 
 """
 SPO performance for an epoch.
 """
 type EpochPerf {
-	epochNo: Int!
-	spoSkHex: String!
-	produced: Int!
-	expected: Int!
-	identityLabel: String
-	stakeSnapshot: String
-	poolIdHex: String
-	validatorClass: String
+  epochNo: Int!
+  spoSkHex: String!
+  produced: Int!
+  expected: Int!
+  identityLabel: String
+  stakeSnapshot: String
+  poolIdHex: String
+  validatorClass: String
+}
+
+"""
+Prefix filter on an indexed field of a standard event; not supported on Misc events.
+"""
+input FieldPrefixFilter {
+  """
+  The indexed field name; one of `nullifier`, `commitment`, `ciphertext`, `domainSep`,
+  `tokenType`, `sender` or `recipient`.
+  """
+  fieldName: String!
+  """
+  The hex-encoded field value prefix. An empty string matches all values; otherwise
+  events whose field value starts with this prefix are returned.
+  """
+  prefix: HexEncoded!
 }
 
 """
 First valid epoch for an SPO identity.
 """
 type FirstValidEpoch {
-	idKey: String!
-	firstValidEpoch: Int!
+  idKey: String!
+  firstValidEpoch: Int!
 }
 
 scalar HexEncoded
@@ -636,321 +1108,452 @@ scalar HexEncoded
 A Merkle tree collapsed update between two indices.
 """
 type MerkleTreeCollapsedUpdate {
-	"""
-	The start index.
-	"""
-	startIndex: Int!
-	"""
-	The end index.
-	"""
-	endIndex: Int!
-	"""
-	The hex-encoded value.
-	"""
-	update: HexEncoded!
-	"""
-	The protocol version.
-	"""
-	protocolVersion: Int!
+  """
+  The start index.
+  """
+  startIndex: Int!
+  """
+  The end index.
+  """
+  endIndex: Int!
+  """
+  The hex-encoded value.
+  """
+  update: HexEncoded!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+}
+
+type MiscContractEvent implements ContractEvent @beta {
+  """
+  The ID of this contract event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event payload.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all contract events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The event schema version, as declared by the emitting contract's compiler.
+  """
+  version: Int!
+  """
+  The hex-encoded address of the emitting contract.
+  """
+  contractAddress: HexEncoded!
+  """
+  The ID of the transaction this event was emitted from.
+  """
+  transactionId: Int!
+  """
+  The hex-encoded contract-defined event name (32 bytes).
+  """
+  name: HexEncoded!
+  """
+  The hex-encoded opaque event payload, up to 256 bytes; consumers decode it with their
+  contract's descriptor.
+  """
+  payload: HexEncoded!
+  """
+  The transaction this event was emitted from.
+  """
+  transaction: Transaction!
 }
 
 type Mutation {
-	"""
-	Connect the wallet with the given viewing key and return a session ID.
-	"""
-	connect(viewingKey: ViewingKey!, options: ConnectOptions): HexEncoded!
-	"""
-	Disconnect the wallet with the given session ID.
-	"""
-	disconnect(sessionId: HexEncoded!): Unit!
+  """
+  Connect the wallet with the given viewing key and return a session ID.
+  """
+  connect(viewingKey: ViewingKey!, options: ConnectOptions): HexEncoded!
+  """
+  Disconnect the wallet with the given session ID.
+  """
+  disconnect(sessionId: HexEncoded!): Unit!
 }
 
 type ParamChange implements DustLedgerEvent {
-	"""
-	The ID of this dust ledger event.
-	"""
-	id: Int!
-	"""
-	The hex-encoded serialized event.
-	"""
-	raw: HexEncoded!
-	"""
-	The maximum ID of all dust ledger events.
-	"""
-	maxId: Int!
-	"""
-	The protocol version.
-	"""
-	protocolVersion: Int!
+  """
+  The ID of this dust ledger event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all dust ledger events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+}
+
+type PausedEvent implements ContractEvent @beta {
+  """
+  The ID of this contract event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event payload.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all contract events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The event schema version, as declared by the emitting contract's compiler.
+  """
+  version: Int!
+  """
+  The hex-encoded address of the emitting contract.
+  """
+  contractAddress: HexEncoded!
+  """
+  The ID of the transaction this event was emitted from.
+  """
+  transactionId: Int!
+  """
+  The transaction this event was emitted from.
+  """
+  transaction: Transaction!
 }
 
 """
 Pool metadata from Cardano.
 """
 type PoolMetadata {
-	poolIdHex: String!
-	hexId: String
-	name: String
-	ticker: String
-	homepageUrl: String
-	logoUrl: String
+  poolIdHex: String!
+  hexId: String
+  name: String
+  ticker: String
+  homepageUrl: String
+  logoUrl: String
 }
 
 """
 Presence event for an SPO in an epoch.
 """
 type PresenceEvent {
-	epochNo: Int!
-	idKey: String!
-	source: String!
-	status: String
+  epochNo: Int!
+  idKey: String!
+  source: String!
+  status: String
 }
 
 type Query {
-	"""
-	Find a block for the given optional offset; if not present, the latest block is returned.
-	"""
-	block(offset: BlockOffset): Block
-	"""
-	Get a Merkle tree collapsed update for the given zswap state index range.
-	"""
-	zswapMerkleTreeCollapsedUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate!
-	"""
-	Find transactions for the given offset.
-	"""
-	transactions(offset: TransactionOffset!): [Transaction!]!
-	"""
-	Find a contract action for the given address and optional offset.
-	"""
-	contractAction(address: HexEncoded!, offset: ContractActionOffset): ContractAction
-	"""
-	Get DUST generation status for specific Cardano reward addresses.
-	"""
-	dustGenerationStatus(cardanoRewardAddresses: [CardanoRewardAddress!]!): [DustGenerationStatus!]!
-	"""
-	Get all active DUST registrations and aggregated generation stats for Cardano reward
-	addresses.
-	"""
-	dustGenerations(cardanoRewardAddresses: [CardanoRewardAddress!]!): [DustGenerations!]!
-	"""
-	Get a collapsed Merkle tree update for the dust commitment tree.
-	"""
-	dustCommitmentMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate!
-	"""
-	Get a collapsed Merkle tree update for the dust generation tree.
-	"""
-	dustGenerationMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate!
-	"""
-	Get the full history of D-parameter changes for governance auditability.
-	"""
-	dParameterHistory: [DParameterChange!]!
-	"""
-	Get the full history of Terms and Conditions changes for governance auditability.
-	"""
-	termsAndConditionsHistory: [TermsAndConditionsChange!]!
-	"""
-	List SPO identities with pagination.
-	"""
-	spoIdentities(limit: Int, offset: Int): [SpoIdentity!]!
-	"""
-	Get SPO identity by pool ID.
-	"""
-	spoIdentityByPoolId(poolIdHex: String!): SpoIdentity
-	"""
-	Get total count of SPOs.
-	"""
-	spoCount: Int
-	"""
-	Get pool metadata by pool ID.
-	"""
-	poolMetadata(poolIdHex: String!): PoolMetadata
-	"""
-	List pool metadata with pagination.
-	"""
-	poolMetadataList(limit: Int, offset: Int, withNameOnly: Boolean): [PoolMetadata!]!
-	"""
-	Get SPO with metadata by pool ID.
-	"""
-	spoByPoolId(poolIdHex: String!): Spo
-	"""
-	List SPOs with optional search.
-	"""
-	spoList(limit: Int, offset: Int, search: String): [Spo!]!
-	"""
-	Get composite SPO data (identity + metadata + performance).
-	"""
-	spoCompositeByPoolId(poolIdHex: String!): SpoComposite
-	"""
-	Get SPO identifiers ordered by performance.
-	"""
-	stakePoolOperators(limit: Int): [String!]!
-	"""
-	Get latest SPO performance entries.
-	"""
-	spoPerformanceLatest(limit: Int, offset: Int): [EpochPerf!]!
-	"""
-	Get SPO performance by SPO key.
-	"""
-	spoPerformanceBySpoSk(spoSkHex: String!, limit: Int, offset: Int): [EpochPerf!]!
-	"""
-	Get epoch performance for all SPOs.
-	"""
-	epochPerformance(epoch: Int!, limit: Int, offset: Int): [EpochPerf!]!
-	"""
-	Get current epoch information.
-	"""
-	currentEpochInfo: EpochInfo
-	"""
-	Get epoch utilization (produced/expected ratio).
-	"""
-	epochUtilization(epoch: Int!): Float
-	"""
-	Get committee membership for an epoch.
-	"""
-	committee(epoch: Int!): [CommitteeMember!]!
-	"""
-	Get cumulative registration totals for an epoch range.
-	"""
-	registeredTotalsSeries(fromEpoch: Int!, toEpoch: Int!): [RegisteredTotals!]!
-	"""
-	Get registration statistics for an epoch range.
-	"""
-	registeredSpoSeries(fromEpoch: Int!, toEpoch: Int!): [RegisteredStat!]!
-	"""
-	Get raw presence events for an epoch range.
-	"""
-	registeredPresence(fromEpoch: Int!, toEpoch: Int!): [PresenceEvent!]!
-	"""
-	Get first valid epoch for each SPO identity.
-	"""
-	registeredFirstValidEpochs(uptoEpoch: Int): [FirstValidEpoch!]!
-	"""
-	Get stake distribution with search and ordering.
-	"""
-	stakeDistribution(limit: Int, offset: Int, search: String, orderByStakeDesc: Boolean): [StakeShare!]!
+  """
+  Find a block for the given optional offset; if not present, the latest block is returned.
+  """
+  block(offset: BlockOffset): Block
+  """
+  Get a Merkle tree collapsed update for the given zswap state index range.
+  """
+  zswapMerkleTreeCollapsedUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate!
+  """
+  Find transactions for the given offset.
+  """
+  transactions(offset: TransactionOffset!): [Transaction!]!
+  """
+  Find a contract action for the given address and optional offset.
+  """
+  contractAction(address: HexEncoded!, offset: ContractActionOffset): ContractAction
+  """
+  Find a contract by address, resolved as of the given block offset (or its latest state if no
+  offset is given). Returns null if the contract has no action at or before that block.
+  """
+  contract(address: HexEncoded!, offset: BlockOffset): Contract @beta
+  """
+  Get DUST generation status for specific Cardano reward addresses.
+  """
+  dustGenerationStatus(cardanoRewardAddresses: [CardanoRewardAddress!]!): [DustGenerationStatus!]!
+  """
+  Get all active DUST registrations and aggregated generation stats for Cardano reward
+  addresses.
+  """
+  dustGenerations(cardanoRewardAddresses: [CardanoRewardAddress!]!): [DustGenerations!]!
+  """
+  Get a collapsed Merkle tree update for the dust commitment tree.
+  """
+  dustCommitmentMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate! @beta
+  """
+  Get a collapsed Merkle tree update for the dust generation tree.
+  """
+  dustGenerationMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate! @beta
+  """
+  Find contract events matching the filter, ordered by ID; `limit` defaults to 100 and is
+  capped at 500, `offset` defaults to 0.
+
+  Block-range bounds (`fromBlock`, `toBlock`) live on `ContractEventFilter`
+  for symmetry with the subscription. `limit`/`offset` are top-level args.
+  """
+  contractEvents(filter: ContractEventFilter!, limit: Int, offset: Int): [ContractEvent!]! @beta
+  """
+  Get the full history of D-parameter changes for governance auditability.
+  """
+  dParameterHistory: [DParameterChange!]!
+  """
+  Get the full history of Terms and Conditions changes for governance auditability.
+  """
+  termsAndConditionsHistory: [TermsAndConditionsChange!]!
+  """
+  List SPO identities with pagination.
+  """
+  spoIdentities(limit: Int, offset: Int): [SpoIdentity!]!
+  """
+  Get SPO identity by pool ID.
+  """
+  spoIdentityByPoolId(poolIdHex: String!): SpoIdentity
+  """
+  Get total count of SPOs.
+  """
+  spoCount: Int
+  """
+  Get pool metadata by pool ID.
+  """
+  poolMetadata(poolIdHex: String!): PoolMetadata
+  """
+  List pool metadata with pagination.
+  """
+  poolMetadataList(limit: Int, offset: Int, withNameOnly: Boolean): [PoolMetadata!]!
+  """
+  Get SPO with metadata by pool ID.
+  """
+  spoByPoolId(poolIdHex: String!): Spo
+  """
+  List SPOs with optional search.
+  """
+  spoList(limit: Int, offset: Int, search: String): [Spo!]!
+  """
+  Get composite SPO data (identity + metadata + performance).
+  """
+  spoCompositeByPoolId(poolIdHex: String!): SpoComposite
+  """
+  Get SPO identifiers ordered by performance.
+  """
+  stakePoolOperators(limit: Int): [String!]!
+  """
+  Get latest SPO performance entries.
+  """
+  spoPerformanceLatest(limit: Int, offset: Int): [EpochPerf!]!
+  """
+  Get SPO performance by SPO key.
+  """
+  spoPerformanceBySpoSk(spoSkHex: String!, limit: Int, offset: Int): [EpochPerf!]!
+  """
+  Get epoch performance for all SPOs.
+  """
+  epochPerformance(epoch: Int!, limit: Int, offset: Int): [EpochPerf!]!
+  """
+  Get current epoch information.
+  """
+  currentEpochInfo: EpochInfo
+  """
+  Get epoch utilization (produced/expected ratio).
+  """
+  epochUtilization(epoch: Int!): Float
+  """
+  Get committee membership for an epoch.
+  """
+  committee(epoch: Int!): [CommitteeMember!]!
+  """
+  Get cumulative registration totals for an epoch range.
+  """
+  registeredTotalsSeries(fromEpoch: Int!, toEpoch: Int!): [RegisteredTotals!]!
+  """
+  Get registration statistics for an epoch range.
+  """
+  registeredSpoSeries(fromEpoch: Int!, toEpoch: Int!): [RegisteredStat!]!
+  """
+  Get raw presence events for an epoch range.
+  """
+  registeredPresence(fromEpoch: Int!, toEpoch: Int!): [PresenceEvent!]!
+  """
+  Get first valid epoch for each SPO identity.
+  """
+  registeredFirstValidEpochs(uptoEpoch: Int): [FirstValidEpoch!]!
+  """
+  Get stake distribution with search and ordering.
+  """
+  stakeDistribution(limit: Int, offset: Int, search: String, orderByStakeDesc: Boolean): [StakeShare!]!
+  """
+  List c2m-bridge events with optional filters.
+  """
+  bridgeEvents(
+    recipient: HexEncoded
+    variant: BridgeEventVariant
+    blockHeightFrom: Int
+    blockHeightTo: Int
+    offset: Int
+    limit: Int
+  ): [BridgeEvent!]! @beta
+  """
+  Get the c2m-bridge balance summary (deposited, claimed, balance) for an address.
+  """
+  bridgeBalance(address: HexEncoded!): BridgeBalance! @beta
+  """
+  Convenience query for a recipient's deposit history. By default returns only successful
+  `UserTransfer` events; pass `includeUnapproved: true` to also include `UnapprovedTransfer`.
+  """
+  bridgeDeposits(recipient: HexEncoded!, includeUnapproved: Boolean, offset: Int, limit: Int): [BridgeEvent!]! @beta
+  """
+  List Reserve top-up events (ReserveTransfer), optionally bounded by block height.
+  """
+  bridgeReserveInflows(blockHeightFrom: Int, blockHeightTo: Int, offset: Int, limit: Int): [BridgeEvent!]! @beta
+  """
+  List treasury-redirected events (Invalid, Unapproved, SubminimalFlush), optionally
+  filtered by reason and block range.
+  """
+  bridgeTreasuryInflows(
+    reason: BridgeTreasuryReason
+    blockHeightFrom: Int
+    blockHeightTo: Int
+    offset: Int
+    limit: Int
+  ): [BridgeEvent!]! @beta
+  """
+  Aggregate snapshot of bridge inflows to protocol pools (Reserve and Treasury).
+  """
+  bridgePoolSummary(atBlock: Int): BridgePoolSummary! @beta
 }
 
 """
 Registration statistics for an epoch.
 """
 type RegisteredStat {
-	epochNo: Int!
-	federatedValidCount: Int!
-	federatedInvalidCount: Int!
-	registeredValidCount: Int!
-	registeredInvalidCount: Int!
-	dparam: Float
+  epochNo: Int!
+  federatedValidCount: Int!
+  federatedInvalidCount: Int!
+  registeredValidCount: Int!
+  registeredInvalidCount: Int!
+  dparam: Float
 }
 
 """
 Cumulative registration totals for an epoch.
 """
 type RegisteredTotals {
-	epochNo: Int!
-	totalRegistered: Int!
-	newlyRegistered: Int!
+  epochNo: Int!
+  totalRegistered: Int!
+  newlyRegistered: Int!
 }
 
 """
 A regular Midnight transaction.
 """
 type RegularTransaction implements Transaction {
-	"""
-	The transaction ID.
-	"""
-	id: Int!
-	"""
-	The hex-encoded transaction hash.
-	"""
-	hash: HexEncoded!
-	"""
-	The protocol version.
-	"""
-	protocolVersion: Int!
-	"""
-	The hex-encoded serialized transaction content.
-	"""
-	raw: HexEncoded!
-	"""
-	The result of applying this transaction to the ledger state.
-	"""
-	transactionResult: TransactionResult!
-	"""
-	The hex-encoded serialized transaction identifiers.
-	"""
-	identifiers: [HexEncoded!]!
-	"""
-	The hex-encoded serialized zswap state Merkle tree root.
-	"""
-	zswapMerkleTreeRoot: HexEncoded!
-	"""
-	The hex-encoded serialized zswap state Merkle tree root.
-	"""
-	merkleTreeRoot: HexEncoded! @deprecated(reason: "Use zswapMerkleTreeRoot instead")
-	"""
-	The start index into the zswap state.
-	"""
-	zswapStartIndex: Int!
-	"""
-	The start index into the zswap state.
-	"""
-	startIndex: Int! @deprecated(reason: "Use zswapStartIndex instead")
-	"""
-	The end index into the zswap state; exclusive, i.e. the next free index.
-	"""
-	zswapEndIndex: Int!
-	"""
-	The end index into the zswap state; exclusive, i.e. the next free index.
-	"""
-	endIndex: Int! @deprecated(reason: "Use zswapEndIndex instead")
-	"""
-	The dust commitment tree start index.
-	"""
-	dustCommitmentStartIndex: Int!
-	"""
-	The dust commitment tree end index.
-	"""
-	dustCommitmentEndIndex: Int!
-	"""
-	The dust generation tree start index.
-	"""
-	dustGenerationStartIndex: Int!
-	"""
-	The dust generation tree end index.
-	"""
-	dustGenerationEndIndex: Int!
-	"""
-	The fee for this transaction in SPECK (atomic unit of DUST).
-	"""
-	fee: String!
-	"""
-	Fee information for this transaction.
-	"""
-	fees: TransactionFees! @deprecated(reason: "Use fee instead")
-	"""
-	The block for this transaction.
-	"""
-	block: Block!
-	"""
-	The contract actions for this transaction.
-	"""
-	contractActions: [ContractAction!]!
-	"""
-	Unshielded UTXOs created by this transaction.
-	"""
-	unshieldedCreatedOutputs: [UnshieldedUtxo!]!
-	"""
-	Unshielded UTXOs spent (consumed) by this transaction.
-	"""
-	unshieldedSpentOutputs: [UnshieldedUtxo!]!
-	"""
-	Zswap ledger events of this transaction.
-	"""
-	zswapLedgerEvents: [ZswapLedgerEvent!]!
-	"""
-	Dust ledger events of this transaction.
-	"""
-	dustLedgerEvents: [DustLedgerEvent!]!
+  """
+  The transaction ID.
+  """
+  id: Int!
+  """
+  The hex-encoded transaction hash.
+  """
+  hash: HexEncoded!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The hex-encoded serialized transaction content.
+  """
+  raw: HexEncoded!
+  """
+  The result of applying this transaction to the ledger state.
+  """
+  transactionResult: TransactionResult!
+  """
+  The hex-encoded serialized transaction identifiers.
+  """
+  identifiers: [HexEncoded!]!
+  """
+  The hex-encoded serialized zswap state Merkle tree root.
+  """
+  zswapMerkleTreeRoot: HexEncoded!
+  """
+  The hex-encoded serialized zswap state Merkle tree root.
+  """
+  merkleTreeRoot: HexEncoded! @deprecated(reason: "Use zswapMerkleTreeRoot instead")
+  """
+  The start index into the zswap state.
+  """
+  zswapStartIndex: Int!
+  """
+  The start index into the zswap state.
+  """
+  startIndex: Int! @deprecated(reason: "Use zswapStartIndex instead")
+  """
+  The end index into the zswap state; exclusive, i.e. the next free index.
+  """
+  zswapEndIndex: Int!
+  """
+  The end index into the zswap state; exclusive, i.e. the next free index.
+  """
+  endIndex: Int! @deprecated(reason: "Use zswapEndIndex instead")
+  """
+  The dust commitment tree start index.
+  """
+  dustCommitmentStartIndex: Int! @beta
+  """
+  The dust commitment tree end index.
+  """
+  dustCommitmentEndIndex: Int! @beta
+  """
+  The dust generation tree start index.
+  """
+  dustGenerationStartIndex: Int! @beta
+  """
+  The dust generation tree end index.
+  """
+  dustGenerationEndIndex: Int! @beta
+  """
+  The fee for this transaction in SPECK (atomic unit of DUST).
+  """
+  fee: String!
+  """
+  Fee information for this transaction.
+  """
+  fees: TransactionFees! @deprecated(reason: "Use fee instead")
+  """
+  The block for this transaction.
+  """
+  block: Block!
+  """
+  The contract actions for this transaction.
+  """
+  contractActions: [ContractAction!]!
+  """
+  Unshielded UTXOs created by this transaction.
+  """
+  unshieldedCreatedOutputs: [UnshieldedUtxo!]!
+  """
+  Unshielded UTXOs spent (consumed) by this transaction.
+  """
+  unshieldedSpentOutputs: [UnshieldedUtxo!]!
+  """
+  Zswap ledger events of this transaction.
+  """
+  zswapLedgerEvents: [ZswapLedgerEvent!]!
+  """
+  Dust ledger events of this transaction.
+  """
+  dustLedgerEvents: [DustLedgerEvent!]!
 }
 
 """
@@ -958,20 +1561,20 @@ A transaction relevant for the subscribing wallet and an optional zswap state Me
 collapsed update.
 """
 type RelevantTransaction {
-	"""
-	A transaction relevant for the subscribing wallet.
-	"""
-	transaction: RegularTransaction!
-	"""
-	Only include a zswap state Merkle tree collapsed update if there is a gap between the
-	current zswap index "driving" the subscription and the zswap start index of the
-	transaction.
-	"""
-	zswapCollapsedUpdate: MerkleTreeCollapsedUpdate
-	"""
-	An optional collapsed Merkle tree.
-	"""
-	collapsedMerkleTree: CollapsedMerkleTree @deprecated(reason: "Use zswapCollapsedUpdate instead")
+  """
+  A transaction relevant for the subscribing wallet.
+  """
+  transaction: RegularTransaction!
+  """
+  Only include a zswap state Merkle tree collapsed update if there is a gap between the
+  current zswap index "driving" the subscription and the zswap start index of the
+  transaction.
+  """
+  zswapCollapsedUpdate: MerkleTreeCollapsedUpdate
+  """
+  An optional collapsed Merkle tree.
+  """
+  collapsedMerkleTree: CollapsedMerkleTree @deprecated(reason: "Use zswapCollapsedUpdate instead")
 }
 
 """
@@ -979,40 +1582,222 @@ One of many segments for a partially successful transaction result showing succe
 segment.
 """
 type Segment {
-	"""
-	Segment ID.
-	"""
-	id: Int!
-	"""
-	Successful or not.
-	"""
-	success: Boolean!
+  """
+  Segment ID.
+  """
+  id: Int!
+  """
+  Successful or not.
+  """
+  success: Boolean!
+}
+
+type ShieldedBurnEvent implements ContractEvent @beta {
+  """
+  The ID of this contract event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event payload.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all contract events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The event schema version, as declared by the emitting contract's compiler.
+  """
+  version: Int!
+  """
+  The hex-encoded address of the emitting contract.
+  """
+  contractAddress: HexEncoded!
+  """
+  The ID of the transaction this event was emitted from.
+  """
+  transactionId: Int!
+  """
+  The hex-encoded nullifier; filterable via `fieldPrefixes`.
+  """
+  nullifier: HexEncoded!
+  """
+  The optional amount as a decimal string; hidden in some shielded burns.
+  """
+  amount: String
+  """
+  The transaction this event was emitted from.
+  """
+  transaction: Transaction!
+}
+
+type ShieldedMintEvent implements ContractEvent @beta {
+  """
+  The ID of this contract event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event payload.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all contract events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The event schema version, as declared by the emitting contract's compiler.
+  """
+  version: Int!
+  """
+  The hex-encoded address of the emitting contract.
+  """
+  contractAddress: HexEncoded!
+  """
+  The ID of the transaction this event was emitted from.
+  """
+  transactionId: Int!
+  """
+  The hex-encoded commitment; filterable via `fieldPrefixes`.
+  """
+  commitment: HexEncoded!
+  """
+  The hex-encoded domain separator; filterable via `fieldPrefixes`.
+  """
+  domainSep: HexEncoded!
+  """
+  The optional amount as a decimal string; hidden in some shielded mints.
+  """
+  amount: String
+  """
+  The transaction this event was emitted from.
+  """
+  transaction: Transaction!
 }
 
 """
 A transaction containing a shielded (zswap) nullifier match with block context.
 """
 type ShieldedNullifierTransaction {
-	"""
-	The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
-	"""
-	transactionId: Int!
-	"""
-	The hex-encoded transaction hash (32-byte chain identifier).
-	"""
-	transactionHash: HexEncoded!
-	"""
-	The hex-encoded block hash (use to query block with ledger parameters).
-	"""
-	blockHash: HexEncoded!
-	"""
-	The block height containing this transaction.
-	"""
-	blockHeight: Int!
-	"""
-	The hex-encoded matched nullifier.
-	"""
-	nullifier: HexEncoded!
+  """
+  The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
+  """
+  transactionId: Int!
+  """
+  The hex-encoded transaction hash (32-byte chain identifier).
+  """
+  transactionHash: HexEncoded!
+  """
+  The hex-encoded block hash (use to query block with ledger parameters).
+  """
+  blockHash: HexEncoded!
+  """
+  The block height containing this transaction.
+  """
+  blockHeight: Int!
+  """
+  The hex-encoded matched nullifier.
+  """
+  nullifier: HexEncoded!
+  """
+  The transaction containing this nullifier match.
+  """
+  transaction: Transaction! @beta
+}
+
+type ShieldedReceiveEvent implements ContractEvent @beta {
+  """
+  The ID of this contract event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event payload.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all contract events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The event schema version, as declared by the emitting contract's compiler.
+  """
+  version: Int!
+  """
+  The hex-encoded address of the emitting contract.
+  """
+  contractAddress: HexEncoded!
+  """
+  The ID of the transaction this event was emitted from.
+  """
+  transactionId: Int!
+  """
+  The hex-encoded commitment; filterable via `fieldPrefixes`.
+  """
+  commitment: HexEncoded!
+  """
+  The hex-encoded optional ciphertext of the shielded coin receipt, up to 512 bytes;
+  filterable via `fieldPrefixes`.
+  """
+  ciphertext: HexEncoded
+  """
+  The hex-encoded receiving contract address; set when received by a contract, null for
+  user recipients. Named to avoid collision with the emitting `contractAddress`.
+  """
+  receivingContractAddress: HexEncoded
+  """
+  The transaction this event was emitted from.
+  """
+  transaction: Transaction!
+}
+
+type ShieldedSpendEvent implements ContractEvent @beta {
+  """
+  The ID of this contract event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event payload.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all contract events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The event schema version, as declared by the emitting contract's compiler.
+  """
+  version: Int!
+  """
+  The hex-encoded address of the emitting contract.
+  """
+  contractAddress: HexEncoded!
+  """
+  The ID of the transaction this event was emitted from.
+  """
+  transactionId: Int!
+  """
+  The hex-encoded nullifier; filterable via `fieldPrefixes`.
+  """
+  nullifier: HexEncoded!
+  """
+  The transaction this event was emitted from.
+  """
+  transaction: Transaction!
 }
 
 """
@@ -1024,80 +1809,80 @@ union ShieldedTransactionsEvent = RelevantTransaction | ShieldedTransactionsProg
 Information about the shielded transactions indexing progress.
 """
 type ShieldedTransactionsProgress {
-	"""
-	The highest end index into the zswap state for all transactions. It represents the known
-	state of the blockchain. A value of zero (completely unlikely) means that no shielded
-	transactions have been indexed yet.
-	"""
-	highestZswapEndIndex: Int!
-	"""
-	The highest end index into the zswap state for all transactions. It represents the known
-	state of the blockchain. A value of zero (completely unlikely) means that no shielded
-	transactions have been indexed yet.
-	"""
-	highestEndIndex: Int! @deprecated(reason: "Use highestZswapEndIndex instead")
-	"""
-	The highest highest end index into the zswap state for all transactions checked for
-	relevance. Initially less than and eventually (when some wallet has been fully indexed)
-	equal to `highest_end_index`. A value of zero (very unlikely) means that no wallet
-	has subscribed before and indexing for the subscribing wallet has not yet started.
-	"""
-	highestCheckedZswapEndIndex: Int!
-	"""
-	The highest highest end index into the zswap state for all transactions checked for
-	relevance. Initially less than and eventually (when some wallet has been fully indexed)
-	equal to `highest_end_index`. A value of zero (very unlikely) means that no wallet
-	has subscribed before and indexing for the subscribing wallet has not yet started.
-	"""
-	highestCheckedEndIndex: Int! @deprecated(reason: "Use highestCheckedZswapEndIndex instead")
-	"""
-	The highest highest end index into the zswap state for all relevant transactions for the
-	subscribing wallet. Usually less than `highest_checked_end_index` unless the latest
-	checked transaction is relevant for the subscribing wallet. A value of zero means that
-	no relevant transactions have been indexed for the subscribing wallet.
-	"""
-	highestRelevantZswapEndIndex: Int!
-	"""
-	The highest highest end index into the zswap state for all relevant transactions for the
-	subscribing wallet. Usually less than `highest_checked_end_index` unless the latest
-	checked transaction is relevant for the subscribing wallet. A value of zero means that
-	no relevant transactions have been indexed for the subscribing wallet.
-	"""
-	highestRelevantEndIndex: Int! @deprecated(reason: "Use highestRelevantZswapEndIndex instead")
+  """
+  The highest end index into the zswap state for all transactions. It represents the known
+  state of the blockchain. A value of zero (completely unlikely) means that no shielded
+  transactions have been indexed yet.
+  """
+  highestZswapEndIndex: Int!
+  """
+  The highest end index into the zswap state for all transactions. It represents the known
+  state of the blockchain. A value of zero (completely unlikely) means that no shielded
+  transactions have been indexed yet.
+  """
+  highestEndIndex: Int! @deprecated(reason: "Use highestZswapEndIndex instead")
+  """
+  The highest highest end index into the zswap state for all transactions checked for
+  relevance. Initially less than and eventually (when some wallet has been fully indexed)
+  equal to `highest_end_index`. A value of zero (very unlikely) means that no wallet
+  has subscribed before and indexing for the subscribing wallet has not yet started.
+  """
+  highestCheckedZswapEndIndex: Int!
+  """
+  The highest highest end index into the zswap state for all transactions checked for
+  relevance. Initially less than and eventually (when some wallet has been fully indexed)
+  equal to `highest_end_index`. A value of zero (very unlikely) means that no wallet
+  has subscribed before and indexing for the subscribing wallet has not yet started.
+  """
+  highestCheckedEndIndex: Int! @deprecated(reason: "Use highestCheckedZswapEndIndex instead")
+  """
+  The highest highest end index into the zswap state for all relevant transactions for the
+  subscribing wallet. Usually less than `highest_checked_end_index` unless the latest
+  checked transaction is relevant for the subscribing wallet. A value of zero means that
+  no relevant transactions have been indexed for the subscribing wallet.
+  """
+  highestRelevantZswapEndIndex: Int!
+  """
+  The highest highest end index into the zswap state for all relevant transactions for the
+  subscribing wallet. Usually less than `highest_checked_end_index` unless the latest
+  checked transaction is relevant for the subscribing wallet. A value of zero means that
+  no relevant transactions have been indexed for the subscribing wallet.
+  """
+  highestRelevantEndIndex: Int! @deprecated(reason: "Use highestRelevantZswapEndIndex instead")
 }
 
 """
 SPO with optional metadata.
 """
 type Spo {
-	poolIdHex: String!
-	validatorClass: String!
-	sidechainPubkeyHex: String!
-	auraPubkeyHex: String
-	name: String
-	ticker: String
-	homepageUrl: String
-	logoUrl: String
+  poolIdHex: String!
+  validatorClass: String!
+  sidechainPubkeyHex: String!
+  auraPubkeyHex: String
+  name: String
+  ticker: String
+  homepageUrl: String
+  logoUrl: String
 }
 
 """
 Composite SPO data (identity + metadata + performance).
 """
 type SpoComposite {
-	identity: SpoIdentity
-	metadata: PoolMetadata
-	performance: [EpochPerf!]!
+  identity: SpoIdentity
+  metadata: PoolMetadata
+  performance: [EpochPerf!]!
 }
 
 """
 SPO identity information.
 """
 type SpoIdentity {
-	poolIdHex: String!
-	mainchainPubkeyHex: String!
-	sidechainPubkeyHex: String!
-	auraPubkeyHex: String
-	validatorClass: String!
+  poolIdHex: String!
+  mainchainPubkeyHex: String!
+  sidechainPubkeyHex: String!
+  auraPubkeyHex: String
+  validatorClass: String!
 }
 
 """
@@ -1106,248 +1891,287 @@ Stake share information for an SPO.
 Values are sourced from mainchain pool data (e.g., Blockfrost) and keyed by Cardano pool_id.
 """
 type StakeShare {
-	"""
-	Cardano pool ID (56-character hex string).
-	"""
-	poolIdHex: String!
-	"""
-	Pool name from metadata.
-	"""
-	name: String
-	"""
-	Pool ticker from metadata.
-	"""
-	ticker: String
-	"""
-	Pool homepage URL from metadata.
-	"""
-	homepageUrl: String
-	"""
-	Pool logo URL from metadata.
-	"""
-	logoUrl: String
-	"""
-	Current live stake in lovelace.
-	"""
-	liveStake: String
-	"""
-	Current active stake in lovelace.
-	"""
-	activeStake: String
-	"""
-	Number of live delegators.
-	"""
-	liveDelegators: Int
-	"""
-	Saturation ratio (0.0 to 1.0+).
-	"""
-	liveSaturation: Float
-	"""
-	Declared pledge in lovelace.
-	"""
-	declaredPledge: String
-	"""
-	Current live pledge in lovelace.
-	"""
-	livePledge: String
-	"""
-	Stake share as a fraction of total stake.
-	"""
-	stakeShare: Float
+  """
+  Cardano pool ID (56-character hex string).
+  """
+  poolIdHex: String!
+  """
+  Pool name from metadata.
+  """
+  name: String
+  """
+  Pool ticker from metadata.
+  """
+  ticker: String
+  """
+  Pool homepage URL from metadata.
+  """
+  homepageUrl: String
+  """
+  Pool logo URL from metadata.
+  """
+  logoUrl: String
+  """
+  Current live stake in lovelace.
+  """
+  liveStake: String
+  """
+  Current active stake in lovelace.
+  """
+  activeStake: String
+  """
+  Number of live delegators.
+  """
+  liveDelegators: Int
+  """
+  Saturation ratio (0.0 to 1.0+).
+  """
+  liveSaturation: Float
+  """
+  Declared pledge in lovelace.
+  """
+  declaredPledge: String
+  """
+  Current live pledge in lovelace.
+  """
+  livePledge: String
+  """
+  Stake share as a fraction of total stake.
+  """
+  stakeShare: Float
 }
 
 type Subscription {
-	"""
-	Subscribe to blocks starting at the given offset or at the latest block if the offset is
-	omitted.
-	"""
-	blocks(offset: BlockOffset): Block!
-	"""
-	Subscribe to contract actions with the given address starting at the given offset or at the
-	latest block if the offset is omitted.
-	"""
-	contractActions(address: HexEncoded!, offset: BlockOffset): ContractAction!
-	"""
-	Subscribe to dust generation entries for a dust address within an index range.
-	Entries are interleaved with collapsed Merkle tree updates and
-	`DustGenerationDtimeUpdateItem` events for entries the subscriber owns.
-	The subscription finishes after reaching the end index with a final collapsed update.
-	"""
-	dustGenerations(dustAddress: DustAddress!, startIndex: Int!, endIndex: Int!): DustGenerationsEvent!
-	"""
-	Subscribe to dust ledger events starting at the given ID or at the very start if omitted.
-	"""
-	dustLedgerEvents(id: Int): DustLedgerEvent!
-	"""
-	Subscribe to transactions containing dust nullifiers matching the provided prefixes.
-	Returns transaction and block references for wallet to fetch full data.
-	If `toBlock` is specified, the subscription finishes after reaching that block.
-	"""
-	dustNullifierTransactions(nullifierPrefixes: [HexEncoded!]!, fromBlock: Int, toBlock: Int): DustNullifierTransaction!
-	"""
-	Subscribe to transactions containing shielded (zswap) nullifiers matching the provided
-	prefixes. Returns transaction and block references for wallet to fetch full data.
-	If `toBlock` is specified, the subscription finishes after reaching that block.
-	"""
-	shieldedNullifierTransactions(nullifierPrefixes: [HexEncoded!]!, fromBlock: Int, toBlock: Int): ShieldedNullifierTransaction!
-	"""
-	Subscribe to shielded transaction events for the given session ID starting at the given
-	index or at zero if omitted.
-	"""
-	shieldedTransactions(sessionId: HexEncoded!, index: Int): ShieldedTransactionsEvent!
-	"""
-	Subscribe unshielded transaction events for the given address and the given transaction ID
-	or zero if omitted.
-	"""
-	unshieldedTransactions(address: UnshieldedAddress!, transactionId: Int): UnshieldedTransactionsEvent!
-	"""
-	Subscribe to zswap ledger events starting at the given ID or at the very start if omitted.
-	"""
-	zswapLedgerEvents(id: Int): ZswapLedgerEvent!
+  """
+  Subscribe to blocks starting at the given offset or at the latest block if the offset is
+  omitted.
+  """
+  blocks(offset: BlockOffset): Block!
+  """
+  Subscribe to c2m-bridge events.
+
+  Backfills events with id > `from` then live-tails new events. Filters apply across both
+  phases.
+  """
+  bridgeEvents(from: Int, recipient: HexEncoded, variant: BridgeEventVariant): BridgeEvent! @beta
+  """
+  Subscribe to bridge pool updates. Emits a snapshot of the pool summary alongside each
+  pool-affecting event (Reserve, Invalid, Unapproved, SubminimalFlush). Useful for
+  observability dashboards.
+  """
+  bridgePoolUpdates: BridgePoolUpdate! @beta
+  """
+  Subscribe to a recipient's bridge balance. Emits the current balance on subscribe and
+  re-emits whenever a bridge event for the recipient indexes or the recipient's unshielded
+  UTXOs change (a claim emits no bridge event, but it creates unshielded UTXOs for
+  the recipient).
+  """
+  bridgeBalance(address: HexEncoded!): BridgeBalance! @beta
+  """
+  Subscribe to contract actions with the given address starting at the given offset or at the
+  latest block if the offset is omitted.
+  """
+  contractActions(address: HexEncoded!, offset: BlockOffset): ContractAction!
+  """
+  Subscribe to contract events matching the given filter, starting at the given event ID
+  (inclusive) and returning events in monotonic ID order; completes once the chain has
+  reached `filter.toBlock` if that is set.
+  """
+  contractEvents(filter: ContractEventFilter!, id: Int): ContractEvent! @beta
+  """
+  Subscribe to a dust address's generations as a consistent snapshot at `block_hash`. The
+  wallet's owned generation entries, interleaved with collapsed Merkle tree updates for the
+  non-owned gaps, are served at that block's state (deterministic, independent of the tip).
+  The dtime updates for the wallet's own generations in `(dtime_cutoff_height, block_hash]`
+  are issued first, as a clean delta for the generations set rather than the tree (pass `0`
+  to replay all). The subscription completes once emitted; re-subscribe at a newer
+  `block_hash` to advance.
+  """
+  dustGenerations(dustAddress: DustAddress!, blockHash: HexEncoded!, dtimeCutoffHeight: Int!): DustGenerationsEvent!
+    @beta
+  """
+  Subscribe to dust ledger events starting at the given ID or at the very start if omitted.
+  """
+  dustLedgerEvents(id: Int): DustLedgerEvent!
+  """
+  Subscribe to transactions containing dust nullifiers whose 32-byte little-endian form
+  starts with one of the provided prefixes. Returns transaction and block references for
+  the wallet to fetch full data. If `toBlock` is specified, the subscription finishes
+  after reaching that block.
+  """
+  dustNullifierTransactions(
+    nullifierLeBytesPrefixes: [HexEncoded!]!
+    fromBlock: Int
+    toBlock: Int
+  ): DustNullifierTransaction!
+  """
+  Subscribe to transactions containing shielded (zswap) nullifiers matching the provided
+  prefixes. Returns transaction and block references for wallet to fetch full data.
+  If `toBlock` is specified, the subscription finishes after reaching that block.
+  """
+  shieldedNullifierTransactions(
+    nullifierPrefixes: [HexEncoded!]!
+    fromBlock: Int
+    toBlock: Int
+  ): ShieldedNullifierTransaction!
+  """
+  Subscribe to shielded transaction events for the given session ID starting at the given
+  index or at zero if omitted.
+  """
+  shieldedTransactions(sessionId: HexEncoded!, index: Int): ShieldedTransactionsEvent!
+  """
+  Subscribe unshielded transaction events for the given address and the given transaction ID
+  or zero if omitted.
+  """
+  unshieldedTransactions(address: UnshieldedAddress!, transactionId: Int): UnshieldedTransactionsEvent!
+  """
+  Subscribe to zswap ledger events starting at the given ID or at the very start if omitted.
+  """
+  zswapLedgerEvents(id: Int): ZswapLedgerEvent!
 }
 
 """
 System parameters at a specific block height.
 """
 type SystemParameters {
-	"""
-	The D-parameter controlling validator committee composition.
-	"""
-	dParameter: DParameter!
-	"""
-	The current Terms and Conditions, if any have been set.
-	"""
-	termsAndConditions: TermsAndConditions
+  """
+  The D-parameter controlling validator committee composition.
+  """
+  dParameter: DParameter!
+  """
+  The current Terms and Conditions, if any have been set.
+  """
+  termsAndConditions: TermsAndConditions
 }
 
 """
 A system Midnight transaction.
 """
 type SystemTransaction implements Transaction {
-	"""
-	The transaction ID.
-	"""
-	id: Int!
-	"""
-	The hex-encoded transaction hash.
-	"""
-	hash: HexEncoded!
-	"""
-	The protocol version.
-	"""
-	protocolVersion: Int!
-	"""
-	The hex-encoded serialized transaction content.
-	"""
-	raw: HexEncoded!
-	"""
-	The block for this transaction.
-	"""
-	block: Block!
-	"""
-	The contract actions for this transaction.
-	"""
-	contractActions: [ContractAction!]!
-	"""
-	Unshielded UTXOs created by this transaction.
-	"""
-	unshieldedCreatedOutputs: [UnshieldedUtxo!]!
-	"""
-	Unshielded UTXOs spent (consumed) by this transaction.
-	"""
-	unshieldedSpentOutputs: [UnshieldedUtxo!]!
-	"""
-	Zswap ledger events of this transaction.
-	"""
-	zswapLedgerEvents: [ZswapLedgerEvent!]!
-	"""
-	Dust ledger events of this transaction.
-	"""
-	dustLedgerEvents: [DustLedgerEvent!]!
+  """
+  The transaction ID.
+  """
+  id: Int!
+  """
+  The hex-encoded transaction hash.
+  """
+  hash: HexEncoded!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The hex-encoded serialized transaction content.
+  """
+  raw: HexEncoded!
+  """
+  The block for this transaction.
+  """
+  block: Block!
+  """
+  The contract actions for this transaction.
+  """
+  contractActions: [ContractAction!]!
+  """
+  Unshielded UTXOs created by this transaction.
+  """
+  unshieldedCreatedOutputs: [UnshieldedUtxo!]!
+  """
+  Unshielded UTXOs spent (consumed) by this transaction.
+  """
+  unshieldedSpentOutputs: [UnshieldedUtxo!]!
+  """
+  Zswap ledger events of this transaction.
+  """
+  zswapLedgerEvents: [ZswapLedgerEvent!]!
+  """
+  Dust ledger events of this transaction.
+  """
+  dustLedgerEvents: [DustLedgerEvent!]!
 }
 
 """
 Terms and Conditions agreement.
 """
 type TermsAndConditions {
-	"""
-	The hex-encoded hash of the Terms and Conditions document.
-	"""
-	hash: HexEncoded!
-	"""
-	The URL where the Terms and Conditions can be found.
-	"""
-	url: String!
+  """
+  The hex-encoded hash of the Terms and Conditions document.
+  """
+  hash: HexEncoded!
+  """
+  The URL where the Terms and Conditions can be found.
+  """
+  url: String!
 }
 
 """
 Terms and Conditions change record for history queries.
 """
 type TermsAndConditionsChange {
-	"""
-	The block height where this T&C version became effective.
-	"""
-	blockHeight: Int!
-	"""
-	The hex-encoded block hash where this T&C version became effective.
-	"""
-	blockHash: HexEncoded!
-	"""
-	The UNIX timestamp when this T&C version became effective.
-	"""
-	timestamp: Int!
-	"""
-	The hex-encoded hash of the Terms and Conditions document.
-	"""
-	hash: HexEncoded!
-	"""
-	The URL where the Terms and Conditions can be found.
-	"""
-	url: String!
+  """
+  The block height where this T&C version became effective.
+  """
+  blockHeight: Int!
+  """
+  The hex-encoded block hash where this T&C version became effective.
+  """
+  blockHash: HexEncoded!
+  """
+  The UNIX timestamp when this T&C version became effective.
+  """
+  timestamp: Int!
+  """
+  The hex-encoded hash of the Terms and Conditions document.
+  """
+  hash: HexEncoded!
+  """
+  The URL where the Terms and Conditions can be found.
+  """
+  url: String!
 }
 
 """
 A Midnight transaction.
 """
 interface Transaction {
-	id: Int!
-	hash: HexEncoded!
-	protocolVersion: Int!
-	raw: HexEncoded!
-	block: Block!
-	contractActions: [ContractAction!]!
-	unshieldedCreatedOutputs: [UnshieldedUtxo!]!
-	unshieldedSpentOutputs: [UnshieldedUtxo!]!
-	zswapLedgerEvents: [ZswapLedgerEvent!]!
-	dustLedgerEvents: [DustLedgerEvent!]!
+  id: Int!
+  hash: HexEncoded!
+  protocolVersion: Int!
+  raw: HexEncoded!
+  block: Block!
+  contractActions: [ContractAction!]!
+  unshieldedCreatedOutputs: [UnshieldedUtxo!]!
+  unshieldedSpentOutputs: [UnshieldedUtxo!]!
+  zswapLedgerEvents: [ZswapLedgerEvent!]!
+  dustLedgerEvents: [DustLedgerEvent!]!
 }
 
 """
 Fees information for a transaction.
 """
 type TransactionFees {
-	"""
-	The fees for this transaction in SPECK (atomic unit of DUST).
-	"""
-	paidFees: String!
-	"""
-	The fees for this transaction in SPECK (atomic unit of DUST).
-	"""
-	estimatedFees: String! @deprecated(reason: "Use paidFees instead")
+  """
+  The fees for this transaction in SPECK (atomic unit of DUST).
+  """
+  paidFees: String!
+  """
+  The fees for this transaction in SPECK (atomic unit of DUST).
+  """
+  estimatedFees: String! @deprecated(reason: "Use paidFees instead")
 }
 
 """
 Either a transaction hash or a transaction identifier.
 """
 input TransactionOffset @oneOf {
-	"""
-	A hex-encoded transaction hash.
-	"""
-	hash: HexEncoded
-	"""
-	A hex-encoded transaction identifier.
-	"""
-	identifier: HexEncoded
+  """
+  A hex-encoded transaction hash.
+  """
+  hash: HexEncoded
+  """
+  A hex-encoded transaction identifier.
+  """
+  identifier: HexEncoded
 }
 
 """
@@ -1355,39 +2179,270 @@ The result of applying a transaction to the ledger state. In case of a partial s
 there will be segments.
 """
 type TransactionResult {
-	status: TransactionResultStatus!
-	segments: [Segment!]
+  status: TransactionResultStatus!
+  segments: [Segment!]
 }
 
 """
 The status of the transaction result: success, partial success or failure.
 """
 enum TransactionResultStatus {
-	SUCCESS
-	PARTIAL_SUCCESS
-	FAILURE
+  SUCCESS
+  PARTIAL_SUCCESS
+  FAILURE
 }
 
 scalar Unit
 
+type UnpausedEvent implements ContractEvent @beta {
+  """
+  The ID of this contract event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event payload.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all contract events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The event schema version, as declared by the emitting contract's compiler.
+  """
+  version: Int!
+  """
+  The hex-encoded address of the emitting contract.
+  """
+  contractAddress: HexEncoded!
+  """
+  The ID of the transaction this event was emitted from.
+  """
+  transactionId: Int!
+  """
+  The transaction this event was emitted from.
+  """
+  transaction: Transaction!
+}
+
 scalar UnshieldedAddress
+
+type UnshieldedBurnEvent implements ContractEvent @beta {
+  """
+  The ID of this contract event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event payload.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all contract events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The event schema version, as declared by the emitting contract's compiler.
+  """
+  version: Int!
+  """
+  The hex-encoded address of the emitting contract.
+  """
+  contractAddress: HexEncoded!
+  """
+  The ID of the transaction this event was emitted from.
+  """
+  transactionId: Int!
+  """
+  The spending user or contract address; filterable via `fieldPrefixes`.
+  """
+  sender: AddressOrContract!
+  """
+  The hex-encoded token type; filterable via `fieldPrefixes`.
+  """
+  tokenType: HexEncoded!
+  """
+  The amount as a decimal string.
+  """
+  amount: String!
+  """
+  The transaction this event was emitted from.
+  """
+  transaction: Transaction!
+}
+
+type UnshieldedMintEvent implements ContractEvent @beta {
+  """
+  The ID of this contract event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event payload.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all contract events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The event schema version, as declared by the emitting contract's compiler.
+  """
+  version: Int!
+  """
+  The hex-encoded address of the emitting contract.
+  """
+  contractAddress: HexEncoded!
+  """
+  The ID of the transaction this event was emitted from.
+  """
+  transactionId: Int!
+  """
+  The hex-encoded domain separator; filterable via `fieldPrefixes`.
+  """
+  domainSep: HexEncoded!
+  """
+  The hex-encoded token type; filterable via `fieldPrefixes`.
+  """
+  tokenType: HexEncoded!
+  """
+  The amount as a decimal string.
+  """
+  amount: String!
+  """
+  The transaction this event was emitted from.
+  """
+  transaction: Transaction!
+}
+
+type UnshieldedReceiveEvent implements ContractEvent @beta {
+  """
+  The ID of this contract event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event payload.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all contract events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The event schema version, as declared by the emitting contract's compiler.
+  """
+  version: Int!
+  """
+  The hex-encoded address of the emitting contract.
+  """
+  contractAddress: HexEncoded!
+  """
+  The ID of the transaction this event was emitted from.
+  """
+  transactionId: Int!
+  """
+  The receiving user or contract address; filterable via `fieldPrefixes`.
+  """
+  recipient: AddressOrContract!
+  """
+  The hex-encoded domain separator; filterable via `fieldPrefixes`.
+  """
+  domainSep: HexEncoded!
+  """
+  The hex-encoded token type; filterable via `fieldPrefixes`.
+  """
+  tokenType: HexEncoded!
+  """
+  The amount as a decimal string.
+  """
+  amount: String!
+  """
+  The transaction this event was emitted from.
+  """
+  transaction: Transaction!
+}
+
+type UnshieldedSpendEvent implements ContractEvent @beta {
+  """
+  The ID of this contract event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event payload.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all contract events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
+  """
+  The event schema version, as declared by the emitting contract's compiler.
+  """
+  version: Int!
+  """
+  The hex-encoded address of the emitting contract.
+  """
+  contractAddress: HexEncoded!
+  """
+  The ID of the transaction this event was emitted from.
+  """
+  transactionId: Int!
+  """
+  The spending user or contract address; filterable via `fieldPrefixes`.
+  """
+  sender: AddressOrContract!
+  """
+  The hex-encoded domain separator; filterable via `fieldPrefixes`.
+  """
+  domainSep: HexEncoded!
+  """
+  The hex-encoded token type; filterable via `fieldPrefixes`.
+  """
+  tokenType: HexEncoded!
+  """
+  The amount as a decimal string.
+  """
+  amount: String!
+  """
+  The transaction this event was emitted from.
+  """
+  transaction: Transaction!
+}
 
 """
 A transaction that created and/or spent UTXOs alongside these and other information.
 """
 type UnshieldedTransaction {
-	"""
-	The transaction that created and/or spent UTXOs.
-	"""
-	transaction: Transaction!
-	"""
-	UTXOs created in the above transaction, possibly empty.
-	"""
-	createdUtxos: [UnshieldedUtxo!]!
-	"""
-	UTXOs spent in the above transaction, possibly empty.
-	"""
-	spentUtxos: [UnshieldedUtxo!]!
+  """
+  The transaction that created and/or spent UTXOs.
+  """
+  transaction: Transaction!
+  """
+  UTXOs created in the above transaction, possibly empty.
+  """
+  createdUtxos: [UnshieldedUtxo!]!
+  """
+  UTXOs spent in the above transaction, possibly empty.
+  """
+  spentUtxos: [UnshieldedUtxo!]!
 }
 
 """
@@ -1399,56 +2454,56 @@ union UnshieldedTransactionsEvent = UnshieldedTransaction | UnshieldedTransactio
 Information about the unshielded indexing progress.
 """
 type UnshieldedTransactionsProgress {
-	"""
-	The highest transaction ID of all currently known transactions for a subscribed address.
-	"""
-	highestTransactionId: Int!
+  """
+  The highest transaction ID of all currently known transactions for a subscribed address.
+  """
+  highestTransactionId: Int!
 }
 
 """
 Represents an unshielded UTXO.
 """
 type UnshieldedUtxo {
-	"""
-	Owner Bech32m-encoded address.
-	"""
-	owner: UnshieldedAddress!
-	"""
-	Token hex-encoded serialized token type.
-	"""
-	tokenType: HexEncoded!
-	"""
-	UTXO value (quantity) as a string to support u128.
-	"""
-	value: String!
-	"""
-	The hex-encoded serialized intent hash.
-	"""
-	intentHash: HexEncoded!
-	"""
-	Index of this output within its creating transaction.
-	"""
-	outputIndex: Int!
-	"""
-	The creation time in seconds.
-	"""
-	ctime: Int
-	"""
-	The hex-encoded initial nonce for DUST generation tracking.
-	"""
-	initialNonce: HexEncoded!
-	"""
-	Whether this UTXO is registered for DUST generation.
-	"""
-	registeredForDustGeneration: Boolean!
-	"""
-	Transaction that created this UTXO.
-	"""
-	createdAtTransaction: Transaction!
-	"""
-	Transaction that spent this UTXO.
-	"""
-	spentAtTransaction: Transaction
+  """
+  Owner Bech32m-encoded address.
+  """
+  owner: UnshieldedAddress!
+  """
+  Token hex-encoded serialized token type.
+  """
+  tokenType: HexEncoded!
+  """
+  UTXO value (quantity) as a string to support u128.
+  """
+  value: String!
+  """
+  The hex-encoded serialized intent hash.
+  """
+  intentHash: HexEncoded!
+  """
+  Index of this output within its creating transaction.
+  """
+  outputIndex: Int!
+  """
+  The creation time in seconds.
+  """
+  ctime: Int
+  """
+  The hex-encoded initial nonce for DUST generation tracking.
+  """
+  initialNonce: HexEncoded!
+  """
+  Whether this UTXO is registered for DUST generation.
+  """
+  registeredForDustGeneration: Boolean!
+  """
+  Transaction that created this UTXO.
+  """
+  createdAtTransaction: Transaction!
+  """
+  Transaction that spent this UTXO.
+  """
+  spentAtTransaction: Transaction
 }
 
 scalar ViewingKey
@@ -1457,28 +2512,39 @@ scalar ViewingKey
 A zswap related ledger event.
 """
 type ZswapLedgerEvent {
-	"""
-	The ID of this zswap ledger event.
-	"""
-	id: Int!
-	"""
-	The hex-encoded serialized event.
-	"""
-	raw: HexEncoded!
-	"""
-	The maximum ID of all zswap ledger events.
-	"""
-	maxId: Int!
-	"""
-	The protocol version.
-	"""
-	protocolVersion: Int!
+  """
+  The ID of this zswap ledger event.
+  """
+  id: Int!
+  """
+  The hex-encoded serialized event.
+  """
+  raw: HexEncoded!
+  """
+  The maximum ID of all zswap ledger events.
+  """
+  maxId: Int!
+  """
+  The protocol version.
+  """
+  protocolVersion: Int!
 }
 
 """
+Marks a schema field or type as in-flight / unstable. Consumers should
+expect the marked surface to change without notice; stability is signalled
+by removal of the directive.
+
+Currently used for the dust-generation API surface that's in mid-redesign
+pending #1181. See #1173.
+"""
+directive @beta on FIELD_DEFINITION | OBJECT
+"""
 Marks an element of a GraphQL schema as no longer supported.
 """
-directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
+directive @deprecated(
+  reason: String = "No longer supported"
+) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
 """
 Directs the executor to include this field or fragment only when the `if` argument is true.
 """
@@ -1492,8 +2558,7 @@ Directs the executor to skip this field or fragment when the `if` argument is tr
 """
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 schema {
-	query: Query
-	mutation: Mutation
-	subscription: Subscription
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
 }
-

--- a/packages/indexer-client/package.json
+++ b/packages/indexer-client/package.json
@@ -32,6 +32,7 @@
     "@graphql-typed-document-node/core": "^3.2.0",
     "@midnightntwrk/wallet-sdk-utilities": "1.2.1",
     "effect": "^3.19.19",
+    "fflate": "^0.8.2",
     "graphql": "^17.0.0",
     "graphql-http": "^1.22.4",
     "graphql-ws": "^6.0.7"

--- a/packages/indexer-client/schema.lock
+++ b/packages/indexer-client/schema.lock
@@ -3,5 +3,5 @@
 # To change where the schema is fetched from, edit schema.config.yml (repo/path), not this file.
 #   yarn schema:sync --filter=@midnightntwrk/wallet-sdk-indexer-client -- --tag <version>
 
-tag: v4.3.2
-sha256: ee13e3f7d73c50934c2bff8771afb4f87a4a91e01567f6595b39af6c142f5bef
+tag: v4.4.0-rc.1
+sha256: 6c3058d26bcfd8d77cba59e54af73595d8cf888ea0187d6dd72a42f75f62ea20

--- a/packages/indexer-client/src/effect/DeflateWebSocket.ts
+++ b/packages/indexer-client/src/effect/DeflateWebSocket.ts
@@ -1,0 +1,116 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { strFromU8, unzlibSync } from 'fflate';
+import { GRAPHQL_TRANSPORT_WS_PROTOCOL } from 'graphql-ws';
+
+/**
+ * The indexer's opt-in compression subprotocol. Servers offering it send graphql-transport-ws JSON messages of >= 256
+ * bytes as binary frames containing the zlib-compressed (RFC 1950) UTF-8 JSON; smaller messages remain plain text
+ * frames. See midnight-indexer `indexer-api/src/infra/api/v4/ws_deflate.rs` for the wire format.
+ */
+export const GRAPHQL_TRANSPORT_WS_DEFLATE = 'graphql-transport-ws+deflate';
+
+/**
+ * The wrapper's constructor shape, as consumed by `graphql-ws`'s `webSocketImpl` option (typed `unknown` there).
+ * Deliberately not `typeof WebSocket`: only the surface `graphql-ws` uses is implemented — which includes the
+ * readyState constants it reads off the constructor itself, hence their presence here.
+ */
+export type DeflateWebSocketConstructor = {
+  new (url: string | URL, protocols?: string | string[]): unknown;
+  readonly CONNECTING: number;
+  readonly OPEN: number;
+  readonly CLOSING: number;
+  readonly CLOSED: number;
+};
+
+/**
+ * Creates a WebSocket-constructor for `graphql-ws`'s `webSocketImpl` option that negotiates the indexer's
+ * {@link GRAPHQL_TRANSPORT_WS_DEFLATE} subprotocol and transparently inflates the resulting binary frames back into the
+ * text messages `graphql-ws` expects.
+ *
+ * `graphql-ws` hardcodes the offered subprotocol to `graphql-transport-ws`, so this wrapper replaces the offer with
+ * both protocols; per the indexer's wire contract the standard protocol must be offered alongside the deflate variant.
+ * Against a server that does not offer the deflate variant, negotiation falls back to the standard protocol and this
+ * wrapper is a pass-through.
+ *
+ * Only the surface `graphql-ws` actually uses is exposed: the readyState statics, `readyState`, `send`, `close`, and
+ * the `onopen`/`onmessage`/`onclose`/`onerror` setters.
+ *
+ * @param Base - The underlying WebSocket constructor (default: the global `WebSocket`)
+ */
+export const makeDeflateWebSocket = (Base: typeof WebSocket = WebSocket): DeflateWebSocketConstructor =>
+  class DeflateWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+
+    readonly #socket: WebSocket;
+
+    // graphql-ws passes its hardcoded subprotocol as the second argument; it is deliberately
+    // ignored and replaced with the deflate + standard pair.
+    constructor(url: string | URL, _protocols?: string | string[]) {
+      this.#socket = new Base(url, [GRAPHQL_TRANSPORT_WS_DEFLATE, GRAPHQL_TRANSPORT_WS_PROTOCOL]);
+      this.#socket.binaryType = 'arraybuffer';
+    }
+
+    get readyState(): number {
+      return this.#socket.readyState;
+    }
+
+    get protocol(): string {
+      return this.#socket.protocol;
+    }
+
+    set onopen(handler: WebSocket['onopen']) {
+      this.#socket.onopen = handler;
+    }
+
+    set onclose(handler: WebSocket['onclose']) {
+      this.#socket.onclose = handler;
+    }
+
+    set onerror(handler: WebSocket['onerror']) {
+      this.#socket.onerror = handler;
+    }
+
+    set onmessage(handler: WebSocket['onmessage']) {
+      this.#socket.onmessage =
+        handler &&
+        ((event) => {
+          handler.call(this.#socket, event.data instanceof ArrayBuffer ? inflate(event) : event);
+        });
+    }
+
+    send(data: string): void {
+      this.#socket.send(data);
+    }
+
+    close(code?: number, reason?: string): void {
+      this.#socket.close(code, reason);
+    }
+  };
+
+// On a corrupt frame the original binary event is passed through instead: graphql-ws's own
+// message parsing then fails and closes the socket with 4400 Bad Response, which is exactly
+// the treatment a malformed server message deserves.
+const inflate = (event: MessageEvent): MessageEvent => {
+  try {
+    // Type cast required because: the `instanceof ArrayBuffer` check at the call site narrows
+    // `event.data`, but the narrowing does not survive extraction into this helper.
+    const data = strFromU8(unzlibSync(new Uint8Array(event.data as ArrayBuffer)));
+    return new MessageEvent('message', { data });
+  } catch {
+    return event;
+  }
+};

--- a/packages/indexer-client/src/effect/WsSubscriptionClient.ts
+++ b/packages/indexer-client/src/effect/WsSubscriptionClient.ts
@@ -16,6 +16,7 @@ import { type GraphQLError, print } from 'graphql';
 import { SubscriptionClient } from './SubscriptionClient.js';
 import { type Query } from './Query.js';
 import { withBackpressure, type Source } from './Backpressure.js';
+import { makeDeflateWebSocket } from './DeflateWebSocket.js';
 import {
   type InvalidProtocolSchemeError,
   WsURL,
@@ -45,18 +46,80 @@ const toClientOrServerError = (err: unknown): ClientError | ServerError =>
 // Layer / class
 // ============================================================================
 
+/**
+ * @internal Test-only transport seams for {@link layer} — deliberately NOT part of
+ * {@link SubscriptionClient.ServerConfig}. Compression is always offered (falling back
+ * automatically against servers without it) and connection reuse is fixed policy; consumers get
+ * no knobs for either. These seams exist solely so integration tests can run a compression-off
+ * reference and observe raw frames on the wire.
+ */
+export interface TransportInternals {
+  /** Offer the deflate compression subprotocol (default: true). */
+  readonly compression?: boolean | undefined;
+  /** The underlying WebSocket constructor (default: the global `WebSocket`). */
+  readonly webSocketImpl?: typeof WebSocket | undefined;
+}
+
+/**
+ * Builds a {@link SubscriptionClient} layer backed by a `graphql-ws` WebSocket connection to the indexer.
+ *
+ * The connection negotiates the indexer's compression subprotocol (with automatic fallback against servers that predate
+ * compression) and is held open for the client's entire scope (`lazy: false`), so backpressure pause/resume cycles and
+ * re-subscriptions always reuse it instead of paying a reconnect handshake. Correctness never depends on connection
+ * lifetime (resume is always cursor-based), so this is pure policy, not configuration. Non-lazy mode also makes
+ * disposal total: graphql-ws never arms its lazy-close timer, whose handle its `dispose()` leaks — a pending timer that
+ * would otherwise keep a short-lived Node process alive after the wallet stopped. The client is scoped — it is
+ * disposed, closing the connection and cancelling its timers, when the surrounding scope closes.
+ *
+ * @example
+ *   ```typescript
+ *   const events = ZswapEvents.run({ id: 0 }).pipe(
+ *     Stream.runCollect,
+ *     Effect.provide(WsSubscriptionClient.layer({ url: 'ws://localhost:8088/api/v4/graphql/ws' })),
+ *     Effect.scoped,
+ *   );
+ *   ```;
+ *
+ * @param config - The indexer WebSocket endpoint and optional keep-alive interval
+ * @param internals - `@internal` test-only transport seams; production callers omit this
+ * @returns A scoped layer providing `SubscriptionClient`, failing with `InvalidProtocolSchemeError` if `config.url` is
+ *   not a WebSocket URL
+ */
 export const layer: (
   config: SubscriptionClient.ServerConfig,
-) => Layer.Layer<SubscriptionClient, InvalidProtocolSchemeError, Scope.Scope> = (config) =>
+  internals?: TransportInternals,
+) => Layer.Layer<SubscriptionClient, InvalidProtocolSchemeError, Scope.Scope> = (config, internals) =>
   Layer.scoped(
     SubscriptionClient,
     WsURL.make(config.url).pipe(
       Effect.flatMap((url) =>
         Effect.acquireRelease(
-          Effect.sync(() =>
-            createClient({ url: url.toString(), shouldRetry: () => false, keepAlive: config.keepAlive ?? 15_000 }),
-          ),
-          (client) => Effect.sync(() => client.dispose()),
+          Effect.sync(() => {
+            // Resolved at acquire time, guarded so runtimes without the global reach graphql-ws's
+            // own probing and descriptive "implementation missing" error instead of a ReferenceError.
+            const webSocketImpl =
+              internals?.webSocketImpl ?? (typeof WebSocket === 'undefined' ? undefined : WebSocket);
+            return createClient({
+              url: url.toString(),
+              shouldRetry: () => false,
+              lazy: false,
+              // A connection failing while nothing is subscribed needs no handling: active
+              // subscriptions surface transport errors through their own sinks, and the next
+              // subscribe dials afresh. Without this graphql-ws would console.error the event.
+              onNonLazyError: () => undefined,
+              keepAlive: config.keepAlive ?? 15_000,
+              webSocketImpl:
+                internals?.compression === false
+                  ? internals.webSocketImpl
+                  : webSocketImpl === undefined
+                    ? undefined
+                    : makeDeflateWebSocket(webSocketImpl),
+            });
+          }),
+          // dispose() is async and rejects when the connection attempt it awaits has already
+          // failed — which still means "nothing left to close", i.e. successful disposal. Await
+          // it so the rejection is absorbed here instead of floating as an unhandled rejection.
+          (client) => Effect.promise(() => Promise.resolve(client.dispose()).then(undefined, () => undefined)),
         ),
       ),
       Effect.map((client) => new WebSocketSubscriptionClientImpl(client)),

--- a/packages/indexer-client/src/effect/test/composeEnvironment.ts
+++ b/packages/indexer-client/src/effect/test/composeEnvironment.ts
@@ -1,0 +1,66 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnightntwrk/wallet-sdk-utilities/testing';
+import { randomUUID } from 'node:crypto';
+import { DockerComposeEnvironment, Wait, type StartedDockerComposeEnvironment } from 'testcontainers';
+
+/** Converts minutes to the milliseconds vitest hook/test timeouts expect. */
+export const timeoutMinutes = (mins: number): number => 1_000 * 60 * mins;
+
+/** A started (or startable) indexer+node compose stack, scoped to one test file. */
+export interface ComposeTestEnvironment {
+  /** Starts the stack; wire into `beforeAll` (allow `timeoutMinutes(3)` — image pulls are slow). */
+  readonly start: () => Promise<void>;
+  /** Tears the stack down; wire into `afterAll`. */
+  readonly stop: () => Promise<void>;
+  /** The indexer's mapped host port (falls back to 8088 before `start` resolves). */
+  readonly getIndexerPort: () => number;
+}
+
+/**
+ * The one compose scaffold every indexer-client integration test shares: a uniquely-named indexer+node environment
+ * (unique so parallel test files never collide on container names), readiness gated on the node listening and the
+ * indexer having indexed a block — connecting any earlier races indexer startup and flakes.
+ *
+ * @param composeFiles - Compose file name(s) under the shared compose directory; overrides later in the list win, e.g.
+ *   `['docker-compose.yml', 'docker-compose.ws-no-deflate.yml']`.
+ */
+export const makeComposeEnvironment = (composeFiles: string | string[]): ComposeTestEnvironment => {
+  const environmentId = randomUUID();
+
+  const environmentVars = buildTestEnvironmentVariables(['APP_INFRA_SECRET'], {
+    additionalVars: {
+      TESTCONTAINERS_UID: environmentId,
+    },
+  });
+
+  const environment = new DockerComposeEnvironment(getComposeDirectory(), composeFiles)
+    .withWaitStrategy(`node_${environmentId}`, Wait.forListeningPorts())
+    .withWaitStrategy(`indexer_${environmentId}`, Wait.forLogMessage(/block indexed/))
+    .withEnvironment(environmentVars);
+
+  // Mutation is deliberate and confined to this helper: the started environment only exists
+  // after the async `start` hook runs, which is inherently stateful test setup
+  // (`.claude/rules/functional-style.md` permits this).
+  let startedEnvironment: StartedDockerComposeEnvironment | undefined = undefined;
+
+  return {
+    start: async () => {
+      startedEnvironment = await environment.up();
+    },
+    stop: async () => {
+      await startedEnvironment?.down();
+    },
+    getIndexerPort: () => startedEnvironment?.getContainer(`indexer_${environmentId}`).getMappedPort(8088) ?? 8088,
+  };
+};

--- a/packages/indexer-client/src/effect/test/deflateWebSocket.test.ts
+++ b/packages/indexer-client/src/effect/test/deflateWebSocket.test.ts
@@ -1,0 +1,202 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { strToU8, zlibSync } from 'fflate';
+import { GRAPHQL_TRANSPORT_WS_PROTOCOL } from 'graphql-ws';
+import { describe, expect, it } from 'vitest';
+import { GRAPHQL_TRANSPORT_WS_DEFLATE, makeDeflateWebSocket } from '../DeflateWebSocket.js';
+
+/**
+ * The socket the wrapper sits on top of. A hand-written fake rather than a mock: it records what the wrapper did to it
+ * and lets a test deliver a frame, which is everything these tests need to observe.
+ */
+interface FakeSocket {
+  readonly url: string | URL;
+  readonly protocols: string | string[] | undefined;
+  binaryType: WebSocket['binaryType'];
+  readyState: number;
+  protocol: string;
+  onmessage: ((event: MessageEvent) => void) | null;
+  readonly sent: string[];
+  readonly closeCalls: { readonly code: number | undefined; readonly reason: string | undefined }[];
+}
+
+/**
+ * A `typeof WebSocket` stand-in that opens no connection, appending each construction to `instances`.
+ *
+ * Mutation is deliberate and confined to this test fake: the wrapper reaches its underlying socket through assignments
+ * and method calls, so recording them is inherently stateful. `.claude/rules/functional-style.md` permits this for test
+ * setup.
+ */
+const makeFakeBase = (instances: FakeSocket[]): typeof WebSocket => {
+  class FakeWebSocket implements FakeSocket {
+    readonly url: string | URL;
+    readonly protocols: string | string[] | undefined;
+    binaryType: WebSocket['binaryType'] = 'blob';
+    readyState = 0;
+    protocol = '';
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    readonly sent: string[] = [];
+    readonly closeCalls: { readonly code: number | undefined; readonly reason: string | undefined }[] = [];
+
+    constructor(url: string | URL, protocols?: string | string[]) {
+      this.url = url;
+      this.protocols = protocols;
+      instances.push(this);
+    }
+
+    send(data: string): void {
+      this.sent.push(data);
+    }
+
+    close(code?: number, reason?: string): void {
+      this.closeCalls.push({ code, reason });
+    }
+  }
+
+  // Type cast required because: `typeof WebSocket` describes the full DOM constructor, while the wrapper only ever
+  // touches the members implemented above — implementing the remainder would add noise without adding coverage.
+  return FakeWebSocket as unknown as typeof WebSocket;
+};
+
+/** The slice of the wrapper's surface `graphql-ws` uses, which is all these tests exercise. */
+interface WrapperSocket {
+  readonly readyState: number;
+  readonly protocol: string;
+  onmessage: WebSocket['onmessage'];
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+}
+
+/** Builds a standalone `ArrayBuffer` so `event.data instanceof ArrayBuffer` holds, as it does for a real binary frame. */
+const toArrayBuffer = (bytes: Uint8Array): ArrayBuffer => {
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return buffer;
+};
+
+const binaryFrame = (data: ArrayBuffer): MessageEvent => new MessageEvent('message', { data });
+
+const deflated = (json: string): ArrayBuffer => toArrayBuffer(zlibSync(strToU8(json)));
+
+/** Constructs the wrapper over a fresh fake, returning both halves. */
+const connect = (): { readonly socket: WrapperSocket; readonly fake: FakeSocket } => {
+  const instances: FakeSocket[] = [];
+  const DeflateWebSocket = makeDeflateWebSocket(makeFakeBase(instances));
+  // Type cast required because: the constructor is typed to return `unknown` for graphql-ws's `webSocketImpl` option,
+  // so the surface under test has to be named here.
+  const socket = new DeflateWebSocket('ws://indexer.test/graphql/ws', GRAPHQL_TRANSPORT_WS_PROTOCOL) as WrapperSocket;
+  return { socket, fake: instances[0] };
+};
+
+describe('makeDeflateWebSocket', () => {
+  describe('subprotocol negotiation', () => {
+    it('should offer the deflate subprotocol ahead of the standard one, replacing what graphql-ws asked for', () => {
+      const { fake } = connect();
+
+      // Both must be offered, deflate first: the indexer requires the standard protocol alongside the variant, and
+      // ordering is what expresses the preference. graphql-ws's own single-protocol argument is discarded.
+      expect(fake.protocols).toEqual([GRAPHQL_TRANSPORT_WS_DEFLATE, GRAPHQL_TRANSPORT_WS_PROTOCOL]);
+    });
+
+    it('should switch the underlying socket to arraybuffer frames', () => {
+      const { fake } = connect();
+
+      // Without this the compressed frames would arrive as Blobs and the inflate path would never match.
+      expect(fake.binaryType).toBe('arraybuffer');
+    });
+  });
+
+  describe('inbound frames', () => {
+    it('should inflate a zlib binary frame into the text message graphql-ws expects', () => {
+      const { socket, fake } = connect();
+      const payload = JSON.stringify({ type: 'next', id: '1', payload: { data: { blocks: [1, 2, 3] } } });
+      const received: MessageEvent[] = [];
+      socket.onmessage = (event) => received.push(event);
+
+      fake.onmessage?.(binaryFrame(deflated(payload)));
+
+      expect(received).toHaveLength(1);
+      expect(received[0].data).toBe(payload);
+    });
+
+    it('should pass a corrupt binary frame through untouched, leaving graphql-ws to reject it', () => {
+      const { socket, fake } = connect();
+      // Not valid zlib — inflation must fail.
+      const corrupt = binaryFrame(toArrayBuffer(new Uint8Array([0x00, 0x01, 0x02, 0x03])));
+      const received: MessageEvent[] = [];
+      socket.onmessage = (event) => received.push(event);
+
+      fake.onmessage?.(corrupt);
+
+      // The very same event, not a rewritten one: graphql-ws's message parsing then fails and closes the socket with
+      // 4400 Bad Response, which is the right treatment for a malformed server message. Swallowing it or throwing
+      // inside the handler would both strand the client instead.
+      expect(received).toHaveLength(1);
+      expect(received[0]).toBe(corrupt);
+    });
+
+    it('should leave text frames untouched', () => {
+      const { socket, fake } = connect();
+      // Messages below the server's 256 B compression threshold stay plain text and must not be touched.
+      const ack = new MessageEvent('message', { data: JSON.stringify({ type: 'connection_ack' }) });
+      const received: MessageEvent[] = [];
+      socket.onmessage = (event) => received.push(event);
+
+      fake.onmessage?.(ack);
+
+      expect(received).toEqual([ack]);
+    });
+
+    it('should clear the underlying handler when onmessage is set to null', () => {
+      const { socket, fake } = connect();
+      socket.onmessage = () => undefined;
+
+      socket.onmessage = null;
+
+      // A wrapper that installed its own closure regardless would keep the socket referenced and keep delivering.
+      expect(fake.onmessage).toBeNull();
+    });
+  });
+
+  describe('delegation to the underlying socket', () => {
+    it('should report the underlying readyState and negotiated protocol', () => {
+      const { socket, fake } = connect();
+      fake.readyState = 1;
+      fake.protocol = GRAPHQL_TRANSPORT_WS_DEFLATE;
+
+      expect(socket.readyState).toBe(1);
+      expect(socket.protocol).toBe(GRAPHQL_TRANSPORT_WS_DEFLATE);
+    });
+
+    it('should forward sends and closes', () => {
+      const { socket, fake } = connect();
+
+      socket.send('{"type":"ping"}');
+      socket.close(1000, 'done');
+
+      expect(fake.sent).toEqual(['{"type":"ping"}']);
+      expect(fake.closeCalls).toEqual([{ code: 1000, reason: 'done' }]);
+    });
+
+    it('should expose the readyState constants graphql-ws reads off the constructor', () => {
+      const DeflateWebSocket = makeDeflateWebSocket(makeFakeBase([]));
+
+      expect([
+        DeflateWebSocket.CONNECTING,
+        DeflateWebSocket.OPEN,
+        DeflateWebSocket.CLOSING,
+        DeflateWebSocket.CLOSED,
+      ]).toEqual([0, 1, 2, 3]);
+    });
+  });
+});

--- a/packages/indexer-client/src/effect/test/deflateWireStats.ts
+++ b/packages/indexer-client/src/effect/test/deflateWireStats.ts
@@ -1,0 +1,147 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Test kit for the WebSocket deflate-compression integration tests: a counting WebSocket that observes raw frames below
+ * the deflate wrapper, the wire-savings measure the tests assert on, and a human-readable report of the same numbers so
+ * a run's actual savings stay visible in the test output.
+ */
+import { strFromU8, unzlibSync } from 'fflate';
+import { type TestContext } from 'vitest';
+
+/** Per-frame wire observation, taken below the deflate wrapper (i.e. before any inflation). */
+export interface Frame {
+  readonly binary: boolean;
+  /** Bytes on the wire. */
+  readonly wire: number;
+  /** Bytes after inflation (equal to `wire` for text frames). */
+  readonly inflated: number;
+  /** The graphql-transport-ws message type (`connection_ack`, `next`, `complete`, ...). */
+  readonly type: string;
+}
+
+export interface WireStats {
+  readonly frames: Frame[];
+  protocol: string;
+  /** Number of physical WebSocket connections constructed. */
+  sockets: number;
+}
+
+export const emptyWireStats = (): WireStats => ({ frames: [], protocol: '', sockets: 0 });
+
+const messageType = (json: string): string => {
+  try {
+    // Type cast required because: JSON.parse returns `any`; the ?? fallback below covers a
+    // missing/non-string field, which is the only shape risk that matters here.
+    return ((JSON.parse(json) as { type?: string }).type ?? 'unknown') || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+};
+
+/**
+ * Records every frame as it arrives on the underlying socket, accumulating into `stats`. Observation only
+ * (`addEventListener`), so the deflate wrapper's `onmessage` interception is unaffected.
+ *
+ * Mutation of `stats` is deliberate and the reason `WireStats` has mutable fields: frames arrive one event at a time
+ * over the life of a connection, so there is no value to fold over and no functional alternative that a plain DOM event
+ * listener can express. `.claude/rules/functional-style.md` permits this for test instrumentation; it stays confined to
+ * this file, and every reader of `stats` treats it as read-only.
+ */
+export const makeCountingWebSocket = (stats: WireStats): typeof WebSocket =>
+  class CountingWebSocket extends WebSocket {
+    constructor(...args: ConstructorParameters<typeof WebSocket>) {
+      super(...args);
+      stats.sockets += 1;
+      this.addEventListener('open', () => {
+        stats.protocol = this.protocol;
+      });
+      this.addEventListener('message', (event: MessageEvent) => {
+        const data: unknown = event.data;
+        const binary = data instanceof ArrayBuffer;
+        // Inflate once and derive everything from the result: this runs for every frame of every
+        // replay, and inflating twice to measure and to classify was pure waste.
+        const text = binary ? strFromU8(unzlibSync(new Uint8Array(data))) : String(data);
+        const inflated = new TextEncoder().encode(text).byteLength;
+        stats.frames.push({
+          binary,
+          wire: binary ? data.byteLength : inflated,
+          inflated,
+          type: messageType(text),
+        });
+      });
+    }
+  };
+
+export const total = (frames: readonly Frame[], of: (f: Frame) => number): number =>
+  frames.reduce((sum, f) => sum + of(f), 0);
+
+/**
+ * The fraction of bytes compression kept off the wire, as observed within a single run: total wire bytes against the
+ * total the same frames occupy once inflated. This is the measure the tests assert a floor on.
+ *
+ * Deliberately intra-run — comparing a compressed run's totals against a separate uncompressed run's is racy, because
+ * frames already in flight when a stream is torn down still reach the wire and their number varies between runs.
+ *
+ * @returns A ratio in `[0, 1)`; `0` for a run in which nothing was compressed.
+ */
+export const savingsRatio = (stats: WireStats): number => {
+  const inflated = total(stats.frames, (f) => f.inflated);
+  return inflated === 0 ? 0 : 1 - total(stats.frames, (f) => f.wire) / inflated;
+};
+
+/** The `annotate` function from a test's context, used to attach evidence to the test in the reporter output. */
+export type Annotate = TestContext['annotate'];
+
+/**
+ * Attaches `lines` to the running test as reporter annotations, in order. Preferred over `console.log`: the notes are
+ * attached to the specific test rather than emitted as loose stdout, they survive into the JUnit and HTML reports, and
+ * concurrent tests cannot interleave them.
+ */
+export const annotateAll = (annotate: Annotate, lines: readonly string[]): Promise<unknown> =>
+  lines.reduce<Promise<unknown>>((queued, line) => queued.then(() => annotate(line)), Promise.resolve());
+
+/**
+ * Records the savings a deflate-offered run actually achieved, optionally alongside a compression-off reference run
+ * (omitted for fallback scenarios where only one run makes sense). Evidence only — the pass/fail decision lives in the
+ * tests' own assertions; this keeps the achieved numbers visible instead of having to be re-derived by hand.
+ */
+export const report = (
+  annotate: Annotate,
+  label: string,
+  events: number,
+  deflate: WireStats,
+  plain?: WireStats,
+): Promise<unknown> => {
+  const compressed = deflate.frames.filter((f) => f.binary);
+  const uncompressed = deflate.frames.filter((f) => !f.binary);
+  const wire = total(deflate.frames, (f) => f.wire);
+  const inflated = total(deflate.frames, (f) => f.inflated);
+  // e.g. "1 connection_ack, 19 complete" — the protocol chatter that stays below the server's
+  // 256 B compression threshold and therefore remains plain text.
+  const byType = [...new Set(uncompressed.map((f) => f.type))]
+    .map((type) => `${uncompressed.filter((f) => f.type === type).length} ${type}`)
+    .join(', ');
+  return annotateAll(annotate, [
+    `ws compression savings — ${label}`,
+    `events drained: ${events}`,
+    ...(plain
+      ? [`plain run: ${total(plain.frames, (f) => f.wire)} B over ${plain.frames.length} frames (all text)`]
+      : []),
+    `deflate run (wire): ${wire} B over ${deflate.frames.length} frames (${compressed.length} compressed)`,
+    `uncompressed: ${uncompressed.length} frames / ${total(uncompressed, (f) => f.wire)} B (${byType}) — ` +
+      'below the server 256 B threshold or server without deflate support, sent as plain text',
+    `deflate (inflated): ${inflated} B`,
+    `saved: ${inflated - wire} B (${(100 * savingsRatio(deflate)).toFixed(1)}%)`,
+  ]);
+};

--- a/packages/indexer-client/src/effect/test/httpConnectionReuse.integration.test.ts
+++ b/packages/indexer-client/src/effect/test/httpConnectionReuse.integration.test.ts
@@ -1,0 +1,183 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Proves the transport split for one-shot GraphQL calls:
+ *
+ * - HTTP queries reuse pooled keep-alive TCP connections across requests — the wallet's 1 Hz `TransactionStatus` poll
+ *   does NOT reconnect per request.
+ * - The HTTP pool and the subscription WebSocket are separate connections by construction: a WebSocket is an upgraded TCP
+ *   socket speaking only WS frames, so `fetch` can never reuse it.
+ *
+ * Physical connections are observed via Node's `diagnostics_channel`: undici (the engine behind the global `fetch`)
+ * publishes `undici:client:connected` for every real TCP connect.
+ */
+import { Effect, Layer, Stream } from 'effect';
+import diagnostics from 'node:diagnostics_channel';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { BlockHash } from '../../graphql/queries/BlockHash.js';
+import { ZswapEvents } from '../../graphql/subscriptions/ZswapEvents.js';
+import { makeComposeEnvironment, timeoutMinutes } from './composeEnvironment.js';
+import { HttpQueryClient, WsSubscriptionClient } from '../index.js';
+import { annotateAll, emptyWireStats, makeCountingWebSocket, type WireStats } from './deflateWireStats.js';
+
+const environment = makeComposeEnvironment('docker-compose.yml');
+
+/**
+ * Counts real TCP connections opened by undici (global fetch and friends) towards a port.
+ *
+ * The accumulator is mutable by necessity: `diagnostics_channel` delivers events through a callback over the life of
+ * the test, so there is nothing to fold over. Permitted for test instrumentation by
+ * `.claude/rules/functional-style.md`, and confined to this helper — callers see only `count`/`stop`.
+ */
+const trackConnections = (port: number): { count: () => number; stop: () => void } => {
+  const seen: unknown[] = [];
+  const onConnect = (message: unknown): void => {
+    // Type cast required because: diagnostics_channel payloads are untyped by design; the
+    // undici event shape is stable and documented (connectParams.port as string).
+    const params = (message as { connectParams?: { port?: string | number } }).connectParams;
+    if (Number(params?.port) === port) seen.push(message);
+  };
+  diagnostics.subscribe('undici:client:connected', onConnect);
+  return {
+    count: () => seen.length,
+    stop: () => diagnostics.unsubscribe('undici:client:connected', onConnect),
+  };
+};
+
+describe('HTTP connection reuse for one-shot GraphQL calls', () => {
+  describe('with available Indexer Server', () => {
+    beforeAll(() => environment.start(), timeoutMinutes(3));
+
+    afterAll(() => environment.stop(), timeoutMinutes(1));
+
+    it(
+      'should reuse one pooled connection for sequential queries and stay off the WebSocket',
+      async ({ annotate }) => {
+        const port = environment.getIndexerPort();
+        const connections = trackConnections(port);
+        const wsStats: WireStats = emptyWireStats();
+        const SEQUENTIAL = 10;
+        const CONCURRENT = 10;
+
+        const burst = (count: number) =>
+          Effect.all(
+            Array.from({ length: count }, () => BlockHash.run({ offset: null })),
+            { concurrency: 'unbounded' },
+          );
+
+        // Paced like the wallet's real poll (which ticks every 1 s). The gap keeps the
+        // connection count low: undici returns a socket to the pool a beat after the response
+        // completes, so a zero-gap follow-up can race past it and open a second socket — a pool
+        // artifact, not a reconnect.
+        const poll = (count: number) =>
+          Effect.all(
+            Array.from({ length: count }, (_, i) =>
+              (i === 0 ? Effect.void : Effect.sleep('50 millis')).pipe(
+                Effect.zipRight(BlockHash.run({ offset: null })),
+              ),
+            ),
+            { concurrency: 1 },
+          );
+
+        try {
+          const observed = await Effect.gen(function* () {
+            // Open the subscription WebSocket first; the client holds it open for its whole
+            // scope, so any accidental transport sharing would surface below. Its connect may
+            // itself register on the undici channel, hence the baseline.
+            yield* ZswapEvents.run({ id: 0 }).pipe(Stream.take(1), Stream.runDrain);
+            const baseline = connections.count();
+
+            // Paced sequential queries — the shape of the wallet's 1 Hz TransactionStatus poll.
+            const sequential = yield* poll(SEQUENTIAL);
+            const afterSequential = connections.count();
+
+            // Concurrent burst — independent requests; the pool may add sockets.
+            const concurrent = yield* burst(CONCURRENT);
+            const afterBurst = connections.count();
+
+            // Poll again — the pool must serve these from already-open sockets.
+            yield* poll(SEQUENTIAL);
+            const afterReuse = connections.count();
+
+            // Idle past undici's keep-alive window (default 4 s): the pooled sockets close,
+            // and the next query pays a fresh TCP connect — the HTTP counterpart of the WS
+            // warm-window expiry.
+            yield* Effect.sleep('5 seconds');
+            yield* poll(1);
+            const afterIdleExpiry = connections.count();
+
+            return { sequential, concurrent, baseline, afterSequential, afterBurst, afterReuse, afterIdleExpiry };
+          }).pipe(
+            // One merged provide rather than two chained ones: the transports are independent, and a
+            // single provide keeps their scopes siblings instead of nesting one inside the other.
+            Effect.provide(
+              Layer.merge(
+                HttpQueryClient.layer({ url: `http://127.0.0.1:${port}/api/v4/graphql` }),
+                WsSubscriptionClient.layer(
+                  { url: `ws://127.0.0.1:${port}/api/v4/graphql/ws` },
+                  { webSocketImpl: makeCountingWebSocket(wsStats) },
+                ),
+              ),
+            ),
+            Effect.scoped,
+            Effect.runPromise,
+          );
+
+          const { sequential, concurrent, baseline, afterSequential, afterBurst, afterReuse, afterIdleExpiry } =
+            observed;
+
+          // Every request answered.
+          expect(sequential).toHaveLength(SEQUENTIAL);
+          expect(concurrent).toHaveLength(CONCURRENT);
+          sequential.concat(concurrent).forEach((r) => expect(r.block?.hash).toBeTruthy());
+
+          // Sequential requests ride pooled keep-alive connections — no per-request reconnect
+          // (this is the wallet's polling shape). Reuse means O(1) sockets regardless of request
+          // count; the small bound tolerates a pool race on a slow runner (a socket not yet back
+          // in the pool when the next paced request lands) while a reconnect-per-request
+          // regression would open all SEQUENTIAL connections and still fail loudly.
+          expect(afterSequential - baseline).toBeGreaterThanOrEqual(1);
+          expect(afterSequential - baseline).toBeLessThanOrEqual(3);
+
+          // After the burst, further sequential queries are served from the already-open pool.
+          // At most one fresh socket is tolerated: the first post-burst request can race a busy
+          // socket's return to the pool — a pool artifact, not a torn-down-per-request pool.
+          expect(afterReuse - afterBurst).toBeLessThanOrEqual(1);
+
+          // The idle-expiry phase is measured and reported below but deliberately NOT asserted:
+          // whether the pooled socket expired (one fresh connect) or survived the 5 s idle
+          // (zero — e.g. a server keep-alive hint stretching undici's default 4 s window) is
+          // library/server timing, not the transport-split contract under test. `poll(1)`
+          // bounds it to 0 or 1 by construction.
+
+          // And none of it rode the WebSocket: exactly one WS connection carrying only the
+          // subscription — HTTP cannot reuse an upgraded socket, and provably didn't.
+          expect(wsStats.sockets).toBe(1);
+
+          await annotateAll(annotate, [
+            'http connection reuse (one-shot GraphQL calls)',
+            `sequential queries: ${SEQUENTIAL} requests → ${afterSequential - baseline} TCP connection (keep-alive reuse)`,
+            `concurrent burst: ${CONCURRENT} requests → ${afterBurst - afterSequential} extra pooled connection(s)`,
+            `sequential after burst: ${SEQUENTIAL} requests → ${afterReuse - afterBurst} new connections (pool reused)`,
+            `after 5 s idle: 1 request → ${afterIdleExpiry - afterReuse} new connection (keep-alive window ~4 s expired)`,
+            `websocket connections: ${wsStats.sockets} (subscription only — HTTP never rides the WS socket)`,
+          ]);
+        } finally {
+          connections.stop();
+        }
+      },
+      timeoutMinutes(1),
+    );
+  });
+});

--- a/packages/indexer-client/src/effect/test/syncThroughput.integration.test.ts
+++ b/packages/indexer-client/src/effect/test/syncThroughput.integration.test.ts
@@ -1,0 +1,199 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { Chunk, Effect, Stream } from 'effect';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ZswapEvents } from '../../graphql/subscriptions/ZswapEvents.js';
+import { GRAPHQL_TRANSPORT_WS_DEFLATE } from '../DeflateWebSocket.js';
+import { makeComposeEnvironment, timeoutMinutes } from './composeEnvironment.js';
+import { WsSubscriptionClient } from '../index.js';
+import { startThrottledProxy } from './throttledProxy.js';
+import {
+  annotateAll,
+  emptyWireStats,
+  makeCountingWebSocket,
+  savingsRatio,
+  total,
+  type WireStats,
+} from './deflateWireStats.js';
+
+/**
+ * Sync time over a bandwidth-limited link — the claim behind "compression speeds up sync".
+ *
+ * Between local containers the wire is effectively infinite, so plain and deflate drains take the same time and any
+ * timing comparison is noise. Real wallets sync over links where the wire IS the bottleneck; the throttled proxy
+ * recreates that regime deliberately, which is the only regime where byte savings can convert into time savings. The
+ * assertion is strictly relative — deflate vs plain, same server, same link — because absolute durations depend on
+ * machine load and would flake.
+ */
+
+/** The simulated client link: ~1 Mbit/s, slow enough that transfer dominates the drain. */
+const LINK_BYTES_PER_SECOND = 128 * 1024;
+
+/**
+ * Replays multiplexed on one socket — the data-volume multiplier (no chain setup needed). Indexer 4.4.0 introduced a
+ * per-connection subscription cap of exactly 20 ("subscription limit exceeded" beyond it), so this sits at that cap;
+ * the slower link above compensates for the bounded volume to keep the drain transfer-dominated.
+ */
+const REPLAY_COUNT = 20;
+
+/**
+ * The floor on the relative time saving. Theory says the saving approaches the byte savings ratio (~37-45% on these
+ * streams) as the link saturates; 15% is a wide margin below that, so the test only fails when compression genuinely
+ * stops converting bytes into time.
+ */
+const MIN_TIME_SAVING = 0.15;
+
+const drainThrough = (proxyPort: number, compression: boolean, stats: WireStats, replays: number = REPLAY_COUNT) =>
+  Effect.all(
+    Array.from({ length: replays }, () =>
+      ZswapEvents.run({ id: 0 }).pipe(
+        Stream.takeUntil(({ zswapLedgerEvents: e }) => e.id >= e.maxId),
+        Stream.runCollect,
+        Effect.map(Chunk.toReadonlyArray),
+      ),
+    ),
+    { concurrency: 'unbounded' },
+  ).pipe(
+    Effect.provide(
+      WsSubscriptionClient.layer(
+        { url: `ws://127.0.0.1:${proxyPort}/api/v4/graphql/ws` },
+        { compression, webSocketImpl: makeCountingWebSocket(stats) },
+      ),
+    ),
+    Effect.scoped,
+    Effect.runPromise,
+  );
+
+/**
+ * Sequential batches of {@link REPLAY_COUNT} replays, each on a fresh connection (the per-connection subscription cap
+ * rules out widening a single drain) — the depth multiplier for long-duration measurements. 1 keeps the routine CI run
+ * short; raise it locally to watch the saving hold over minutes of wall-clock sync.
+ */
+const BATCHES = 1;
+
+interface TimedDrain {
+  readonly elapsedMs: number;
+  readonly events: number;
+  readonly stats: WireStats;
+}
+
+const timedDrain = async (proxyPort: number, compression: boolean): Promise<TimedDrain> => {
+  const stats = emptyWireStats();
+  const startedAt = performance.now();
+  const batchResults = await Array.from({ length: BATCHES }).reduce<Promise<number>>(
+    (queued) =>
+      queued.then(async (sum) => {
+        const replays = await drainThrough(proxyPort, compression, stats);
+        return sum + replays.reduce((batchSum, events) => batchSum + events.length, 0);
+      }),
+    Promise.resolve(0),
+  );
+  const elapsedMs = performance.now() - startedAt;
+  return { elapsedMs, events: batchResults, stats };
+};
+
+const throughputLine = (label: string, run: TimedDrain): string => {
+  const wireBytes = total(run.stats.frames, (f) => f.wire);
+  return (
+    `${label}: ${run.events} events, ${wireBytes} B on the wire in ${Math.round(run.elapsedMs)} ms ` +
+    `(${Math.round(wireBytes / (run.elapsedMs / 1_000))} B/s effective)`
+  );
+};
+
+describe('sync throughput over a bandwidth-limited link', () => {
+  describe('deflate-capable indexer (compose default)', () => {
+    const environment = makeComposeEnvironment('docker-compose.yml');
+
+    beforeAll(() => environment.start(), timeoutMinutes(3));
+
+    afterAll(() => environment.stop(), timeoutMinutes(1));
+
+    it(
+      `drains the replay at least ${MIN_TIME_SAVING * 100}% faster with compression`,
+      async ({ annotate }) => {
+        const proxy = await startThrottledProxy({
+          targetHost: '127.0.0.1',
+          targetPort: environment.getIndexerPort(),
+          bytesPerSecond: LINK_BYTES_PER_SECOND,
+        });
+        try {
+          // Light untimed warm-up so first-connection effects (server caches, JIT) hit neither
+          // measured run.
+          await drainThrough(proxy.port, false, emptyWireStats(), 2);
+
+          const plain = await timedDrain(proxy.port, false);
+          const deflate = await timedDrain(proxy.port, true);
+
+          // Fair comparison preconditions: same data volume, and each run really used the
+          // protocol it claims to measure.
+          expect(plain.events).toBe(deflate.events);
+          expect(plain.stats.protocol).toBe('graphql-transport-ws');
+          expect(deflate.stats.protocol).toBe(GRAPHQL_TRANSPORT_WS_DEFLATE);
+          expect(savingsRatio(deflate.stats)).toBeGreaterThan(0);
+
+          // The claim under test: on a link where transfer dominates, byte savings convert
+          // into time savings.
+          expect(deflate.elapsedMs).toBeLessThanOrEqual(plain.elapsedMs * (1 - MIN_TIME_SAVING));
+
+          const saved = 1 - deflate.elapsedMs / plain.elapsedMs;
+          await annotateAll(annotate, [
+            `sync throughput — ${REPLAY_COUNT} multiplexed replays over a ${LINK_BYTES_PER_SECOND} B/s link`,
+            throughputLine('plain  ', plain),
+            throughputLine('deflate', deflate),
+            `time saved: ${(100 * saved).toFixed(1)}% (byte savings this run: ${(100 * savingsRatio(deflate.stats)).toFixed(1)}%)`,
+          ]);
+        } finally {
+          await proxy.stop();
+        }
+      },
+      timeoutMinutes(3),
+    );
+  });
+
+  describe('pre-deflate indexer (4.3.x baseline)', () => {
+    const environment = makeComposeEnvironment(['docker-compose.yml', 'docker-compose.ws-no-deflate.yml']);
+
+    beforeAll(() => environment.start(), timeoutMinutes(3));
+
+    afterAll(() => environment.stop(), timeoutMinutes(1));
+
+    // Evidence only, deliberately unasserted against the run above: a timing delta between
+    // indexer versions mixes compression with whatever else changed server-side, so it is
+    // recorded for the comparison table but never gated on.
+    it(
+      'records the baseline drain time of the previous indexer version',
+      async ({ annotate }) => {
+        const proxy = await startThrottledProxy({
+          targetHost: '127.0.0.1',
+          targetPort: environment.getIndexerPort(),
+          bytesPerSecond: LINK_BYTES_PER_SECOND,
+        });
+        try {
+          await drainThrough(proxy.port, false, emptyWireStats(), 2); // warm-up, untimed
+          const baseline = await timedDrain(proxy.port, false);
+
+          expect(baseline.events).toBeGreaterThan(0);
+          expect(baseline.stats.protocol).toBe('graphql-transport-ws');
+
+          await annotateAll(annotate, [
+            `sync throughput baseline — indexer 4.3.x, ${REPLAY_COUNT} multiplexed replays over a ${LINK_BYTES_PER_SECOND} B/s link`,
+            throughputLine('plain  ', baseline),
+          ]);
+        } finally {
+          await proxy.stop();
+        }
+      },
+      timeoutMinutes(3),
+    );
+  });
+});

--- a/packages/indexer-client/src/effect/test/throttledProxy.integration.test.ts
+++ b/packages/indexer-client/src/effect/test/throttledProxy.integration.test.ts
@@ -1,0 +1,104 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import net from 'node:net';
+import { describe, expect, it } from 'vitest';
+import { startThrottledProxy, type ThrottledProxy } from './throttledProxy.js';
+
+// The sync-throughput measurements stand on this proxy: if its cap leaked, "deflate drains
+// faster" could be an artifact of the harness. These tests pin the two properties the
+// measurements rely on — bytes pass unmodified, and the cap is a hard floor on transfer time.
+// Loopback sockets only; no Docker or external services.
+
+/** A loopback server that echoes everything back, reporting its own port. */
+const startEchoServer = (): Promise<{ readonly port: number; readonly stop: () => Promise<void> }> =>
+  new Promise((resolve, reject) => {
+    const server = net.createServer((socket) => socket.pipe(socket));
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        reject(new Error('Echo server failed to bind an ephemeral port'));
+        return;
+      }
+      resolve({
+        port: address.port,
+        stop: () => new Promise<void>((resolveStop) => server.close(() => resolveStop())),
+      });
+    });
+  });
+
+/** Sends `payload` through `port`, resolving with everything echoed back once the socket ends. */
+const roundTrip = (port: number, payload: Buffer): Promise<Buffer> =>
+  new Promise((resolve, reject) => {
+    const socket = net.connect(port, '127.0.0.1');
+    // Mutation confined to test setup: chunks arrive over time; there is nothing to fold over.
+    const received: Buffer[] = [];
+    socket.on('data', (chunk: Buffer) => {
+      received.push(chunk);
+      if (received.reduce((sum, c) => sum + c.byteLength, 0) >= payload.byteLength) {
+        socket.end();
+        resolve(Buffer.concat(received));
+      }
+    });
+    socket.on('error', reject);
+    socket.write(payload);
+  });
+
+describe('throttledProxy', () => {
+  it('delivers bytes unmodified when uncapped', async () => {
+    const echo = await startEchoServer();
+    const proxy: ThrottledProxy = await startThrottledProxy({
+      targetHost: '127.0.0.1',
+      targetPort: echo.port,
+      bytesPerSecond: Number.POSITIVE_INFINITY,
+    });
+    try {
+      const payload = Buffer.from(Array.from({ length: 64 * 1024 }, (_, i) => i % 251));
+
+      const echoed = await roundTrip(proxy.port, payload);
+
+      expect(echoed.equals(payload)).toBe(true);
+    } finally {
+      await proxy.stop();
+      await echo.stop();
+    }
+  });
+
+  it('enforces the bandwidth cap as a hard floor on transfer time', async () => {
+    const echo = await startEchoServer();
+    // 128 KiB each way at 256 KiB/s: >= 0.5 s per direction by construction.
+    const proxy = await startThrottledProxy({
+      targetHost: '127.0.0.1',
+      targetPort: echo.port,
+      bytesPerSecond: 256 * 1024,
+    });
+    try {
+      const payload = Buffer.from(Array.from({ length: 128 * 1024 }, (_, i) => i % 251));
+
+      const startedAt = performance.now();
+      const echoed = await roundTrip(proxy.port, payload);
+      const elapsedMs = performance.now() - startedAt;
+
+      expect(echoed.equals(payload)).toBe(true);
+      // The provable floor: the last echoed byte cannot arrive before the whole payload has
+      // crossed the upstream direction, which alone takes >= 500 ms at this cap. The two
+      // directions overlap (the echo pipelines), so their floors do NOT add. Only the lower
+      // bound is asserted — the cap makes "too fast" impossible, while "how slow" depends on
+      // machine load and would flake.
+      expect(elapsedMs).toBeGreaterThanOrEqual(500);
+    } finally {
+      await proxy.stop();
+      await echo.stop();
+    }
+  });
+});

--- a/packages/indexer-client/src/effect/test/throttledProxy.ts
+++ b/packages/indexer-client/src/effect/test/throttledProxy.ts
@@ -1,0 +1,111 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import net from 'node:net';
+
+/**
+ * A bandwidth-capped TCP proxy for sync-throughput measurements: it forwards every byte unmodified but no faster than
+ * `bytesPerSecond`, turning the effectively infinite loopback link between test containers into a realistic client link
+ * where the wire is the bottleneck — the only regime in which compression can convert byte savings into time savings.
+ *
+ * The cap is enforced per direction with a cumulative pacing clock: each chunk pushes the direction's `readyAt` forward
+ * by the chunk's transfer time at the configured rate, and is delivered when that clock is due. The proxy can therefore
+ * never exceed the cap over any interval longer than one chunk, which is what makes lower-bound timing assertions on it
+ * deterministic.
+ */
+export interface ThrottledProxy {
+  /** The local port the proxy listens on; point the client here instead of at the target. */
+  readonly port: number;
+  /** Closes the listener and every open connection. */
+  readonly stop: () => Promise<void>;
+}
+
+/**
+ * Pipes `source` into `dest` at no more than `bytesPerSecond`.
+ *
+ * Mutation is deliberate and confined to this helper: pacing is inherently stateful (a clock advanced per chunk), and
+ * sockets are an inherently mutable external API — `.claude/rules/functional-style.md` permits both for test
+ * instrumentation.
+ */
+const pipeThrottled = (source: net.Socket, dest: net.Socket, bytesPerSecond: number): void => {
+  let readyAt = Date.now();
+
+  source.on('data', (chunk: Buffer) => {
+    readyAt = Math.max(readyAt, Date.now()) + (chunk.byteLength / bytesPerSecond) * 1_000;
+    const delay = readyAt - Date.now();
+    if (delay <= 0) {
+      dest.write(chunk);
+      return;
+    }
+    // Pause so upstream backpressure applies while the chunk waits for its transfer slot.
+    source.pause();
+    setTimeout(() => {
+      if (!dest.destroyed) dest.write(chunk);
+      source.resume();
+    }, delay);
+  });
+
+  source.on('end', () => {
+    const delay = Math.max(0, readyAt - Date.now());
+    setTimeout(() => {
+      if (!dest.destroyed) dest.end();
+    }, delay);
+  });
+
+  source.on('error', () => dest.destroy());
+};
+
+/**
+ * Starts the proxy on an ephemeral port, forwarding to `targetHost:targetPort` with both directions capped at
+ * `bytesPerSecond` (pass `Number.POSITIVE_INFINITY` for an uncapped pass-through, useful as a control).
+ */
+export const startThrottledProxy = (options: {
+  readonly targetHost: string;
+  readonly targetPort: number;
+  readonly bytesPerSecond: number;
+}): Promise<ThrottledProxy> => {
+  // Mutation confined to this helper: the set of live sockets only exists so `stop` can tear
+  // down connections that are mid-transfer.
+  const openSockets = new Set<net.Socket>();
+
+  const server = net.createServer((client) => {
+    const upstream = net.connect(options.targetPort, options.targetHost);
+    openSockets.add(client);
+    openSockets.add(upstream);
+    client.on('close', () => openSockets.delete(client));
+    upstream.on('close', () => openSockets.delete(upstream));
+    upstream.on('error', () => client.destroy());
+    client.on('error', () => upstream.destroy());
+
+    pipeThrottled(client, upstream, options.bytesPerSecond);
+    pipeThrottled(upstream, client, options.bytesPerSecond);
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        reject(new Error('Throttled proxy failed to bind an ephemeral port'));
+        return;
+      }
+      resolve({
+        port: address.port,
+        stop: () =>
+          new Promise<void>((resolveStop) => {
+            openSockets.forEach((socket) => socket.destroy());
+            server.close(() => resolveStop());
+          }),
+      });
+    });
+  });
+};

--- a/packages/indexer-client/src/effect/test/wsDeflate.integration.test.ts
+++ b/packages/indexer-client/src/effect/test/wsDeflate.integration.test.ts
@@ -1,0 +1,271 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { Chunk, Effect, Stream } from 'effect';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { DustLedgerEvents } from '../../graphql/subscriptions/DustLedgerEvents.js';
+import { ZswapEvents } from '../../graphql/subscriptions/ZswapEvents.js';
+import { GRAPHQL_TRANSPORT_WS_DEFLATE } from '../DeflateWebSocket.js';
+import { makeComposeEnvironment, timeoutMinutes } from './composeEnvironment.js';
+import { WsSubscriptionClient } from '../index.js';
+import {
+  annotateAll,
+  emptyWireStats,
+  makeCountingWebSocket,
+  report,
+  savingsRatio,
+  type WireStats,
+} from './deflateWireStats.js';
+
+/**
+ * The floor every compressed replay stream must clear. Deliberately well below what these streams actually achieve
+ * (comfortably above a third of the wire), because the exact ratio depends on how the local test chain's data happens
+ * to compress and drifts with indexer and node versions. What this guards is compression silently breaking — a wrapper
+ * that stops negotiating the subprotocol, or a server that stops compressing, collapses the ratio to roughly zero.
+ */
+const MIN_SAVINGS_RATIO = 0.25;
+
+/**
+ * Mirrors the server's documented compression threshold: messages at or above this size arrive as compressed binary
+ * frames, smaller ones legitimately stay plain text. The assertions target this wire contract rather than counting
+ * events — per-event counting would fail the day any single event happens to serialize under the threshold, even though
+ * compression is working exactly as specified.
+ */
+const SERVER_COMPRESSION_THRESHOLD_B = 256;
+
+// The compose default (indexer >= 4.4.0) offers the deflate subprotocol out of the box; the
+// pre-deflate scenario lives in wsDeflateFallback.integration.test.ts via its own override.
+const environment = makeComposeEnvironment('docker-compose.yml');
+
+describe('WebSocket deflate compression', () => {
+  describe('with available Indexer Server', () => {
+    beforeAll(() => environment.start(), timeoutMinutes(3));
+
+    afterAll(() => environment.stop(), timeoutMinutes(1));
+
+    // Drains the full backlog: replays every event from id 0 and stops once caught up with
+    // maxId — bounded by data, not wall-clock time.
+    const collectEvents = (compression: boolean, stats: WireStats) =>
+      ZswapEvents.run({ id: 0 }).pipe(
+        Stream.takeUntil(({ zswapLedgerEvents: e }) => e.id >= e.maxId),
+        Stream.runCollect,
+        Effect.map(Chunk.toReadonlyArray),
+        Effect.provide(
+          WsSubscriptionClient.layer(
+            { url: `ws://127.0.0.1:${environment.getIndexerPort()}/api/v4/graphql/ws` },
+            { compression, webSocketImpl: makeCountingWebSocket(stats) },
+          ),
+        ),
+        Effect.scoped,
+        Effect.runPromise,
+      );
+
+    it(
+      'should negotiate deflate, deliver identical data, and reduce bytes over the wire',
+      async ({ annotate }) => {
+        const plain: WireStats = emptyWireStats();
+        const deflate: WireStats = emptyWireStats();
+
+        const plainEvents = await collectEvents(false, plain);
+        const deflateEvents = await collectEvents(true, deflate);
+
+        expect(plain.protocol).toBe('graphql-transport-ws');
+        expect(plain.frames.some((f) => f.binary)).toBe(false);
+        expect(deflate.protocol).toBe(GRAPHQL_TRANSPORT_WS_DEFLATE);
+
+        // Same replay from id 0 → identical payloads after inflation. maxId may move between
+        // runs, so compare the stable fields only.
+        const stable = (events: typeof plainEvents) =>
+          events.map(({ zswapLedgerEvents: e }) => ({ id: e.id, raw: e.raw }));
+        expect(stable(deflateEvents)).toEqual(stable(plainEvents));
+
+        // The wire contract: every frame at or above the server's threshold arrived compressed,
+        // each one genuinely smaller than its inflated form.
+        const compressed = deflate.frames.filter((f) => f.binary);
+        expect(compressed.length).toBeGreaterThan(0);
+        deflate.frames
+          .filter((f) => f.inflated >= SERVER_COMPRESSION_THRESHOLD_B)
+          .forEach((f) => expect(f.binary).toBe(true));
+        compressed.forEach((f) => expect(f.wire).toBeLessThan(f.inflated));
+
+        // ...and the run as a whole cleared the savings floor.
+        expect(savingsRatio(deflate)).toBeGreaterThanOrEqual(MIN_SAVINGS_RATIO);
+
+        await report(annotate, 'backlog drain (single subscription)', deflateEvents.length, deflate, plain);
+      },
+      timeoutMinutes(1),
+    );
+
+    it(
+      'should compress the dust sync stream (issue #462: dust replay dominates indexer egress)',
+      async ({ annotate }) => {
+        const plain: WireStats = emptyWireStats();
+        const deflate: WireStats = emptyWireStats();
+
+        // The dust ledger event replay is the stream a fresh dust-wallet sync drains (~1M
+        // events in production), i.e. the dominant egress named in the ticket.
+        const collectDustEvents = (compression: boolean, stats: WireStats) =>
+          DustLedgerEvents.run({ id: 0 }).pipe(
+            Stream.takeUntil(({ dustLedgerEvents: e }) => e.id >= e.maxId),
+            Stream.runCollect,
+            Effect.map(Chunk.toReadonlyArray),
+            Effect.provide(
+              WsSubscriptionClient.layer(
+                { url: `ws://127.0.0.1:${environment.getIndexerPort()}/api/v4/graphql/ws` },
+                { compression, webSocketImpl: makeCountingWebSocket(stats) },
+              ),
+            ),
+            Effect.scoped,
+            Effect.runPromise,
+          );
+
+        const plainEvents = await collectDustEvents(false, plain);
+        const deflateEvents = await collectDustEvents(true, deflate);
+
+        expect(deflate.protocol).toBe(GRAPHQL_TRANSPORT_WS_DEFLATE);
+
+        const stable = (events: typeof plainEvents) =>
+          events.map(({ dustLedgerEvents: e }) => ({ id: e.id, raw: e.raw }));
+        expect(stable(deflateEvents)).toEqual(stable(plainEvents));
+
+        // Same wire contract as the zswap test: threshold-or-above frames are compressed.
+        const compressed = deflate.frames.filter((f) => f.binary);
+        expect(compressed.length).toBeGreaterThan(0);
+        deflate.frames
+          .filter((f) => f.inflated >= SERVER_COMPRESSION_THRESHOLD_B)
+          .forEach((f) => expect(f.binary).toBe(true));
+        compressed.forEach((f) => expect(f.wire).toBeLessThan(f.inflated));
+
+        expect(savingsRatio(deflate)).toBeGreaterThanOrEqual(MIN_SAVINGS_RATIO);
+
+        await report(annotate, 'dust sync stream (dustLedgerEvents replay)', deflateEvents.length, deflate, plain);
+      },
+      timeoutMinutes(1),
+    );
+
+    it(
+      'should hold the savings under high volume (20 concurrent subscriptions on one socket)',
+      async ({ annotate }) => {
+        const plain: WireStats = emptyWireStats();
+        const deflate: WireStats = emptyWireStats();
+
+        await drainConcurrently(false, plain);
+        const deflateEvents = await drainConcurrently(true, deflate);
+
+        expect(deflate.protocol).toBe(GRAPHQL_TRANSPORT_WS_DEFLATE);
+        expect(deflateEvents).toHaveLength(REPLAY_COUNT);
+        deflateEvents.forEach((events) => expect(events.length).toBeGreaterThan(0));
+
+        // All of it multiplexed over a single physical connection.
+        expect(deflate.sockets).toBe(1);
+
+        const eventCount = deflateEvents.reduce((sum, events) => sum + events.length, 0);
+        // Same wire contract as above, held under concurrency: threshold-or-above frames compressed.
+        const compressed = deflate.frames.filter((f) => f.binary);
+        expect(compressed.length).toBeGreaterThan(0);
+        deflate.frames
+          .filter((f) => f.inflated >= SERVER_COMPRESSION_THRESHOLD_B)
+          .forEach((f) => expect(f.binary).toBe(true));
+        compressed.forEach((f) => expect(f.wire).toBeLessThan(f.inflated));
+
+        // The savings hold at volume, not just on a single quiet subscription.
+        expect(savingsRatio(deflate)).toBeGreaterThanOrEqual(MIN_SAVINGS_RATIO);
+
+        await report(annotate, `high volume (${REPLAY_COUNT} concurrent replays)`, eventCount, deflate, plain);
+      },
+      timeoutMinutes(2),
+    );
+
+    // One full subscribe → drain → unsubscribe round trip: after it the client has zero active
+    // subscriptions, exactly like a backpressure pause.
+    const drainOnce = ZswapEvents.run({ id: 0 }).pipe(
+      Stream.takeUntil(({ zswapLedgerEvents: e }) => e.id >= e.maxId),
+      Stream.runDrain,
+    );
+
+    it(
+      'should reuse the warm connection across repeated disconnect/wait/resubscribe cycles',
+      async ({ annotate }) => {
+        const stats: WireStats = emptyWireStats();
+        const CYCLES = 5;
+        const GAP_MS = 200;
+
+        // Each cycle fully tears the subscription down, then idles with the connection unused
+        // before subscribing again — the shape of a backpressure pause/resume.
+        await Effect.gen(function* () {
+          yield* drainOnce;
+          yield* Effect.repeat(Effect.sleep(`${GAP_MS} millis`).pipe(Effect.zipRight(drainOnce)), {
+            times: CYCLES - 2,
+          });
+          yield* Effect.sleep(`${GAP_MS} millis`);
+          yield* drainOnce;
+        }).pipe(
+          Effect.provide(
+            WsSubscriptionClient.layer(
+              { url: `ws://127.0.0.1:${environment.getIndexerPort()}/api/v4/graphql/ws` },
+              { webSocketImpl: makeCountingWebSocket(stats) },
+            ),
+          ),
+          Effect.scoped,
+          Effect.runPromise,
+        );
+
+        // All cycles ride one physical connection — the client holds it for its whole scope
+        // (lazy: false), which is what makes backpressure pause/resume cycles cheap. A client
+        // closing at zero subscriptions would open CYCLES connections here.
+        expect(stats.sockets).toBe(1);
+        expect(stats.protocol).toBe(GRAPHQL_TRANSPORT_WS_DEFLATE);
+
+        await annotateAll(annotate, [
+          'ws connection reuse (connection held for the client scope)',
+          `disconnect/wait/resubscribe cycles: ${CYCLES} (${GAP_MS} ms idle gap each)`,
+          `physical connections: ${stats.sockets} — all cycles reused one connection ` +
+            `(a lazily-closing client would have opened ${CYCLES})`,
+          `protocol: ${stats.protocol}`,
+        ]);
+      },
+      timeoutMinutes(1),
+    );
+
+    // NOTE: there is deliberately no idle-expiry test anymore. The client holds its connection
+    // for its whole scope (lazy: false) — connections are bounded by client lifetime, not by an
+    // idle window — and "disposal closes the connection and cancels every timer" is pinned by a
+    // unit test in wsSubscriptionClient.test.ts.
+
+    /**
+     * Multiplexes many full-backlog replays over a single WebSocket connection — the graphql-ws protocol runs
+     * concurrent operations on one socket — so a large data volume flows through one connection without waiting on
+     * chain growth.
+     */
+    const REPLAY_COUNT = 20;
+    const drainConcurrently = (compression: boolean, stats: WireStats) =>
+      Effect.all(
+        Array.from({ length: REPLAY_COUNT }, () =>
+          ZswapEvents.run({ id: 0 }).pipe(
+            Stream.takeUntil(({ zswapLedgerEvents: e }) => e.id >= e.maxId),
+            Stream.runCollect,
+            Effect.map(Chunk.toReadonlyArray),
+          ),
+        ),
+        { concurrency: 'unbounded' },
+      ).pipe(
+        Effect.provide(
+          WsSubscriptionClient.layer(
+            { url: `ws://127.0.0.1:${environment.getIndexerPort()}/api/v4/graphql/ws` },
+            { compression, webSocketImpl: makeCountingWebSocket(stats) },
+          ),
+        ),
+        Effect.scoped,
+        Effect.runPromise,
+      );
+  });
+});

--- a/packages/indexer-client/src/effect/test/wsDeflateFallback.integration.test.ts
+++ b/packages/indexer-client/src/effect/test/wsDeflateFallback.integration.test.ts
@@ -1,0 +1,97 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { Chunk, Effect, Stream } from 'effect';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ZswapEvents } from '../../graphql/subscriptions/ZswapEvents.js';
+import { makeComposeEnvironment, timeoutMinutes } from './composeEnvironment.js';
+import { WsSubscriptionClient } from '../index.js';
+import { emptyWireStats, makeCountingWebSocket, report, savingsRatio, type WireStats } from './deflateWireStats.js';
+
+// The ws-no-deflate override freezes the last pre-deflate indexer (4.3.x) — exactly the
+// scenario under test — so this keeps working no matter what the compose default moves to.
+const environment = makeComposeEnvironment(['docker-compose.yml', 'docker-compose.ws-no-deflate.yml']);
+
+describe('WebSocket deflate compression fallback', () => {
+  describe('with an Indexer Server that predates the deflate subprotocol', () => {
+    beforeAll(() => environment.start(), timeoutMinutes(3));
+
+    afterAll(() => environment.stop(), timeoutMinutes(1));
+
+    it(
+      'should fall back to the standard protocol and deliver everything uncompressed',
+      async ({ annotate }) => {
+        const stats: WireStats = emptyWireStats();
+
+        // Note: `compression` is NOT set — this proves the out-of-the-box default (deflate
+        // offered) degrades gracefully against an old indexer.
+        const events = await ZswapEvents.run({ id: 0 }).pipe(
+          Stream.takeUntil(({ zswapLedgerEvents: e }) => e.id >= e.maxId),
+          Stream.runCollect,
+          Effect.map(Chunk.toReadonlyArray),
+          Effect.provide(
+            WsSubscriptionClient.layer(
+              { url: `ws://127.0.0.1:${environment.getIndexerPort()}/api/v4/graphql/ws` },
+              { webSocketImpl: makeCountingWebSocket(stats) },
+            ),
+          ),
+          Effect.scoped,
+          Effect.runPromise,
+        );
+
+        // The server declined the offered deflate variant and picked the standard protocol.
+        expect(stats.protocol).toBe('graphql-transport-ws');
+
+        // Everything arrives as plain text — the deflate wrapper is a pass-through — and the
+        // subscription behaves exactly as before the compression feature existed. Nothing was
+        // compressed, so there is nothing to save: the counterpart to the savings floor the
+        // deflate tests assert.
+        expect(stats.frames.some((f) => f.binary)).toBe(false);
+        expect(savingsRatio(stats)).toBe(0);
+        expect(events.length).toBeGreaterThan(0);
+        // Replay is ordered: ids grow strictly. The exact numbering is the server's business —
+        // the first id and any gaps between ids are version-dependent, so density (+1 steps) is
+        // deliberately not asserted.
+        events.slice(1).forEach(({ zswapLedgerEvents: e }, index) => {
+          expect(e.id).toBeGreaterThan(events[index].zswapLedgerEvents.id);
+        });
+        // ...and complete: the stream only ends once the server-declared tip is reached.
+        const lastEvent = events[events.length - 1].zswapLedgerEvents;
+        expect(lastEvent.id).toBeGreaterThanOrEqual(lastEvent.maxId);
+
+        // Fallback delivery matches what a client that never offered deflate receives: same
+        // events, same order. This pins the actual contract — "behaves exactly as before the
+        // compression feature existed" — against a reference run instead of assumptions about
+        // the server's id numbering.
+        const referenceEvents = await ZswapEvents.run({ id: 0 }).pipe(
+          Stream.takeUntil(({ zswapLedgerEvents: e }) => e.id >= e.maxId),
+          Stream.runCollect,
+          Effect.map(Chunk.toReadonlyArray),
+          Effect.provide(
+            WsSubscriptionClient.layer(
+              { url: `ws://127.0.0.1:${environment.getIndexerPort()}/api/v4/graphql/ws` },
+              { compression: false },
+            ),
+          ),
+          Effect.scoped,
+          Effect.runPromise,
+        );
+        expect(events.map(({ zswapLedgerEvents: e }) => e.id)).toEqual(
+          referenceEvents.map(({ zswapLedgerEvents: e }) => e.id),
+        );
+
+        await report(annotate, `fallback (indexer without deflate, protocol=${stats.protocol})`, events.length, stats);
+      },
+      timeoutMinutes(1),
+    );
+  });
+});

--- a/packages/indexer-client/src/effect/test/wsSubscriptionClient.test.ts
+++ b/packages/indexer-client/src/effect/test/wsSubscriptionClient.test.ts
@@ -10,13 +10,215 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { Effect } from 'effect';
-import { describe, it } from 'vitest';
+import { Cause, Effect, Exit, Stream } from 'effect';
+import { parse } from 'graphql';
+import { GRAPHQL_TRANSPORT_WS_PROTOCOL } from 'graphql-ws';
+import { describe, expect, it, vi } from 'vitest';
+import { type Query } from '../Query.js';
 import * as SubscriptionClient from '../SubscriptionClient.js';
 import * as WsSubscriptionClient from '../WsSubscriptionClient.js';
 
+/**
+ * A `typeof WebSocket` stand-in that opens no connection but completes the graphql-transport-ws handshake (ack on init)
+ * and immediately completes any subscription, so a full connect → subscribe → complete → dispose cycle can run without
+ * a network.
+ *
+ * Mutation is deliberate and confined to this test fake: graphql-ws drives the socket through handler assignments and
+ * state reads, so mimicking it is inherently stateful (`.claude/rules/functional-style.md` permits this for test
+ * setup).
+ */
+const makeHandshakeFake = (): typeof WebSocket => {
+  class HandshakeFakeWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+
+    readyState = HandshakeFakeWebSocket.CONNECTING;
+    protocol = GRAPHQL_TRANSPORT_WS_PROTOCOL;
+    onopen: (() => void) | null = null;
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onclose: ((event: unknown) => void) | null = null;
+    onerror: ((event: unknown) => void) | null = null;
+
+    constructor() {
+      void Promise.resolve().then(() => {
+        this.readyState = HandshakeFakeWebSocket.OPEN;
+        this.onopen?.();
+      });
+    }
+
+    send(data: string): void {
+      const message = JSON.parse(data) as { readonly type: string; readonly id?: string };
+      const reply = (payload: object): void =>
+        void Promise.resolve().then(() =>
+          this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(payload) })),
+        );
+      if (message.type === 'connection_init') reply({ type: 'connection_ack' });
+      if (message.type === 'subscribe') reply({ id: message.id, type: 'complete' });
+    }
+
+    close(code?: number, reason?: string): void {
+      this.readyState = HandshakeFakeWebSocket.CLOSED;
+      this.onclose?.({ code: code ?? 1000, reason: reason ?? '', wasClean: true });
+    }
+  }
+
+  // Type cast required because: `typeof WebSocket` describes the full DOM constructor, while
+  // graphql-ws only ever touches the members implemented above.
+  return HandshakeFakeWebSocket as unknown as typeof WebSocket;
+};
+
+/**
+ * A `typeof WebSocket` stand-in whose connection always fails, mimicking an unreachable server: the constructor reports
+ * error + close on the next microtask, as undici does when nothing is listening. Mutation confined to test setup, as
+ * with the handshake fake above.
+ */
+const makeUnreachableFake = (): typeof WebSocket => {
+  class UnreachableFakeWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+
+    readyState = UnreachableFakeWebSocket.CONNECTING;
+    protocol = '';
+    onopen: (() => void) | null = null;
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onclose: ((event: unknown) => void) | null = null;
+    onerror: ((event: unknown) => void) | null = null;
+
+    constructor() {
+      void Promise.resolve().then(() => {
+        this.readyState = UnreachableFakeWebSocket.CLOSED;
+        this.onerror?.(new Event('error'));
+        this.onclose?.({ code: 1006, reason: '', wasClean: false });
+      });
+    }
+
+    send(): void {}
+
+    close(): void {
+      this.readyState = UnreachableFakeWebSocket.CLOSED;
+    }
+  }
+
+  // Type cast required because: `typeof WebSocket` describes the full DOM constructor, while
+  // graphql-ws only ever touches the members implemented above.
+  return UnreachableFakeWebSocket as unknown as typeof WebSocket;
+};
+
+/** Awaits `n` chained microtask ticks, letting promise-driven library internals settle. */
+const flushMicrotasks = (n: number): Promise<void> =>
+  n === 0 ? Promise.resolve() : Promise.resolve().then(() => flushMicrotasks(n - 1));
+
+// Type cast required because: the fake server ignores the query text entirely; any syntactically
+// valid subscription document satisfies `print()`.
+const anySubscription = parse('subscription { events }') as Query.Document<unknown, Record<string, never>>;
+
 describe('WsSubscriptionClient', () => {
   describe('layer', () => {
+    // graphql-ws guards its own WebSocket lookup, raising a descriptive "implementation missing"
+    // error that tells the caller to pass `webSocketImpl`; the layer must not regress that into an
+    // opaque ReferenceError by referencing the global unconditionally.
+    it('fails with the descriptive graphql-ws error, not a ReferenceError, when no global WebSocket binding exists', async () => {
+      const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'WebSocket');
+      // Type cast required because: removing a global binding is the scenario under test, and
+      // TypeScript's globalThis type does not model its absence.
+      delete (globalThis as { WebSocket?: unknown }).WebSocket;
+      try {
+        const exit = await Effect.gen(function* () {
+          return yield* SubscriptionClient.SubscriptionClient;
+        }).pipe(
+          Effect.provide(WsSubscriptionClient.layer({ url: 'ws://localhost:8088/api/v4/graphql/ws' })),
+          Effect.scoped,
+          Effect.runPromiseExit,
+        );
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        const defect = Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined;
+        expect(defect).toBeInstanceOf(Error);
+        expect(defect).not.toBeInstanceOf(ReferenceError);
+        expect((defect as Error).message).toContain('WebSocket implementation missing');
+      } finally {
+        if (descriptor !== undefined) {
+          Object.defineProperty(globalThis, 'WebSocket', descriptor);
+        }
+      }
+    });
+
+    // Disposal must be total: on Node, any timer graphql-ws leaves pending keeps the event loop —
+    // and thus a short-lived process — alive after the wallet has fully stopped. The precondition
+    // (timers armed while the client is alive, e.g. the keep-alive ping) makes the final
+    // assertion non-vacuous without pinning which timers the client uses internally.
+    it('leaves no pending timers once the scoped client is disposed', async () => {
+      vi.useFakeTimers();
+      try {
+        const armedWhileAlive = await Effect.gen(function* () {
+          const client = yield* SubscriptionClient.SubscriptionClient;
+          yield* Stream.runDrain(client.subscribe(anySubscription, {}));
+          // Let graphql-ws's post-unsubscribe promise chain settle before sampling.
+          yield* Effect.promise(() => flushMicrotasks(20));
+          return vi.getTimerCount();
+        }).pipe(
+          Effect.provide(
+            WsSubscriptionClient.layer(
+              { url: 'ws://indexer.test/graphql/ws', keepAlive: 15_000 },
+              { compression: false, webSocketImpl: makeHandshakeFake() },
+            ),
+          ),
+          Effect.scoped,
+          Effect.runPromise,
+        );
+
+        // Sanity precondition: the client really had live timers before the scope closed.
+        expect(armedWhileAlive).toBeGreaterThan(0);
+        // The behavior under test: disposal cancels everything.
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    // The client dials eagerly (lazy: false), and graphql-ws's `dispose()` is async — it awaits
+    // the connection promise, which REJECTS when the server is unreachable. Closing the scope
+    // while that attempt is in flight must not leak the rejection: a floating rejection crashes
+    // Node processes running with --unhandled-rejections=strict and fails any embedder's
+    // diagnostics, even though disposal achieved its goal (nothing left to close).
+    it('disposes cleanly while the connection attempt is still failing, leaking no rejection', async () => {
+      const rejections: unknown[] = [];
+      const capture = (reason: unknown): void => {
+        rejections.push(reason);
+      };
+      // Vitest's own listeners would report the captured rejection as a suite-level unhandled
+      // error before the assertion runs; detach them for the duration and restore verbatim.
+      const priorListeners = process.listeners('unhandledRejection');
+      process.removeAllListeners('unhandledRejection');
+      process.on('unhandledRejection', capture);
+      try {
+        await Effect.gen(function* () {
+          return yield* SubscriptionClient.SubscriptionClient;
+        }).pipe(
+          Effect.provide(
+            WsSubscriptionClient.layer(
+              { url: 'ws://indexer.test/graphql/ws' },
+              { compression: false, webSocketImpl: makeUnreachableFake() },
+            ),
+          ),
+          Effect.scoped,
+          Effect.runPromise,
+        );
+        // Give the rejected connection promise time to surface as an unhandledRejection tick.
+        await flushMicrotasks(20);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(rejections).toEqual([]);
+      } finally {
+        process.removeListener('unhandledRejection', capture);
+        priorListeners.forEach((listener) => process.on('unhandledRejection', listener));
+      }
+    });
+
     // Ensures that we cannot construct a layer for WsSubscriptionClient when we use common incorrect URI schemes.
     it.each(['ftp:', 'mailto:', 'http:', 'https:', 'file:'])(
       'should fail when constructed with %s as the URI scheme',

--- a/packages/indexer-client/src/graphql/generated/graphql.ts
+++ b/packages/indexer-client/src/graphql/generated/graphql.ts
@@ -6,29 +6,32 @@ export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' |
 import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 /** Either a block hash or a block height. */
 export type BlockOffset =
-  {   /** A hex-encoded block hash. */
-  readonly hash: string; readonly height?: never; }
-  |  { readonly hash?: never;   /** A block height. */
-  readonly height: number; };
+  | {
+      /** A hex-encoded block hash. */
+      readonly hash: string;
+      readonly height?: never;
+    }
+  | { readonly hash?: never; /** A block height. */ readonly height: number };
 
 /** The status of the transaction result: success, partial success or failure. */
-export type TransactionResultStatus =
-  | 'FAILURE'
-  | 'PARTIAL_SUCCESS'
-  | 'SUCCESS'
-  | '%future added value';
+export type TransactionResultStatus = 'FAILURE' | 'PARTIAL_SUCCESS' | 'SUCCESS' | '%future added value';
 
 export type BlockHashQueryVariables = Exact<{
   offset: BlockOffset | null | undefined;
 }>;
 
-
-export type BlockHashQuery = { readonly block: { readonly height: number, readonly hash: string, readonly ledgerParameters: string, readonly timestamp: number } | null };
+export type BlockHashQuery = {
+  readonly block: {
+    readonly height: number;
+    readonly hash: string;
+    readonly ledgerParameters: string;
+    readonly timestamp: number;
+  } | null;
+};
 
 export type ConnectMutationVariables = Exact<{
   viewingKey: string;
 }>;
-
 
 export type ConnectMutation = { readonly connect: string };
 
@@ -36,86 +39,899 @@ export type DisconnectMutationVariables = Exact<{
   sessionId: string;
 }>;
 
-
 export type DisconnectMutation = { readonly disconnect: null };
 
-export type FetchTermsAndConditionsQueryVariables = Exact<{ [key: string]: never; }>;
+export type FetchTermsAndConditionsQueryVariables = Exact<{ [key: string]: never }>;
 
-
-export type FetchTermsAndConditionsQuery = { readonly block: { readonly systemParameters: { readonly termsAndConditions: { readonly hash: string, readonly url: string } | null } } | null };
+export type FetchTermsAndConditionsQuery = {
+  readonly block: {
+    readonly systemParameters: { readonly termsAndConditions: { readonly hash: string; readonly url: string } | null };
+  } | null;
+};
 
 export type TransactionHistoryDetailQueryVariables = Exact<{
   transactionHash: string;
 }>;
 
-
-export type TransactionHistoryDetailQuery = { readonly transactions: ReadonlyArray<
-    | { readonly __typename: 'RegularTransaction', readonly identifiers: ReadonlyArray<string>, readonly hash: string, readonly fees: { readonly paidFees: string }, readonly transactionResult: { readonly status: TransactionResultStatus }, readonly block: { readonly hash: string, readonly height: number, readonly timestamp: number } }
-    | { readonly __typename: 'SystemTransaction', readonly hash: string, readonly block: { readonly hash: string, readonly height: number, readonly timestamp: number } }
-  > };
+export type TransactionHistoryDetailQuery = {
+  readonly transactions: ReadonlyArray<
+    | {
+        readonly __typename: 'BridgeClaimTransaction';
+        readonly hash: string;
+        readonly block: { readonly hash: string; readonly height: number; readonly timestamp: number };
+      }
+    | {
+        readonly __typename: 'RegularTransaction';
+        readonly identifiers: ReadonlyArray<string>;
+        readonly hash: string;
+        readonly fees: { readonly paidFees: string };
+        readonly transactionResult: { readonly status: TransactionResultStatus };
+        readonly block: { readonly hash: string; readonly height: number; readonly timestamp: number };
+      }
+    | {
+        readonly __typename: 'SystemTransaction';
+        readonly hash: string;
+        readonly block: { readonly hash: string; readonly height: number; readonly timestamp: number };
+      }
+  >;
+};
 
 export type TransactionStatusQueryVariables = Exact<{
   transactionId: string;
 }>;
 
-
-export type TransactionStatusQuery = { readonly transactions: ReadonlyArray<
-    | { readonly __typename: 'RegularTransaction', readonly identifiers: ReadonlyArray<string>, readonly transactionResult: { readonly __typename: 'TransactionResult', readonly status: TransactionResultStatus, readonly segments: ReadonlyArray<{ readonly id: number, readonly success: boolean }> | null } }
+export type TransactionStatusQuery = {
+  readonly transactions: ReadonlyArray<
+    | { readonly __typename: 'BridgeClaimTransaction' }
+    | {
+        readonly __typename: 'RegularTransaction';
+        readonly identifiers: ReadonlyArray<string>;
+        readonly transactionResult: {
+          readonly __typename: 'TransactionResult';
+          readonly status: TransactionResultStatus;
+          readonly segments: ReadonlyArray<{ readonly id: number; readonly success: boolean }> | null;
+        };
+      }
     | { readonly __typename: 'SystemTransaction' }
-  > };
+  >;
+};
 
 export type DustLedgerEventsSubscriptionVariables = Exact<{
   id: number | null | undefined;
 }>;
 
-
-export type DustLedgerEventsSubscription = { readonly dustLedgerEvents:
-    | { readonly id: number, readonly raw: string, readonly maxId: number, readonly type: 'DustGenerationDtimeUpdate' }
-    | { readonly id: number, readonly raw: string, readonly maxId: number, readonly type: 'DustInitialUtxo' }
-    | { readonly id: number, readonly raw: string, readonly maxId: number, readonly type: 'DustSpendProcessed' }
-    | { readonly id: number, readonly raw: string, readonly maxId: number, readonly type: 'ParamChange' }
-   };
+export type DustLedgerEventsSubscription = {
+  readonly dustLedgerEvents:
+    | { readonly id: number; readonly raw: string; readonly maxId: number; readonly type: 'DustGenerationDtimeUpdate' }
+    | { readonly id: number; readonly raw: string; readonly maxId: number; readonly type: 'DustInitialUtxo' }
+    | { readonly id: number; readonly raw: string; readonly maxId: number; readonly type: 'DustSpendProcessed' }
+    | { readonly id: number; readonly raw: string; readonly maxId: number; readonly type: 'ParamChange' };
+};
 
 export type ShieldedTransactionsSubscriptionVariables = Exact<{
   sessionId: string;
   index: number | null | undefined;
 }>;
 
-
-export type ShieldedTransactionsSubscription = { readonly shieldedTransactions:
-    | { readonly __typename: 'RelevantTransaction', readonly transaction: { readonly id: number, readonly raw: string, readonly hash: string, readonly protocolVersion: number, readonly identifiers: ReadonlyArray<string>, readonly startIndex: number, readonly endIndex: number, readonly fees: { readonly paidFees: string, readonly estimatedFees: string }, readonly transactionResult: { readonly status: TransactionResultStatus, readonly segments: ReadonlyArray<{ readonly id: number, readonly success: boolean }> | null } }, readonly collapsedMerkleTree: { readonly startIndex: number, readonly endIndex: number, readonly update: string, readonly protocolVersion: number } | null }
-    | { readonly __typename: 'ShieldedTransactionsProgress', readonly highestEndIndex: number, readonly highestCheckedEndIndex: number, readonly highestRelevantEndIndex: number }
-   };
+export type ShieldedTransactionsSubscription = {
+  readonly shieldedTransactions:
+    | {
+        readonly __typename: 'RelevantTransaction';
+        readonly transaction: {
+          readonly id: number;
+          readonly raw: string;
+          readonly hash: string;
+          readonly protocolVersion: number;
+          readonly identifiers: ReadonlyArray<string>;
+          readonly startIndex: number;
+          readonly endIndex: number;
+          readonly fees: { readonly paidFees: string; readonly estimatedFees: string };
+          readonly transactionResult: {
+            readonly status: TransactionResultStatus;
+            readonly segments: ReadonlyArray<{ readonly id: number; readonly success: boolean }> | null;
+          };
+        };
+        readonly collapsedMerkleTree: {
+          readonly startIndex: number;
+          readonly endIndex: number;
+          readonly update: string;
+          readonly protocolVersion: number;
+        } | null;
+      }
+    | {
+        readonly __typename: 'ShieldedTransactionsProgress';
+        readonly highestEndIndex: number;
+        readonly highestCheckedEndIndex: number;
+        readonly highestRelevantEndIndex: number;
+      };
+};
 
 export type UnshieldedTransactionsSubscriptionVariables = Exact<{
   address: string;
   transactionId: number | null | undefined;
 }>;
 
-
-export type UnshieldedTransactionsSubscription = { readonly unshieldedTransactions:
-    | { readonly type: 'UnshieldedTransaction', readonly transaction:
-        | { readonly identifiers: ReadonlyArray<string>, readonly id: number, readonly hash: string, readonly protocolVersion: number, readonly type: 'RegularTransaction', readonly fees: { readonly paidFees: string, readonly estimatedFees: string }, readonly transactionResult: { readonly status: TransactionResultStatus, readonly segments: ReadonlyArray<{ readonly id: number, readonly success: boolean }> | null }, readonly block: { readonly hash: string, readonly height: number, readonly timestamp: number } }
-        | { readonly id: number, readonly hash: string, readonly protocolVersion: number, readonly type: 'SystemTransaction', readonly block: { readonly hash: string, readonly height: number, readonly timestamp: number } }
-      , readonly createdUtxos: ReadonlyArray<{ readonly owner: string, readonly tokenType: string, readonly value: string, readonly outputIndex: number, readonly intentHash: string, readonly ctime: number | null, readonly registeredForDustGeneration: boolean }>, readonly spentUtxos: ReadonlyArray<{ readonly owner: string, readonly tokenType: string, readonly value: string, readonly outputIndex: number, readonly intentHash: string, readonly ctime: number | null, readonly registeredForDustGeneration: boolean }> }
-    | { readonly highestTransactionId: number, readonly type: 'UnshieldedTransactionsProgress' }
-   };
+export type UnshieldedTransactionsSubscription = {
+  readonly unshieldedTransactions:
+    | {
+        readonly type: 'UnshieldedTransaction';
+        readonly transaction:
+          | {
+              readonly id: number;
+              readonly hash: string;
+              readonly protocolVersion: number;
+              readonly type: 'BridgeClaimTransaction';
+              readonly block: { readonly hash: string; readonly height: number; readonly timestamp: number };
+            }
+          | {
+              readonly identifiers: ReadonlyArray<string>;
+              readonly id: number;
+              readonly hash: string;
+              readonly protocolVersion: number;
+              readonly type: 'RegularTransaction';
+              readonly fees: { readonly paidFees: string; readonly estimatedFees: string };
+              readonly transactionResult: {
+                readonly status: TransactionResultStatus;
+                readonly segments: ReadonlyArray<{ readonly id: number; readonly success: boolean }> | null;
+              };
+              readonly block: { readonly hash: string; readonly height: number; readonly timestamp: number };
+            }
+          | {
+              readonly id: number;
+              readonly hash: string;
+              readonly protocolVersion: number;
+              readonly type: 'SystemTransaction';
+              readonly block: { readonly hash: string; readonly height: number; readonly timestamp: number };
+            };
+        readonly createdUtxos: ReadonlyArray<{
+          readonly owner: string;
+          readonly tokenType: string;
+          readonly value: string;
+          readonly outputIndex: number;
+          readonly intentHash: string;
+          readonly ctime: number | null;
+          readonly registeredForDustGeneration: boolean;
+        }>;
+        readonly spentUtxos: ReadonlyArray<{
+          readonly owner: string;
+          readonly tokenType: string;
+          readonly value: string;
+          readonly outputIndex: number;
+          readonly intentHash: string;
+          readonly ctime: number | null;
+          readonly registeredForDustGeneration: boolean;
+        }>;
+      }
+    | { readonly highestTransactionId: number; readonly type: 'UnshieldedTransactionsProgress' };
+};
 
 export type ZswapEventsSubscriptionVariables = Exact<{
   id: number | null | undefined;
 }>;
 
+export type ZswapEventsSubscription = {
+  readonly zswapLedgerEvents: {
+    readonly id: number;
+    readonly raw: string;
+    readonly protocolVersion: number;
+    readonly maxId: number;
+  };
+};
 
-export type ZswapEventsSubscription = { readonly zswapLedgerEvents: { readonly id: number, readonly raw: string, readonly protocolVersion: number, readonly maxId: number } };
-
-
-export const BlockHashDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"BlockHash"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"offset"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"BlockOffset"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"block"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"Variable","name":{"kind":"Name","value":"offset"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"height"}},{"kind":"Field","name":{"kind":"Name","value":"hash"}},{"kind":"Field","name":{"kind":"Name","value":"ledgerParameters"}},{"kind":"Field","name":{"kind":"Name","value":"timestamp"}}]}}]}}]} as unknown as DocumentNode<BlockHashQuery, BlockHashQueryVariables>;
-export const ConnectDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"Connect"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"viewingKey"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ViewingKey"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"connect"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"viewingKey"},"value":{"kind":"Variable","name":{"kind":"Name","value":"viewingKey"}}}]}]}}]} as unknown as DocumentNode<ConnectMutation, ConnectMutationVariables>;
-export const DisconnectDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"Disconnect"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"sessionId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"HexEncoded"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"disconnect"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"sessionId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"sessionId"}}}]}]}}]} as unknown as DocumentNode<DisconnectMutation, DisconnectMutationVariables>;
-export const FetchTermsAndConditionsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FetchTermsAndConditions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"block"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"systemParameters"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"termsAndConditions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"hash"}},{"kind":"Field","name":{"kind":"Name","value":"url"}}]}}]}}]}}]}}]} as unknown as DocumentNode<FetchTermsAndConditionsQuery, FetchTermsAndConditionsQueryVariables>;
-export const TransactionHistoryDetailDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"TransactionHistoryDetail"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"transactionHash"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"HexEncoded"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"transactions"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"hash"},"value":{"kind":"Variable","name":{"kind":"Name","value":"transactionHash"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"hash"}},{"kind":"Field","name":{"kind":"Name","value":"block"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"hash"}},{"kind":"Field","name":{"kind":"Name","value":"height"}},{"kind":"Field","name":{"kind":"Name","value":"timestamp"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"RegularTransaction"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"identifiers"}},{"kind":"Field","name":{"kind":"Name","value":"fees"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"paidFees"}}]}},{"kind":"Field","name":{"kind":"Name","value":"transactionResult"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}}]}}]}}]}}]}}]} as unknown as DocumentNode<TransactionHistoryDetailQuery, TransactionHistoryDetailQueryVariables>;
-export const TransactionStatusDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"TransactionStatus"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"transactionId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"HexEncoded"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"transactions"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"identifier"},"value":{"kind":"Variable","name":{"kind":"Name","value":"transactionId"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"RegularTransaction"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"identifiers"}},{"kind":"Field","name":{"kind":"Name","value":"transactionResult"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"segments"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"success"}}]}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"__typename"}}]}}]}}]}}]}}]} as unknown as DocumentNode<TransactionStatusQuery, TransactionStatusQueryVariables>;
-export const DustLedgerEventsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"subscription","name":{"kind":"Name","value":"DustLedgerEvents"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"dustLedgerEvents"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"type"},"name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"raw"}},{"kind":"Field","name":{"kind":"Name","value":"maxId"}}]}}]}}]} as unknown as DocumentNode<DustLedgerEventsSubscription, DustLedgerEventsSubscriptionVariables>;
-export const ShieldedTransactionsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"subscription","name":{"kind":"Name","value":"ShieldedTransactions"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"sessionId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"HexEncoded"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"index"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"shieldedTransactions"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"sessionId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"sessionId"}}},{"kind":"Argument","name":{"kind":"Name","value":"index"},"value":{"kind":"Variable","name":{"kind":"Name","value":"index"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"ShieldedTransactionsProgress"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"highestEndIndex"}},{"kind":"Field","name":{"kind":"Name","value":"highestCheckedEndIndex"}},{"kind":"Field","name":{"kind":"Name","value":"highestRelevantEndIndex"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"RelevantTransaction"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"transaction"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"raw"}},{"kind":"Field","name":{"kind":"Name","value":"hash"}},{"kind":"Field","name":{"kind":"Name","value":"protocolVersion"}},{"kind":"Field","name":{"kind":"Name","value":"identifiers"}},{"kind":"Field","name":{"kind":"Name","value":"startIndex"}},{"kind":"Field","name":{"kind":"Name","value":"endIndex"}},{"kind":"Field","name":{"kind":"Name","value":"fees"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"paidFees"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedFees"}}]}},{"kind":"Field","name":{"kind":"Name","value":"transactionResult"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"segments"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"success"}}]}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"collapsedMerkleTree"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"startIndex"}},{"kind":"Field","name":{"kind":"Name","value":"endIndex"}},{"kind":"Field","name":{"kind":"Name","value":"update"}},{"kind":"Field","name":{"kind":"Name","value":"protocolVersion"}}]}}]}}]}}]}}]} as unknown as DocumentNode<ShieldedTransactionsSubscription, ShieldedTransactionsSubscriptionVariables>;
-export const UnshieldedTransactionsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"subscription","name":{"kind":"Name","value":"UnshieldedTransactions"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"address"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UnshieldedAddress"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"transactionId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"unshieldedTransactions"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"address"},"value":{"kind":"Variable","name":{"kind":"Name","value":"address"}}},{"kind":"Argument","name":{"kind":"Name","value":"transactionId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"transactionId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"UnshieldedTransaction"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"type"},"name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"transaction"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"type"},"name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"hash"}},{"kind":"Field","name":{"kind":"Name","value":"protocolVersion"}},{"kind":"Field","name":{"kind":"Name","value":"block"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"hash"}},{"kind":"Field","name":{"kind":"Name","value":"height"}},{"kind":"Field","name":{"kind":"Name","value":"timestamp"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"RegularTransaction"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"identifiers"}},{"kind":"Field","name":{"kind":"Name","value":"fees"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"paidFees"}},{"kind":"Field","name":{"kind":"Name","value":"estimatedFees"}}]}},{"kind":"Field","name":{"kind":"Name","value":"transactionResult"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"segments"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"success"}}]}}]}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"createdUtxos"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"owner"}},{"kind":"Field","name":{"kind":"Name","value":"tokenType"}},{"kind":"Field","name":{"kind":"Name","value":"value"}},{"kind":"Field","name":{"kind":"Name","value":"outputIndex"}},{"kind":"Field","name":{"kind":"Name","value":"intentHash"}},{"kind":"Field","name":{"kind":"Name","value":"ctime"}},{"kind":"Field","name":{"kind":"Name","value":"registeredForDustGeneration"}}]}},{"kind":"Field","name":{"kind":"Name","value":"spentUtxos"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"owner"}},{"kind":"Field","name":{"kind":"Name","value":"tokenType"}},{"kind":"Field","name":{"kind":"Name","value":"value"}},{"kind":"Field","name":{"kind":"Name","value":"outputIndex"}},{"kind":"Field","name":{"kind":"Name","value":"intentHash"}},{"kind":"Field","name":{"kind":"Name","value":"ctime"}},{"kind":"Field","name":{"kind":"Name","value":"registeredForDustGeneration"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"UnshieldedTransactionsProgress"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"type"},"name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"highestTransactionId"}}]}}]}}]}}]} as unknown as DocumentNode<UnshieldedTransactionsSubscription, UnshieldedTransactionsSubscriptionVariables>;
-export const ZswapEventsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"subscription","name":{"kind":"Name","value":"ZswapEvents"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"zswapLedgerEvents"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"raw"}},{"kind":"Field","name":{"kind":"Name","value":"protocolVersion"}},{"kind":"Field","name":{"kind":"Name","value":"maxId"}}]}}]}}]} as unknown as DocumentNode<ZswapEventsSubscription, ZswapEventsSubscriptionVariables>;
+export const BlockHashDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'BlockHash' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'offset' } },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'BlockOffset' } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'block' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'offset' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'offset' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'height' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'hash' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'ledgerParameters' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'timestamp' } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<BlockHashQuery, BlockHashQueryVariables>;
+export const ConnectDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'Connect' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'viewingKey' } },
+          type: { kind: 'NonNullType', type: { kind: 'NamedType', name: { kind: 'Name', value: 'ViewingKey' } } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'connect' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'viewingKey' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'viewingKey' } },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ConnectMutation, ConnectMutationVariables>;
+export const DisconnectDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'Disconnect' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'sessionId' } },
+          type: { kind: 'NonNullType', type: { kind: 'NamedType', name: { kind: 'Name', value: 'HexEncoded' } } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'disconnect' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'sessionId' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'sessionId' } },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DisconnectMutation, DisconnectMutationVariables>;
+export const FetchTermsAndConditionsDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'FetchTermsAndConditions' },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'block' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'systemParameters' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'termsAndConditions' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'hash' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'url' } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<FetchTermsAndConditionsQuery, FetchTermsAndConditionsQueryVariables>;
+export const TransactionHistoryDetailDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'TransactionHistoryDetail' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'transactionHash' } },
+          type: { kind: 'NonNullType', type: { kind: 'NamedType', name: { kind: 'Name', value: 'HexEncoded' } } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'transactions' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'offset' },
+                value: {
+                  kind: 'ObjectValue',
+                  fields: [
+                    {
+                      kind: 'ObjectField',
+                      name: { kind: 'Name', value: 'hash' },
+                      value: { kind: 'Variable', name: { kind: 'Name', value: 'transactionHash' } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'hash' } },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'block' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'hash' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'height' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'timestamp' } },
+                    ],
+                  },
+                },
+                {
+                  kind: 'InlineFragment',
+                  typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'RegularTransaction' } },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'identifiers' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'fees' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [{ kind: 'Field', name: { kind: 'Name', value: 'paidFees' } }],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'transactionResult' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [{ kind: 'Field', name: { kind: 'Name', value: 'status' } }],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<TransactionHistoryDetailQuery, TransactionHistoryDetailQueryVariables>;
+export const TransactionStatusDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'TransactionStatus' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'transactionId' } },
+          type: { kind: 'NonNullType', type: { kind: 'NamedType', name: { kind: 'Name', value: 'HexEncoded' } } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'transactions' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'offset' },
+                value: {
+                  kind: 'ObjectValue',
+                  fields: [
+                    {
+                      kind: 'ObjectField',
+                      name: { kind: 'Name', value: 'identifier' },
+                      value: { kind: 'Variable', name: { kind: 'Name', value: 'transactionId' } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+                {
+                  kind: 'InlineFragment',
+                  typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'RegularTransaction' } },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'identifiers' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'transactionResult' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'segments' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                                  { kind: 'Field', name: { kind: 'Name', value: 'success' } },
+                                ],
+                              },
+                            },
+                            { kind: 'Field', name: { kind: 'Name', value: 'status' } },
+                            { kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<TransactionStatusQuery, TransactionStatusQueryVariables>;
+export const DustLedgerEventsDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'subscription',
+      name: { kind: 'Name', value: 'DustLedgerEvents' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'id' } },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'dustLedgerEvents' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'id' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'id' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', alias: { kind: 'Name', value: 'type' }, name: { kind: 'Name', value: '__typename' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'raw' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'maxId' } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DustLedgerEventsSubscription, DustLedgerEventsSubscriptionVariables>;
+export const ShieldedTransactionsDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'subscription',
+      name: { kind: 'Name', value: 'ShieldedTransactions' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'sessionId' } },
+          type: { kind: 'NonNullType', type: { kind: 'NamedType', name: { kind: 'Name', value: 'HexEncoded' } } },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'index' } },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'shieldedTransactions' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'sessionId' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'sessionId' } },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'index' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'index' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+                {
+                  kind: 'InlineFragment',
+                  typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'ShieldedTransactionsProgress' } },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'highestEndIndex' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'highestCheckedEndIndex' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'highestRelevantEndIndex' } },
+                    ],
+                  },
+                },
+                {
+                  kind: 'InlineFragment',
+                  typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'RelevantTransaction' } },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'transaction' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'raw' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'hash' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'protocolVersion' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'identifiers' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'startIndex' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'endIndex' } },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'fees' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  { kind: 'Field', name: { kind: 'Name', value: 'paidFees' } },
+                                  { kind: 'Field', name: { kind: 'Name', value: 'estimatedFees' } },
+                                ],
+                              },
+                            },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'transactionResult' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  { kind: 'Field', name: { kind: 'Name', value: 'status' } },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'segments' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                                        { kind: 'Field', name: { kind: 'Name', value: 'success' } },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'collapsedMerkleTree' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'startIndex' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'endIndex' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'update' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'protocolVersion' } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ShieldedTransactionsSubscription, ShieldedTransactionsSubscriptionVariables>;
+export const UnshieldedTransactionsDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'subscription',
+      name: { kind: 'Name', value: 'UnshieldedTransactions' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'address' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'UnshieldedAddress' } },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'transactionId' } },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'unshieldedTransactions' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'address' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'address' } },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'transactionId' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'transactionId' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'InlineFragment',
+                  typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'UnshieldedTransaction' } },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        alias: { kind: 'Name', value: 'type' },
+                        name: { kind: 'Name', value: '__typename' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'transaction' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              alias: { kind: 'Name', value: 'type' },
+                              name: { kind: 'Name', value: '__typename' },
+                            },
+                            { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'hash' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'protocolVersion' } },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'block' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  { kind: 'Field', name: { kind: 'Name', value: 'hash' } },
+                                  { kind: 'Field', name: { kind: 'Name', value: 'height' } },
+                                  { kind: 'Field', name: { kind: 'Name', value: 'timestamp' } },
+                                ],
+                              },
+                            },
+                            {
+                              kind: 'InlineFragment',
+                              typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'RegularTransaction' } },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  { kind: 'Field', name: { kind: 'Name', value: 'identifiers' } },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'fees' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        { kind: 'Field', name: { kind: 'Name', value: 'paidFees' } },
+                                        { kind: 'Field', name: { kind: 'Name', value: 'estimatedFees' } },
+                                      ],
+                                    },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'transactionResult' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        { kind: 'Field', name: { kind: 'Name', value: 'status' } },
+                                        {
+                                          kind: 'Field',
+                                          name: { kind: 'Name', value: 'segments' },
+                                          selectionSet: {
+                                            kind: 'SelectionSet',
+                                            selections: [
+                                              { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                                              { kind: 'Field', name: { kind: 'Name', value: 'success' } },
+                                            ],
+                                          },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'createdUtxos' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'owner' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'tokenType' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'value' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'outputIndex' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'intentHash' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'ctime' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'registeredForDustGeneration' } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'spentUtxos' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'owner' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'tokenType' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'value' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'outputIndex' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'intentHash' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'ctime' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'registeredForDustGeneration' } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: 'InlineFragment',
+                  typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'UnshieldedTransactionsProgress' } },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        alias: { kind: 'Name', value: 'type' },
+                        name: { kind: 'Name', value: '__typename' },
+                      },
+                      { kind: 'Field', name: { kind: 'Name', value: 'highestTransactionId' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<UnshieldedTransactionsSubscription, UnshieldedTransactionsSubscriptionVariables>;
+export const ZswapEventsDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'subscription',
+      name: { kind: 'Name', value: 'ZswapEvents' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'id' } },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'zswapLedgerEvents' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'id' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'id' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'raw' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'protocolVersion' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'maxId' } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ZswapEventsSubscription, ZswapEventsSubscriptionVariables>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2395,6 +2395,7 @@ __metadata:
     "@graphql-typed-document-node/core": "npm:^3.2.0"
     "@midnightntwrk/wallet-sdk-utilities": "npm:1.2.1"
     effect: "npm:^3.19.19"
+    fflate: "npm:^0.8.2"
     graphql: "npm:^17.0.0"
     graphql-http: "npm:^1.22.4"
     graphql-ws: "npm:^6.0.7"


### PR DESCRIPTION
# Description

The indexer's subscription streams dominate its egress during wallet sync — a fresh dust-wallet sync drains the full
`dustLedgerEvents` replay, which is large, highly repetitive JSON. Indexer 4.4.0 added an opt-in WebSocket compression
subprotocol for exactly this; this PR makes the wallet's indexer client negotiate it.

Subscriptions now offer `graphql-transport-ws+deflate` alongside the standard subprotocol. Against an indexer that
supports it, payloads at or above the server's 256 B threshold arrive as zlib binary frames and are inflated
client-side. Against an older indexer, negotiation silently selects the standard protocol and the wrapper is a
pass-through — no version pinning, no configuration, no consumer changes.

Ref #462

# Proposed Solution

| File | What |
| --- | --- |
| `src/effect/DeflateWebSocket.ts` | New `makeDeflateWebSocket(Base)`: replaces graphql-ws's hardcoded subprotocol offer with the deflate + standard pair, sets `binaryType`, inflates binary frames in the `onmessage` setter. Only the surface graphql-ws actually uses is implemented — including the readyState constants it reads off the constructor, which the exported constructor type now declares. |
| `src/effect/WsSubscriptionClient.ts` | Wires the wrapper into `createClient` and holds the connection for the client's entire scope (`lazy: false`), so backpressure pause/resume cycles reuse one socket and disposal is total — no timer survives to keep a short-lived process alive. Disposal is awaited (a failed connection attempt no longer leaks an unhandled rejection), and the global `WebSocket` lookup is guarded so runtimes without the global get graphql-ws's descriptive error instead of a `ReferenceError`. An `@internal` second `layer` parameter carries test-only transport seams. |
| `src/effect/SubscriptionClient.ts` | Untouched — the public config stays `{ url, keepAlive }` deliberately. |
| `schema.lock` / `indexer.gql` / `src/graphql/generated/` | Pinned GraphQL schema bumped to `v4.4.0-rc.1` via `schema:sync`, matching the server the tests run against. The schema's new `BridgeClaimTransaction` variant required one downstream fix: capabilities' `pendingTransactionsService` now narrows to `RegularTransaction` (the only variant carrying `identifiers`/`transactionResult`) instead of excluding known others, so future variants are ignored rather than breaking compilation. |
| `package.json` | Adds `fflate` (sync zlib, Node + browser). |

Compression is always on rather than configurable: correctness never depends on it, fallback is automatic, and a knob
would only create a way to get it wrong. The `@internal TransportInternals` parameter exists solely so integration tests
can run a compression-off reference and observe raw frames.

# Important Changes Introduced

- **Deliberate deviation from the ticket:** inflation uses `fflate.unzlibSync`, not the browser
  `DecompressionStream('deflate')` the ticket suggested. Synchronous inflate preserves message ordering without a
  reordering queue, and keeps one code path for Node and the browser.
- **Connection lifetime:** the client runs graphql-ws in non-lazy mode — one connection held for the client's whole
  scope, reused by every backpressure pause/resume cycle, closed (with all timers cancelled) when the scope closes.
  Fixed policy, not configuration. This replaced an earlier 30 s warm-window design whose lazy-close timer graphql-ws's
  `dispose()` never cancels, which would have delayed short-lived processes' exit by up to the window.
- **Compose defaults moved to indexer `4.4.0-rc.1`** (`docker-compose.yml` + `docker-compose-dynamic.yml`), platform-
  pinned `linux/amd64` because the rc images publish no arm64 build (the multi-arch index refuses auto-selection on
  arm64 hosts; emulation works once pinned). Both pins carry their exit condition: move to stable multi-arch 4.4.0 and
  drop the pin when it ships. A new `docker-compose.ws-no-deflate.yml` freezes 4.3.2 so the fallback scenario stays
  deliberately testable regardless of the default tag.
- **Discovered while measuring:** indexer 4.4.0 introduces a per-connection subscription cap of 20 (4.3.x accepted
  more). No wallet impact — the facade holds a handful of subscriptions — but the multiplexing tests now sit exactly at
  that cap, documented in `syncThroughput.integration.test.ts`.
- **HTTP needs no wallet work:** `fetch` already negotiates gzip for one-shot queries; the server side shipped in the
  same indexer release.
- **Scope note:** the connection-reuse work and the HTTP pooling test ride along in this PR. Happy to split them out if
  reviewers want tighter scope.
- **Follow-up:** preprod-scale measurement of the dust sync stream (~1M events) belongs to rollout, not to this change.

# Testing

Unit (no infra): `deflateWebSocket.test.ts` (9 tests) covers the wrapper against a hand-written fake socket — both
subprotocols offered with deflate first, `binaryType` switched to arraybuffer, a zlib frame inflated to the text
graphql-ws expects, a **corrupt frame passed through untouched** so graphql-ws rejects it with 4400, text frames left
alone, handler clearing, and `readyState`/`protocol`/`send`/`close` delegation. `wsSubscriptionClient.test.ts` adds
three client-lifecycle tests: the descriptive graphql-ws error (not a `ReferenceError`) on runtimes with no global
`WebSocket`, disposal cancelling every pending timer, and disposal mid-failed-connect leaking no unhandled rejection.

Integration (Docker, one parallel CI job per file):

| File | Covers |
| --- | --- |
| `wsDeflate.integration.test.ts` | Against 4.4.0-rc.1: subprotocol negotiated; inflated payloads byte-identical to an uncompressed reference run; savings floor cleared on the zswap backlog drain, on the `dustLedgerEvents` stream from the ticket, and across 20 concurrent replays multiplexed on one socket; one physical connection across 5 disconnect/resubscribe cycles. |
| `wsDeflateFallback.integration.test.ts` | Against the pinned pre-deflate indexer (4.3.2 via `ws-no-deflate` override): standard protocol selected, zero binary frames, replay strictly ordered, complete to the server-declared tip, and id-sequence-identical to a client that never offered deflate. |
| `httpConnectionReuse.integration.test.ts` | One-shot queries reuse pooled keep-alive connections (O(1) sockets vs O(n) requests) and never ride the WebSocket, observed via undici's `diagnostics_channel`. |
| `throttledProxy.integration.test.ts` | The bandwidth-capped TCP proxy the throughput measurement stands on: bytes pass unmodified, and the cap is a hard floor on transfer time (so lower-bound timing assertions are deterministic, not statistical). |
| `syncThroughput.integration.test.ts` | Deflate vs plain drain time through the capped link, same server, same link — CI asserts deflate ≥ 15% faster on a short 1-batch drain. The 4.3.x baseline leg is recorded as evidence, deliberately unasserted (cross-version timing would gate on unrelated server changes). |

The compose scaffold these files share lives once in `test/composeEnvironment.ts`. Assertions target contracts rather
than incidental exactness: every frame at or above the server's 256 B threshold arrives compressed (sub-threshold
protocol chatter legitimately stays text), and connection counts are asserted as bounds that tolerate pool timing while
still failing loudly on a reconnect-per-request regression.

**The negotiated-subprotocol assertion is what catches this feature breaking** — removing deflate from the offer fails
the deflate integration tests immediately. The **byte floor** (a run's own wire bytes against its own inflated bytes)
catches the narrower case of the server ceasing to compress while still negotiating deflate. The fallback test asserts
the complementary zero.

Measured on the local test chain (recorded as Vitest annotations in every run):

| Stream | Events | Plain wire | Deflate wire | Saved |
| --- | ---: | ---: | ---: | ---: |
| zswap backlog drain | 28 | 22,581 B | 14,169 B | 37.3% |
| `dustLedgerEvents` replay (the ticket's hot path) | 100 | 94,669 B | 51,576 B | 45.5% |
| 20 concurrent replays, one socket | 560 | 452,342 B | 283,944 B | 37.2% |

### Sync-time measurement (bandwidth-limited link)

`syncThroughput.integration.test.ts` proves the time claim behind the byte savings by draining replays through a
bandwidth-capped TCP proxy (`throttledProxy.ts`) that makes the wire the bottleneck — the regime real wallets sync
in. **CI runs a short 1-batch drain and asserts only the relative claim** (deflate ≥ 15% faster than plain, same
server, same link). The figures below are from a one-off local run of the same test with `BATCHES` temporarily
raised to 34, pushing ~15 MB over the wire for a longer measurement window — the constant's doc comment describes
that knob, so the run is reproducible.

Simulated link: 131,072 B/s (~1 Mbit/s) per direction · 34 sequential batches × 20 concurrent replays (the 4.4.0
per-connection cap) · 19,040 events in every run · warm-ups untimed.

| Run | Bytes on wire | Drain time | Effective throughput |
| --- | ---: | ---: | ---: |
| Baseline — indexer 4.3.x, plain | 15,338,930 B | 120,802 ms | 126,976 B/s |
| Indexer 4.4.0-rc.1, plain | 15,338,930 B | 120,920 ms | 126,852 B/s |
| Indexer 4.4.0-rc.1, deflate | 9,611,780 B | **77,314 ms** | 124,321 B/s |

| Comparison | Bytes saved | Time saved |
| --- | ---: | ---: |
| deflate vs rc plain (isolates compression) | 37.3% | **36.1%** |
| deflate vs 4.3.x baseline (the upgrade as users experience it) | 37.3% | **36.0%** |

Time saved converges on bytes saved as fixed costs amortize (33.6% on the short drain → 36.1% over two minutes,
against a 37.3% byte ratio), and the two plain runs differ by 0.1% — the delta is compression, not other server
changes.

To see the annotations in the terminal:

```bash
yarn test --filter=@midnightntwrk/wallet-sdk-indexer-client --force -- \
  src/effect/test/wsDeflate.integration.test.ts \
  src/effect/test/wsDeflateFallback.integration.test.ts \
  src/effect/test/httpConnectionReuse.integration.test.ts \
  --reporter=verbose
```

Docker required.
