### PR TITLE
feat(dust-wallet): run the projections dust sync in the background

### DIFF
--- a/.changeset/dust-projections-background-sync.md
+++ b/.changeset/dust-projections-background-sync.md
@@ -1,0 +1,24 @@
+---
+'@midnightntwrk/wallet-sdk-dust-wallet': minor
+---
+
+feat(dust-wallet): make the projections sync work under background synchronization
+
+The projections ("event-less") sync synchronizes in finite passes — each pass ends its own stream — where the
+event-based service holds a long-lived subscription. Background synchronization reads the wallet state once and runs
+`updates` once, and its retry only re-runs a pass on failure, not on completion. A wallet built with the projections
+sync and started in the background therefore converged once and then never observed anything again, silently. The
+only usable shape was `manualSync` plus an explicit `facade.doSync()` at every point that would otherwise wait for
+the background sync to catch up.
+
+A sync service can now declare `backgroundRepeatDelay`, and background synchronization re-runs its pass on that
+delay. Because the pass is re-run from the top, each one re-reads the wallet state and resumes from what the previous
+one applied. The projections service declares it; the event-based and simulator services do not, and are unaffected
+— their `updates` never completes, so nothing repeats.
+
+The delay is configurable as `backgroundSyncInterval` (milliseconds, default 5000) on the dust wallet's sync
+configuration. Passes cannot overlap at any interval: a pass that cannot take the sync lock yields to the one already
+running and waits for the next interval. An idle pass costs a single block query, because both the generation
+subscription and the commitment load short-circuit on an unchanged tip.
+
+`facade.doSync()` is unchanged — it still runs exactly one pass and returns.

--- a/.changeset/dust-projections-background-sync.md
+++ b/.changeset/dust-projections-background-sync.md
@@ -1,0 +1,30 @@
+---
+'@midnightntwrk/wallet-sdk-dust-wallet': minor
+'@midnightntwrk/wallet-sdk-testkit': patch
+---
+
+feat(dust-wallet): make the projections sync work under background synchronization
+
+The projections ("event-less") sync synchronizes in finite passes — each pass ends its own stream — where the
+event-based service holds a long-lived subscription. Background synchronization reads the wallet state once and runs
+`updates` once, and its retry only re-runs a pass on failure, not on completion. A wallet built with the projections
+sync and started in the background therefore converged once and then never observed anything again, silently. The
+only usable shape was `manualSync` plus an explicit `facade.doSync()` at every point that would otherwise wait for
+the background sync to catch up.
+
+A sync service can now declare `backgroundRepeatDelay`, and background synchronization re-runs its pass on that
+delay. Because the pass is re-run from the top, each one re-reads the wallet state and resumes from what the previous
+one applied. The projections service declares it; the event-based and simulator services do not, and are unaffected
+— their `updates` never completes, so nothing repeats.
+
+The delay is configurable as `backgroundSyncInterval` (milliseconds, default 5000) on the dust wallet's sync
+configuration. Passes cannot overlap at any interval: a pass that cannot take the sync lock yields to the one already
+running and waits for the next interval. An idle pass costs a single block query, because both the generation
+subscription and the commitment load short-circuit on an unchanged tip.
+
+`facade.doSync()` is unchanged — it still runs exactly one pass and returns.
+
+`backgroundRepeatDelay` is declared on both twins' `SyncService`, since both variants' background
+synchronization reads it, but only the ledger-v9 twin's projections service sets one — the finite-pass
+projections sync remains a ledger-v9 capability. The testkit's `eventLessDustWallet` documentation is
+corrected accordingly: it no longer tells callers the sync is one-shot and must be driven by hand.

--- a/.changeset/dust-projections-background-sync.md
+++ b/.changeset/dust-projections-background-sync.md
@@ -1,9 +1,9 @@
 ---
-'@midnightntwrk/wallet-sdk-dust-wallet': minor
+'@midnightntwrk/wallet-sdk-dust-wallet': major
 '@midnightntwrk/wallet-sdk-testkit': patch
 ---
 
-feat(dust-wallet): make the projections sync work under background synchronization
+feat(dust-wallet)!: make the projections sync work under background synchronization
 
 The projections ("event-less") sync synchronizes in finite passes — each pass ends its own stream — where the
 event-based service holds a long-lived subscription. Background synchronization reads the wallet state once and runs
@@ -12,19 +12,20 @@ sync and started in the background therefore converged once and then never obser
 only usable shape was `manualSync` plus an explicit `facade.doSync()` at every point that would otherwise wait for
 the background sync to catch up.
 
-A sync service can now declare `backgroundRepeatDelay`, and background synchronization re-runs its pass on that
-delay. Because the pass is re-run from the top, each one re-reads the wallet state and resumes from what the previous
-one applied. The projections service declares it; the event-based and simulator services do not, and are unaffected
-— their `updates` never completes, so nothing repeats.
+**Breaking:** every `SyncService` now states how often background synchronization runs its `updates`, as a required
+`backgroundRepeat` of `BackgroundRepeat.Once()` — the answer for a long-lived subscription, which is every service
+the SDK ships bar one — or `BackgroundRepeat.WithDelay({ delay })`. A custom sync service must add the field. It is
+stated rather than inferred because only the service knows whether its `updates` is finite.
 
-The delay is configurable as `backgroundSyncInterval` (milliseconds, default 5000) on the dust wallet's sync
-configuration. Passes cannot overlap at any interval: a pass that cannot take the sync lock yields to the one already
-running and waits for the next interval. An idle pass costs a single block query, because both the generation
-subscription and the commitment load short-circuit on an unchanged tip.
+The projections service is `WithDelay`, configurable as `backgroundSyncInterval` (milliseconds, default 5000) on the
+dust wallet's sync configuration. Because a repeated pass is re-run from the top, each one re-reads the wallet state
+and resumes from what the previous one applied. Passes cannot overlap at any interval: a pass that cannot take the
+sync lock yields to the one already running and waits for the next interval. An idle pass costs a single block query,
+because both the generation subscription and the commitment load short-circuit on an unchanged tip.
 
 `facade.doSync()` is unchanged — it still runs exactly one pass and returns.
 
-`backgroundRepeatDelay` is declared on both twins' `SyncService`, since both variants' background
-synchronization reads it, but only the ledger-v9 twin's projections service sets one — the finite-pass
-projections sync remains a ledger-v9 capability. The testkit's `eventLessDustWallet` documentation is
-corrected accordingly: it no longer tells callers the sync is one-shot and must be driven by hand.
+`BackgroundRepeat` is declared in both twins, since both variants' background synchronization reads it, but only the
+ledger-v9 twin's projections service is `WithDelay` — the finite-pass projections sync remains a ledger-v9
+capability. The testkit's `eventLessDustWallet` documentation is corrected accordingly: it no longer tells callers the
+sync is one-shot and must be driven by hand.

