### PR TITLE
docs(prover-client): fix config field name in README (serverUrl -> url)

### DIFF
--- a/packages/prover-client/README.md
+++ b/packages/prover-client/README.md
@@ -22,7 +22,7 @@ import { HttpProverClient } from '@midnightntwrk/wallet-sdk-prover-client';
 
 // Initialize the client with the Proof Server URL
 const proverClient = new HttpProverClient({
-  serverUrl: 'http://localhost:6300',
+  url: 'http://localhost:6300',
 });
 
 // Prove an unproven transaction
@@ -41,7 +41,7 @@ const provenTransaction = await proverClient.proveTransaction(unprovenTransactio
 
 ```typescript
 class HttpProverClient {
-  constructor(config: { serverUrl: string });
+  constructor(config: { url: string });
 
   proveTransaction<S extends Signaturish, B extends Bindingish>(
     transaction: Transaction<S, PreProof, B>,


### PR DESCRIPTION
The `prover-client` README's basic-usage example and API signature reference a `serverUrl` config field:

```ts
new HttpProverClient({ serverUrl: 'http://localhost:6300' });
```

But `HttpProverClient` takes a `ProverClient.ServerConfig` whose field is `url` (`src/effect/ProverClient.ts` declares `readonly url`, and `src/effect/HttpProverClient.ts` reads `config.url`). `serverUrl` does not exist in the sources, so copying the documented example fails at runtime.

This aligns the README (both the example and the API signature) with the actual field name.