--- a/packages/dust-wallet/src/test/forkHarness.ts
+++ b/packages/dust-wallet/src/test/forkHarness.ts
@@ -230,6 +230,7 @@ type V2SourceConfiguration = Readonly<{
 const v1SyncService = (
   configuration: V1SourceConfiguration,
 ): V1Sync.SyncService<V1CoreWallet, V8SecretKey, V1Sync.WalletSyncUpdate> => ({
+  backgroundRepeat: V1Sync.BackgroundRepeat.Once(),
   updates: (state, secretKey) => {
     const from = resumeFrom(state.progress.appliedIndex);
     return pipe(
@@ -253,6 +254,7 @@ const v1SyncService = (
 const v2SyncService = (
   configuration: V2SourceConfiguration,
 ): V2Sync.SyncService<V2CoreWallet, V9SecretKey, V2Update> => ({
+  backgroundRepeat: V2Sync.BackgroundRepeat.Once(),
   updates: (state, secretKey) => {
     const from = resumeFrom(state.progress.appliedIndex);
     return pipe(

--- a/packages/dust-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/dust-wallet/src/v1/RunningV1Variant.ts
@@ -21,6 +21,7 @@ import {
   Duration,
   Schedule,
   Array as Arr,
+  identity,
   Ref,
 } from 'effect';
 import { type TransactionHistoryService } from './TransactionHistory.js';
@@ -147,6 +148,8 @@ export class RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
   }
 
   startSyncInBackground(startAux: TStartAux): Effect.Effect<void> {
+    const repeatDelay = this.#v1Context.syncService.backgroundRepeatDelay;
+
     return this.startSync(startAux).pipe(
       Stream.retry(
         pipe(
@@ -160,6 +163,13 @@ export class RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
           }),
         ),
       ),
+      // A sync service whose `updates` is finite — the projections service ends its stream after one pass — would
+      // otherwise leave the wallet frozen at whatever that first pass saw. Repeating re-runs `startSync`, which
+      // re-reads the wallet state, so each pass resumes from what the previous one applied. The retry above cannot
+      // serve this purpose: it re-runs a pass on failure, not on completion. Repeating outside the retry keeps a
+      // transient failure to the pass it happened in, rather than restarting the whole cycle. A service with a
+      // long-lived `updates` declares no delay, and is left exactly as it was.
+      repeatDelay === undefined ? identity : Stream.repeat(Schedule.spaced(repeatDelay)),
       Stream.runScoped(Sink.drain),
       Effect.forkScoped,
       Effect.provideService(Scope.Scope, this.#scope),

--- a/packages/dust-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/dust-wallet/src/v1/RunningV1Variant.ts
@@ -21,7 +21,6 @@ import {
   Duration,
   Schedule,
   Array as Arr,
-  identity,
   Ref,
 } from 'effect';
 import { type TransactionHistoryService } from './TransactionHistory.js';
@@ -43,7 +42,7 @@ import {
 } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type UtxoWithMeta } from './types/Dust.js';
 import { type KeysCapability } from './Keys.js';
-import { type BlockData, type ChangesResult, type SyncCapability, type SyncService } from './Sync.js';
+import { BackgroundRepeat, type BlockData, type ChangesResult, type SyncCapability, type SyncService } from './Sync.js';
 import { type V8 } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import {
   type CoinsAndBalancesCapability,
@@ -173,9 +172,7 @@ export class RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
   }
 
   startSyncInBackground(startAux: TStartAux): Effect.Effect<void> {
-    const repeatDelay = this.#v1Context.syncService.backgroundRepeatDelay;
-
-    return this.startSync(startAux).pipe(
+    const pass = this.startSync(startAux).pipe(
       Stream.retry(
         pipe(
           Schedule.exponential(Duration.seconds(1), 2),
@@ -188,13 +185,18 @@ export class RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
           }),
         ),
       ),
-      // A sync service whose `updates` is finite — the projections service ends its stream after one pass — would
-      // otherwise leave the wallet frozen at whatever that first pass saw. Repeating re-runs `startSync`, which
-      // re-reads the wallet state, so each pass resumes from what the previous one applied. The retry above cannot
-      // serve this purpose: it re-runs a pass on failure, not on completion. Repeating outside the retry keeps a
-      // transient failure to the pass it happened in, rather than restarting the whole cycle. A service with a
-      // long-lived `updates` declares no delay, and is left exactly as it was.
-      repeatDelay === undefined ? identity : Stream.repeat(Schedule.spaced(repeatDelay)),
+    );
+
+    // A service that synchronizes in finite passes would otherwise leave the wallet frozen at whatever its first pass
+    // saw. Repeating re-runs `startSync`, which re-reads the wallet state, so each pass resumes from what the previous
+    // one applied. The retry above cannot serve this purpose: it re-runs a pass on failure, not on completion.
+    // Repeating outside it keeps a transient failure to the pass it happened in, rather than restarting the cycle.
+    const passes = BackgroundRepeat.$match(this.#v1Context.syncService.backgroundRepeat, {
+      Once: () => pass,
+      WithDelay: ({ delay }) => Stream.repeat(pass, Schedule.spaced(delay)),
+    });
+
+    return passes.pipe(
       Stream.runScoped(Sink.drain),
       Effect.forkScoped,
       Effect.provideService(Scope.Scope, this.#scope),

--- a/packages/dust-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/dust-wallet/src/v1/RunningV1Variant.ts
@@ -21,6 +21,7 @@ import {
   Duration,
   Schedule,
   Array as Arr,
+  identity,
   Ref,
 } from 'effect';
 import { type TransactionHistoryService } from './TransactionHistory.js';
@@ -172,6 +173,8 @@ export class RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
   }
 
   startSyncInBackground(startAux: TStartAux): Effect.Effect<void> {
+    const repeatDelay = this.#v1Context.syncService.backgroundRepeatDelay;
+
     return this.startSync(startAux).pipe(
       Stream.retry(
         pipe(
@@ -185,6 +188,13 @@ export class RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
           }),
         ),
       ),
+      // A sync service whose `updates` is finite — the projections service ends its stream after one pass — would
+      // otherwise leave the wallet frozen at whatever that first pass saw. Repeating re-runs `startSync`, which
+      // re-reads the wallet state, so each pass resumes from what the previous one applied. The retry above cannot
+      // serve this purpose: it re-runs a pass on failure, not on completion. Repeating outside the retry keeps a
+      // transient failure to the pass it happened in, rather than restarting the whole cycle. A service with a
+      // long-lived `updates` declares no delay, and is left exactly as it was.
+      repeatDelay === undefined ? identity : Stream.repeat(Schedule.spaced(repeatDelay)),
       Stream.runScoped(Sink.drain),
       Effect.forkScoped,
       Effect.provideService(Scope.Scope, this.#scope),

--- a/packages/dust-wallet/src/v1/Sync.ts
+++ b/packages/dust-wallet/src/v1/Sync.ts
@@ -96,6 +96,16 @@ import { type Dust } from './types/index.js';
 export interface SyncService<TState, TStartAux, TUpdate> {
   updates: (state: TState, auxData: TStartAux) => Stream.Stream<TUpdate, WalletError, Scope.Scope>;
   blockData: (height?: number) => Effect.Effect<BlockData, WalletError>;
+  /**
+   * Delay after which background synchronization re-runs `updates` once it has completed.
+   *
+   * Only meaningful for a service whose `updates` is finite. The projections service ends its stream after a single
+   * pass, so without this a wallet synchronizing in the background would converge once and then never observe anything
+   * again — the variant's background retry does not cover it, because that re-runs a pass on failure, not on
+   * completion. A service whose `updates` is a long-lived subscription omits this and is left running one pass, as that
+   * pass never ends.
+   */
+  readonly backgroundRepeatDelay?: Duration.DurationInput;
 }
 
 export type ChangesResult = {
@@ -145,6 +155,19 @@ export type DefaultSyncConfiguration = {
   networkId: NetworkId;
   batchUpdates?: BatchUpdatesConfig;
   anonymityLevel?: number;
+  /**
+   * Delay in milliseconds between background synchronization passes, for a sync service that synchronizes in finite
+   * passes rather than over a live subscription — currently only the projections service. Ignored by the event-based
+   * service, whose subscription never completes.
+   *
+   * Lower values keep the wallet closer to the chain tip at the cost of more idle queries; a pass with nothing to do
+   * costs one block query, because the generation subscription and the commitment load both short-circuit on an
+   * unchanged tip. Passes never overlap regardless of this value: a pass that cannot take the sync lock yields to the
+   * one already running and waits for the next interval.
+   *
+   * @default 5000
+   */
+  backgroundSyncInterval?: number;
 };
 
 export type SimulatorSyncConfiguration = {
@@ -469,6 +492,8 @@ export const makeEventLessSyncService = (
   const anonymityLevel = config.anonymityLevel ?? 7;
 
   return {
+    // Each pass ends its own stream, so background synchronization has to be told to run another one.
+    backgroundRepeatDelay: Duration.millis(config.backgroundSyncInterval ?? 5_000),
     updates: (
       state: CoreWallet,
       secretKey: DustSecretKey,

--- a/packages/dust-wallet/src/v1/Sync.ts
+++ b/packages/dust-wallet/src/v1/Sync.ts
@@ -52,6 +52,15 @@ import { Uint8ArraySchema } from './Serialization.js';
 export interface SyncService<TState, TStartAux, TUpdate> {
   updates: (state: TState, auxData: TStartAux) => Stream.Stream<TUpdate, WalletError, Scope.Scope>;
   blockData: () => Effect.Effect<BlockData, WalletError>;
+  /**
+   * Delay after which background synchronization re-runs `updates` once it has completed.
+   *
+   * Only meaningful for a service whose `updates` is finite. A service whose `updates` is a long-lived subscription
+   * omits this and is left running the one pass, because that pass never ends — which is every service this variant
+   * has, the finite-pass projections sync being a ledger-v9 capability that no published ledger-v8 can support. The
+   * field is declared in both twins so their background synchronization reads one contract.
+   */
+  readonly backgroundRepeatDelay?: Duration.DurationInput;
 }
 
 // TODO: use schema instead

--- a/packages/dust-wallet/src/v1/Sync.ts
+++ b/packages/dust-wallet/src/v1/Sync.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import {
+  Data,
   Effect,
   Either,
   Layer,
@@ -49,18 +50,48 @@ import { CoreWallet } from './CoreWallet.js';
 import { type NetworkId } from './types/ledger.js';
 import { Uint8ArraySchema } from './Serialization.js';
 
+/**
+ * How often background synchronization runs a sync service's `updates`.
+ *
+ * @remarks
+ *   Every service states this, because the answer cannot be inferred from the service: it follows from whether `updates`
+ *   is finite, which only the service knows. A service whose `updates` is a long-lived subscription is
+ *   {@link BackgroundRepeat.Once} — that single pass never ends, so there is nothing to repeat. A service that
+ *   synchronizes in finite passes is {@link BackgroundRepeat.WithDelay}, or a wallet synchronizing in the background
+ *   would converge once and then never observe anything again. The variant's background retry does not cover the
+ *   latter: it re-runs a pass on failure, not on completion.
+ *
+ *   Every service this variant has is {@link BackgroundRepeat.Once}: the finite-pass projections sync is a ledger-v9
+ *   capability that no published ledger-v8 can support. The type is declared in both twins so that their background
+ *   synchronization reads one contract, and so that a ledger-v8 service which one day synchronizes in finite passes has
+ *   the vocabulary to say so.
+ */
+export type BackgroundRepeat = Data.TaggedEnum<{
+  /** Run `updates` once and leave it running. For a service whose `updates` never completes. */
+  Once: {}; // eslint-disable-line @typescript-eslint/no-empty-object-type
+
+  /** Re-run `updates` this long after each pass completes. For a service that synchronizes in finite passes. */
+  WithDelay: { readonly delay: Duration.DurationInput };
+}>;
+/**
+ * Constructors and matchers for {@link BackgroundRepeat}.
+ *
+ * @example
+ *   ```ts
+ *   const service: SyncService<CoreWallet, DustSecretKey, WalletSyncUpdate> = {
+ *     backgroundRepeat: BackgroundRepeat.Once(),
+ *     updates: (state, secretKey) => subscribe(state, secretKey),
+ *     blockData: () => latestBlock(),
+ *   };
+ *   ```;
+ */
+export const BackgroundRepeat = Data.taggedEnum<BackgroundRepeat>();
+
 export interface SyncService<TState, TStartAux, TUpdate> {
   updates: (state: TState, auxData: TStartAux) => Stream.Stream<TUpdate, WalletError, Scope.Scope>;
   blockData: () => Effect.Effect<BlockData, WalletError>;
-  /**
-   * Delay after which background synchronization re-runs `updates` once it has completed.
-   *
-   * Only meaningful for a service whose `updates` is finite. A service whose `updates` is a long-lived subscription
-   * omits this and is left running the one pass, because that pass never ends — which is every service this variant
-   * has, the finite-pass projections sync being a ledger-v9 capability that no published ledger-v8 can support. The
-   * field is declared in both twins so their background synchronization reads one contract.
-   */
-  readonly backgroundRepeatDelay?: Duration.DurationInput;
+  /** How often background synchronization re-runs {@link SyncService.updates}. See {@link BackgroundRepeat}. */
+  readonly backgroundRepeat: BackgroundRepeat;
 }
 
 // TODO: use schema instead
@@ -523,6 +554,8 @@ export const makeDefaultSyncService = (
 ): SyncService<CoreWallet, DustSecretKey, WalletSyncUpdate> => {
   const indexerSyncService = makeIndexerSyncService(config);
   return {
+    // A long-lived indexer subscription: the one pass never ends, so there is nothing to repeat.
+    backgroundRepeat: BackgroundRepeat.Once(),
     updates: (
       state: CoreWallet,
       secretKey: DustSecretKey,
@@ -773,6 +806,8 @@ export const makeSimulatorSyncService = (
   config: SimulatorSyncConfiguration,
 ): SyncService<CoreWallet, DustSecretKey, SimulatorSyncUpdate> => {
   return {
+    // A live feed of simulator states: the one pass never ends, so there is nothing to repeat.
+    backgroundRepeat: BackgroundRepeat.Once(),
     updates: (_state: CoreWallet, secretKey: DustSecretKey) => {
       // Get the initial state immediately to ensure we process the genesis block.
       // Then subscribe to state$ for subsequent changes, but deduplicate by block number

--- a/packages/dust-wallet/src/v1/test/runningV1Variant.test.ts
+++ b/packages/dust-wallet/src/v1/test/runningV1Variant.test.ts
@@ -17,7 +17,7 @@ import {
   LedgerParameters,
 } from '@midnightntwrk/ledger-v9';
 import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Duration, Effect, Exit, Ref, Scope, Stream, SubscriptionRef, TestClock, TestContext } from 'effect';
+import { Duration, Effect, Exit, pipe, Ref, Scope, Stream, SubscriptionRef, TestClock, TestContext } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { chooseCoin, makeDefaultCoinsAndBalancesCapability } from '../CoinsAndBalances.js';
 import { CoreWallet } from '../CoreWallet.js';
@@ -156,5 +156,116 @@ describe('RunningV1Variant.startSync tx-history fan-out', () => {
     expect(result.maxInFlight).toBe(8);
     // The cap only queues work, it never drops it.
     expect(result.recorded).toBe(12);
+  });
+});
+
+/**
+ * The projections sync service ends its `updates` stream after a single pass, where the event-based service's is a
+ * long-lived subscription. Background sync must therefore re-run a finite `updates`, or a wallet built on the
+ * projections service converges once and never observes anything again — and the existing `Stream.retry` does not help,
+ * because it re-runs on failure, not on completion.
+ *
+ * A service declares that it needs this by setting `backgroundRepeatDelay`; a service with a long-lived `updates` omits
+ * it and must be unaffected.
+ */
+describe('RunningV1Variant background sync of a finite updates stream', () => {
+  /**
+   * A service whose `updates` completes after emitting once. It records the `appliedIndex` of the state each pass was
+   * handed, so a test can tell whether later passes see the state earlier ones produced or a stale snapshot.
+   */
+  const finiteSyncServiceOf = (
+    seenAppliedIndexes: Ref.Ref<readonly number[]>,
+    backgroundRepeatDelay?: Duration.DurationInput,
+  ): SyncService<CoreWallet, null, FakeSyncUpdate> => ({
+    ...syncServiceOf([]),
+    updates: (state) =>
+      pipe(
+        Ref.update(seenAppliedIndexes, (seen) => [...seen, Number(state.progress.appliedIndex)]),
+        Stream.fromEffect,
+        Stream.as(['tx'] as FakeSyncUpdate),
+      ),
+    ...(backgroundRepeatDelay !== undefined ? { backgroundRepeatDelay } : {}),
+  });
+
+  /** Advances the applied index by one per pass, so the next pass can be seen to start from the new value. */
+  const advancingCapability: SyncCapability<CoreWallet, FakeSyncUpdate, ChangesResult> = {
+    applyUpdate: (state, sources) => [
+      CoreWallet.updateProgress(state, { appliedIndex: state.progress.appliedIndex + 1n }),
+      { changes: sources.map(changeOf), protocolVersion: 1 },
+    ],
+  };
+
+  const runBackgroundFor = async (
+    backgroundRepeatDelay: Duration.DurationInput | undefined,
+    elapsed: Duration.DurationInput,
+  ): Promise<readonly number[]> =>
+    Effect.gen(function* () {
+      const seen = yield* Ref.make<readonly number[]>([]);
+      const secretKey = DustSecretKey.fromSeed(Buffer.alloc(32, 1));
+      const stateRef = yield* SubscriptionRef.make(
+        CoreWallet.initEmpty(LedgerParameters.initialParameters().dust, secretKey, networkId),
+      );
+      const scope = yield* Scope.make();
+      const variant = new RunningV1Variant(
+        scope,
+        { stateRef },
+        {
+          ...variantContextOf([], { getTransactionDetails: () => Effect.die('unused'), put: () => Effect.void }),
+          syncService: finiteSyncServiceOf(seen, backgroundRepeatDelay),
+          syncCapability: advancingCapability,
+        },
+      );
+
+      yield* variant.startSyncInBackground(null);
+      yield* TestClock.adjust(elapsed);
+      const result = yield* Ref.get(seen);
+      yield* Scope.close(scope, Exit.void);
+      return result;
+    }).pipe(Effect.provide(TestContext.TestContext), Effect.runPromise);
+
+  it('re-runs the pass on the declared delay, each pass starting from the state the last one produced', async () => {
+    // 5s delay over 12s of clock: the initial pass plus two repeats. Each pass must observe the applied index the
+    // previous pass advanced, which is only true if the repeat re-reads state rather than reusing a snapshot.
+    const seen = await runBackgroundFor(Duration.seconds(5), Duration.seconds(12));
+
+    expect(seen).toEqual([0, 1, 2]);
+  });
+
+  it('leaves a service that declares no delay running exactly one pass', async () => {
+    // Guards the event-based service: its `updates` never completes in production, and nothing here may start
+    // re-running passes behind its back.
+    const seen = await runBackgroundFor(undefined, Duration.minutes(5));
+
+    expect(seen).toEqual([0]);
+  });
+
+  it('keeps an explicitly driven sync to a single pass even when a repeat delay is declared', async () => {
+    // `sync()` backs `facade.doSync()`, which must return. If the repeat leaked into it, the caller would never be
+    // handed control back.
+    const seen = await Effect.gen(function* () {
+      const seenRef = yield* Ref.make<readonly number[]>([]);
+      const secretKey = DustSecretKey.fromSeed(Buffer.alloc(32, 1));
+      const stateRef = yield* SubscriptionRef.make(
+        CoreWallet.initEmpty(LedgerParameters.initialParameters().dust, secretKey, networkId),
+      );
+      const scope = yield* Scope.make();
+      const variant = new RunningV1Variant(
+        scope,
+        { stateRef },
+        {
+          ...variantContextOf([], { getTransactionDetails: () => Effect.die('unused'), put: () => Effect.void }),
+          syncService: finiteSyncServiceOf(seenRef, Duration.seconds(5)),
+          syncCapability: advancingCapability,
+        },
+      );
+
+      yield* variant.sync(null);
+      yield* TestClock.adjust(Duration.minutes(5));
+      const result = yield* Ref.get(seenRef);
+      yield* Scope.close(scope, Exit.void);
+      return result;
+    }).pipe(Effect.provide(TestContext.TestContext), Effect.runPromise);
+
+    expect(seen).toEqual([0]);
   });
 });

--- a/packages/dust-wallet/src/v1/test/runningV1Variant.test.ts
+++ b/packages/dust-wallet/src/v1/test/runningV1Variant.test.ts
@@ -40,7 +40,7 @@ import { makeDefaultKeysCapability } from '../Keys.js';
 import { StateChange, VersionChangeType } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { RunningV1Variant } from '../RunningV1Variant.js';
 import { makeDefaultV1SerializationCapability } from '../Serialization.js';
-import { type ChangesResult, type SyncCapability, type SyncService } from '../Sync.js';
+import { BackgroundRepeat, type ChangesResult, type SyncCapability, type SyncService } from '../Sync.js';
 import { makeDefaultTransactingCapability } from '../Transacting.js';
 import { type TransactionHistoryService } from '../TransactionHistory.js';
 
@@ -60,6 +60,7 @@ const changeOf = (source: string): DustStateChanges => ({
 });
 
 const syncServiceOf = (batches: readonly FakeSyncUpdate[]): SyncService<CoreWallet, null, FakeSyncUpdate> => ({
+  backgroundRepeat: BackgroundRepeat.Once(),
   updates: () => Stream.fromIterable(batches),
   blockData: () =>
     Effect.succeed({
@@ -124,6 +125,7 @@ const immediateHistoryService = (recorded: Ref.Ref<number>): TransactionHistoryS
  *   service is. How often it was opened is therefore how many synchronization passes actually ran.
  */
 const countingSyncService = (subscriptions: Ref.Ref<number>): SyncService<CoreWallet, null, FakeSyncUpdate> => ({
+  backgroundRepeat: BackgroundRepeat.Once(),
   updates: () =>
     Stream.unwrap(
       Ref.update(subscriptions, (n) => n + 1).pipe(
@@ -240,6 +242,7 @@ describe('RunningV1Variant sync serialization', () => {
       const gate = yield* Deferred.make<void>();
 
       const gatedSyncService: SyncService<CoreWallet, null, FakeSyncUpdate> = {
+        backgroundRepeat: BackgroundRepeat.Once(),
         updates: () =>
           Stream.unwrap(
             Effect.gen(function* () {
@@ -431,8 +434,8 @@ describe('RunningV1Variant.state protocol version signalling', () => {
  * projections service converges once and never observes anything again — and the existing `Stream.retry` does not help,
  * because it re-runs on failure, not on completion.
  *
- * A service declares that it needs this by setting `backgroundRepeatDelay`; a service with a long-lived `updates` omits
- * it and must be unaffected.
+ * A service declares that it needs this as `BackgroundRepeat.WithDelay`; one with a long-lived `updates` declares
+ * `BackgroundRepeat.Once` and must be unaffected.
  */
 describe('RunningV1Variant background sync of a finite updates stream', () => {
   /**
@@ -441,16 +444,16 @@ describe('RunningV1Variant background sync of a finite updates stream', () => {
    */
   const finiteSyncServiceOf = (
     seenAppliedIndexes: Ref.Ref<readonly number[]>,
-    backgroundRepeatDelay?: Duration.DurationInput,
+    backgroundRepeat: BackgroundRepeat,
   ): SyncService<CoreWallet, null, FakeSyncUpdate> => ({
     ...syncServiceOf([]),
+    backgroundRepeat,
     updates: (state) =>
       pipe(
         Ref.update(seenAppliedIndexes, (seen) => [...seen, Number(state.progress.appliedIndex)]),
         Stream.fromEffect,
         Stream.as(['tx'] as FakeSyncUpdate),
       ),
-    ...(backgroundRepeatDelay !== undefined ? { backgroundRepeatDelay } : {}),
   });
 
   /** The whole timeline: nothing in this block is about which versions the variant owns. */
@@ -468,7 +471,7 @@ describe('RunningV1Variant background sync of a finite updates stream', () => {
   };
 
   const runBackgroundFor = async (
-    backgroundRepeatDelay: Duration.DurationInput | undefined,
+    backgroundRepeat: BackgroundRepeat,
     elapsed: Duration.DurationInput,
   ): Promise<readonly number[]> =>
     Effect.gen(function* () {
@@ -483,7 +486,7 @@ describe('RunningV1Variant background sync of a finite updates stream', () => {
         { stateRef, activationRange: wholeRange },
         {
           ...variantContextOf([], { getTransactionDetails: () => Effect.die('unused'), put: () => Effect.void }),
-          syncService: finiteSyncServiceOf(seen, backgroundRepeatDelay),
+          syncService: finiteSyncServiceOf(seen, backgroundRepeat),
           syncCapability: advancingCapability,
         },
       );
@@ -498,20 +501,23 @@ describe('RunningV1Variant background sync of a finite updates stream', () => {
   it('re-runs the pass on the declared delay, each pass starting from the state the last one produced', async () => {
     // 5s delay over 12s of clock: the initial pass plus two repeats. Each pass must observe the applied index the
     // previous pass advanced, which is only true if the repeat re-reads state rather than reusing a snapshot.
-    const seen = await runBackgroundFor(Duration.seconds(5), Duration.seconds(12));
+    const seen = await runBackgroundFor(
+      BackgroundRepeat.WithDelay({ delay: Duration.seconds(5) }),
+      Duration.seconds(12),
+    );
 
     expect(seen).toEqual([0, 1, 2]);
   });
 
-  it('leaves a service that declares no delay running exactly one pass', async () => {
+  it('leaves a service that declares `Once` running exactly one pass', async () => {
     // Guards the event-based service: its `updates` never completes in production, and nothing here may start
     // re-running passes behind its back.
-    const seen = await runBackgroundFor(undefined, Duration.minutes(5));
+    const seen = await runBackgroundFor(BackgroundRepeat.Once(), Duration.minutes(5));
 
     expect(seen).toEqual([0]);
   });
 
-  it('keeps an explicitly driven sync to a single pass even when a repeat delay is declared', async () => {
+  it('keeps an explicitly driven sync to a single pass even when a repeat is declared', async () => {
     // `sync()` backs `facade.doSync()`, which must return. If the repeat leaked into it, the caller would never be
     // handed control back.
     const seen = await Effect.gen(function* () {
@@ -526,7 +532,7 @@ describe('RunningV1Variant background sync of a finite updates stream', () => {
         { stateRef, activationRange: wholeRange },
         {
           ...variantContextOf([], { getTransactionDetails: () => Effect.die('unused'), put: () => Effect.void }),
-          syncService: finiteSyncServiceOf(seenRef, Duration.seconds(5)),
+          syncService: finiteSyncServiceOf(seenRef, BackgroundRepeat.WithDelay({ delay: Duration.seconds(5) })),
           syncCapability: advancingCapability,
         },
       );

--- a/packages/dust-wallet/src/v1/test/runningV1Variant.test.ts
+++ b/packages/dust-wallet/src/v1/test/runningV1Variant.test.ts
@@ -25,6 +25,7 @@ import {
   Effect,
   Exit,
   Fiber,
+  pipe,
   Ref,
   Scope,
   Stream,
@@ -421,5 +422,122 @@ describe('RunningV1Variant.state protocol version signalling', () => {
     expect(versionChangesOf(collected)).toEqual([]);
     // The stream still reports the state itself, so an empty result would be a false pass.
     expect(Chunk.toArray(collected).filter(StateChange.isState).length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * The projections sync service ends its `updates` stream after a single pass, where the event-based service's is a
+ * long-lived subscription. Background sync must therefore re-run a finite `updates`, or a wallet built on the
+ * projections service converges once and never observes anything again — and the existing `Stream.retry` does not help,
+ * because it re-runs on failure, not on completion.
+ *
+ * A service declares that it needs this by setting `backgroundRepeatDelay`; a service with a long-lived `updates` omits
+ * it and must be unaffected.
+ */
+describe('RunningV1Variant background sync of a finite updates stream', () => {
+  /**
+   * A service whose `updates` completes after emitting once. It records the `appliedIndex` of the state each pass was
+   * handed, so a test can tell whether later passes see the state earlier ones produced or a stale snapshot.
+   */
+  const finiteSyncServiceOf = (
+    seenAppliedIndexes: Ref.Ref<readonly number[]>,
+    backgroundRepeatDelay?: Duration.DurationInput,
+  ): SyncService<CoreWallet, null, FakeSyncUpdate> => ({
+    ...syncServiceOf([]),
+    updates: (state) =>
+      pipe(
+        Ref.update(seenAppliedIndexes, (seen) => [...seen, Number(state.progress.appliedIndex)]),
+        Stream.fromEffect,
+        Stream.as(['tx'] as FakeSyncUpdate),
+      ),
+    ...(backgroundRepeatDelay !== undefined ? { backgroundRepeatDelay } : {}),
+  });
+
+  /** The whole timeline: nothing in this block is about which versions the variant owns. */
+  const wholeRange = ProtocolVersion.makeRange(
+    ProtocolVersion.MinSupportedVersion,
+    ProtocolVersion.MaxSupportedVersion,
+  );
+
+  /** Advances the applied index by one per pass, so the next pass can be seen to start from the new value. */
+  const advancingCapability: SyncCapability<CoreWallet, FakeSyncUpdate, ChangesResult> = {
+    applyUpdate: (state, sources) => [
+      CoreWallet.updateProgress(state, { appliedIndex: state.progress.appliedIndex + 1n }),
+      { changes: sources.map(changeOf), protocolVersion: 1 },
+    ],
+  };
+
+  const runBackgroundFor = async (
+    backgroundRepeatDelay: Duration.DurationInput | undefined,
+    elapsed: Duration.DurationInput,
+  ): Promise<readonly number[]> =>
+    Effect.gen(function* () {
+      const seen = yield* Ref.make<readonly number[]>([]);
+      const secretKey = DustSecretKey.fromSeed(Buffer.alloc(32, 1));
+      const stateRef = yield* SubscriptionRef.make(
+        CoreWallet.initEmpty(LedgerParameters.initialParameters().dust, secretKey, networkId),
+      );
+      const scope = yield* Scope.make();
+      const variant = new RunningV1Variant(
+        scope,
+        { stateRef, activationRange: wholeRange },
+        {
+          ...variantContextOf([], { getTransactionDetails: () => Effect.die('unused'), put: () => Effect.void }),
+          syncService: finiteSyncServiceOf(seen, backgroundRepeatDelay),
+          syncCapability: advancingCapability,
+        },
+      );
+
+      yield* variant.startSyncInBackground(null);
+      yield* TestClock.adjust(elapsed);
+      const result = yield* Ref.get(seen);
+      yield* Scope.close(scope, Exit.void);
+      return result;
+    }).pipe(Effect.provide(TestContext.TestContext), Effect.runPromise);
+
+  it('re-runs the pass on the declared delay, each pass starting from the state the last one produced', async () => {
+    // 5s delay over 12s of clock: the initial pass plus two repeats. Each pass must observe the applied index the
+    // previous pass advanced, which is only true if the repeat re-reads state rather than reusing a snapshot.
+    const seen = await runBackgroundFor(Duration.seconds(5), Duration.seconds(12));
+
+    expect(seen).toEqual([0, 1, 2]);
+  });
+
+  it('leaves a service that declares no delay running exactly one pass', async () => {
+    // Guards the event-based service: its `updates` never completes in production, and nothing here may start
+    // re-running passes behind its back.
+    const seen = await runBackgroundFor(undefined, Duration.minutes(5));
+
+    expect(seen).toEqual([0]);
+  });
+
+  it('keeps an explicitly driven sync to a single pass even when a repeat delay is declared', async () => {
+    // `sync()` backs `facade.doSync()`, which must return. If the repeat leaked into it, the caller would never be
+    // handed control back.
+    const seen = await Effect.gen(function* () {
+      const seenRef = yield* Ref.make<readonly number[]>([]);
+      const secretKey = DustSecretKey.fromSeed(Buffer.alloc(32, 1));
+      const stateRef = yield* SubscriptionRef.make(
+        CoreWallet.initEmpty(LedgerParameters.initialParameters().dust, secretKey, networkId),
+      );
+      const scope = yield* Scope.make();
+      const variant = new RunningV1Variant(
+        scope,
+        { stateRef, activationRange: wholeRange },
+        {
+          ...variantContextOf([], { getTransactionDetails: () => Effect.die('unused'), put: () => Effect.void }),
+          syncService: finiteSyncServiceOf(seenRef, Duration.seconds(5)),
+          syncCapability: advancingCapability,
+        },
+      );
+
+      yield* variant.sync(null);
+      yield* TestClock.adjust(Duration.minutes(5));
+      const result = yield* Ref.get(seenRef);
+      yield* Scope.close(scope, Exit.void);
+      return result;
+    }).pipe(Effect.provide(TestContext.TestContext), Effect.runPromise);
+
+    expect(seen).toEqual([0]);
   });
 });

--- a/packages/dust-wallet/src/v2/RunningV2Variant.ts
+++ b/packages/dust-wallet/src/v2/RunningV2Variant.ts
@@ -21,6 +21,7 @@ import {
   Duration,
   Schedule,
   Array as Arr,
+  identity,
   Ref,
 } from 'effect';
 import { type TransactionHistoryService } from './TransactionHistory.js';
@@ -173,6 +174,8 @@ export class RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
   }
 
   startSyncInBackground(startAux: TStartAux): Effect.Effect<void> {
+    const repeatDelay = this.#v2Context.syncService.backgroundRepeatDelay;
+
     return this.startSync(startAux).pipe(
       Stream.retry(
         pipe(
@@ -186,6 +189,13 @@ export class RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
           }),
         ),
       ),
+      // A sync service whose `updates` is finite — the projections service ends its stream after one pass — would
+      // otherwise leave the wallet frozen at whatever that first pass saw. Repeating re-runs `startSync`, which
+      // re-reads the wallet state, so each pass resumes from what the previous one applied. The retry above cannot
+      // serve this purpose: it re-runs a pass on failure, not on completion. Repeating outside the retry keeps a
+      // transient failure to the pass it happened in, rather than restarting the whole cycle. A service with a
+      // long-lived `updates` declares no delay, and is left exactly as it was.
+      repeatDelay === undefined ? identity : Stream.repeat(Schedule.spaced(repeatDelay)),
       Stream.runScoped(Sink.drain),
       Effect.forkScoped,
       Effect.provideService(Scope.Scope, this.#scope),

--- a/packages/dust-wallet/src/v2/RunningV2Variant.ts
+++ b/packages/dust-wallet/src/v2/RunningV2Variant.ts
@@ -21,7 +21,6 @@ import {
   Duration,
   Schedule,
   Array as Arr,
-  identity,
   Ref,
 } from 'effect';
 import { type TransactionHistoryService } from './TransactionHistory.js';
@@ -43,7 +42,7 @@ import {
 } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type UtxoWithMeta } from './types/Dust.js';
 import { type KeysCapability } from './Keys.js';
-import { type ChangesResult, type SyncCapability, type SyncService } from './Sync.js';
+import { BackgroundRepeat, type ChangesResult, type SyncCapability, type SyncService } from './Sync.js';
 import { type BlockData } from './SyncSchema.js';
 import { type SimulatorState } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import {
@@ -174,9 +173,7 @@ export class RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
   }
 
   startSyncInBackground(startAux: TStartAux): Effect.Effect<void> {
-    const repeatDelay = this.#v2Context.syncService.backgroundRepeatDelay;
-
-    return this.startSync(startAux).pipe(
+    const pass = this.startSync(startAux).pipe(
       Stream.retry(
         pipe(
           Schedule.exponential(Duration.seconds(1), 2),
@@ -189,13 +186,18 @@ export class RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
           }),
         ),
       ),
-      // A sync service whose `updates` is finite — the projections service ends its stream after one pass — would
-      // otherwise leave the wallet frozen at whatever that first pass saw. Repeating re-runs `startSync`, which
-      // re-reads the wallet state, so each pass resumes from what the previous one applied. The retry above cannot
-      // serve this purpose: it re-runs a pass on failure, not on completion. Repeating outside the retry keeps a
-      // transient failure to the pass it happened in, rather than restarting the whole cycle. A service with a
-      // long-lived `updates` declares no delay, and is left exactly as it was.
-      repeatDelay === undefined ? identity : Stream.repeat(Schedule.spaced(repeatDelay)),
+    );
+
+    // A service that synchronizes in finite passes would otherwise leave the wallet frozen at whatever its first pass
+    // saw. Repeating re-runs `startSync`, which re-reads the wallet state, so each pass resumes from what the previous
+    // one applied. The retry above cannot serve this purpose: it re-runs a pass on failure, not on completion.
+    // Repeating outside it keeps a transient failure to the pass it happened in, rather than restarting the cycle.
+    const passes = BackgroundRepeat.$match(this.#v2Context.syncService.backgroundRepeat, {
+      Once: () => pass,
+      WithDelay: ({ delay }) => Stream.repeat(pass, Schedule.spaced(delay)),
+    });
+
+    return passes.pipe(
       Stream.runScoped(Sink.drain),
       Effect.forkScoped,
       Effect.provideService(Scope.Scope, this.#scope),

--- a/packages/dust-wallet/src/v2/Sync.ts
+++ b/packages/dust-wallet/src/v2/Sync.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 import {
   Array as Arr,
+  Data,
   Effect,
   Either,
   HashMap,
@@ -98,19 +99,43 @@ import {
 } from './Utils.js';
 import { type Dust } from './types/index.js';
 
+/**
+ * How often background synchronization runs a sync service's `updates`.
+ *
+ * @remarks
+ *   Every service states this, because the answer cannot be inferred from the service: it follows from whether `updates`
+ *   is finite, which only the service knows. A service whose `updates` is a long-lived subscription is
+ *   {@link BackgroundRepeat.Once} — that single pass never ends, so there is nothing to repeat. A service that
+ *   synchronizes in finite passes is {@link BackgroundRepeat.WithDelay}, or a wallet synchronizing in the background
+ *   would converge once and then never observe anything again. The variant's background retry does not cover the
+ *   latter: it re-runs a pass on failure, not on completion.
+ */
+export type BackgroundRepeat = Data.TaggedEnum<{
+  /** Run `updates` once and leave it running. For a service whose `updates` never completes. */
+  Once: {}; // eslint-disable-line @typescript-eslint/no-empty-object-type
+
+  /** Re-run `updates` this long after each pass completes. For a service that synchronizes in finite passes. */
+  WithDelay: { readonly delay: Duration.DurationInput };
+}>;
+/**
+ * Constructors and matchers for {@link BackgroundRepeat}.
+ *
+ * @example
+ *   ```ts
+ *   const service: SyncService<CoreWallet, DustSecretKey, WalletSyncUpdate> = {
+ *     backgroundRepeat: BackgroundRepeat.Once(),
+ *     updates: (state, secretKey) => subscribe(state, secretKey),
+ *     blockData: () => latestBlock(),
+ *   };
+ *   ```;
+ */
+export const BackgroundRepeat = Data.taggedEnum<BackgroundRepeat>();
+
 export interface SyncService<TState, TStartAux, TUpdate> {
   updates: (state: TState, auxData: TStartAux) => Stream.Stream<TUpdate, WalletError, Scope.Scope>;
   blockData: (height?: number) => Effect.Effect<BlockData, WalletError>;
-  /**
-   * Delay after which background synchronization re-runs `updates` once it has completed.
-   *
-   * Only meaningful for a service whose `updates` is finite. The projections service ends its stream after a single
-   * pass, so without this a wallet synchronizing in the background would converge once and then never observe anything
-   * again — the variant's background retry does not cover it, because that re-runs a pass on failure, not on
-   * completion. A service whose `updates` is a long-lived subscription omits this and is left running one pass, as that
-   * pass never ends.
-   */
-  readonly backgroundRepeatDelay?: Duration.DurationInput;
+  /** How often background synchronization re-runs {@link SyncService.updates}. See {@link BackgroundRepeat}. */
+  readonly backgroundRepeat: BackgroundRepeat;
 }
 
 export type ChangesResult = {
@@ -421,6 +446,8 @@ export const makeDefaultSyncService = (
 ): SyncService<CoreWallet, DustSecretKey, WalletSyncUpdate> => {
   const indexerSyncService = makeIndexerSyncService(config);
   return {
+    // A long-lived indexer subscription: the one pass never ends, so there is nothing to repeat.
+    backgroundRepeat: BackgroundRepeat.Once(),
     updates: (
       state: CoreWallet,
       secretKey: DustSecretKey,
@@ -742,7 +769,7 @@ export const makeEventLessSyncService = (
 
   return {
     // Each pass ends its own stream, so background synchronization has to be told to run another one.
-    backgroundRepeatDelay: Duration.millis(config.backgroundSyncInterval ?? 5_000),
+    backgroundRepeat: BackgroundRepeat.WithDelay({ delay: Duration.millis(config.backgroundSyncInterval ?? 5_000) }),
     updates: (
       state: CoreWallet,
       secretKey: DustSecretKey,
@@ -1283,6 +1310,8 @@ export const makeSimulatorSyncService = (
   config: SimulatorSyncConfiguration,
 ): SyncService<CoreWallet, DustSecretKey, SimulatorSyncUpdate> => {
   return {
+    // A live feed of simulator states: the one pass never ends, so there is nothing to repeat.
+    backgroundRepeat: BackgroundRepeat.Once(),
     updates: (_state: CoreWallet, secretKey: DustSecretKey) => {
       // Get the initial state immediately to ensure we process the genesis block.
       // Then subscribe to state$ for subsequent changes, but deduplicate by block number

--- a/packages/dust-wallet/src/v2/Sync.ts
+++ b/packages/dust-wallet/src/v2/Sync.ts
@@ -101,6 +101,16 @@ import { type Dust } from './types/index.js';
 export interface SyncService<TState, TStartAux, TUpdate> {
   updates: (state: TState, auxData: TStartAux) => Stream.Stream<TUpdate, WalletError, Scope.Scope>;
   blockData: (height?: number) => Effect.Effect<BlockData, WalletError>;
+  /**
+   * Delay after which background synchronization re-runs `updates` once it has completed.
+   *
+   * Only meaningful for a service whose `updates` is finite. The projections service ends its stream after a single
+   * pass, so without this a wallet synchronizing in the background would converge once and then never observe anything
+   * again — the variant's background retry does not cover it, because that re-runs a pass on failure, not on
+   * completion. A service whose `updates` is a long-lived subscription omits this and is left running one pass, as that
+   * pass never ends.
+   */
+  readonly backgroundRepeatDelay?: Duration.DurationInput;
 }
 
 export type ChangesResult = {
@@ -255,6 +265,19 @@ export type DefaultSyncConfiguration = {
   versionWatch?: VersionWatchConfig;
   /** The ledger parameters codecs blocks are read with; defaults to {@link defaultLedgerParametersCodecs}. */
   ledgerParametersCodecs?: LedgerParametersCodec.LedgerParametersCodecs<LedgerParameters>;
+  /**
+   * Delay in milliseconds between background synchronization passes, for a sync service that synchronizes in finite
+   * passes rather than over a live subscription — currently only the projections service. Ignored by the event-based
+   * service, whose subscription never completes.
+   *
+   * Lower values keep the wallet closer to the chain tip at the cost of more idle queries; a pass with nothing to do
+   * costs one block query, because the generation subscription and the commitment load both short-circuit on an
+   * unchanged tip. Passes never overlap regardless of this value: a pass that cannot take the sync lock yields to the
+   * one already running and waits for the next interval.
+   *
+   * @default 5000
+   */
+  backgroundSyncInterval?: number;
 };
 
 /** How often the chain is asked its version when the configuration does not say. */
@@ -718,6 +741,8 @@ export const makeEventLessSyncService = (
   const anonymityLevel = config.anonymityLevel ?? 7;
 
   return {
+    // Each pass ends its own stream, so background synchronization has to be told to run another one.
+    backgroundRepeatDelay: Duration.millis(config.backgroundSyncInterval ?? 5_000),
     updates: (
       state: CoreWallet,
       secretKey: DustSecretKey,

--- a/packages/dust-wallet/src/v2/test/runningV2Variant.test.ts
+++ b/packages/dust-wallet/src/v2/test/runningV2Variant.test.ts
@@ -40,7 +40,7 @@ import { makeDefaultKeysCapability } from '../Keys.js';
 import { StateChange, VersionChangeType } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { RunningV2Variant } from '../RunningV2Variant.js';
 import { makeDefaultV2SerializationCapability } from '../Serialization.js';
-import { type ChangesResult, type SyncCapability, type SyncService } from '../Sync.js';
+import { BackgroundRepeat, type ChangesResult, type SyncCapability, type SyncService } from '../Sync.js';
 import { makeDefaultTransactingCapability } from '../Transacting.js';
 import { type TransactionHistoryService } from '../TransactionHistory.js';
 
@@ -60,6 +60,7 @@ const changeOf = (source: string): DustStateChanges => ({
 });
 
 const syncServiceOf = (batches: readonly FakeSyncUpdate[]): SyncService<CoreWallet, null, FakeSyncUpdate> => ({
+  backgroundRepeat: BackgroundRepeat.Once(),
   updates: () => Stream.fromIterable(batches),
   blockData: () =>
     Effect.succeed({
@@ -129,6 +130,7 @@ const immediateHistoryService = (recorded: Ref.Ref<number>): TransactionHistoryS
  *   service is. How often it was opened is therefore how many synchronization passes actually ran.
  */
 const countingSyncService = (subscriptions: Ref.Ref<number>): SyncService<CoreWallet, null, FakeSyncUpdate> => ({
+  backgroundRepeat: BackgroundRepeat.Once(),
   updates: () =>
     Stream.unwrap(
       Ref.update(subscriptions, (n) => n + 1).pipe(
@@ -238,6 +240,7 @@ describe('RunningV2Variant sync serialization', () => {
       const gate = yield* Deferred.make<void>();
 
       const gatedSyncService: SyncService<CoreWallet, null, FakeSyncUpdate> = {
+        backgroundRepeat: BackgroundRepeat.Once(),
         updates: () =>
           Stream.unwrap(
             Effect.gen(function* () {
@@ -430,8 +433,8 @@ describe('RunningV2Variant.state protocol version signalling', () => {
  * projections service converges once and never observes anything again — and the existing `Stream.retry` does not help,
  * because it re-runs on failure, not on completion.
  *
- * A service declares that it needs this by setting `backgroundRepeatDelay`; a service with a long-lived `updates` omits
- * it and must be unaffected.
+ * A service declares that it needs this as `BackgroundRepeat.WithDelay`; one with a long-lived `updates` declares
+ * `BackgroundRepeat.Once` and must be unaffected.
  */
 describe('RunningV2Variant background sync of a finite updates stream', () => {
   /**
@@ -440,16 +443,16 @@ describe('RunningV2Variant background sync of a finite updates stream', () => {
    */
   const finiteSyncServiceOf = (
     seenAppliedIndexes: Ref.Ref<readonly number[]>,
-    backgroundRepeatDelay?: Duration.DurationInput,
+    backgroundRepeat: BackgroundRepeat,
   ): SyncService<CoreWallet, null, FakeSyncUpdate> => ({
     ...syncServiceOf([]),
+    backgroundRepeat,
     updates: (state) =>
       pipe(
         Ref.update(seenAppliedIndexes, (seen) => [...seen, Number(state.progress.appliedIndex)]),
         Stream.fromEffect,
         Stream.as(['tx'] as FakeSyncUpdate),
       ),
-    ...(backgroundRepeatDelay !== undefined ? { backgroundRepeatDelay } : {}),
   });
 
   /** The whole timeline: nothing in this block is about which versions the variant owns. */
@@ -467,7 +470,7 @@ describe('RunningV2Variant background sync of a finite updates stream', () => {
   };
 
   const runBackgroundFor = async (
-    backgroundRepeatDelay: Duration.DurationInput | undefined,
+    backgroundRepeat: BackgroundRepeat,
     elapsed: Duration.DurationInput,
   ): Promise<readonly number[]> =>
     Effect.gen(function* () {
@@ -482,7 +485,7 @@ describe('RunningV2Variant background sync of a finite updates stream', () => {
         { stateRef, activationRange: wholeRange },
         {
           ...variantContextOf([], { getTransactionDetails: () => Effect.die('unused'), put: () => Effect.void }),
-          syncService: finiteSyncServiceOf(seen, backgroundRepeatDelay),
+          syncService: finiteSyncServiceOf(seen, backgroundRepeat),
           syncCapability: advancingCapability,
         },
       );
@@ -497,20 +500,23 @@ describe('RunningV2Variant background sync of a finite updates stream', () => {
   it('re-runs the pass on the declared delay, each pass starting from the state the last one produced', async () => {
     // 5s delay over 12s of clock: the initial pass plus two repeats. Each pass must observe the applied index the
     // previous pass advanced, which is only true if the repeat re-reads state rather than reusing a snapshot.
-    const seen = await runBackgroundFor(Duration.seconds(5), Duration.seconds(12));
+    const seen = await runBackgroundFor(
+      BackgroundRepeat.WithDelay({ delay: Duration.seconds(5) }),
+      Duration.seconds(12),
+    );
 
     expect(seen).toEqual([0, 1, 2]);
   });
 
-  it('leaves a service that declares no delay running exactly one pass', async () => {
+  it('leaves a service that declares `Once` running exactly one pass', async () => {
     // Guards the event-based service: its `updates` never completes in production, and nothing here may start
     // re-running passes behind its back.
-    const seen = await runBackgroundFor(undefined, Duration.minutes(5));
+    const seen = await runBackgroundFor(BackgroundRepeat.Once(), Duration.minutes(5));
 
     expect(seen).toEqual([0]);
   });
 
-  it('keeps an explicitly driven sync to a single pass even when a repeat delay is declared', async () => {
+  it('keeps an explicitly driven sync to a single pass even when a repeat is declared', async () => {
     // `sync()` backs `facade.doSync()`, which must return. If the repeat leaked into it, the caller would never be
     // handed control back.
     const seen = await Effect.gen(function* () {
@@ -525,7 +531,7 @@ describe('RunningV2Variant background sync of a finite updates stream', () => {
         { stateRef, activationRange: wholeRange },
         {
           ...variantContextOf([], { getTransactionDetails: () => Effect.die('unused'), put: () => Effect.void }),
-          syncService: finiteSyncServiceOf(seenRef, Duration.seconds(5)),
+          syncService: finiteSyncServiceOf(seenRef, BackgroundRepeat.WithDelay({ delay: Duration.seconds(5) })),
           syncCapability: advancingCapability,
         },
       );

--- a/packages/dust-wallet/src/v2/test/runningV2Variant.test.ts
+++ b/packages/dust-wallet/src/v2/test/runningV2Variant.test.ts
@@ -25,6 +25,7 @@ import {
   Effect,
   Exit,
   Fiber,
+  pipe,
   Ref,
   Scope,
   Stream,
@@ -420,5 +421,122 @@ describe('RunningV2Variant.state protocol version signalling', () => {
     expect(versionChangesOf(collected)).toEqual([]);
     // The stream still reports the state itself, so an empty result would be a false pass.
     expect(Chunk.toArray(collected).filter(StateChange.isState).length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * The projections sync service ends its `updates` stream after a single pass, where the event-based service's is a
+ * long-lived subscription. Background sync must therefore re-run a finite `updates`, or a wallet built on the
+ * projections service converges once and never observes anything again — and the existing `Stream.retry` does not help,
+ * because it re-runs on failure, not on completion.
+ *
+ * A service declares that it needs this by setting `backgroundRepeatDelay`; a service with a long-lived `updates` omits
+ * it and must be unaffected.
+ */
+describe('RunningV2Variant background sync of a finite updates stream', () => {
+  /**
+   * A service whose `updates` completes after emitting once. It records the `appliedIndex` of the state each pass was
+   * handed, so a test can tell whether later passes see the state earlier ones produced or a stale snapshot.
+   */
+  const finiteSyncServiceOf = (
+    seenAppliedIndexes: Ref.Ref<readonly number[]>,
+    backgroundRepeatDelay?: Duration.DurationInput,
+  ): SyncService<CoreWallet, null, FakeSyncUpdate> => ({
+    ...syncServiceOf([]),
+    updates: (state) =>
+      pipe(
+        Ref.update(seenAppliedIndexes, (seen) => [...seen, Number(state.progress.appliedIndex)]),
+        Stream.fromEffect,
+        Stream.as(['tx'] as FakeSyncUpdate),
+      ),
+    ...(backgroundRepeatDelay !== undefined ? { backgroundRepeatDelay } : {}),
+  });
+
+  /** The whole timeline: nothing in this block is about which versions the variant owns. */
+  const wholeRange = ProtocolVersion.makeRange(
+    ProtocolVersion.MinSupportedVersion,
+    ProtocolVersion.MaxSupportedVersion,
+  );
+
+  /** Advances the applied index by one per pass, so the next pass can be seen to start from the new value. */
+  const advancingCapability: SyncCapability<CoreWallet, FakeSyncUpdate, ChangesResult> = {
+    applyUpdate: (state, sources) => [
+      CoreWallet.updateProgress(state, { appliedIndex: state.progress.appliedIndex + 1n }),
+      { changes: sources.map(changeOf), protocolVersion: 1 },
+    ],
+  };
+
+  const runBackgroundFor = async (
+    backgroundRepeatDelay: Duration.DurationInput | undefined,
+    elapsed: Duration.DurationInput,
+  ): Promise<readonly number[]> =>
+    Effect.gen(function* () {
+      const seen = yield* Ref.make<readonly number[]>([]);
+      const secretKey = DustSecretKey.fromSeed(Buffer.alloc(32, 1));
+      const stateRef = yield* SubscriptionRef.make(
+        CoreWallet.initEmpty(LedgerParameters.initialParameters().dust, secretKey, networkId),
+      );
+      const scope = yield* Scope.make();
+      const variant = new RunningV2Variant(
+        scope,
+        { stateRef, activationRange: wholeRange },
+        {
+          ...variantContextOf([], { getTransactionDetails: () => Effect.die('unused'), put: () => Effect.void }),
+          syncService: finiteSyncServiceOf(seen, backgroundRepeatDelay),
+          syncCapability: advancingCapability,
+        },
+      );
+
+      yield* variant.startSyncInBackground(null);
+      yield* TestClock.adjust(elapsed);
+      const result = yield* Ref.get(seen);
+      yield* Scope.close(scope, Exit.void);
+      return result;
+    }).pipe(Effect.provide(TestContext.TestContext), Effect.runPromise);
+
+  it('re-runs the pass on the declared delay, each pass starting from the state the last one produced', async () => {
+    // 5s delay over 12s of clock: the initial pass plus two repeats. Each pass must observe the applied index the
+    // previous pass advanced, which is only true if the repeat re-reads state rather than reusing a snapshot.
+    const seen = await runBackgroundFor(Duration.seconds(5), Duration.seconds(12));
+
+    expect(seen).toEqual([0, 1, 2]);
+  });
+
+  it('leaves a service that declares no delay running exactly one pass', async () => {
+    // Guards the event-based service: its `updates` never completes in production, and nothing here may start
+    // re-running passes behind its back.
+    const seen = await runBackgroundFor(undefined, Duration.minutes(5));
+
+    expect(seen).toEqual([0]);
+  });
+
+  it('keeps an explicitly driven sync to a single pass even when a repeat delay is declared', async () => {
+    // `sync()` backs `facade.doSync()`, which must return. If the repeat leaked into it, the caller would never be
+    // handed control back.
+    const seen = await Effect.gen(function* () {
+      const seenRef = yield* Ref.make<readonly number[]>([]);
+      const secretKey = DustSecretKey.fromSeed(Buffer.alloc(32, 1));
+      const stateRef = yield* SubscriptionRef.make(
+        CoreWallet.initEmpty(LedgerParameters.initialParameters().dust, secretKey, networkId),
+      );
+      const scope = yield* Scope.make();
+      const variant = new RunningV2Variant(
+        scope,
+        { stateRef, activationRange: wholeRange },
+        {
+          ...variantContextOf([], { getTransactionDetails: () => Effect.die('unused'), put: () => Effect.void }),
+          syncService: finiteSyncServiceOf(seenRef, Duration.seconds(5)),
+          syncCapability: advancingCapability,
+        },
+      );
+
+      yield* variant.sync(null);
+      yield* TestClock.adjust(Duration.minutes(5));
+      const result = yield* Ref.get(seenRef);
+      yield* Scope.close(scope, Exit.void);
+      return result;
+    }).pipe(Effect.provide(TestContext.TestContext), Effect.runPromise);
+
+    expect(seen).toEqual([0]);
   });
 });

--- a/packages/wallet-sdk-testkit/src/dust-sync.ts
+++ b/packages/wallet-sdk-testkit/src/dust-sync.ts
@@ -29,12 +29,10 @@ export type DustWalletFactory = (config: DefaultDustConfiguration) => DustWallet
  * The sync service is swapped in at build time, so a wallet built without this factory gets the event-based sync no
  * matter what else it configures.
  *
- * **This is a one-shot sync and must be driven explicitly.** Where the event-based service's `updates` is a long-lived
- * indexer subscription, the projections service does a single pass up to the block it read at the start and then ends
- * its stream. Background syncing therefore converges once and never observes anything afterwards, and the variant's
- * background retry only re-runs the pass on _failure_, not on completion. Pair this factory with `manualSync: true` —
- * see {@link projectionsDustSyncOptions} — and call `facade.doSync(dustSecretKey)` at every point that would otherwise
- * wait for background convergence.
+ * The projections sync synchronizes in finite passes rather than over a live subscription, but background
+ * synchronization re-runs those passes on an interval, so this factory can be used on its own and the usual state
+ * waiters behave as they do for the event-based sync. Pair it with `manualSync` — see {@link projectionsDustSyncOptions}
+ * — only when a caller wants to decide when each pass happens.
  */
 export const eventLessDustWallet: DustWalletFactory = (config) =>
   CustomDustWallet(
@@ -46,12 +44,15 @@ export const eventLessDustWallet: DustWalletFactory = (config) =>
 export const eventBasedDustWallet: DustWalletFactory = DustWallet;
 
 /**
- * The correct way to opt a wallet into the projections-based dust sync: the factory plus `manualSync`, so the caller
- * owns when each snapshot is taken.
+ * The projections dust sync with background synchronization switched off, so the caller decides when each pass runs.
  *
- * A caller that spreads this in still has to drive `facade.doSync(dustSecretKey)` itself — after start, and again after
- * anything that changes dust state. Waiting on `waitForSyncedState()` alone will block, because with `manualSync`
+ * Use this when a test needs passes to happen at known points — asserting on the state a specific pass produced, for
+ * instance. A caller that spreads this in must drive `facade.doSync(dustSecretKey)` itself, after start and again after
+ * anything that changes dust state; waiting on `waitForSyncedState()` alone will block, because with `manualSync`
  * nothing advances the dust wallet until `doSync` runs.
+ *
+ * For a test that just wants the wallet to keep up on its own, pass `{ dustWallet: eventLessDustWallet }` instead and
+ * let background synchronization run the passes.
  */
 export const projectionsDustSyncOptions: {
   readonly dustWallet: DustWalletFactory;

--- a/packages/wallet-sdk-testkit/src/dust-sync.ts
+++ b/packages/wallet-sdk-testkit/src/dust-sync.ts
@@ -43,12 +43,17 @@ export type DustWalletFactory = (config: DefaultDustConfiguration) => {
  * The sync service is swapped in at build time, so a wallet built without this factory gets the event-based sync no
  * matter what else it configures.
  *
- * **This is a one-shot sync and must be driven explicitly.** Where the event-based service's `updates` is a long-lived
- * indexer subscription, the projections service does a single pass up to the block it read at the start and then ends
- * its stream. Background syncing therefore converges once and never observes anything afterwards, and the variant's
- * background retry only re-runs the pass on _failure_, not on completion. Pair this factory with `manualSync: true` —
- * see {@link projectionsDustSyncOptions} — and call `facade.doSync(seeds)` at every point that would otherwise wait for
- * background convergence.
+ * The projections sync synchronizes in finite passes rather than over a live subscription, but background
+ * synchronization re-runs those passes on an interval, so this factory can be used on its own and the usual state
+ * waiters behave as they do for the event-based sync. Pair it with `manualSync` — see {@link projectionsDustSyncOptions}
+ * — only when a caller wants to decide when each pass happens.
+ *
+ * **A wallet built this way syncs, but must not transact.** `CustomDustWallet` is a single-variant composition, whose
+ * one variant answers for the whole protocol timeline: it reports the minimum supported version and stamps whatever it
+ * builds at that version. A facade acts at the lowest version its three sub-wallets report, so this sub-wallet holds
+ * the facade below the ledger-v9 boundary, and the facade then refuses the shielded wallet's ledger-v9 transaction
+ * because the two sides of a boundary cannot be merged. Build transactions on a wallet using the shipped two-variant
+ * dust wallet, and use one built here to observe the result.
  */
 export const eventLessDustWallet: DustWalletFactory = (config) =>
   CustomDustWallet(
@@ -64,12 +69,16 @@ export const eventLessDustWallet: DustWalletFactory = (config) =>
 export const eventBasedDustWallet: DustWalletFactory = DustWallet;
 
 /**
- * The correct way to opt a wallet into the projections-based dust sync: the factory plus `manualSync`, so the caller
- * owns when each snapshot is taken.
+ * The projections dust sync with background synchronization switched off, so the caller decides when each pass runs.
  *
- * A caller that spreads this in still has to drive `facade.doSync(seeds)` itself — after start, and again after
- * anything that changes dust state. Waiting on `waitForSyncedState()` alone will block, because with `manualSync`
+ * Use this when a test needs passes to happen at known points — asserting on the state a specific pass produced, for
+ * instance. A caller that spreads this in must drive `facade.doSync(seeds)` itself, after start and again after
+ * anything that changes dust state; waiting on `waitForSyncedState()` alone will block, because with `manualSync`
  * nothing advances the dust wallet until `doSync` runs.
+ *
+ * For a test that just wants the wallet to keep up on its own, pass `{ dustWallet: eventLessDustWallet }` instead and
+ * let background synchronization run the passes. Either way the wallet syncs but must not transact — see
+ * {@link eventLessDustWallet}.
  */
 export const projectionsDustSyncOptions: {
   readonly dustWallet: DustWalletFactory;


### PR DESCRIPTION
Makes the projections-based ("event-less") Dust sync usable under background synchronization. Stacked on #637 — review that first; this branch's own contribution is 5 files.

## The problem

The projections sync synchronizes in **finite passes**: `doEventlessSync` ends its stream once a pass completes. The event-based service instead holds a long-lived indexer subscription that never completes.

Background synchronization was written for the latter. `RunningV1Variant.startSync` reads the wallet state **once** and invokes `updates` **once**, and `startSyncInBackground` wraps that in `Stream.retry` — which re-runs a pass on *failure*, not on *completion*.

So a wallet built with the projections sync and started in the background converged once and then never observed anything again, **silently**. The only usable shape was `manualSync: true` plus an explicit `facade.doSync()` at every point that would otherwise wait for the background sync to catch up — which is not how an application uses the SDK. Any consumer calling `wallet.start()` with a projections Dust wallet hit this.

## The change

A sync service may now declare `backgroundRepeatDelay`; background synchronization re-runs its pass on that delay.

```ts
repeatDelay === undefined ? identity : Stream.repeat(Schedule.spaced(repeatDelay)),
```

Because the repeat re-runs `startSync`, each pass re-reads the wallet state and resumes from what the previous pass applied — no change to the `SyncService` contract's shape, and no state threading.

The projections service declares it, defaulting to 5s and configurable as `backgroundSyncInterval` (ms). The event-based and simulator services omit it and are **untouched** — their `updates` never completes, so `Stream.repeat` never fires.

Three details worth checking during review, because each is easy to get wrong:

| Decision | Why |
| --- | --- |
| Repeat lives in `startSyncInBackground`, not the shared `startSync` | `sync()` — which backs `facade.doSync()` — also calls `startSync`. A repeat there would mean `doSync()` never returns. |
| Repeat sits **outside** `Stream.retry` | A transient failure is then retried within the pass it happened in, rather than restarting the whole cycle. |
| Existing `#syncLock` left alone | Each pass acquires and releases it, so passes cannot overlap. A pass that cannot take the lock is skipped and waits for the next interval. |

## Tests

Three, in `runningV1Variant.test.ts`, using `TestClock` so they are deterministic rather than timing-dependent:

- **`re-runs the pass on the declared delay, each pass starting from the state the last one produced`** — asserts the observed applied indexes are `[0, 1, 2]`. This is the load-bearing one: it fails unless the repeat re-reads state, which is the entire reason it wraps `startSync` rather than `updates`.
- **`leaves a service that declares no delay running exactly one pass`** — guards the event-based service against acquiring a repeat behind its back.
- **`keeps an explicitly driven sync to a single pass even when a repeat delay is declared`** — guards `doSync()`'s contract.

The latter two pass before the change as well as after; they are the regression net, not the demonstration. The first fails before and passes after.

`dust-wallet` unit suite: 91 passed, 1 expected fail (a pre-existing `it.fails` pinning the progress-monotonicity defect).

## Verified against a live network

On stagenet, a projections wallet in background mode reaches a synced state with **no `doSync` call** — `connected=true`, `gap=0`, `complete=true` — which is only possible if passes are repeating. Before this change that configuration converged once and stopped.

That run was done from a **clean** state cache, deliberately: e2e state snapshots on that network had been corrupted by an unrelated harness bug (`afterEach` saves wallet state even when a test fails, so one failure poisons every later run). Earlier stagenet readings taken on poisoned snapshots are not trustworthy, and are not offered as evidence here.

## Reviewer notes

- **The 5s default is a judgement call and I would like a second opinion.** It was not chosen by measurement. At 5s each wallet issues roughly 12 block queries a minute indefinitely. An idle pass is cheap — the generation subscription and the commitment load both short-circuit on an unchanged tip — but nothing here justifies 5s over 15s or 30s.
- **A persistent apply failure now recurs every interval** rather than once. That is correct behaviour given bad input, but it turns one error into a stream of them; surfacing a repeatedly-failing pass rather than retrying it silently would be a reasonable follow-up.
- Also included: a JSDoc correction in the testkit's `dust-sync.ts`, which told callers the projections sync was one-shot and had to be hand-driven. This change makes that untrue, so the text is fixed here rather than left to contradict the code.

## Not in this PR

Pointing the testkit healthcheck scenarios at the projections sync by default. That is split out to `feat/testkit-healthcheck-projections-default`, because it is a breaking change for downstream monitoring and is additionally blocked on the state-cache bug above. Keeping them separate means this change can land on its own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
