### PR TITLE
feat(shielded): fork boundary wiring and cross-version state migration

### DIFF
--- a/.changeset/shielded-fork-boundary-wiring.md
+++ b/.changeset/shielded-fork-boundary-wiring.md
@@ -1,0 +1,49 @@
+---
+'@midnightntwrk/wallet-sdk-shielded': minor
+---
+
+Make the shielded wallet able to follow the chain across a hard fork: sync now recognises the protocol version the
+indexer reports, hands over at the variant boundary, and starts the next ledger version's variant on a fresh state.
+
+**Behavioural change: wallet state now tracks the reported protocol version.** Until now nothing wrote the indexer's
+`protocolVersion` into the wallet state, so it stayed pinned at its initial value and a protocol version change could
+never be signalled. It is now recorded on every applied batch. The value only ever increases — a source that briefly
+reports an older version (a reconnect replaying from an earlier cursor, say) cannot drag the wallet back below a
+boundary it has already crossed.
+
+**Breaking for custom `withSync` authors: `SyncCapability.applyUpdate` takes a third argument.** The signature is now
+`applyUpdate(state, update, activeRange)`, where `activeRange` is the half-open protocol version range the running
+variant owns, derived from `withVariant(sinceVersion)` registration. A custom capability must accept it and split its
+batch at the boundary: everything from the first item at or beyond the range's end belongs to the next variant and must
+be left unapplied, with the applied index stopping at the last item actually applied so that suffix is re-fetched rather
+than skipped. `splitAtVersionBoundary` and `annotateVersion` are exported from the `Sync` module and implement exactly
+that rule — the built-in indexer and simulator capabilities both go through them, and a custom capability should too.
+
+A variant also emits a version change when the state it _starts_ from already sits outside its range, which heals a
+snapshot serialized between the annotation and the migration it should have caused.
+
+**New: configurable state migration.** Each variant gains a `Migration` module and the builder gains `withMigration` /
+`withMigrationDefaults`, so how a variant produces its first state from whatever preceded it is a build-time choice
+rather than a fixed one. Three strategies ship: `makeEmptyWalletMigration` (an empty wallet, which is what an
+unconfigured builder has always produced and what `startEmpty` relies on — unchanged), `makeCarryOverMigration` (carry
+state unchanged between two variants of the same ledger version), and `makeCrossLedgerMigration` (start the next ledger
+version fresh). A builder that never mentions migration keeps building and behaves exactly as before.
+
+**Crossing a ledger version carries identity and nothing else.** The indexer replays the timeline after the fork,
+re-emitting the wallet's history as events of the new ledger version, so a migrated wallet re-discovers exactly the same
+coins by ordinary synchronization — decrypting them with the keys the sync restart supplies. `makeCrossLedgerMigration`
+therefore carries the public keys, the network and the protocol version that triggered the hand-over onto an empty local
+state, and carries no coins: doing so would double-count what the replay is about to deliver, and rebuilding a Merkle
+tree needs secret keys that migration by design does not have.
+
+Sync progress is **reset** rather than carried, on the assumption that a replayed timeline restarts its event ids.
+Should the indexer continue them past the boundary instead, the projection parks progress at the fork rather than
+rewinding it — a one-line change, which is why `PreviousLedgerWallet` still exposes progress. The assumption is
+recorded against the indexer team and is the one thing here that must be confirmed before release.
+
+`ShieldedWallet.start` now holds on to the keys it was given and re-establishes background synchronization on the
+variant a migration activates; `stop` releases them. Previously a migration left the wallet with no running sync, and no
+keys to restart it with.
+
+The shielded wallet still registers a single ledger-v9 variant, so nothing about a live wallet's behaviour changes
+today.

--- a/.changeset/shielded-fork-boundary-wiring.md
+++ b/.changeset/shielded-fork-boundary-wiring.md
@@ -29,17 +29,19 @@ unconfigured builder has always produced and what `startEmpty` relies on — unc
 state unchanged between two variants of the same ledger version), and `makeCrossLedgerMigration` (start the next ledger
 version fresh). A builder that never mentions migration keeps building and behaves exactly as before.
 
-**Crossing a ledger version carries identity and nothing else.** The indexer replays the timeline after the fork,
-re-emitting the wallet's history as events of the new ledger version, so a migrated wallet re-discovers exactly the same
-coins by ordinary synchronization — decrypting them with the keys the sync restart supplies. `makeCrossLedgerMigration`
-therefore carries the public keys, the network and the protocol version that triggered the hand-over onto an empty local
-state, and carries no coins: doing so would double-count what the replay is about to deliver, and rebuilding a Merkle
-tree needs secret keys that migration by design does not have.
+**Crossing a ledger version carries identity and position, and no coins.** The indexer replays the timeline after the
+fork, re-emitting the wallet's history as events of the new ledger version, so a migrated wallet re-discovers exactly
+the same coins by ordinary synchronization — decrypting them with the keys the sync restart supplies.
+`makeCrossLedgerMigration` therefore carries the public keys, the network and the protocol version that triggered the
+hand-over onto an empty local state, and carries no coins: doing so would double-count what the replay is about to
+deliver, and rebuilding a Merkle tree needs secret keys that migration by design does not have.
 
-Sync progress is **reset** rather than carried, on the assumption that a replayed timeline restarts its event ids.
-Should the indexer continue them past the boundary instead, the projection parks progress at the fork rather than
-rewinding it — a one-line change, which is why `PreviousLedgerWallet` still exposes progress. The assumption is
-recorded against the indexer team and is the one thing here that must be confirmed before release.
+Sync progress is **parked at the fork**: the previous variant's cursor crosses unchanged. The replay is not a second
+timeline but the same one continuing — the indexer numbers the replayed events onwards from whatever id it had reached
+when the fork happened, never from zero — so a migrated wallet resumes from the inherited cursor and meets the replay
+there. Rewinding to zero would leave it waiting on a stretch of history that the new ledger version's events do not
+occupy. `isConnected` is the one part of progress that does not cross: nothing is synchronizing behind a just-migrated
+state until the restart reconnects it.
 
 `ShieldedWallet.start` now holds on to the keys it was given and re-establishes background synchronization on the
 variant a migration activates; `stop` releases them. Previously a migration left the wallet with no running sync, and no

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -14,13 +14,14 @@ import { type ProtocolState, ProtocolVersion, type SyncProgress } from '@midnigh
 import {
   type BaseV2Configuration,
   type DefaultV2Configuration,
+  type RunningV2Variant,
   V2Builder,
   V2Tag,
   type V2Variant,
   CoreWallet,
 } from './v2/index.js';
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { Effect, Either, type Scope } from 'effect';
+import { Effect, Either, Option, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
 import { type BalancingResult } from './v2/Transacting.js';
 import { type SerializationCapability } from './v2/Serialization.js';
@@ -244,6 +245,27 @@ export function CustomShieldedWallet<
 
     readonly state: rx.Observable<ShieldedWalletState<TSerialized>>;
 
+    /**
+     * The start-aux the application last called {@link start} with.
+     *
+     * @remarks
+     *   Sync needs the secret keys, and a migration starts a fresh variant whose sync has never been started. The keys
+     *   cannot come from the state — they are deliberately absent from anything serialized — and they do not exist yet
+     *   when the wallet is first constructed, so they are held here, in memory, for the lifetime of the wallet. Cleared
+     *   by {@link stop} so a stopped wallet cannot be silently resurrected by a late activation.
+     */
+    readonly #retainedAux = Ref.unsafeMake<Option.Option<TStartAux>>(Option.none());
+
+    /**
+     * Whether the activation watcher has been registered.
+     *
+     * @remarks
+     *   Registration is per wallet, not per `start`: watchers accumulate, so registering on every call would restart sync
+     *   once per historical `start` on the next activation. Flipped with `getAndSet` so concurrent `start` calls cannot
+     *   both observe it unset.
+     */
+    readonly #watcherRegistered = Ref.unsafeMake(false);
+
     constructor(
       runtime: Runtime.Runtime<
         [Variant.VersionedVariant<V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>>]
@@ -262,7 +284,35 @@ export function CustomShieldedWallet<
     }
 
     start(secretKeys: TStartAux): Promise<void> {
-      return this.runtime.dispatch({ [V2Tag]: (v2) => v2.startSyncInBackground(secretKeys) }).pipe(Effect.runPromise);
+      return Effect.gen(this, function* () {
+        yield* Ref.set(this.#retainedAux, Option.some(secretKeys));
+
+        // Registered before the first dispatch, and only once: `onVariantActivation` resolves only after its
+        // subscription is live, so an activation racing this call is queued rather than missed.
+        const alreadyRegistered = yield* Ref.getAndSet(this.#watcherRegistered, true);
+        if (!alreadyRegistered) {
+          yield* this.runtime.onVariantActivation({
+            [V2Tag]: (v2: RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>) =>
+              Ref.get(this.#retainedAux).pipe(
+                Effect.flatMap(
+                  Option.match({
+                    // Stopped, or never started: there is nothing to resume and no keys to resume it with.
+                    onNone: () => Effect.void,
+                    onSome: (retained: TStartAux) => v2.startSyncInBackground(retained),
+                  }),
+                ),
+              ),
+          });
+        }
+
+        yield* this.runtime.dispatch({ [V2Tag]: (v2) => v2.startSyncInBackground(secretKeys) });
+      }).pipe(Effect.runPromise);
+    }
+
+    async stop(): Promise<void> {
+      // Released before the runtime is torn down: the keys outlive neither the wallet nor an in-flight activation.
+      Ref.set(this.#retainedAux, Option.none()).pipe(Effect.runSync);
+      await super.stop();
     }
 
     balanceTransaction(

--- a/packages/shielded-wallet/src/test/shieldedWallet.test.ts
+++ b/packages/shielded-wallet/src/test/shieldedWallet.test.ts
@@ -14,7 +14,7 @@ import * as ledger from '@midnightntwrk/ledger-v9';
 import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Effect, Scope, Stream } from 'effect';
 import { describe, expect, it } from 'vitest';
-import { ShieldedWallet, type ShieldedWalletClass } from '../ShieldedWallet.js';
+import { type CustomizedShieldedWallet, ShieldedWallet } from '../ShieldedWallet.js';
 import { type DefaultV2Configuration, TransactionHistory, V2Tag } from '../v2/index.js';
 
 const configuration: DefaultV2Configuration = {
@@ -27,10 +27,10 @@ const configuration: DefaultV2Configuration = {
  * What the wallet asked of its runtime.
  *
  * @remarks
- *   The runtime is stubbed rather than driven through a real migration because the behaviour under test is entirely
- *   the wallet's: which keys it holds on to, and how many watchers it registers. Registering two variants to provoke a
- *   real activation would test the runtime — which already has its own coverage — and would need the multi-variant
- *   wallet type that is deliberately still deferred.
+ *   The runtime is stubbed rather than driven through a real migration because the behaviour under test is entirely the
+ *   wallet's: which keys it holds on to, and how many watchers it registers. Registering two variants to provoke a real
+ *   activation would test the runtime — which already has its own coverage — and would need the multi-variant wallet
+ *   type that is deliberately still deferred.
  */
 type RuntimeRecorder = {
   /** The start-aux each `dispatch` to `startSyncInBackground` was given, in order. */
@@ -38,14 +38,16 @@ type RuntimeRecorder = {
   /** The start-aux the activation watcher restarted sync with, in order. */
   readonly resumed: ledger.ZswapSecretKeys[];
   /** One entry per `onVariantActivation` registration. */
-  readonly watchers: ((variant: { startSyncInBackground: (aux: ledger.ZswapSecretKeys) => Effect.Effect<void> }) => Effect.Effect<void>)[];
+  readonly watchers: ((variant: {
+    startSyncInBackground: (aux: ledger.ZswapSecretKeys) => Effect.Effect<void>;
+  }) => Effect.Effect<void>)[];
 };
 
 const makeRecorder = (): RuntimeRecorder => ({ dispatched: [], resumed: [], watchers: [] });
 
 const walletWith = (
   recorder: RuntimeRecorder,
-): Effect.Effect<{ wallet: InstanceType<ShieldedWalletClass>; scope: Scope.CloseableScope }> =>
+): Effect.Effect<{ wallet: CustomizedShieldedWallet; scope: Scope.CloseableScope }> =>
   Effect.gen(function* () {
     const scope = yield* Scope.make();
     const WalletClass = ShieldedWallet(configuration);
@@ -63,17 +65,19 @@ const walletWith = (
       progress: Effect.succeed({ sourceGap: 0n, applyGap: 0n }),
       currentVariant: Effect.succeed(runningVariant),
       dispatch: (impl: Record<symbol, (variant: typeof runningVariant) => Effect.Effect<unknown>>) =>
-        impl[V2Tag]!(runningVariant),
+        impl[V2Tag](runningVariant),
       onVariantActivation: (impl: Record<symbol, RuntimeRecorder['watchers'][number]>) =>
         Effect.sync(() => {
-          recorder.watchers.push(impl[V2Tag]!);
+          recorder.watchers.push(impl[V2Tag]);
         }),
     };
 
-    // Type cast required because: `Runtime.Runtime` is parameterised over the variant HList and its members are typed
-    // with `Poly.PolyFunction`, which no structural stub can be inferred into. The five members above are the whole
-    // interface, and each is exercised by the assertions below.
-    const wallet = new WalletClass(stub as never, scope);
+    // Type casts required because: `Runtime.Runtime` is parameterised over the variant HList and its members are
+    // typed with `Poly.PolyFunction`, which no structural stub can be inferred into — the five members above are the
+    // whole interface, and each is exercised by the assertions below. The result is narrowed because
+    // `BaseWalletClass`'s construct signature is declared to return the base `WalletLike`, so `new` on the class type
+    // loses the shielded API; the production static factories narrow at exactly the same point.
+    const wallet = new WalletClass(stub as never, scope) as CustomizedShieldedWallet;
     return { wallet, scope };
   });
 

--- a/packages/shielded-wallet/src/test/shieldedWallet.test.ts
+++ b/packages/shielded-wallet/src/test/shieldedWallet.test.ts
@@ -1,0 +1,155 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect, Scope, Stream } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { ShieldedWallet, type ShieldedWalletClass } from '../ShieldedWallet.js';
+import { type DefaultV2Configuration, TransactionHistory, V2Tag } from '../v2/index.js';
+
+const configuration: DefaultV2Configuration = {
+  networkId: NetworkId.NetworkId.Undeployed,
+  indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
+};
+
+/**
+ * What the wallet asked of its runtime.
+ *
+ * @remarks
+ *   The runtime is stubbed rather than driven through a real migration because the behaviour under test is entirely
+ *   the wallet's: which keys it holds on to, and how many watchers it registers. Registering two variants to provoke a
+ *   real activation would test the runtime — which already has its own coverage — and would need the multi-variant
+ *   wallet type that is deliberately still deferred.
+ */
+type RuntimeRecorder = {
+  /** The start-aux each `dispatch` to `startSyncInBackground` was given, in order. */
+  readonly dispatched: ledger.ZswapSecretKeys[];
+  /** The start-aux the activation watcher restarted sync with, in order. */
+  readonly resumed: ledger.ZswapSecretKeys[];
+  /** One entry per `onVariantActivation` registration. */
+  readonly watchers: ((variant: { startSyncInBackground: (aux: ledger.ZswapSecretKeys) => Effect.Effect<void> }) => Effect.Effect<void>)[];
+};
+
+const makeRecorder = (): RuntimeRecorder => ({ dispatched: [], resumed: [], watchers: [] });
+
+const walletWith = (
+  recorder: RuntimeRecorder,
+): Effect.Effect<{ wallet: InstanceType<ShieldedWalletClass>; scope: Scope.CloseableScope }> =>
+  Effect.gen(function* () {
+    const scope = yield* Scope.make();
+    const WalletClass = ShieldedWallet(configuration);
+
+    const runningVariant = {
+      __polyTag__: V2Tag,
+      startSyncInBackground: (aux: ledger.ZswapSecretKeys) =>
+        Effect.sync(() => {
+          recorder.dispatched.push(aux);
+        }),
+    };
+
+    const stub = {
+      stateChanges: Stream.empty,
+      progress: Effect.succeed({ sourceGap: 0n, applyGap: 0n }),
+      currentVariant: Effect.succeed(runningVariant),
+      dispatch: (impl: Record<symbol, (variant: typeof runningVariant) => Effect.Effect<unknown>>) =>
+        impl[V2Tag]!(runningVariant),
+      onVariantActivation: (impl: Record<symbol, RuntimeRecorder['watchers'][number]>) =>
+        Effect.sync(() => {
+          recorder.watchers.push(impl[V2Tag]!);
+        }),
+    };
+
+    // Type cast required because: `Runtime.Runtime` is parameterised over the variant HList and its members are typed
+    // with `Poly.PolyFunction`, which no structural stub can be inferred into. The five members above are the whole
+    // interface, and each is exercised by the assertions below.
+    const wallet = new WalletClass(stub as never, scope);
+    return { wallet, scope };
+  });
+
+/** Fires an activation at every registered watcher, recording which keys sync was restarted with. */
+const activate = (recorder: RuntimeRecorder): Effect.Effect<void> =>
+  Effect.forEach(
+    recorder.watchers,
+    (watcher) =>
+      watcher({
+        startSyncInBackground: (aux) =>
+          Effect.sync(() => {
+            recorder.resumed.push(aux);
+          }),
+      }),
+    { discard: true },
+  );
+
+const keysFrom = (seed: number): ledger.ZswapSecretKeys => ledger.ZswapSecretKeys.fromSeed(Buffer.alloc(32, seed));
+
+describe('ShieldedWallet post-migration sync restart', () => {
+  it('registers the activation watcher exactly once, however often start is called', async () => {
+    const recorder = makeRecorder();
+    const first = keysFrom(1);
+    const second = keysFrom(2);
+
+    await Effect.gen(function* () {
+      const { wallet } = yield* walletWith(recorder);
+      yield* Effect.promise(() => wallet.start(first));
+      yield* Effect.promise(() => wallet.start(second));
+    }).pipe(Effect.runPromise);
+
+    // Registering per call would restart sync once per historical start on the next activation.
+    expect(recorder.watchers.length).toBe(1);
+    // Each start still dispatches, exactly as before.
+    expect(recorder.dispatched).toEqual([first, second]);
+  });
+
+  it('restarts sync on the activated variant with the keys most recently started with', async () => {
+    const recorder = makeRecorder();
+    const first = keysFrom(1);
+    const second = keysFrom(2);
+
+    await Effect.gen(function* () {
+      const { wallet } = yield* walletWith(recorder);
+      yield* Effect.promise(() => wallet.start(first));
+      yield* activate(recorder);
+      yield* Effect.promise(() => wallet.start(second));
+      yield* activate(recorder);
+    }).pipe(Effect.runPromise);
+
+    expect(recorder.resumed).toEqual([first, second]);
+  });
+
+  it('does not restart sync after stop, because the retained keys are released', async () => {
+    const recorder = makeRecorder();
+    const keys = keysFrom(1);
+
+    await Effect.gen(function* () {
+      const { wallet } = yield* walletWith(recorder);
+      yield* Effect.promise(() => wallet.start(keys));
+      yield* Effect.promise(() => wallet.stop());
+      yield* activate(recorder);
+    }).pipe(Effect.runPromise);
+
+    expect(recorder.resumed).toEqual([]);
+  });
+
+  it('does not restart sync when a variant activates before start was ever called', async () => {
+    const recorder = makeRecorder();
+
+    await Effect.gen(function* () {
+      yield* walletWith(recorder);
+      yield* activate(recorder);
+    }).pipe(Effect.runPromise);
+
+    expect(recorder.watchers).toEqual([]);
+    expect(recorder.resumed).toEqual([]);
+  });
+});

--- a/packages/shielded-wallet/src/v1/CoreWallet.ts
+++ b/packages/shielded-wallet/src/v1/CoreWallet.ts
@@ -165,36 +165,39 @@ export const CoreWallet = {
    * Projects a wallet inherited from the previous ledger version onto a fresh state of this one.
    *
    * @remarks
-   *   Nothing but identity crosses the boundary. Serialized local state is not readable by this ledger version, and it
-   *   does not need to be: the indexer replays the timeline after the fork, so this variant re-discovers the same coins
-   *   by ordinary sync of the replayed events, decrypting them with the keys the sync restart supplies. Carrying coins
+   *   No coin data crosses the boundary. Serialized local state is not readable by this ledger version, and it does not
+   *   need to be: the indexer replays the timeline after the fork, so this variant re-discovers the same coins by
+   *   ordinary sync of the replayed events, decrypting them with the keys the sync restart supplies. Carrying coins
    *   across would duplicate what the replay is about to deliver.
    *
-   *   What crosses is therefore the public keys — which decide what the replay can be decrypted into — the network, and
-   *   the protocol version that triggered the hand-over, kept so the new variant starts inside its own activation range
-   *   rather than immediately signalling backwards.
+   *   What crosses is therefore identity and position: the public keys — which decide what the replay can be decrypted
+   *   into — the network, the protocol version that triggered the hand-over, kept so the new variant starts inside its
+   *   own activation range rather than immediately signalling backwards, and the cursor the previous variant stopped
+   *   at.
    *
-   *   **Sync progress is reset, not carried**, on the assumption that the replayed timeline restarts its event ids: a
-   *   migrated wallet must re-read it from the beginning. Should the indexer instead continue ids past the boundary,
-   *   this becomes `SyncProgress.createSyncProgress({ ...previous.progress, isConnected: false })` — parking at the
-   *   fork rather than rewinding — and nothing else changes. See the cursor-semantics question in the hard-fork plan.
+   *   **Sync progress is parked at the fork, not rewound**: the previous wallet's cursor crosses unchanged. The replay is
+   *   not a second timeline but the same one continuing — the indexer numbers the replayed events onwards from whatever
+   *   id it had reached when the fork happened, never from zero — so resuming from the inherited cursor is what puts
+   *   this wallet in front of them. Rewinding to zero would park it on a stretch of history that this ledger version's
+   *   events do not occupy. What does not cross is `isConnected`: no sync is running behind this state yet.
    *
    *   Coin hashes start empty for the same reason the tree does: they are commitments and nullifiers computed under the
    *   previous ledger's codec, and this version recomputes its own as the replayed coins arrive.
    * @param previous The plain data read off the previous ledger version's wallet.
-   * @returns A wallet of this ledger version holding no coins and no progress, ready to sync the replayed timeline.
+   * @returns A wallet of this ledger version holding no coins, positioned at the fork, ready to sync the replay.
    */
   fromPreviousVersion(previous: {
     readonly publicKeys: PublicKeys;
     readonly networkId: string;
     readonly protocolVersion: bigint;
+    readonly progress: SyncProgress.SyncProgressData;
   }): CoreWallet {
     return {
       state: new ledger.ZswapLocalState(),
       publicKeys: previous.publicKeys,
       networkId: previous.networkId,
       coinHashes: CoinHashesMap.empty,
-      progress: SyncProgress.createSyncProgress(),
+      progress: SyncProgress.createSyncProgress({ ...previous.progress, isConnected: false }),
       protocolVersion: ProtocolVersion.ProtocolVersion(previous.protocolVersion),
     };
   },

--- a/packages/shielded-wallet/src/v1/CoreWallet.ts
+++ b/packages/shielded-wallet/src/v1/CoreWallet.ts
@@ -145,6 +145,60 @@ export const CoreWallet = {
     return this.empty(PublicKeys.fromSecretKeys(keys), networkId);
   },
 
+  /**
+   * Records an observed protocol version on the wallet, never going backwards.
+   *
+   * @remarks
+   *   The version is a signal, not a measurement: writing one outside the running variant's activation range is what
+   *   makes it hand over to the next variant. A source that briefly reports an older version — a reconnect replaying
+   *   from an earlier cursor, say — must therefore not be able to drag the wallet back below a boundary it has already
+   *   crossed, which would ask the runtime to migrate backwards. Taking the maximum makes that unrepresentable.
+   * @param wallet The wallet to annotate.
+   * @param version The protocol version just observed.
+   * @returns `wallet` unchanged if it already records `version` or a later one, otherwise a copy recording `version`.
+   */
+  withProtocolVersion(wallet: CoreWallet, version: ProtocolVersion.ProtocolVersion): CoreWallet {
+    return version > wallet.protocolVersion ? { ...wallet, protocolVersion: version } : wallet;
+  },
+
+  /**
+   * Projects a wallet inherited from the previous ledger version onto a fresh state of this one.
+   *
+   * @remarks
+   *   Nothing but identity crosses the boundary. Serialized local state is not readable by this ledger version, and it
+   *   does not need to be: the indexer replays the timeline after the fork, so this variant re-discovers the same coins
+   *   by ordinary sync of the replayed events, decrypting them with the keys the sync restart supplies. Carrying coins
+   *   across would duplicate what the replay is about to deliver.
+   *
+   *   What crosses is therefore the public keys — which decide what the replay can be decrypted into — the network, and
+   *   the protocol version that triggered the hand-over, kept so the new variant starts inside its own activation range
+   *   rather than immediately signalling backwards.
+   *
+   *   **Sync progress is reset, not carried**, on the assumption that the replayed timeline restarts its event ids: a
+   *   migrated wallet must re-read it from the beginning. Should the indexer instead continue ids past the boundary,
+   *   this becomes `SyncProgress.createSyncProgress({ ...previous.progress, isConnected: false })` — parking at the
+   *   fork rather than rewinding — and nothing else changes. See the cursor-semantics question in the hard-fork plan.
+   *
+   *   Coin hashes start empty for the same reason the tree does: they are commitments and nullifiers computed under the
+   *   previous ledger's codec, and this version recomputes its own as the replayed coins arrive.
+   * @param previous The plain data read off the previous ledger version's wallet.
+   * @returns A wallet of this ledger version holding no coins and no progress, ready to sync the replayed timeline.
+   */
+  fromPreviousVersion(previous: {
+    readonly publicKeys: PublicKeys;
+    readonly networkId: string;
+    readonly protocolVersion: bigint;
+  }): CoreWallet {
+    return {
+      state: new ledger.ZswapLocalState(),
+      publicKeys: previous.publicKeys,
+      networkId: previous.networkId,
+      coinHashes: CoinHashesMap.empty,
+      progress: SyncProgress.createSyncProgress(),
+      protocolVersion: ProtocolVersion.ProtocolVersion(previous.protocolVersion),
+    };
+  },
+
   applyCollapsedUpdate(wallet: CoreWallet, collapsed: ledger.MerkleTreeCollapsedUpdate): CoreWallet {
     const newState = wallet.state.applyCollapsedUpdate(collapsed);
     return { ...wallet, state: newState };

--- a/packages/shielded-wallet/src/v1/Migration.ts
+++ b/packages/shielded-wallet/src/v1/Migration.ts
@@ -45,7 +45,7 @@ export type EmptyWalletMigrationConfiguration = {
  *   exactly as it did.
  * @example
  *   ```typescript
- *   const builder = new V1Builder().withDefaults().withMigration(makeEmptyWalletMigration({ networkId }));
+ *   const builder = new V2Builder().withDefaults().withMigration(makeEmptyWalletMigration({ networkId }));
  *   ```;
  *
  * @param configuration Supplies the network the scaffold state claims to be on.
@@ -82,8 +82,9 @@ export const makeCarryOverMigration = (): StateMigration<CoreWallet> => ({
  *   projection reads is plain data — the ledger's key and network types are all string aliases — so a structural
  *   description is both sufficient and the only version-agnostic option.
  *
- *   `progress` is required but deliberately not carried: it is the input the alternative cursor semantics would need (see
- *   {@link makeCrossLedgerMigration}), and demanding it keeps that switch to a single line.
+ *   `progress` is where the migrated wallet resumes from: the replayed timeline continues the indexer's event ids rather
+ *   than restarting them, so the previous variant's cursor is the position the next one has to start at (see
+ *   {@link makeCrossLedgerMigration}).
  */
 export type PreviousLedgerWallet = Readonly<{
   publicKeys: { readonly coinPublicKey: string; readonly encryptionPublicKey: string };
@@ -93,7 +94,7 @@ export type PreviousLedgerWallet = Readonly<{
 }>;
 
 /**
- * The migration across a ledger-version boundary: a fresh state of this version, carrying identity only.
+ * The migration across a ledger-version boundary: a coinless state of this version, carrying identity and position.
  *
  * @remarks
  *   The indexer replays the timeline after the hard fork, re-emitting the wallet's history as events of the new ledger
@@ -102,11 +103,11 @@ export type PreviousLedgerWallet = Readonly<{
  *   restart hands it. Carrying them across as well would double-count what the replay is about to deliver, on top of
  *   requiring the secret keys that migration by design does not have.
  *
- *   So what crosses is public keys, the network, and the protocol version that triggered the hand-over. Sync progress is
- *   **reset**, on the assumption that the replayed timeline restarts its event ids; if the indexer continues them past
- *   the boundary instead, the fix is to park progress at the fork rather than rewind it — a one-line change in
- *   {@link CoreWallet.fromPreviousVersion}, which is why `progress` stays on {@link PreviousLedgerWallet}. The assumption
- *   is recorded as an open question against the indexer team.
+ *   So what crosses is public keys, the network, the protocol version that triggered the hand-over, and the cursor. Sync
+ *   progress is **parked at the fork** rather than rewound: the indexer numbers the replayed events onwards from
+ *   whatever id it had reached when the fork happened, never from zero, so the inherited cursor is exactly where the
+ *   replay begins. A wallet that rewound to zero would wait on a stretch of the timeline this ledger version's events
+ *   do not occupy.
  *
  *   If the ledger team ships a byte-level translation for wallet local state, it replaces this instance without touching
  *   anything around it — that is the point of the {@link StateMigration} seam.
@@ -119,6 +120,7 @@ export const makeCrossLedgerMigration = (): StateMigration<PreviousLedgerWallet>
         publicKeys: previousState.publicKeys,
         networkId: previousState.networkId,
         protocolVersion: previousState.protocolVersion,
+        progress: previousState.progress,
       }),
     ),
 });

--- a/packages/shielded-wallet/src/v1/Migration.ts
+++ b/packages/shielded-wallet/src/v1/Migration.ts
@@ -1,0 +1,124 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { type NetworkId, type SyncProgress, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect } from 'effect';
+import { CoreWallet, PublicKeys } from './CoreWallet.js';
+import { type WalletError } from './WalletError.js';
+
+/**
+ * How this variant produces its first state from whatever came before it.
+ *
+ * @remarks
+ *   The strategy is injected through the builder rather than hard-coded into the variant, because "whatever came before"
+ *   is not one thing: an empty wallet at first start, a wallet of this same ledger version, or a wallet of the ledger
+ *   version this one replaced. Those are different functions with different input types, and the runtime only ever
+ *   needs one of them per registration — so which one is a build-time decision, expressed as a dictionary in the
+ *   repository's usual dictionary-passing style.
+ * @typeParam TPreviousState The state this migration consumes.
+ */
+export type StateMigration<TPreviousState> = {
+  migrate: (previousState: TPreviousState) => Effect.Effect<CoreWallet, WalletError>;
+};
+
+export type EmptyWalletMigrationConfiguration = {
+  networkId: NetworkId.NetworkId;
+};
+
+/**
+ * The migration used when there is no previous wallet at all.
+ *
+ * @remarks
+ *   It backs `WalletLike.startEmpty`, which builds a wallet before any key material exists. The resulting state has no
+ *   coins and public keys derived from a fixed placeholder seed; it is a scaffold to be replaced by a real start, not a
+ *   wallet anybody can transact with. Preserved verbatim from the pre-fork implementation so that `startEmpty` behaves
+ *   exactly as it did.
+ * @example
+ *   ```typescript
+ *   const builder = new V1Builder().withDefaults().withMigration(makeEmptyWalletMigration({ networkId }));
+ *   ```;
+ *
+ * @param configuration Supplies the network the scaffold state claims to be on.
+ * @returns A migration from `null`.
+ */
+export const makeEmptyWalletMigration = (configuration: EmptyWalletMigrationConfiguration): StateMigration<null> => ({
+  migrate: () => {
+    const seed = WalletSeed.fromString('0000000000000000000000000000000000000000000000000000000000000001');
+    return Effect.succeed(
+      CoreWallet.empty(PublicKeys.fromSecretKeys(ledger.ZswapSecretKeys.fromSeed(seed)), configuration.networkId),
+    );
+  },
+});
+
+/**
+ * The migration between two variants that share this ledger version.
+ *
+ * @remarks
+ *   Both sides speak the same state type, so the carry is the identity: local Merkle tree, coins, coin hashes and sync
+ *   progress all remain valid, and there is nothing to re-anchor. This is the right strategy for a protocol bump that
+ *   does not change serialization.
+ * @returns A migration from a {@link CoreWallet} of this ledger version.
+ */
+export const makeCarryOverMigration = (): StateMigration<CoreWallet> => ({
+  migrate: (previousState) => Effect.succeed(previousState),
+});
+
+/**
+ * The shape a wallet of the _previous_ ledger version must expose to be projected across a hard fork.
+ *
+ * @remarks
+ *   Structural on purpose. The previous variant's `CoreWallet` is built on a different ledger module, and naming that
+ *   module here would drag a second multi-megabyte WASM binary into this variant for the sake of a type. Everything the
+ *   projection reads is plain data — the ledger's key and network types are all string aliases — so a structural
+ *   description is both sufficient and the only version-agnostic option.
+ *
+ *   `progress` is required but deliberately not carried: it is the input the alternative cursor semantics would need (see
+ *   {@link makeCrossLedgerMigration}), and demanding it keeps that switch to a single line.
+ */
+export type PreviousLedgerWallet = Readonly<{
+  publicKeys: { readonly coinPublicKey: string; readonly encryptionPublicKey: string };
+  networkId: string;
+  protocolVersion: bigint;
+  progress: SyncProgress.SyncProgressData;
+}>;
+
+/**
+ * The migration across a ledger-version boundary: a fresh state of this version, carrying identity only.
+ *
+ * @remarks
+ *   The indexer replays the timeline after the hard fork, re-emitting the wallet's history as events of the new ledger
+ *   version. A migrated wallet therefore does not need — and must not attempt — to carry its coins: it re-discovers
+ *   exactly the same ones by ordinary sync, decrypting the replayed events with the keys the post-migration sync
+ *   restart hands it. Carrying them across as well would double-count what the replay is about to deliver, on top of
+ *   requiring the secret keys that migration by design does not have.
+ *
+ *   So what crosses is public keys, the network, and the protocol version that triggered the hand-over. Sync progress is
+ *   **reset**, on the assumption that the replayed timeline restarts its event ids; if the indexer continues them past
+ *   the boundary instead, the fix is to park progress at the fork rather than rewind it — a one-line change in
+ *   {@link CoreWallet.fromPreviousVersion}, which is why `progress` stays on {@link PreviousLedgerWallet}. The assumption
+ *   is recorded as an open question against the indexer team.
+ *
+ *   If the ledger team ships a byte-level translation for wallet local state, it replaces this instance without touching
+ *   anything around it — that is the point of the {@link StateMigration} seam.
+ * @returns A migration from a previous-ledger-version wallet.
+ */
+export const makeCrossLedgerMigration = (): StateMigration<PreviousLedgerWallet> => ({
+  migrate: (previousState) =>
+    Effect.succeed(
+      CoreWallet.fromPreviousVersion({
+        publicKeys: previousState.publicKeys,
+        networkId: previousState.networkId,
+        protocolVersion: previousState.protocolVersion,
+      }),
+    ),
+});

--- a/packages/shielded-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/shielded-wallet/src/v1/RunningV1Variant.ts
@@ -42,8 +42,29 @@ const progress = (state: CoreWallet): StateChange.StateChange<CoreWallet>[] => {
   return [StateChange.ProgressUpdate({ sourceGap, applyGap })];
 };
 
-const protocolVersionChange = (previous: CoreWallet, current: CoreWallet): StateChange.StateChange<CoreWallet>[] => {
-  return previous.protocolVersion != current.protocolVersion
+/**
+ * Reports the protocol version a state observation implies, if any.
+ *
+ * @remarks
+ *   Two situations call for a signal. The ordinary one is a transition: sync annotated the state with a version it did
+ *   not have before, and the runtime decides whether that is a re-annotation inside this variant's range or a hand-over
+ *   to the next one.
+ *
+ *   The other is a state that arrives already outside this variant's range — a snapshot serialized in the window between
+ *   the annotation and the migration it should have caused, or one written by an older protocol version entirely.
+ *   Nothing further will change that value, so waiting for a transition would strand the wallet on a version it does
+ *   not own. Emitting on sight heals it.
+ */
+const protocolVersionChange = (
+  previous: CoreWallet,
+  current: CoreWallet,
+  isInitial: boolean,
+  activationRange: ProtocolVersion.ProtocolVersion.Range,
+): StateChange.StateChange<CoreWallet>[] => {
+  const transitioned = previous.protocolVersion != current.protocolVersion;
+  const strandedOutsideRange = isInitial && !ProtocolVersion.withinRange(current.protocolVersion, activationRange);
+
+  return transitioned || strandedOutsideRange
     ? [
         StateChange.VersionChange({
           change: VersionChangeType.Version({
@@ -104,18 +125,27 @@ export class RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
     this.state = Stream.fromEffect(context.stateRef.get).pipe(
       Stream.flatMap((initialState) =>
         context.stateRef.changes.pipe(
-          Stream.mapAccum(initialState, (previous: CoreWallet, current: CoreWallet) => {
-            return [current, [previous, current]] as const;
-          }),
+          // The accumulator carries the "have we seen anything yet" flag alongside the previous state: the first
+          // observation is the only one that can be a restored state nobody has inspected against this variant's
+          // range yet, and `SubscriptionRef.changes` replays the current value, so it is exactly this element.
+          Stream.mapAccum(
+            { previous: initialState, isInitial: true },
+            (seen, current: CoreWallet) =>
+              [{ previous: current, isInitial: false }, [seen.previous, current, seen.isInitial] as const] as const,
+          ),
         ),
       ),
       Stream.mapConcat(
-        ([previous, current]: readonly [CoreWallet, CoreWallet]): StateChange.StateChange<CoreWallet>[] => {
+        ([previous, current, isInitial]: readonly [
+          CoreWallet,
+          CoreWallet,
+          boolean,
+        ]): StateChange.StateChange<CoreWallet>[] => {
           // TODO: emit progress only upon actual change
           return [
             StateChange.State({ state: current }),
             ...progress(current),
-            ...protocolVersionChange(previous, current),
+            ...protocolVersionChange(previous, current, isInitial, context.activationRange),
           ];
         },
       ),
@@ -139,7 +169,11 @@ export class RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
         SubscriptionRef.modifyEffect(this.#context.stateRef, (state) =>
           Effect.try({
             try: () => {
-              const [newState, changesResult] = this.#v1Context.syncCapability.applyUpdate(state, update);
+              const [newState, changesResult] = this.#v1Context.syncCapability.applyUpdate(
+                state,
+                update,
+                this.#context.activationRange,
+              );
               return [changesResult, newState] as const;
             },
             catch: (err) =>

--- a/packages/shielded-wallet/src/v1/Sync.ts
+++ b/packages/shielded-wallet/src/v1/Sync.ts
@@ -12,7 +12,20 @@
 // limitations under the License.
 
 import * as ledger from '@midnight-ntwrk/ledger-v8';
-import { Chunk, Duration, Effect, Either, ParseResult, pipe, Schedule, Schema, type Scope, Stream } from 'effect';
+import {
+  Chunk,
+  Duration,
+  Effect,
+  Either,
+  Option,
+  ParseResult,
+  pipe,
+  Schedule,
+  Schema,
+  type Scope,
+  Stream,
+} from 'effect';
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { CoreWallet } from './CoreWallet.js';
 import { V8 } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import { ZswapEvents } from '@midnightntwrk/wallet-sdk-indexer-client';
@@ -32,8 +45,79 @@ export type ChangesResult = {
 };
 
 export interface SyncCapability<TState, TUpdate, TResult> {
-  applyUpdate: (state: TState, update: TUpdate) => [TState, TResult];
+  /**
+   * Folds a sync update into the wallet state.
+   *
+   * @param state The state to fold into.
+   * @param update The update to apply.
+   * @param activeRange The half-open protocol version range the running variant owns. Anything the source reports at or
+   *   beyond its end belongs to a later variant and must be left unapplied for that variant to fetch.
+   */
+  applyUpdate: (
+    state: TState,
+    update: TUpdate,
+    activeRange: ProtocolVersion.ProtocolVersion.Range,
+  ) => [TState, TResult];
 }
+
+/** The result of splitting a batch of version-tagged items at a variant's activation boundary. */
+export type BoundarySplit<T> = {
+  /** The leading items this variant owns, in source order. */
+  readonly applied: readonly T[];
+  /** The trailing items belonging to a later protocol version, left for the next variant to re-fetch. */
+  readonly deferred: readonly T[];
+  /**
+   * The protocol version to record on the state: the first deferred item's version when there is one — that is the
+   * signal that triggers migration — otherwise the last applied item's version. `None` for an empty batch.
+   */
+  readonly observedVersion: Option.Option<ProtocolVersion.ProtocolVersion>;
+};
+
+/**
+ * Splits a batch of version-tagged items at the end of a variant's activation range.
+ *
+ * @remarks
+ *   The split is positional, not a filter: everything from the first out-of-range item onwards is deferred, even if a
+ *   later item reports an in-range version again. A batch is a contiguous slice of one timeline, so applying past a
+ *   boundary and then resuming behind it would leave a hole no cursor can describe.
+ *
+ *   This is the one place the boundary rule lives; both the indexer capability (per event) and the simulator capability
+ *   (per block) go through it, so they cannot drift apart.
+ * @param items The batch, in source order.
+ * @param versionOf Reads the protocol version an item was reported at.
+ * @param activeRange The variant's half-open activation range.
+ * @returns The applied/deferred split and the version to record.
+ */
+export const splitAtVersionBoundary = <T>(
+  items: readonly T[],
+  versionOf: (item: T) => number,
+  activeRange: ProtocolVersion.ProtocolVersion.Range,
+): BoundarySplit<T> => {
+  const [, end] = activeRange;
+  const boundary = items.findIndex((item) => BigInt(versionOf(item)) >= end);
+  const [applied, deferred] =
+    boundary < 0 ? [items, [] as readonly T[]] : [items.slice(0, boundary), items.slice(boundary)];
+  const signalling = deferred.at(0) ?? applied.at(-1);
+
+  return {
+    applied,
+    deferred,
+    observedVersion:
+      signalling === undefined
+        ? Option.none()
+        : Option.some(ProtocolVersion.ProtocolVersion(BigInt(versionOf(signalling)))),
+  };
+};
+
+/** Records a batch's observed protocol version on the state, monotonically. A batch that observed none is a no-op. */
+export const annotateVersion = (
+  state: CoreWallet,
+  observedVersion: Option.Option<ProtocolVersion.ProtocolVersion>,
+): CoreWallet =>
+  Option.match(observedVersion, {
+    onNone: () => state,
+    onSome: (version) => CoreWallet.withProtocolVersion(state, version),
+  });
 
 export type IndexerClientConnection = {
   indexerHttpUrl: string;
@@ -270,7 +354,11 @@ export const makeEventsSyncService = (
 
 export const makeEventsSyncCapability = (): SyncCapability<CoreWallet, WalletSyncUpdate, ChangesResult> => {
   return {
-    applyUpdate: (state: CoreWallet, wrappedUpdate: WalletSyncUpdate): [CoreWallet, ChangesResult] => {
+    applyUpdate: (
+      state: CoreWallet,
+      wrappedUpdate: WalletSyncUpdate,
+      activeRange: ProtocolVersion.ProtocolVersion.Range,
+    ): [CoreWallet, ChangesResult] => {
       if (wrappedUpdate.updates.length === 0) {
         return [state, { changes: [], protocolVersion: Number(state.protocolVersion) }];
       }
@@ -284,25 +372,43 @@ export const makeEventsSyncCapability = (): SyncCapability<CoreWallet, WalletSyn
       const appliedIndex = state.progress?.appliedIndex ?? 0n;
       const freshUpdates = wrappedUpdate.updates.filter((u) => BigInt(u.id) > appliedIndex);
 
+      // The tip is a property of the source, not of what this variant chose to apply, so it is read from
+      // the batch tail even when the tail belongs to the next protocol version.
       const lastUpdate = wrappedUpdate.updates.at(-1)!;
       const highestRelevantWalletIndex = BigInt(lastUpdate.maxId);
 
+      const { applied, observedVersion } = splitAtVersionBoundary(
+        freshUpdates,
+        (update) => update.protocolVersion,
+        activeRange,
+      );
+
       const [newState, newChanges]: [CoreWallet, ledger.ZswapStateChanges[]] =
-        freshUpdates.length === 0
+        applied.length === 0
           ? [state, []]
           : CoreWallet.replayEventsWithChanges(
               state,
               wrappedUpdate.secretKeys,
-              freshUpdates.map((u) => u.event),
+              applied.map((u) => u.event),
             );
 
-      const updatedState = CoreWallet.updateProgress(newState, {
+      // `appliedIndex` stops at the last event this variant actually replayed. The next variant resumes one
+      // below it on an inclusive cursor, so the deferred suffix is re-fetched rather than skipped.
+      const updatedState = CoreWallet.updateProgress(annotateVersion(newState, observedVersion), {
         highestRelevantWalletIndex,
-        appliedIndex: freshUpdates.length === 0 ? appliedIndex : BigInt(freshUpdates.at(-1)!.id),
+        appliedIndex: applied.length === 0 ? appliedIndex : BigInt(applied.at(-1)!.id),
         isConnected: true,
       });
 
-      return [updatedState, { changes: newChanges, protocolVersion: lastUpdate.protocolVersion }];
+      return [
+        updatedState,
+        {
+          changes: newChanges,
+          // Tags the changes that were actually produced, so tx-history records the version they were applied
+          // under rather than the one that is about to trigger the hand-over.
+          protocolVersion: applied.at(-1)?.protocolVersion ?? Number(state.protocolVersion),
+        },
+      ];
     },
   };
 };
@@ -350,24 +456,45 @@ export const makeSimulatorSyncService = (
 
 export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, SimulatorSyncUpdate, ChangesResult> => {
   return {
-    applyUpdate: (state: CoreWallet, update: SimulatorSyncUpdate): [CoreWallet, ChangesResult] => {
+    applyUpdate: (
+      state: CoreWallet,
+      update: SimulatorSyncUpdate,
+      activeRange: ProtocolVersion.ProtocolVersion.Range,
+    ): [CoreWallet, ChangesResult] => {
       const { update: simulatorState, secretKeys } = update;
       const lastBlock = V8.getLastBlock(simulatorState);
       if (lastBlock === undefined) {
         return [state, { changes: [], protocolVersion: Number(state.protocolVersion) }];
       }
 
-      // Get all events from blocks starting at appliedIndex (the next block to process).
       // appliedIndex semantics: the first block number we haven't processed yet.
       // Initial: appliedIndex = 0 (haven't processed any blocks)
       // After processing block N: appliedIndex = N + 1 (next block to process)
-      const events = [...V8.getBlockEventsFrom(simulatorState, state.progress.appliedIndex)];
-      const [newState, newChanges] = CoreWallet.replayEventsWithChanges(state, secretKeys, events);
+      //
+      // The boundary is applied at block granularity here — a block carries exactly one protocol version,
+      // stamped when it was produced — but it is the same rule and the same helper the indexer path uses.
+      const pending = simulatorState.blocks.filter((block) => block.number >= state.progress.appliedIndex);
+      const { applied, observedVersion } = splitAtVersionBoundary(
+        pending,
+        (block) => Number(block.protocolVersion),
+        activeRange,
+      );
+
+      const events = applied.flatMap((block) => block.transactions.flatMap((tx) => tx.result.events));
+
+      const [newState, newChanges]: [CoreWallet, ledger.ZswapStateChanges[]] =
+        applied.length === 0 ? [state, []] : CoreWallet.replayEventsWithChanges(state, secretKeys, events);
+
+      const lastAppliedBlock = applied.at(-1);
       return [
-        CoreWallet.updateProgress(newState, {
-          appliedIndex: lastBlock.number + 1n,
+        CoreWallet.updateProgress(annotateVersion(newState, observedVersion), {
+          appliedIndex: lastAppliedBlock === undefined ? state.progress.appliedIndex : lastAppliedBlock.number + 1n,
         }),
-        { changes: newChanges, protocolVersion: Number(state.protocolVersion) },
+        {
+          changes: newChanges,
+          protocolVersion:
+            lastAppliedBlock === undefined ? Number(state.protocolVersion) : Number(lastAppliedBlock.protocolVersion),
+        },
       ];
     },
   };

--- a/packages/shielded-wallet/src/v1/V1Builder.ts
+++ b/packages/shielded-wallet/src/v1/V1Builder.ts
@@ -10,14 +10,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import * as ledger from '@midnight-ntwrk/ledger-v8';
+import type * as ledger from '@midnight-ntwrk/ledger-v8';
 import { Effect, type Either, Scope, type Types } from 'effect';
-import { WalletSeed, type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
-import {
-  type Variant,
-  type VariantBuilder,
-  type WalletRuntimeError,
-} from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type Variant, type VariantBuilder, WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { type EmptyWalletMigrationConfiguration, type StateMigration, makeEmptyWalletMigration } from './Migration.js';
 import { RunningV1Variant, V1Tag } from './RunningV1Variant.js';
 import { makeDefaultV1SerializationCapability, type SerializationCapability } from './Serialization.js';
 import {
@@ -40,7 +37,7 @@ import { type WalletError } from './WalletError.js';
 import { type CoinsAndBalancesCapability, makeDefaultCoinsAndBalancesCapability } from './CoinsAndBalances.js';
 import { type KeysCapability, makeDefaultKeysCapability } from './Keys.js';
 import { type CoinSelection, chooseCoin } from '@midnightntwrk/wallet-sdk-capabilities';
-import { CoreWallet, PublicKeys } from './CoreWallet.js';
+import { type CoreWallet } from './CoreWallet.js';
 import {
   type DefaultTransactionHistoryConfiguration,
   makeDefaultTransactionHistoryService,
@@ -63,10 +60,10 @@ const V1BuilderSymbol: {
   typeId: Symbol('@midnight-ntwrk/wallet#V1Builder') as (typeof V1BuilderSymbol)['typeId'],
 } as const;
 
-export type V1Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData> = Variant.Variant<
+export type V1Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData, TPreviousState = null> = Variant.Variant<
   typeof V1Tag,
   CoreWallet,
-  null,
+  TPreviousState,
   RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData>
 > & {
   deserializeState: (serialized: TSerialized) => Either.Either<CoreWallet, WalletError>;
@@ -89,13 +86,14 @@ export type SerializedStateOf<T extends AnyV1Variant> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   T extends V1Variant<infer TSerialized, any, any, any> ? TSerialized : never;
 
-export type DefaultV1Builder = V1Builder<
+export type DefaultV1Builder<TPreviousState = null> = V1Builder<
   DefaultV1Configuration,
   RunningV1Variant.Context<string, WalletSyncUpdate, ledger.FinalizedTransaction, ledger.ZswapSecretKeys>,
   string,
   WalletSyncUpdate,
   ledger.FinalizedTransaction,
-  ledger.ZswapSecretKeys
+  ledger.ZswapSecretKeys,
+  TPreviousState
 >;
 
 export class V1Builder<
@@ -105,35 +103,65 @@ export class V1Builder<
   TSyncUpdate = never,
   TTransaction = never,
   TStartAux extends object = object,
-> implements VariantBuilder.VariantBuilder<V1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>, TConfig> {
+  TPreviousState = null,
+> implements VariantBuilder.VariantBuilder<
+  V1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState>,
+  TConfig
+> {
   readonly #buildState: V1Builder.PartialBuildState<
     TConfig,
     TContext,
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   >;
 
   constructor(
-    buildState: V1Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> = {},
+    buildState: V1Builder.PartialBuildState<
+      TConfig,
+      TContext,
+      TSerialized,
+      TSyncUpdate,
+      TTransaction,
+      TStartAux,
+      TPreviousState
+    > = {},
   ) {
     this.#buildState = buildState;
   }
 
-  withDefaults(): DefaultV1Builder {
-    return this.withDefaultTransactionType()
-      .withSyncDefaults()
-      .withSerializationDefaults()
-      .withTransactingDefaults()
-      .withCoinsAndBalancesDefaults()
-      .withTransactionHistoryDefaults()
-      .withKeysDefaults()
-      .withCoinSelectionDefaults() as DefaultV1Builder;
+  withDefaults(
+    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, null>,
+  ): DefaultV1Builder {
+    return (
+      this.withDefaultTransactionType()
+        .withSyncDefaults()
+        .withSerializationDefaults()
+        .withTransactingDefaults()
+        .withCoinsAndBalancesDefaults()
+        .withTransactionHistoryDefaults()
+        .withKeysDefaults()
+        // Type cast required because: the chain accumulates `TContext` as an intersection of the individual
+        // `Default*Context` fragments, which is a structurally weaker type than the complete
+        // `RunningV1Variant.Context` that `DefaultV1Builder` names — the defaults do produce a full context, but the
+        // chain's type cannot express that. Routing through `unknown` because the added `migration` key put the two
+        // sides past what TypeScript will accept as directly comparable; the widening itself predates it.
+        .withCoinSelectionDefaults() as unknown as DefaultV1Builder
+    );
   }
 
-  withTransactionType<Transaction>(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, Transaction, TStartAux> {
-    return new V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, Transaction, TStartAux>({
+  withTransactionType<Transaction>(): V1Builder<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    Transaction,
+    TStartAux,
+    TPreviousState
+  > {
+    return new V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, Transaction, TStartAux, TPreviousState>({
       ...this.#buildState,
       transactingCapability: undefined,
       transactionHistoryService: undefined,
@@ -146,7 +174,8 @@ export class V1Builder<
     TSerialized,
     TSyncUpdate,
     ledger.FinalizedTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return this.withTransactionType<ledger.FinalizedTransaction>();
   }
@@ -157,7 +186,8 @@ export class V1Builder<
     TSerialized,
     WalletSyncUpdate,
     TTransaction,
-    ledger.ZswapSecretKeys
+    ledger.ZswapSecretKeys,
+    TPreviousState
   > {
     return this.withSync(makeEventsSyncService, makeEventsSyncCapability);
   }
@@ -176,14 +206,23 @@ export class V1Builder<
       configuration: TSyncConfig,
       getContext: () => TSyncContext,
     ) => SyncCapability<CoreWallet, TSyncUpdate, ChangesResult>,
-  ): V1Builder<TConfig & TSyncConfig, TContext & TSyncContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  ): V1Builder<
+    TConfig & TSyncConfig,
+    TContext & TSyncContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return new V1Builder<
       TConfig & TSyncConfig,
       TContext & TSyncContext,
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       syncService,
@@ -191,7 +230,15 @@ export class V1Builder<
     });
   }
 
-  withSerializationDefaults(): V1Builder<TConfig, TContext, string, TSyncUpdate, TTransaction, TStartAux> {
+  withSerializationDefaults(): V1Builder<
+    TConfig,
+    TContext,
+    string,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return this.withSerialization(makeDefaultV1SerializationCapability);
   }
 
@@ -210,7 +257,8 @@ export class V1Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V1Builder<
       TConfig & TSerializationConfig,
@@ -218,7 +266,8 @@ export class V1Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       serializationCapability,
@@ -226,14 +275,23 @@ export class V1Builder<
   }
 
   withTransactingDefaults(
-    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, ledger.FinalizedTransaction, TStartAux>,
+    this: V1Builder<
+      TConfig,
+      TContext,
+      TSerialized,
+      TSyncUpdate,
+      ledger.FinalizedTransaction,
+      TStartAux,
+      TPreviousState
+    >,
   ): V1Builder<
     TConfig & DefaultTransactingConfiguration,
     TContext & DefaultTransactingContext,
     TSerialized,
     TSyncUpdate,
     ledger.FinalizedTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return this.withTransacting(makeDefaultTransactingCapability);
   }
@@ -249,7 +307,8 @@ export class V1Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V1Builder<
       TConfig & TTransactingConfig,
@@ -257,7 +316,8 @@ export class V1Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       transactingCapability,
@@ -275,7 +335,8 @@ export class V1Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V1Builder<
       TConfig & TCoinSelectionConfig,
@@ -283,18 +344,35 @@ export class V1Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       coinSelection,
     });
   }
 
-  withCoinSelectionDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  withCoinSelectionDefaults(): V1Builder<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return this.withCoinSelection(() => chooseCoin);
   }
 
-  withCoinsAndBalancesDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  withCoinsAndBalancesDefaults(): V1Builder<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return this.withCoinsAndBalances(makeDefaultCoinsAndBalancesCapability);
   }
 
@@ -309,7 +387,8 @@ export class V1Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V1Builder<
       TConfig & TBalancesConfig,
@@ -317,7 +396,8 @@ export class V1Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       coinsAndBalancesCapability,
@@ -325,14 +405,23 @@ export class V1Builder<
   }
 
   withTransactionHistoryDefaults(
-    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, ledger.FinalizedTransaction, TStartAux>,
+    this: V1Builder<
+      TConfig,
+      TContext,
+      TSerialized,
+      TSyncUpdate,
+      ledger.FinalizedTransaction,
+      TStartAux,
+      TPreviousState
+    >,
   ): V1Builder<
     TConfig & DefaultTransactionHistoryConfiguration,
     TContext,
     TSerialized,
     TSyncUpdate,
     ledger.FinalizedTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return this.withTransactionHistory(makeDefaultTransactionHistoryService);
   }
@@ -351,7 +440,8 @@ export class V1Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V1Builder<
       TConfig & TTransactionHistoryConfig,
@@ -359,27 +449,95 @@ export class V1Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       transactionHistoryService,
     });
   }
 
-  withKeysDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  withKeysDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState> {
     return this.withKeys(makeDefaultKeysCapability);
+  }
+
+  /**
+   * Uses the default migration: an empty wallet built from nothing.
+   *
+   * @remarks
+   *   This is what an unconfigured builder already does, so calling it changes no behaviour — it states the choice rather
+   *   than inheriting it. Registering this variant as the target of a real fork means calling
+   *   {@link V1Builder.withMigration} with {@link makeCrossLedgerMigration} instead.
+   */
+  withMigrationDefaults(
+    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, null>,
+  ): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, null> {
+    return this.withMigration((configuration: EmptyWalletMigrationConfiguration) =>
+      makeEmptyWalletMigration(configuration),
+    );
+  }
+
+  /**
+   * Chooses how this variant produces its first state from the state that preceded it.
+   *
+   * @remarks
+   *   The strategy's input type becomes the variant's `TPreviousState`, which is what the runtime type-checks a
+   *   registration against: a variant declaring it migrates from a ledger-v8 wallet cannot be registered after one that
+   *   produces something else.
+   * @example
+   *   ```typescript
+   *   const forkTarget = new V1Builder().withDefaults().withMigration(makeCrossLedgerMigration);
+   *   ```;
+   *
+   * @param migration Builds the migration from the configuration and the sibling capabilities.
+   */
+  withMigration<TMigrationConfig, TPrevious>(
+    migration: (configuration: TMigrationConfig, getContext: () => TContext) => StateMigration<TPrevious>,
+  ): V1Builder<TConfig & TMigrationConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, TPrevious> {
+    const capabilities: V1Builder.CapabilityBuildState<
+      TConfig,
+      TContext,
+      TSerialized,
+      TSyncUpdate,
+      TTransaction,
+      TStartAux
+    > = this.#buildState;
+
+    return new V1Builder<
+      TConfig & TMigrationConfig,
+      TContext,
+      TSerialized,
+      TSyncUpdate,
+      TTransaction,
+      TStartAux,
+      TPrevious
+    >({
+      // Only the capability half crosses: the strategy being replaced is typed against the *old* previous-state
+      // parameter, so it cannot ride along even though it is about to be overwritten.
+      ...capabilities,
+      migration,
+    });
   }
 
   withKeys<TKeysConfig, TKeysContext extends Partial<RunningV1Variant.AnyContext>>(
     keysCapability: (configuration: TKeysConfig, getContext: () => TKeysContext) => KeysCapability<CoreWallet>,
-  ): V1Builder<TConfig & TKeysConfig, TContext & TKeysContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  ): V1Builder<
+    TConfig & TKeysConfig,
+    TContext & TKeysContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return new V1Builder<
       TConfig & TKeysConfig,
       TContext & TKeysContext,
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       keysCapability,
@@ -393,12 +551,13 @@ export class V1Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >,
     configuration: TConfig,
-  ): V1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  ): V1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState> {
     const v1Context = this.#buildContextFromBuildState(configuration);
-    const { networkId } = configuration;
+    const migration = this.#resolveMigration(configuration, () => v1Context);
 
     return {
       __polyTag__: V1Tag,
@@ -418,18 +577,40 @@ export class V1Builder<
           return new RunningV1Variant(scope, context, v1Context);
         });
       },
-      migrateState(_previousState) {
-        const seed = WalletSeed.fromString('0000000000000000000000000000000000000000000000000000000000000001');
-
-        return Effect.succeed(
-          CoreWallet.empty(PublicKeys.fromSecretKeys(ledger.ZswapSecretKeys.fromSeed(seed)), networkId),
-        );
-      },
+      // An unconfigured builder keeps producing an empty wallet, which is what `startEmpty` has always relied on.
+      // Anything else — carrying state within a ledger version, or projecting it across one — is the injected
+      // strategy's business, and its failures are reported on the runtime's state stream rather than thrown.
+      migrateState: (previousState: TPreviousState) =>
+        migration.migrate(previousState).pipe(
+          Effect.mapError(
+            (error) =>
+              new WalletRuntimeError({
+                message: 'Failed to migrate shielded wallet state into this variant',
+                cause: error,
+              }),
+          ),
+        ),
 
       deserializeState: (serialized: TSerialized): Either.Either<CoreWallet, WalletError> => {
         return v1Context.serializationCapability.deserialize(null, serialized);
       },
     };
+  }
+
+  /**
+   * Resolves the configured migration, or the empty-wallet fallback when none was configured.
+   *
+   * @remarks
+   *   The fallback is written as a nullary function on purpose. It ignores whatever preceded it — it builds an empty
+   *   wallet from nothing — which makes it a valid migration from _any_ previous state, but a `StateMigration<null>`
+   *   value could only be widened to `StateMigration<TPreviousState>` through a cast. Declaring no parameter says the
+   *   same thing to the type system without one.
+   */
+  #resolveMigration(configuration: TConfig, getContext: () => TContext): StateMigration<TPreviousState> {
+    const configured = this.#buildState.migration;
+    return configured === undefined
+      ? { migrate: () => makeEmptyWalletMigration(configuration).migrate(null) }
+      : configured(configuration, getContext);
   }
 
   #buildContextFromBuildState(
@@ -439,7 +620,8 @@ export class V1Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >,
     configuration: TConfig,
   ): RunningV1Variant.Context<TSerialized, TSyncUpdate, TTransaction, TStartAux> {
@@ -537,7 +719,17 @@ declare namespace V1Builder {
       HasKeys<TConfig, TContext> &
       HasTransactionHistory<TConfig, TContext>
   >;
-  type PartialBuildState<
+  /**
+   * The migration entry, kept out of {@link FullBuildState} on purpose: absent means "empty wallet", which is the
+   * behaviour every builder had before migrations were configurable, so a builder that never mentions migration must
+   * still be considered complete.
+   */
+  type HasMigration<TConfig, TContext, TPreviousState> = {
+    readonly migration: (configuration: TConfig, getContext: () => TContext) => StateMigration<TPreviousState>;
+  };
+
+  /** The capability half of the build state — everything that does not depend on the previous-state parameter. */
+  type CapabilityBuildState<
     TConfig = object,
     TContext = object,
     TSerialized = never,
@@ -549,6 +741,21 @@ declare namespace V1Builder {
       FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux>[K] | undefined;
   };
 
+  type PartialBuildState<
+    TConfig = object,
+    TContext = object,
+    TSerialized = never,
+    TSyncUpdate = never,
+    TTransaction = never,
+    TStartAux = object,
+    TPreviousState = null,
+  > = {
+    [K in keyof (FullBuildState<never, never, never, never, never, never> & HasMigration<never, never, never>)]?:
+      | (FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> &
+          HasMigration<TConfig, TContext, TPreviousState>)[K]
+      | undefined;
+  };
+
   /** Utility interface that manages the type variance of {@link V1Builder}. */
   interface Variance<R> {
     readonly [V1BuilderSymbol.typeId]: {
@@ -557,8 +764,16 @@ declare namespace V1Builder {
   }
 }
 
-const isBuildStateFull = <TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux>(
-  buildState: V1Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux>,
+const isBuildStateFull = <TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState>(
+  buildState: V1Builder.PartialBuildState<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  >,
 ): buildState is V1Builder.FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> => {
   const allBuildStateKeys = [
     'syncService',

--- a/packages/shielded-wallet/src/v1/index.ts
+++ b/packages/shielded-wallet/src/v1/index.ts
@@ -15,6 +15,7 @@ export * as Sync from './Sync.js';
 export * as Transacting from './Transacting.js';
 export * as TransactionHistory from './TransactionHistory.js';
 export * as Serialization from './Serialization.js';
+export * as Migration from './Migration.js';
 export * as CoinsAndBalances from './CoinsAndBalances.js';
 export * as Keys from './Keys.js';
 export * from './RunningV1Variant.js';

--- a/packages/shielded-wallet/src/v1/test/migration.test.ts
+++ b/packages/shielded-wallet/src/v1/test/migration.test.ts
@@ -1,0 +1,147 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * How this variant builds its first state from whatever preceded it.
+ *
+ * @remarks
+ *   The three strategies differ in exactly one thing — how much of the previous wallet is allowed to survive — so that is
+ *   what these pin down: everything (same ledger version), nothing (no previous wallet at all), and, across a ledger
+ *   version boundary, identity only.
+ */
+
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { CoreWallet, PublicKeys } from '../CoreWallet.js';
+import {
+  type PreviousLedgerWallet,
+  makeCarryOverMigration,
+  makeCrossLedgerMigration,
+  makeEmptyWalletMigration,
+} from '../Migration.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+const seed = Buffer.alloc(32, 7);
+const keys = (): ledger.ZswapSecretKeys => ledger.ZswapSecretKeys.fromSeed(seed);
+
+/** The version that triggered the hand-over: the first one the previous variant saw outside its own range. */
+const forkVersion = ProtocolVersion.ProtocolVersion(7n);
+
+/**
+ * A wallet of the previous ledger version, as plain data.
+ *
+ * @remarks
+ *   Deliberately wider than {@link PreviousLedgerWallet}: it also carries the coins and the cursor that a real pre-fork
+ *   wallet would be holding, so that "those do not cross" is something this file can actually observe rather than
+ *   merely fail to mention. Structural because the real thing is built on the other ledger's WASM module, and a
+ *   projection that reads no ledger object out of it has no reason to load one.
+ */
+type PreviousWalletStandIn = PreviousLedgerWallet & {
+  readonly state: {
+    readonly coins: readonly Readonly<{ type: string; nonce: string; value: bigint; mt_index: bigint }>[];
+  };
+};
+
+const previousWallet = (): PreviousWalletStandIn => {
+  const secretKeys = keys();
+  return {
+    publicKeys: {
+      coinPublicKey: secretKeys.coinPublicKey,
+      encryptionPublicKey: secretKeys.encryptionPublicKey,
+    },
+    networkId,
+    protocolVersion: forkVersion,
+    progress: {
+      appliedIndex: 4321n,
+      highestRelevantWalletIndex: 4400n,
+      highestIndex: 4400n,
+      highestRelevantIndex: 4400n,
+      isConnected: true,
+    },
+    state: {
+      coins: [
+        { type: 'aa'.repeat(32), nonce: 'bb'.repeat(32), value: 100n, mt_index: 0n },
+        { type: 'aa'.repeat(32), nonce: 'cc'.repeat(32), value: 200n, mt_index: 4n },
+      ],
+    },
+  };
+};
+
+describe('the empty-wallet migration', () => {
+  it('produces a wallet with no coins on the configured network', async () => {
+    const wallet = await Effect.runPromise(makeEmptyWalletMigration({ networkId }).migrate(null));
+
+    expect(wallet.networkId).toBe(networkId);
+    expect([...wallet.state.coins]).toEqual([]);
+    expect(wallet.coinHashes).toEqual({});
+    expect(wallet.progress.appliedIndex).toBe(0n);
+    expect(wallet.protocolVersion).toBe(ProtocolVersion.MinSupportedVersion);
+  });
+});
+
+describe('the carry-over migration', () => {
+  it('hands the previous state through untouched', async () => {
+    const previous = CoreWallet.init(new ledger.ZswapLocalState(), keys(), networkId);
+
+    const wallet = await Effect.runPromise(makeCarryOverMigration().migrate(previous));
+
+    expect(wallet).toBe(previous);
+  });
+});
+
+describe('the cross-ledger migration', () => {
+  it('carries the public keys, so the replayed timeline can be decrypted into the same coins', async () => {
+    const previous = previousWallet();
+
+    const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+    expect(wallet.publicKeys).toEqual(PublicKeys.fromSecretKeys(keys()));
+    expect(wallet.networkId).toBe(networkId);
+  });
+
+  it('records the version that triggered the hand-over, so the new variant starts inside its own range', async () => {
+    const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previousWallet()));
+
+    expect(wallet.protocolVersion).toBe(forkVersion);
+  });
+
+  it('starts from an empty local state rather than carrying the previous version coins', async () => {
+    // The indexer replays the timeline after the fork, so these coins arrive again as events of this ledger version.
+    // Carrying them as well would double-count them, and rebuilding the tree would need secret keys this has none of.
+    const previous = previousWallet();
+    expect(previous.state.coins.length).toBeGreaterThan(0);
+
+    const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+    expect([...wallet.state.coins]).toEqual([]);
+    expect(wallet.state.firstFree).toBe(0n);
+    expect(wallet.coinHashes).toEqual({});
+  });
+
+  it('resets sync progress, so the replayed timeline is read from its start', async () => {
+    // The assumption this encodes: replayed events restart their ids. Were they to continue past the boundary, the
+    // migration would park progress at the fork instead — and this expectation would be the one that changed.
+    const previous = previousWallet();
+    expect(previous.progress.appliedIndex).toBeGreaterThan(0n);
+
+    const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+    expect(wallet.progress.appliedIndex).toBe(0n);
+    expect(wallet.progress.highestIndex).toBe(0n);
+    expect(wallet.progress.highestRelevantIndex).toBe(0n);
+    expect(wallet.progress.highestRelevantWalletIndex).toBe(0n);
+    expect(wallet.progress.isConnected).toBe(false);
+  });
+});

--- a/packages/shielded-wallet/src/v1/test/migration.test.ts
+++ b/packages/shielded-wallet/src/v1/test/migration.test.ts
@@ -43,10 +43,11 @@ const forkVersion = ProtocolVersion.ProtocolVersion(7n);
  * A wallet of the previous ledger version, as plain data.
  *
  * @remarks
- *   Deliberately wider than {@link PreviousLedgerWallet}: it also carries the coins and the cursor that a real pre-fork
- *   wallet would be holding, so that "those do not cross" is something this file can actually observe rather than
- *   merely fail to mention. Structural because the real thing is built on the other ledger's WASM module, and a
- *   projection that reads no ledger object out of it has no reason to load one.
+ *   Deliberately wider than {@link PreviousLedgerWallet}: it also carries the coins a real pre-fork wallet would be
+ *   holding, so that "those do not cross" is something this file can actually observe rather than merely fail to
+ *   mention. Its cursor is non-zero for the opposite reason — what does cross has to be seen crossing. Structural
+ *   because the real thing is built on the other ledger's WASM module, and a projection that reads no ledger object out
+ *   of it has no reason to load one.
  */
 type PreviousWalletStandIn = PreviousLedgerWallet & {
   readonly state: {
@@ -130,18 +131,23 @@ describe('the cross-ledger migration', () => {
     expect(wallet.coinHashes).toEqual({});
   });
 
-  it('resets sync progress, so the replayed timeline is read from its start', async () => {
-    // The assumption this encodes: replayed events restart their ids. Were they to continue past the boundary, the
-    // migration would park progress at the fork instead — and this expectation would be the one that changed.
+  it('parks sync progress at the fork, because the replayed timeline continues the ids it left off at', async () => {
+    // The confirmed semantics: after the hard fork the indexer replays the events again, numbering them onwards from
+    // whatever id it had reached when the fork happened — never from zero. So the migrated wallet resumes from where
+    // its predecessor stopped. Rewinding to zero would point it at a stretch of the timeline the replay does not
+    // occupy, and it would sit there waiting for events that already went by under the previous ledger version.
     const previous = previousWallet();
     expect(previous.progress.appliedIndex).toBeGreaterThan(0n);
 
     const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
 
-    expect(wallet.progress.appliedIndex).toBe(0n);
-    expect(wallet.progress.highestIndex).toBe(0n);
-    expect(wallet.progress.highestRelevantIndex).toBe(0n);
-    expect(wallet.progress.highestRelevantWalletIndex).toBe(0n);
+    expect(wallet.progress.appliedIndex).toBe(previous.progress.appliedIndex);
+    expect(wallet.progress.highestIndex).toBe(previous.progress.highestIndex);
+    expect(wallet.progress.highestRelevantIndex).toBe(previous.progress.highestRelevantIndex);
+    expect(wallet.progress.highestRelevantWalletIndex).toBe(previous.progress.highestRelevantWalletIndex);
+    // The position crosses; being connected does not. This state has no running sync behind it yet — the restart that
+    // follows the migration is what reconnects it — and claiming otherwise would report a gap that nothing is closing.
+    expect(previous.progress.isConnected).toBe(true);
     expect(wallet.progress.isConnected).toBe(false);
   });
 });

--- a/packages/shielded-wallet/src/v1/test/runningV1Variant.test.ts
+++ b/packages/shielded-wallet/src/v1/test/runningV1Variant.test.ts
@@ -188,7 +188,7 @@ describe('RunningV1Variant.state protocol version signalling', () => {
 
   /**
    * Drains the variant's state stream for a fixed window and returns everything it emitted. A bounded window rather
-   * than `Stream.take(n)` on purpose: the point of these tests is *how many* version changes appear, so a missing one
+   * than `Stream.take(n)` on purpose: the point of these tests is _how many_ version changes appear, so a missing one
    * has to surface as a failed assertion, not as a hang.
    */
   const emissionsWithin = (
@@ -201,11 +201,14 @@ describe('RunningV1Variant.state protocol version signalling', () => {
       const variant = new RunningV1Variant(
         scope,
         { stateRef, activationRange },
-        variantContextOf([], trackingHistoryService({
-          inFlight: yield* Ref.make(0),
-          maxInFlight: yield* Ref.make(0),
-          recorded: yield* Ref.make(0),
-        })),
+        variantContextOf(
+          [],
+          trackingHistoryService({
+            inFlight: yield* Ref.make(0),
+            maxInFlight: yield* Ref.make(0),
+            recorded: yield* Ref.make(0),
+          }),
+        ),
       );
 
       const collector = yield* Effect.fork(

--- a/packages/shielded-wallet/src/v1/test/runningV1Variant.test.ts
+++ b/packages/shielded-wallet/src/v1/test/runningV1Variant.test.ts
@@ -12,8 +12,21 @@
 // limitations under the License.
 import * as ledger from '@midnight-ntwrk/ledger-v8';
 import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Duration, Effect, Exit, Ref, Scope, Stream, SubscriptionRef, TestClock, TestContext } from 'effect';
+import {
+  Chunk,
+  Duration,
+  Effect,
+  Exit,
+  Fiber,
+  Ref,
+  Scope,
+  Stream,
+  SubscriptionRef,
+  TestClock,
+  TestContext,
+} from 'effect';
 import { describe, expect, it } from 'vitest';
+import { StateChange, VersionChangeType } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { makeDefaultCoinsAndBalancesCapability } from '../CoinsAndBalances.js';
 import { CoreWallet } from '../CoreWallet.js';
 import { makeDefaultKeysCapability } from '../Keys.js';
@@ -146,5 +159,86 @@ describe('RunningV1Variant.startSync tx-history fan-out', () => {
     expect(result.maxInFlight).toBe(8);
     // The cap only queues work, it never drops it.
     expect(result.recorded).toBe(12);
+  });
+});
+
+describe('RunningV1Variant.state protocol version signalling', () => {
+  /** The variant under test owns `[0, 7)`; 7 and above belong to whatever variant comes next. */
+  const activationRange = ProtocolVersion.makeRange(
+    ProtocolVersion.MinSupportedVersion,
+    ProtocolVersion.ProtocolVersion(7n),
+  );
+
+  const walletAtVersion = (protocolVersion: bigint): CoreWallet =>
+    CoreWallet.restore(
+      new ledger.ZswapLocalState(),
+      ledger.ZswapSecretKeys.fromSeed(Buffer.alloc(32, 1)),
+      { appliedIndex: 0n, highestRelevantWalletIndex: 0n, highestIndex: 0n, highestRelevantIndex: 0n },
+      protocolVersion,
+      networkId,
+    );
+
+  const versionChangesOf = (changes: Chunk.Chunk<StateChange.StateChange<CoreWallet>>): readonly bigint[] =>
+    Chunk.toArray(changes)
+      .filter(StateChange.isVersionChange)
+      .map(({ change }) => {
+        expect(VersionChangeType.isVersion(change)).toBe(true);
+        return VersionChangeType.isVersion(change) ? change.version : -1n;
+      });
+
+  /**
+   * Drains the variant's state stream for a fixed window and returns everything it emitted. A bounded window rather
+   * than `Stream.take(n)` on purpose: the point of these tests is *how many* version changes appear, so a missing one
+   * has to surface as a failed assertion, not as a hang.
+   */
+  const emissionsWithin = (
+    initialState: CoreWallet,
+    act: (stateRef: SubscriptionRef.SubscriptionRef<CoreWallet>) => Effect.Effect<void> = () => Effect.void,
+  ): Promise<Chunk.Chunk<StateChange.StateChange<CoreWallet>>> =>
+    Effect.gen(function* () {
+      const stateRef = yield* SubscriptionRef.make(initialState);
+      const scope = yield* Scope.make();
+      const variant = new RunningV1Variant(
+        scope,
+        { stateRef, activationRange },
+        variantContextOf([], trackingHistoryService({
+          inFlight: yield* Ref.make(0),
+          maxInFlight: yield* Ref.make(0),
+          recorded: yield* Ref.make(0),
+        })),
+      );
+
+      const collector = yield* Effect.fork(
+        variant.state.pipe(Stream.interruptAfter(Duration.millis(300)), Stream.runCollect),
+      );
+      yield* Effect.sleep(Duration.millis(50));
+      yield* act(stateRef);
+      const collected = yield* Fiber.join(collector);
+      yield* Scope.close(scope, Exit.void);
+      return collected;
+    }).pipe(Effect.runPromise);
+
+  it('emits exactly one VersionChange when the state transitions to a new protocol version', async () => {
+    const collected = await emissionsWithin(walletAtVersion(0n), (stateRef) =>
+      SubscriptionRef.set(stateRef, walletAtVersion(5n)),
+    );
+
+    expect(versionChangesOf(collected)).toEqual([5n]);
+  });
+
+  it('emits an immediate healing VersionChange when the initial state is outside the activation range', async () => {
+    // A snapshot serialized after the version was annotated but before the runtime migrated restores here. Without a
+    // healing emission the wallet would sit on a version it does not own and never hand over.
+    const collected = await emissionsWithin(walletAtVersion(9n));
+
+    expect(versionChangesOf(collected)).toEqual([9n]);
+  });
+
+  it('emits no VersionChange when the initial state is inside the activation range', async () => {
+    const collected = await emissionsWithin(walletAtVersion(3n));
+
+    expect(versionChangesOf(collected)).toEqual([]);
+    // The stream still reports the state itself, so an empty result would be a false pass.
+    expect(Chunk.toArray(collected).filter(StateChange.isState).length).toBeGreaterThan(0);
   });
 });

--- a/packages/shielded-wallet/src/v1/test/sync.test.ts
+++ b/packages/shielded-wallet/src/v1/test/sync.test.ts
@@ -98,6 +98,11 @@ const createMockSubscriptionFn = (
   totalRecords: number,
   mockEventHex: string,
   timingOptions?: TimingOptions,
+  /**
+   * The protocol version the indexer reports for each event id. Defaults to a constant 1. Per-item versions are what
+   * the boundary split in `applyUpdate` keys off, so they have to survive batching intact.
+   */
+  protocolVersionOf: (id: number) => number = () => 1,
 ): ((
   _variables: ZswapEventsSubscriptionVariables,
 ) => Stream.Stream<ZswapEventsSubscription, ClientError | ServerError, SubscriptionClient>) => {
@@ -110,7 +115,7 @@ const createMockSubscriptionFn = (
         zswapLedgerEvents: {
           id,
           raw: mockEventHex,
-          protocolVersion: 1,
+          protocolVersion: protocolVersionOf(id),
           maxId: totalRecords,
         },
       })),
@@ -420,6 +425,52 @@ describe('Wallet subscription', () => {
       const variables = await cursorFor(state, secretKeys);
 
       expect(variables).toEqual({ id: 4 });
+    });
+  });
+
+  describe('per-item protocol version decoding', () => {
+    // The version reported for a single event is what decides which side of the fork boundary that event falls on, so
+    // it has to arrive at `applyUpdate` per item — a batch-level summary would erase exactly the transition being
+    // looked for.
+    const versionOf = (id: number): number => (id <= 3 ? 3 : id <= 5 ? 9 : 11);
+
+    const collectUpdates = async (eventCount: number, batchSize: number) => {
+      const mockEventHex = await createMockEventHex();
+      const mockSubscriptionFn = createMockSubscriptionFn(eventCount, mockEventHex, undefined, versionOf);
+      const secretKeys = ledger.ZswapSecretKeys.fromSeed(Buffer.alloc(32, 0));
+      const initialState = CoreWallet.initEmpty(secretKeys, NetworkId.NetworkId.Undeployed);
+
+      return await Effect.gen(function* () {
+        const syncService = makeEventsSyncService({
+          indexerClientConnection: {
+            indexerHttpUrl: 'http://localhost:8088/api/v4/graphql',
+            indexerWsUrl: 'ws://localhost:8088/api/v4/graphql/ws',
+          },
+          batchUpdates: { size: batchSize, spacing: 0 },
+        });
+
+        return yield* syncService.updates(initialState, secretKeys).pipe(Stream.runCollect);
+      }).pipe(Effect.provideService(ZswapEvents.tag, mockSubscriptionFn), Effect.scoped, Effect.runPromise);
+    };
+
+    it('carries the indexer-reported version of every event through a single batch', async () => {
+      const updates = await collectUpdates(6, 10);
+
+      expect(Chunk.size(updates)).toBe(1);
+      const batch = updates.pipe(Chunk.unsafeHead);
+      expect(batch.updates.map((u) => u.id)).toEqual([1, 2, 3, 4, 5, 6]);
+      expect(batch.updates.map((u) => u.protocolVersion)).toEqual([3, 3, 3, 9, 9, 11]);
+    });
+
+    it('keeps each event paired with its own version when the batch boundary splits them', async () => {
+      const updates = await collectUpdates(6, 2);
+
+      expect(Chunk.size(updates)).toBe(3);
+      expect(Chunk.toArray(updates).map((batch) => batch.updates.map((u) => u.protocolVersion))).toEqual([
+        [3, 3],
+        [3, 9],
+        [9, 11],
+      ]);
     });
   });
 });

--- a/packages/shielded-wallet/src/v1/test/syncCapability.test.ts
+++ b/packages/shielded-wallet/src/v1/test/syncCapability.test.ts
@@ -1,0 +1,279 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { V8 } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { Effect, Option, Scope, Stream } from 'effect';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { CoreWallet } from '../CoreWallet.js';
+import {
+  type EventsSyncUpdate,
+  WalletSyncUpdate,
+  makeEventsSyncCapability,
+  makeSimulatorSyncCapability,
+} from '../Sync.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+
+/**
+ * The boundary under test. The variant owns `[0, 7)`; anything reported at 7 or beyond belongs to the next variant and
+ * must not be applied here.
+ */
+const activeRange = ProtocolVersion.makeRange(ProtocolVersion.ProtocolVersion(0n), ProtocolVersion.ProtocolVersion(7n));
+
+const secretKeys = (): ledger.ZswapSecretKeys => ledger.ZswapSecretKeys.fromSeed(Buffer.alloc(32, 7));
+
+/** The six genesis mints, in ascending amount order: 100, 200, ..., 600 — 2100 in total. */
+const MINT_COUNT = 6;
+const MINT_TOTAL = 2100n;
+
+const mintingSimulator = (protocolVersion?: ProtocolVersion.ProtocolVersion) =>
+  V8.Simulator.init({
+    ...(protocolVersion === undefined ? {} : { protocolVersion }),
+    genesisMints: Array.from({ length: MINT_COUNT }, (_, i) => ({
+      type: 'shielded' as const,
+      tokenType: ledger.shieldedToken().raw,
+      amount: BigInt((i + 1) * 100),
+      recipient: secretKeys(),
+    })) as never,
+  });
+
+const simulatorStateAt = (protocolVersion?: ProtocolVersion.ProtocolVersion): Promise<V8.SimulatorState> =>
+  Effect.gen(function* () {
+    const simulator = yield* mintingSimulator(protocolVersion);
+    return Option.getOrThrow(yield* simulator.state$.pipe(Stream.take(1), Stream.runHead));
+  }).pipe(Effect.scoped, Effect.runPromise);
+
+/**
+ * Serialized bytes of the six real `zswapOutput` events the genesis mints emit, in chain order.
+ *
+ * They are kept as bytes rather than as `ledger.Event` instances on purpose: `replayEventsWithChanges` consumes the
+ * event objects it is handed (wasm-bindgen moves ownership), so a second use of the same instance throws. Every test
+ * deserializes its own instances.
+ */
+let eventBytes: readonly Uint8Array[];
+
+beforeAll(async () => {
+  const state = await simulatorStateAt();
+  eventBytes = V8.getLastBlockEvents(state).map((event) => event.serialize());
+  expect(eventBytes.length).toBe(MINT_COUNT);
+});
+
+/** Builds a batch of sync updates, one per `(id, protocolVersion)` pair, each carrying its own fresh event instance. */
+const batch = (items: readonly (readonly [id: number, protocolVersion: number])[]): WalletSyncUpdate =>
+  WalletSyncUpdate.create(
+    items.map(
+      ([id, protocolVersion]): EventsSyncUpdate => ({
+        _tag: 'EventsSyncUpdate',
+        id,
+        protocolVersion,
+        maxId: MINT_COUNT,
+        event: ledger.Event.deserialize(eventBytes[id - 1]!),
+      }),
+    ),
+    secretKeys(),
+  );
+
+const freshWallet = (): CoreWallet => CoreWallet.initEmpty(secretKeys(), networkId);
+
+const coinIndices = (wallet: CoreWallet): readonly bigint[] =>
+  [...wallet.state.coins].map((coin) => coin.mt_index).sort((a, b) => Number(a - b));
+
+const totalValue = (wallet: CoreWallet): bigint => [...wallet.state.coins].reduce((sum, coin) => sum + coin.value, 0n);
+
+describe('makeEventsSyncCapability.applyUpdate boundary handling', () => {
+  const capability = makeEventsSyncCapability();
+
+  it('applies every update and annotates the state when the whole batch is inside the active range', () => {
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 3],
+        [2, 3],
+        [3, 3],
+        [4, 3],
+        [5, 3],
+        [6, 3],
+      ]),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(6n);
+    expect(state.progress.highestRelevantWalletIndex).toBe(BigInt(MINT_COUNT));
+    expect(state.progress.isConnected).toBe(true);
+    expect(state.protocolVersion).toBe(3n);
+    expect(coinIndices(state)).toEqual([0n, 1n, 2n, 3n, 4n, 5n]);
+    expect(totalValue(state)).toBe(MINT_TOTAL);
+    expect(state.state.firstFree).toBe(6n);
+    expect(result.changes.length).toBe(1);
+    expect(result.changes[0]!.receivedCoins.length).toBe(MINT_COUNT);
+    expect(result.protocolVersion).toBe(3);
+  });
+
+  it('re-annotates the state on a version bump that stays inside the active range', () => {
+    const [afterFirst] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 3],
+        [2, 3],
+        [3, 3],
+      ]),
+      activeRange,
+    );
+    expect(afterFirst.protocolVersion).toBe(3n);
+
+    const [state, result] = capability.applyUpdate(
+      afterFirst,
+      batch([
+        [4, 5],
+        [5, 5],
+        [6, 5],
+      ]),
+      activeRange,
+    );
+
+    expect(state.protocolVersion).toBe(5n);
+    expect(state.progress.appliedIndex).toBe(6n);
+    expect(coinIndices(state)).toEqual([0n, 1n, 2n, 3n, 4n, 5n]);
+    expect(totalValue(state)).toBe(MINT_TOTAL);
+    expect(result.changes.length).toBe(1);
+    expect(result.changes[0]!.receivedCoins.length).toBe(3);
+  });
+
+  it('applies only the prefix of a straddling batch and takes the version from the first suffix item', () => {
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 3],
+        [2, 3],
+        [3, 3],
+        [4, 9],
+        [5, 9],
+        [6, 11],
+      ]),
+      activeRange,
+    );
+
+    // Prefix only: the last applied id is 3, so the next variant resumes there and re-fetches ids 4-6.
+    expect(state.progress.appliedIndex).toBe(3n);
+    // The suffix's first version is what makes the variant hand over — not the batch's last version.
+    expect(state.protocolVersion).toBe(9n);
+    expect(coinIndices(state)).toEqual([0n, 1n, 2n]);
+    expect(state.state.firstFree).toBe(3n);
+    // Changes come from the prefix alone.
+    expect(result.changes.length).toBe(1);
+    expect(result.changes[0]!.receivedCoins.length).toBe(3);
+    // The reported version tags the applied changes, so it is the prefix's version.
+    expect(result.protocolVersion).toBe(3);
+    // The tip is a property of the source, so it still comes from the batch tail.
+    expect(state.progress.highestRelevantWalletIndex).toBe(BigInt(MINT_COUNT));
+  });
+
+  it('applies nothing when the whole batch is at or beyond the end of the active range', () => {
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 7],
+        [2, 7],
+        [3, 9],
+        [4, 9],
+        [5, 9],
+        [6, 9],
+      ]),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(0n);
+    expect(state.protocolVersion).toBe(7n);
+    expect(coinIndices(state)).toEqual([]);
+    expect(state.state.firstFree).toBe(0n);
+    expect(result.changes).toEqual([]);
+    expect(state.progress.highestRelevantWalletIndex).toBe(BigInt(MINT_COUNT));
+  });
+
+  it('never lowers the recorded protocol version when a later batch reports a stale lower one', () => {
+    const [afterFirst] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 5],
+        [2, 5],
+        [3, 5],
+      ]),
+      activeRange,
+    );
+    expect(afterFirst.protocolVersion).toBe(5n);
+
+    const [state] = capability.applyUpdate(
+      afterFirst,
+      batch([
+        [4, 2],
+        [5, 2],
+        [6, 2],
+      ]),
+      activeRange,
+    );
+
+    // The batch still applies; only the version annotation is held at its high-water mark.
+    expect(state.protocolVersion).toBe(5n);
+    expect(state.progress.appliedIndex).toBe(6n);
+    expect(coinIndices(state)).toEqual([0n, 1n, 2n, 3n, 4n, 5n]);
+  });
+
+  it('leaves the state untouched for an empty batch', () => {
+    const initial = freshWallet();
+    const [state, result] = capability.applyUpdate(initial, WalletSyncUpdate.create([], secretKeys()), activeRange);
+
+    expect(state.progress.appliedIndex).toBe(0n);
+    expect(state.protocolVersion).toBe(ProtocolVersion.MinSupportedVersion);
+    expect(coinIndices(state)).toEqual([]);
+    expect(result.changes).toEqual([]);
+    expect(result.protocolVersion).toBe(Number(initial.protocolVersion));
+  });
+});
+
+describe('makeSimulatorSyncCapability.applyUpdate boundary handling', () => {
+  const capability = makeSimulatorSyncCapability();
+
+  it('applies an in-range block and annotates the state with the block version', async () => {
+    const simulatorState = await simulatorStateAt(ProtocolVersion.ProtocolVersion(3n));
+
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      { update: simulatorState, secretKeys: secretKeys() },
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(1n);
+    expect(state.protocolVersion).toBe(3n);
+    expect(coinIndices(state)).toEqual([0n, 1n, 2n, 3n, 4n, 5n]);
+    expect(totalValue(state)).toBe(MINT_TOTAL);
+    expect(result.changes.length).toBe(1);
+  });
+
+  it('applies no block at or beyond the end of the active range, but still annotates the version', async () => {
+    const simulatorState = await simulatorStateAt(ProtocolVersion.ProtocolVersion(9n));
+
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      { update: simulatorState, secretKeys: secretKeys() },
+      activeRange,
+    );
+
+    // The block carries six real mint events; none of them may be applied by this variant.
+    expect(state.progress.appliedIndex).toBe(0n);
+    expect(state.protocolVersion).toBe(9n);
+    expect(coinIndices(state)).toEqual([]);
+    expect(state.state.firstFree).toBe(0n);
+    expect(result.changes).toEqual([]);
+  });
+});

--- a/packages/shielded-wallet/src/v1/test/syncCapability.test.ts
+++ b/packages/shielded-wallet/src/v1/test/syncCapability.test.ts
@@ -13,7 +13,7 @@
 import * as ledger from '@midnight-ntwrk/ledger-v8';
 import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { V8 } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
-import { Effect, Option, Scope, Stream } from 'effect';
+import { Effect, Option, Stream } from 'effect';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { CoreWallet } from '../CoreWallet.js';
 import {
@@ -72,15 +72,13 @@ beforeAll(async () => {
 /** Builds a batch of sync updates, one per `(id, protocolVersion)` pair, each carrying its own fresh event instance. */
 const batch = (items: readonly (readonly [id: number, protocolVersion: number])[]): WalletSyncUpdate =>
   WalletSyncUpdate.create(
-    items.map(
-      ([id, protocolVersion]): EventsSyncUpdate => ({
-        _tag: 'EventsSyncUpdate',
-        id,
-        protocolVersion,
-        maxId: MINT_COUNT,
-        event: ledger.Event.deserialize(eventBytes[id - 1]!),
-      }),
-    ),
+    items.map(([id, protocolVersion]): EventsSyncUpdate => ({
+      _tag: 'EventsSyncUpdate',
+      id,
+      protocolVersion,
+      maxId: MINT_COUNT,
+      event: ledger.Event.deserialize(eventBytes[id - 1]),
+    })),
     secretKeys(),
   );
 
@@ -116,7 +114,7 @@ describe('makeEventsSyncCapability.applyUpdate boundary handling', () => {
     expect(totalValue(state)).toBe(MINT_TOTAL);
     expect(state.state.firstFree).toBe(6n);
     expect(result.changes.length).toBe(1);
-    expect(result.changes[0]!.receivedCoins.length).toBe(MINT_COUNT);
+    expect(result.changes[0].receivedCoins.length).toBe(MINT_COUNT);
     expect(result.protocolVersion).toBe(3);
   });
 
@@ -147,7 +145,7 @@ describe('makeEventsSyncCapability.applyUpdate boundary handling', () => {
     expect(coinIndices(state)).toEqual([0n, 1n, 2n, 3n, 4n, 5n]);
     expect(totalValue(state)).toBe(MINT_TOTAL);
     expect(result.changes.length).toBe(1);
-    expect(result.changes[0]!.receivedCoins.length).toBe(3);
+    expect(result.changes[0].receivedCoins.length).toBe(3);
   });
 
   it('applies only the prefix of a straddling batch and takes the version from the first suffix item', () => {
@@ -172,7 +170,7 @@ describe('makeEventsSyncCapability.applyUpdate boundary handling', () => {
     expect(state.state.firstFree).toBe(3n);
     // Changes come from the prefix alone.
     expect(result.changes.length).toBe(1);
-    expect(result.changes[0]!.receivedCoins.length).toBe(3);
+    expect(result.changes[0].receivedCoins.length).toBe(3);
     // The reported version tags the applied changes, so it is the prefix's version.
     expect(result.protocolVersion).toBe(3);
     // The tip is a property of the source, so it still comes from the batch tail.

--- a/packages/shielded-wallet/src/v2/CoreWallet.ts
+++ b/packages/shielded-wallet/src/v2/CoreWallet.ts
@@ -165,36 +165,39 @@ export const CoreWallet = {
    * Projects a wallet inherited from the previous ledger version onto a fresh state of this one.
    *
    * @remarks
-   *   Nothing but identity crosses the boundary. Serialized local state is not readable by this ledger version, and it
-   *   does not need to be: the indexer replays the timeline after the fork, so this variant re-discovers the same coins
-   *   by ordinary sync of the replayed events, decrypting them with the keys the sync restart supplies. Carrying coins
+   *   No coin data crosses the boundary. Serialized local state is not readable by this ledger version, and it does not
+   *   need to be: the indexer replays the timeline after the fork, so this variant re-discovers the same coins by
+   *   ordinary sync of the replayed events, decrypting them with the keys the sync restart supplies. Carrying coins
    *   across would duplicate what the replay is about to deliver.
    *
-   *   What crosses is therefore the public keys — which decide what the replay can be decrypted into — the network, and
-   *   the protocol version that triggered the hand-over, kept so the new variant starts inside its own activation range
-   *   rather than immediately signalling backwards.
+   *   What crosses is therefore identity and position: the public keys — which decide what the replay can be decrypted
+   *   into — the network, the protocol version that triggered the hand-over, kept so the new variant starts inside its
+   *   own activation range rather than immediately signalling backwards, and the cursor the previous variant stopped
+   *   at.
    *
-   *   **Sync progress is reset, not carried**, on the assumption that the replayed timeline restarts its event ids: a
-   *   migrated wallet must re-read it from the beginning. Should the indexer instead continue ids past the boundary,
-   *   this becomes `SyncProgress.createSyncProgress({ ...previous.progress, isConnected: false })` — parking at the
-   *   fork rather than rewinding — and nothing else changes. See the cursor-semantics question in the hard-fork plan.
+   *   **Sync progress is parked at the fork, not rewound**: the previous wallet's cursor crosses unchanged. The replay is
+   *   not a second timeline but the same one continuing — the indexer numbers the replayed events onwards from whatever
+   *   id it had reached when the fork happened, never from zero — so resuming from the inherited cursor is what puts
+   *   this wallet in front of them. Rewinding to zero would park it on a stretch of history that this ledger version's
+   *   events do not occupy. What does not cross is `isConnected`: no sync is running behind this state yet.
    *
    *   Coin hashes start empty for the same reason the tree does: they are commitments and nullifiers computed under the
    *   previous ledger's codec, and this version recomputes its own as the replayed coins arrive.
    * @param previous The plain data read off the previous ledger version's wallet.
-   * @returns A wallet of this ledger version holding no coins and no progress, ready to sync the replayed timeline.
+   * @returns A wallet of this ledger version holding no coins, positioned at the fork, ready to sync the replay.
    */
   fromPreviousVersion(previous: {
     readonly publicKeys: PublicKeys;
     readonly networkId: string;
     readonly protocolVersion: bigint;
+    readonly progress: SyncProgress.SyncProgressData;
   }): CoreWallet {
     return {
       state: new ledger.ZswapLocalState(),
       publicKeys: previous.publicKeys,
       networkId: previous.networkId,
       coinHashes: CoinHashesMap.empty,
-      progress: SyncProgress.createSyncProgress(),
+      progress: SyncProgress.createSyncProgress({ ...previous.progress, isConnected: false }),
       protocolVersion: ProtocolVersion.ProtocolVersion(previous.protocolVersion),
     };
   },

--- a/packages/shielded-wallet/src/v2/CoreWallet.ts
+++ b/packages/shielded-wallet/src/v2/CoreWallet.ts
@@ -145,6 +145,60 @@ export const CoreWallet = {
     return this.empty(PublicKeys.fromSecretKeys(keys), networkId);
   },
 
+  /**
+   * Records an observed protocol version on the wallet, never going backwards.
+   *
+   * @remarks
+   *   The version is a signal, not a measurement: writing one outside the running variant's activation range is what
+   *   makes it hand over to the next variant. A source that briefly reports an older version — a reconnect replaying
+   *   from an earlier cursor, say — must therefore not be able to drag the wallet back below a boundary it has already
+   *   crossed, which would ask the runtime to migrate backwards. Taking the maximum makes that unrepresentable.
+   * @param wallet The wallet to annotate.
+   * @param version The protocol version just observed.
+   * @returns `wallet` unchanged if it already records `version` or a later one, otherwise a copy recording `version`.
+   */
+  withProtocolVersion(wallet: CoreWallet, version: ProtocolVersion.ProtocolVersion): CoreWallet {
+    return version > wallet.protocolVersion ? { ...wallet, protocolVersion: version } : wallet;
+  },
+
+  /**
+   * Projects a wallet inherited from the previous ledger version onto a fresh state of this one.
+   *
+   * @remarks
+   *   Nothing but identity crosses the boundary. Serialized local state is not readable by this ledger version, and it
+   *   does not need to be: the indexer replays the timeline after the fork, so this variant re-discovers the same coins
+   *   by ordinary sync of the replayed events, decrypting them with the keys the sync restart supplies. Carrying coins
+   *   across would duplicate what the replay is about to deliver.
+   *
+   *   What crosses is therefore the public keys — which decide what the replay can be decrypted into — the network, and
+   *   the protocol version that triggered the hand-over, kept so the new variant starts inside its own activation range
+   *   rather than immediately signalling backwards.
+   *
+   *   **Sync progress is reset, not carried**, on the assumption that the replayed timeline restarts its event ids: a
+   *   migrated wallet must re-read it from the beginning. Should the indexer instead continue ids past the boundary,
+   *   this becomes `SyncProgress.createSyncProgress({ ...previous.progress, isConnected: false })` — parking at the
+   *   fork rather than rewinding — and nothing else changes. See the cursor-semantics question in the hard-fork plan.
+   *
+   *   Coin hashes start empty for the same reason the tree does: they are commitments and nullifiers computed under the
+   *   previous ledger's codec, and this version recomputes its own as the replayed coins arrive.
+   * @param previous The plain data read off the previous ledger version's wallet.
+   * @returns A wallet of this ledger version holding no coins and no progress, ready to sync the replayed timeline.
+   */
+  fromPreviousVersion(previous: {
+    readonly publicKeys: PublicKeys;
+    readonly networkId: string;
+    readonly protocolVersion: bigint;
+  }): CoreWallet {
+    return {
+      state: new ledger.ZswapLocalState(),
+      publicKeys: previous.publicKeys,
+      networkId: previous.networkId,
+      coinHashes: CoinHashesMap.empty,
+      progress: SyncProgress.createSyncProgress(),
+      protocolVersion: ProtocolVersion.ProtocolVersion(previous.protocolVersion),
+    };
+  },
+
   applyCollapsedUpdate(wallet: CoreWallet, collapsed: ledger.MerkleTreeCollapsedUpdate): CoreWallet {
     const newState = wallet.state.applyCollapsedUpdate(collapsed);
     return { ...wallet, state: newState };

--- a/packages/shielded-wallet/src/v2/Migration.ts
+++ b/packages/shielded-wallet/src/v2/Migration.ts
@@ -1,0 +1,124 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { type NetworkId, type SyncProgress, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect } from 'effect';
+import { CoreWallet, PublicKeys } from './CoreWallet.js';
+import { type WalletError } from './WalletError.js';
+
+/**
+ * How this variant produces its first state from whatever came before it.
+ *
+ * @remarks
+ *   The strategy is injected through the builder rather than hard-coded into the variant, because "whatever came before"
+ *   is not one thing: an empty wallet at first start, a wallet of this same ledger version, or a wallet of the ledger
+ *   version this one replaced. Those are different functions with different input types, and the runtime only ever
+ *   needs one of them per registration — so which one is a build-time decision, expressed as a dictionary in the
+ *   repository's usual dictionary-passing style.
+ * @typeParam TPreviousState The state this migration consumes.
+ */
+export type StateMigration<TPreviousState> = {
+  migrate: (previousState: TPreviousState) => Effect.Effect<CoreWallet, WalletError>;
+};
+
+export type EmptyWalletMigrationConfiguration = {
+  networkId: NetworkId.NetworkId;
+};
+
+/**
+ * The migration used when there is no previous wallet at all.
+ *
+ * @remarks
+ *   It backs `WalletLike.startEmpty`, which builds a wallet before any key material exists. The resulting state has no
+ *   coins and public keys derived from a fixed placeholder seed; it is a scaffold to be replaced by a real start, not a
+ *   wallet anybody can transact with. Preserved verbatim from the pre-fork implementation so that `startEmpty` behaves
+ *   exactly as it did.
+ * @example
+ *   ```typescript
+ *   const builder = new V2Builder().withDefaults().withMigration(makeEmptyWalletMigration({ networkId }));
+ *   ```;
+ *
+ * @param configuration Supplies the network the scaffold state claims to be on.
+ * @returns A migration from `null`.
+ */
+export const makeEmptyWalletMigration = (configuration: EmptyWalletMigrationConfiguration): StateMigration<null> => ({
+  migrate: () => {
+    const seed = WalletSeed.fromString('0000000000000000000000000000000000000000000000000000000000000001');
+    return Effect.succeed(
+      CoreWallet.empty(PublicKeys.fromSecretKeys(ledger.ZswapSecretKeys.fromSeed(seed)), configuration.networkId),
+    );
+  },
+});
+
+/**
+ * The migration between two variants that share this ledger version.
+ *
+ * @remarks
+ *   Both sides speak the same state type, so the carry is the identity: local Merkle tree, coins, coin hashes and sync
+ *   progress all remain valid, and there is nothing to re-anchor. This is the right strategy for a protocol bump that
+ *   does not change serialization.
+ * @returns A migration from a {@link CoreWallet} of this ledger version.
+ */
+export const makeCarryOverMigration = (): StateMigration<CoreWallet> => ({
+  migrate: (previousState) => Effect.succeed(previousState),
+});
+
+/**
+ * The shape a wallet of the _previous_ ledger version must expose to be projected across a hard fork.
+ *
+ * @remarks
+ *   Structural on purpose. The previous variant's `CoreWallet` is built on a different ledger module, and naming that
+ *   module here would drag a second multi-megabyte WASM binary into this variant for the sake of a type. Everything the
+ *   projection reads is plain data — the ledger's key and network types are all string aliases — so a structural
+ *   description is both sufficient and the only version-agnostic option.
+ *
+ *   `progress` is required but deliberately not carried: it is the input the alternative cursor semantics would need (see
+ *   {@link makeCrossLedgerMigration}), and demanding it keeps that switch to a single line.
+ */
+export type PreviousLedgerWallet = Readonly<{
+  publicKeys: { readonly coinPublicKey: string; readonly encryptionPublicKey: string };
+  networkId: string;
+  protocolVersion: bigint;
+  progress: SyncProgress.SyncProgressData;
+}>;
+
+/**
+ * The migration across a ledger-version boundary: a fresh state of this version, carrying identity only.
+ *
+ * @remarks
+ *   The indexer replays the timeline after the hard fork, re-emitting the wallet's history as events of the new ledger
+ *   version. A migrated wallet therefore does not need — and must not attempt — to carry its coins: it re-discovers
+ *   exactly the same ones by ordinary sync, decrypting the replayed events with the keys the post-migration sync
+ *   restart hands it. Carrying them across as well would double-count what the replay is about to deliver, on top of
+ *   requiring the secret keys that migration by design does not have.
+ *
+ *   So what crosses is public keys, the network, and the protocol version that triggered the hand-over. Sync progress is
+ *   **reset**, on the assumption that the replayed timeline restarts its event ids; if the indexer continues them past
+ *   the boundary instead, the fix is to park progress at the fork rather than rewind it — a one-line change in
+ *   {@link CoreWallet.fromPreviousVersion}, which is why `progress` stays on {@link PreviousLedgerWallet}. The assumption
+ *   is recorded as an open question against the indexer team.
+ *
+ *   If the ledger team ships a byte-level translation for wallet local state, it replaces this instance without touching
+ *   anything around it — that is the point of the {@link StateMigration} seam.
+ * @returns A migration from a previous-ledger-version wallet.
+ */
+export const makeCrossLedgerMigration = (): StateMigration<PreviousLedgerWallet> => ({
+  migrate: (previousState) =>
+    Effect.succeed(
+      CoreWallet.fromPreviousVersion({
+        publicKeys: previousState.publicKeys,
+        networkId: previousState.networkId,
+        protocolVersion: previousState.protocolVersion,
+      }),
+    ),
+});

--- a/packages/shielded-wallet/src/v2/Migration.ts
+++ b/packages/shielded-wallet/src/v2/Migration.ts
@@ -82,8 +82,9 @@ export const makeCarryOverMigration = (): StateMigration<CoreWallet> => ({
  *   projection reads is plain data — the ledger's key and network types are all string aliases — so a structural
  *   description is both sufficient and the only version-agnostic option.
  *
- *   `progress` is required but deliberately not carried: it is the input the alternative cursor semantics would need (see
- *   {@link makeCrossLedgerMigration}), and demanding it keeps that switch to a single line.
+ *   `progress` is where the migrated wallet resumes from: the replayed timeline continues the indexer's event ids rather
+ *   than restarting them, so the previous variant's cursor is the position the next one has to start at (see
+ *   {@link makeCrossLedgerMigration}).
  */
 export type PreviousLedgerWallet = Readonly<{
   publicKeys: { readonly coinPublicKey: string; readonly encryptionPublicKey: string };
@@ -93,7 +94,7 @@ export type PreviousLedgerWallet = Readonly<{
 }>;
 
 /**
- * The migration across a ledger-version boundary: a fresh state of this version, carrying identity only.
+ * The migration across a ledger-version boundary: a coinless state of this version, carrying identity and position.
  *
  * @remarks
  *   The indexer replays the timeline after the hard fork, re-emitting the wallet's history as events of the new ledger
@@ -102,11 +103,11 @@ export type PreviousLedgerWallet = Readonly<{
  *   restart hands it. Carrying them across as well would double-count what the replay is about to deliver, on top of
  *   requiring the secret keys that migration by design does not have.
  *
- *   So what crosses is public keys, the network, and the protocol version that triggered the hand-over. Sync progress is
- *   **reset**, on the assumption that the replayed timeline restarts its event ids; if the indexer continues them past
- *   the boundary instead, the fix is to park progress at the fork rather than rewind it — a one-line change in
- *   {@link CoreWallet.fromPreviousVersion}, which is why `progress` stays on {@link PreviousLedgerWallet}. The assumption
- *   is recorded as an open question against the indexer team.
+ *   So what crosses is public keys, the network, the protocol version that triggered the hand-over, and the cursor. Sync
+ *   progress is **parked at the fork** rather than rewound: the indexer numbers the replayed events onwards from
+ *   whatever id it had reached when the fork happened, never from zero, so the inherited cursor is exactly where the
+ *   replay begins. A wallet that rewound to zero would wait on a stretch of the timeline this ledger version's events
+ *   do not occupy.
  *
  *   If the ledger team ships a byte-level translation for wallet local state, it replaces this instance without touching
  *   anything around it — that is the point of the {@link StateMigration} seam.
@@ -119,6 +120,7 @@ export const makeCrossLedgerMigration = (): StateMigration<PreviousLedgerWallet>
         publicKeys: previousState.publicKeys,
         networkId: previousState.networkId,
         protocolVersion: previousState.protocolVersion,
+        progress: previousState.progress,
       }),
     ),
 });

--- a/packages/shielded-wallet/src/v2/RunningV2Variant.ts
+++ b/packages/shielded-wallet/src/v2/RunningV2Variant.ts
@@ -42,8 +42,29 @@ const progress = (state: CoreWallet): StateChange.StateChange<CoreWallet>[] => {
   return [StateChange.ProgressUpdate({ sourceGap, applyGap })];
 };
 
-const protocolVersionChange = (previous: CoreWallet, current: CoreWallet): StateChange.StateChange<CoreWallet>[] => {
-  return previous.protocolVersion != current.protocolVersion
+/**
+ * Reports the protocol version a state observation implies, if any.
+ *
+ * @remarks
+ *   Two situations call for a signal. The ordinary one is a transition: sync annotated the state with a version it did
+ *   not have before, and the runtime decides whether that is a re-annotation inside this variant's range or a hand-over
+ *   to the next one.
+ *
+ *   The other is a state that arrives already outside this variant's range — a snapshot serialized in the window between
+ *   the annotation and the migration it should have caused, or one written by an older protocol version entirely.
+ *   Nothing further will change that value, so waiting for a transition would strand the wallet on a version it does
+ *   not own. Emitting on sight heals it.
+ */
+const protocolVersionChange = (
+  previous: CoreWallet,
+  current: CoreWallet,
+  isInitial: boolean,
+  activationRange: ProtocolVersion.ProtocolVersion.Range,
+): StateChange.StateChange<CoreWallet>[] => {
+  const transitioned = previous.protocolVersion != current.protocolVersion;
+  const strandedOutsideRange = isInitial && !ProtocolVersion.withinRange(current.protocolVersion, activationRange);
+
+  return transitioned || strandedOutsideRange
     ? [
         StateChange.VersionChange({
           change: VersionChangeType.Version({
@@ -104,18 +125,27 @@ export class RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
     this.state = Stream.fromEffect(context.stateRef.get).pipe(
       Stream.flatMap((initialState) =>
         context.stateRef.changes.pipe(
-          Stream.mapAccum(initialState, (previous: CoreWallet, current: CoreWallet) => {
-            return [current, [previous, current]] as const;
-          }),
+          // The accumulator carries the "have we seen anything yet" flag alongside the previous state: the first
+          // observation is the only one that can be a restored state nobody has inspected against this variant's
+          // range yet, and `SubscriptionRef.changes` replays the current value, so it is exactly this element.
+          Stream.mapAccum(
+            { previous: initialState, isInitial: true },
+            (seen, current: CoreWallet) =>
+              [{ previous: current, isInitial: false }, [seen.previous, current, seen.isInitial] as const] as const,
+          ),
         ),
       ),
       Stream.mapConcat(
-        ([previous, current]: readonly [CoreWallet, CoreWallet]): StateChange.StateChange<CoreWallet>[] => {
+        ([previous, current, isInitial]: readonly [
+          CoreWallet,
+          CoreWallet,
+          boolean,
+        ]): StateChange.StateChange<CoreWallet>[] => {
           // TODO: emit progress only upon actual change
           return [
             StateChange.State({ state: current }),
             ...progress(current),
-            ...protocolVersionChange(previous, current),
+            ...protocolVersionChange(previous, current, isInitial, context.activationRange),
           ];
         },
       ),
@@ -139,7 +169,11 @@ export class RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
         SubscriptionRef.modifyEffect(this.#context.stateRef, (state) =>
           Effect.try({
             try: () => {
-              const [newState, changesResult] = this.#v2Context.syncCapability.applyUpdate(state, update);
+              const [newState, changesResult] = this.#v2Context.syncCapability.applyUpdate(
+                state,
+                update,
+                this.#context.activationRange,
+              );
               return [changesResult, newState] as const;
             },
             catch: (err) =>

--- a/packages/shielded-wallet/src/v2/Sync.ts
+++ b/packages/shielded-wallet/src/v2/Sync.ts
@@ -12,14 +12,22 @@
 // limitations under the License.
 
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { Chunk, Duration, Effect, Either, ParseResult, pipe, Schedule, Schema, type Scope, Stream } from 'effect';
-import { CoreWallet } from './CoreWallet.js';
 import {
-  type Simulator,
-  type SimulatorState,
-  getLastBlock,
-  getBlockEventsFrom,
-} from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+  Chunk,
+  Duration,
+  Effect,
+  Either,
+  Option,
+  ParseResult,
+  pipe,
+  Schedule,
+  Schema,
+  type Scope,
+  Stream,
+} from 'effect';
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { CoreWallet } from './CoreWallet.js';
+import { type Simulator, type SimulatorState, getLastBlock } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import { ZswapEvents } from '@midnightntwrk/wallet-sdk-indexer-client';
 import { ConnectionHelper, WsSubscriptionClient } from '@midnightntwrk/wallet-sdk-indexer-client/effect';
 import { SyncWalletError, type WalletError } from './WalletError.js';
@@ -37,8 +45,79 @@ export type ChangesResult = {
 };
 
 export interface SyncCapability<TState, TUpdate, TResult> {
-  applyUpdate: (state: TState, update: TUpdate) => [TState, TResult];
+  /**
+   * Folds a sync update into the wallet state.
+   *
+   * @param state The state to fold into.
+   * @param update The update to apply.
+   * @param activeRange The half-open protocol version range the running variant owns. Anything the source reports at or
+   *   beyond its end belongs to a later variant and must be left unapplied for that variant to fetch.
+   */
+  applyUpdate: (
+    state: TState,
+    update: TUpdate,
+    activeRange: ProtocolVersion.ProtocolVersion.Range,
+  ) => [TState, TResult];
 }
+
+/** The result of splitting a batch of version-tagged items at a variant's activation boundary. */
+export type BoundarySplit<T> = {
+  /** The leading items this variant owns, in source order. */
+  readonly applied: readonly T[];
+  /** The trailing items belonging to a later protocol version, left for the next variant to re-fetch. */
+  readonly deferred: readonly T[];
+  /**
+   * The protocol version to record on the state: the first deferred item's version when there is one — that is the
+   * signal that triggers migration — otherwise the last applied item's version. `None` for an empty batch.
+   */
+  readonly observedVersion: Option.Option<ProtocolVersion.ProtocolVersion>;
+};
+
+/**
+ * Splits a batch of version-tagged items at the end of a variant's activation range.
+ *
+ * @remarks
+ *   The split is positional, not a filter: everything from the first out-of-range item onwards is deferred, even if a
+ *   later item reports an in-range version again. A batch is a contiguous slice of one timeline, so applying past a
+ *   boundary and then resuming behind it would leave a hole no cursor can describe.
+ *
+ *   This is the one place the boundary rule lives; both the indexer capability (per event) and the simulator capability
+ *   (per block) go through it, so they cannot drift apart.
+ * @param items The batch, in source order.
+ * @param versionOf Reads the protocol version an item was reported at.
+ * @param activeRange The variant's half-open activation range.
+ * @returns The applied/deferred split and the version to record.
+ */
+export const splitAtVersionBoundary = <T>(
+  items: readonly T[],
+  versionOf: (item: T) => number,
+  activeRange: ProtocolVersion.ProtocolVersion.Range,
+): BoundarySplit<T> => {
+  const [, end] = activeRange;
+  const boundary = items.findIndex((item) => BigInt(versionOf(item)) >= end);
+  const [applied, deferred] =
+    boundary < 0 ? [items, [] as readonly T[]] : [items.slice(0, boundary), items.slice(boundary)];
+  const signalling = deferred.at(0) ?? applied.at(-1);
+
+  return {
+    applied,
+    deferred,
+    observedVersion:
+      signalling === undefined
+        ? Option.none()
+        : Option.some(ProtocolVersion.ProtocolVersion(BigInt(versionOf(signalling)))),
+  };
+};
+
+/** Records a batch's observed protocol version on the state, monotonically. A batch that observed none is a no-op. */
+export const annotateVersion = (
+  state: CoreWallet,
+  observedVersion: Option.Option<ProtocolVersion.ProtocolVersion>,
+): CoreWallet =>
+  Option.match(observedVersion, {
+    onNone: () => state,
+    onSome: (version) => CoreWallet.withProtocolVersion(state, version),
+  });
 
 export type IndexerClientConnection = {
   indexerHttpUrl: string;
@@ -275,7 +354,11 @@ export const makeEventsSyncService = (
 
 export const makeEventsSyncCapability = (): SyncCapability<CoreWallet, WalletSyncUpdate, ChangesResult> => {
   return {
-    applyUpdate: (state: CoreWallet, wrappedUpdate: WalletSyncUpdate): [CoreWallet, ChangesResult] => {
+    applyUpdate: (
+      state: CoreWallet,
+      wrappedUpdate: WalletSyncUpdate,
+      activeRange: ProtocolVersion.ProtocolVersion.Range,
+    ): [CoreWallet, ChangesResult] => {
       if (wrappedUpdate.updates.length === 0) {
         return [state, { changes: [], protocolVersion: Number(state.protocolVersion) }];
       }
@@ -289,25 +372,43 @@ export const makeEventsSyncCapability = (): SyncCapability<CoreWallet, WalletSyn
       const appliedIndex = state.progress?.appliedIndex ?? 0n;
       const freshUpdates = wrappedUpdate.updates.filter((u) => BigInt(u.id) > appliedIndex);
 
+      // The tip is a property of the source, not of what this variant chose to apply, so it is read from
+      // the batch tail even when the tail belongs to the next protocol version.
       const lastUpdate = wrappedUpdate.updates.at(-1)!;
       const highestRelevantWalletIndex = BigInt(lastUpdate.maxId);
 
+      const { applied, observedVersion } = splitAtVersionBoundary(
+        freshUpdates,
+        (update) => update.protocolVersion,
+        activeRange,
+      );
+
       const [newState, newChanges]: [CoreWallet, ledger.ZswapStateChanges[]] =
-        freshUpdates.length === 0
+        applied.length === 0
           ? [state, []]
           : CoreWallet.replayEventsWithChanges(
               state,
               wrappedUpdate.secretKeys,
-              freshUpdates.map((u) => u.event),
+              applied.map((u) => u.event),
             );
 
-      const updatedState = CoreWallet.updateProgress(newState, {
+      // `appliedIndex` stops at the last event this variant actually replayed. The next variant resumes one
+      // below it on an inclusive cursor, so the deferred suffix is re-fetched rather than skipped.
+      const updatedState = CoreWallet.updateProgress(annotateVersion(newState, observedVersion), {
         highestRelevantWalletIndex,
-        appliedIndex: freshUpdates.length === 0 ? appliedIndex : BigInt(freshUpdates.at(-1)!.id),
+        appliedIndex: applied.length === 0 ? appliedIndex : BigInt(applied.at(-1)!.id),
         isConnected: true,
       });
 
-      return [updatedState, { changes: newChanges, protocolVersion: lastUpdate.protocolVersion }];
+      return [
+        updatedState,
+        {
+          changes: newChanges,
+          // Tags the changes that were actually produced, so tx-history records the version they were applied
+          // under rather than the one that is about to trigger the hand-over.
+          protocolVersion: applied.at(-1)?.protocolVersion ?? Number(state.protocolVersion),
+        },
+      ];
     },
   };
 };
@@ -355,24 +456,45 @@ export const makeSimulatorSyncService = (
 
 export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, SimulatorSyncUpdate, ChangesResult> => {
   return {
-    applyUpdate: (state: CoreWallet, update: SimulatorSyncUpdate): [CoreWallet, ChangesResult] => {
+    applyUpdate: (
+      state: CoreWallet,
+      update: SimulatorSyncUpdate,
+      activeRange: ProtocolVersion.ProtocolVersion.Range,
+    ): [CoreWallet, ChangesResult] => {
       const { update: simulatorState, secretKeys } = update;
       const lastBlock = getLastBlock(simulatorState);
       if (lastBlock === undefined) {
         return [state, { changes: [], protocolVersion: Number(state.protocolVersion) }];
       }
 
-      // Get all events from blocks starting at appliedIndex (the next block to process).
       // appliedIndex semantics: the first block number we haven't processed yet.
       // Initial: appliedIndex = 0 (haven't processed any blocks)
       // After processing block N: appliedIndex = N + 1 (next block to process)
-      const events = [...getBlockEventsFrom(simulatorState, state.progress.appliedIndex)];
-      const [newState, newChanges] = CoreWallet.replayEventsWithChanges(state, secretKeys, events);
+      //
+      // The boundary is applied at block granularity here — a block carries exactly one protocol version,
+      // stamped when it was produced — but it is the same rule and the same helper the indexer path uses.
+      const pending = simulatorState.blocks.filter((block) => block.number >= state.progress.appliedIndex);
+      const { applied, observedVersion } = splitAtVersionBoundary(
+        pending,
+        (block) => Number(block.protocolVersion),
+        activeRange,
+      );
+
+      const events = applied.flatMap((block) => block.transactions.flatMap((tx) => tx.result.events));
+
+      const [newState, newChanges]: [CoreWallet, ledger.ZswapStateChanges[]] =
+        applied.length === 0 ? [state, []] : CoreWallet.replayEventsWithChanges(state, secretKeys, events);
+
+      const lastAppliedBlock = applied.at(-1);
       return [
-        CoreWallet.updateProgress(newState, {
-          appliedIndex: lastBlock.number + 1n,
+        CoreWallet.updateProgress(annotateVersion(newState, observedVersion), {
+          appliedIndex: lastAppliedBlock === undefined ? state.progress.appliedIndex : lastAppliedBlock.number + 1n,
         }),
-        { changes: newChanges, protocolVersion: Number(state.protocolVersion) },
+        {
+          changes: newChanges,
+          protocolVersion:
+            lastAppliedBlock === undefined ? Number(state.protocolVersion) : Number(lastAppliedBlock.protocolVersion),
+        },
       ];
     },
   };

--- a/packages/shielded-wallet/src/v2/V2Builder.ts
+++ b/packages/shielded-wallet/src/v2/V2Builder.ts
@@ -10,14 +10,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import * as ledger from '@midnightntwrk/ledger-v9';
+import type * as ledger from '@midnightntwrk/ledger-v9';
 import { Effect, type Either, Scope, type Types } from 'effect';
-import { WalletSeed, type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
-import {
-  type Variant,
-  type VariantBuilder,
-  type WalletRuntimeError,
-} from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type Variant, type VariantBuilder, WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { type EmptyWalletMigrationConfiguration, type StateMigration, makeEmptyWalletMigration } from './Migration.js';
 import { RunningV2Variant, V2Tag } from './RunningV2Variant.js';
 import { makeDefaultV2SerializationCapability, type SerializationCapability } from './Serialization.js';
 import {
@@ -40,7 +37,7 @@ import { type WalletError } from './WalletError.js';
 import { type CoinsAndBalancesCapability, makeDefaultCoinsAndBalancesCapability } from './CoinsAndBalances.js';
 import { type KeysCapability, makeDefaultKeysCapability } from './Keys.js';
 import { type CoinSelection, chooseCoin } from '@midnightntwrk/wallet-sdk-capabilities';
-import { CoreWallet, PublicKeys } from './CoreWallet.js';
+import { type CoreWallet } from './CoreWallet.js';
 import {
   type DefaultTransactionHistoryConfiguration,
   makeDefaultTransactionHistoryService,
@@ -63,10 +60,10 @@ const V2BuilderSymbol: {
   typeId: Symbol('@midnight-ntwrk/wallet#V2Builder') as (typeof V2BuilderSymbol)['typeId'],
 } as const;
 
-export type V2Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData> = Variant.Variant<
+export type V2Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData, TPreviousState = null> = Variant.Variant<
   typeof V2Tag,
   CoreWallet,
-  null,
+  TPreviousState,
   RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData>
 > & {
   deserializeState: (serialized: TSerialized) => Either.Either<CoreWallet, WalletError>;
@@ -89,13 +86,14 @@ export type SerializedStateOf<T extends AnyV2Variant> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   T extends V2Variant<infer TSerialized, any, any, any> ? TSerialized : never;
 
-export type DefaultV2Builder = V2Builder<
+export type DefaultV2Builder<TPreviousState = null> = V2Builder<
   DefaultV2Configuration,
   RunningV2Variant.Context<string, WalletSyncUpdate, ledger.FinalizedTransaction, ledger.ZswapSecretKeys>,
   string,
   WalletSyncUpdate,
   ledger.FinalizedTransaction,
-  ledger.ZswapSecretKeys
+  ledger.ZswapSecretKeys,
+  TPreviousState
 >;
 
 export class V2Builder<
@@ -105,35 +103,65 @@ export class V2Builder<
   TSyncUpdate = never,
   TTransaction = never,
   TStartAux extends object = object,
-> implements VariantBuilder.VariantBuilder<V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>, TConfig> {
+  TPreviousState = null,
+> implements VariantBuilder.VariantBuilder<
+  V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState>,
+  TConfig
+> {
   readonly #buildState: V2Builder.PartialBuildState<
     TConfig,
     TContext,
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   >;
 
   constructor(
-    buildState: V2Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> = {},
+    buildState: V2Builder.PartialBuildState<
+      TConfig,
+      TContext,
+      TSerialized,
+      TSyncUpdate,
+      TTransaction,
+      TStartAux,
+      TPreviousState
+    > = {},
   ) {
     this.#buildState = buildState;
   }
 
-  withDefaults(): DefaultV2Builder {
-    return this.withDefaultTransactionType()
-      .withSyncDefaults()
-      .withSerializationDefaults()
-      .withTransactingDefaults()
-      .withCoinsAndBalancesDefaults()
-      .withTransactionHistoryDefaults()
-      .withKeysDefaults()
-      .withCoinSelectionDefaults() as DefaultV2Builder;
+  withDefaults(
+    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, null>,
+  ): DefaultV2Builder {
+    return (
+      this.withDefaultTransactionType()
+        .withSyncDefaults()
+        .withSerializationDefaults()
+        .withTransactingDefaults()
+        .withCoinsAndBalancesDefaults()
+        .withTransactionHistoryDefaults()
+        .withKeysDefaults()
+        // Type cast required because: the chain accumulates `TContext` as an intersection of the individual
+        // `Default*Context` fragments, which is a structurally weaker type than the complete
+        // `RunningV2Variant.Context` that `DefaultV2Builder` names — the defaults do produce a full context, but the
+        // chain's type cannot express that. Routing through `unknown` because the added `migration` key put the two
+        // sides past what TypeScript will accept as directly comparable; the widening itself predates it.
+        .withCoinSelectionDefaults() as unknown as DefaultV2Builder
+    );
   }
 
-  withTransactionType<Transaction>(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, Transaction, TStartAux> {
-    return new V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, Transaction, TStartAux>({
+  withTransactionType<Transaction>(): V2Builder<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    Transaction,
+    TStartAux,
+    TPreviousState
+  > {
+    return new V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, Transaction, TStartAux, TPreviousState>({
       ...this.#buildState,
       transactingCapability: undefined,
       transactionHistoryService: undefined,
@@ -146,7 +174,8 @@ export class V2Builder<
     TSerialized,
     TSyncUpdate,
     ledger.FinalizedTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return this.withTransactionType<ledger.FinalizedTransaction>();
   }
@@ -157,7 +186,8 @@ export class V2Builder<
     TSerialized,
     WalletSyncUpdate,
     TTransaction,
-    ledger.ZswapSecretKeys
+    ledger.ZswapSecretKeys,
+    TPreviousState
   > {
     return this.withSync(makeEventsSyncService, makeEventsSyncCapability);
   }
@@ -176,14 +206,23 @@ export class V2Builder<
       configuration: TSyncConfig,
       getContext: () => TSyncContext,
     ) => SyncCapability<CoreWallet, TSyncUpdate, ChangesResult>,
-  ): V2Builder<TConfig & TSyncConfig, TContext & TSyncContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  ): V2Builder<
+    TConfig & TSyncConfig,
+    TContext & TSyncContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return new V2Builder<
       TConfig & TSyncConfig,
       TContext & TSyncContext,
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       syncService,
@@ -191,7 +230,15 @@ export class V2Builder<
     });
   }
 
-  withSerializationDefaults(): V2Builder<TConfig, TContext, string, TSyncUpdate, TTransaction, TStartAux> {
+  withSerializationDefaults(): V2Builder<
+    TConfig,
+    TContext,
+    string,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return this.withSerialization(makeDefaultV2SerializationCapability);
   }
 
@@ -210,7 +257,8 @@ export class V2Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V2Builder<
       TConfig & TSerializationConfig,
@@ -218,7 +266,8 @@ export class V2Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       serializationCapability,
@@ -226,14 +275,23 @@ export class V2Builder<
   }
 
   withTransactingDefaults(
-    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, ledger.FinalizedTransaction, TStartAux>,
+    this: V2Builder<
+      TConfig,
+      TContext,
+      TSerialized,
+      TSyncUpdate,
+      ledger.FinalizedTransaction,
+      TStartAux,
+      TPreviousState
+    >,
   ): V2Builder<
     TConfig & DefaultTransactingConfiguration,
     TContext & DefaultTransactingContext,
     TSerialized,
     TSyncUpdate,
     ledger.FinalizedTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return this.withTransacting(makeDefaultTransactingCapability);
   }
@@ -249,7 +307,8 @@ export class V2Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V2Builder<
       TConfig & TTransactingConfig,
@@ -257,7 +316,8 @@ export class V2Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       transactingCapability,
@@ -275,7 +335,8 @@ export class V2Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V2Builder<
       TConfig & TCoinSelectionConfig,
@@ -283,18 +344,35 @@ export class V2Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       coinSelection,
     });
   }
 
-  withCoinSelectionDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  withCoinSelectionDefaults(): V2Builder<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return this.withCoinSelection(() => chooseCoin);
   }
 
-  withCoinsAndBalancesDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  withCoinsAndBalancesDefaults(): V2Builder<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return this.withCoinsAndBalances(makeDefaultCoinsAndBalancesCapability);
   }
 
@@ -309,7 +387,8 @@ export class V2Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V2Builder<
       TConfig & TBalancesConfig,
@@ -317,7 +396,8 @@ export class V2Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       coinsAndBalancesCapability,
@@ -325,14 +405,23 @@ export class V2Builder<
   }
 
   withTransactionHistoryDefaults(
-    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, ledger.FinalizedTransaction, TStartAux>,
+    this: V2Builder<
+      TConfig,
+      TContext,
+      TSerialized,
+      TSyncUpdate,
+      ledger.FinalizedTransaction,
+      TStartAux,
+      TPreviousState
+    >,
   ): V2Builder<
     TConfig & DefaultTransactionHistoryConfiguration,
     TContext,
     TSerialized,
     TSyncUpdate,
     ledger.FinalizedTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return this.withTransactionHistory(makeDefaultTransactionHistoryService);
   }
@@ -351,7 +440,8 @@ export class V2Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V2Builder<
       TConfig & TTransactionHistoryConfig,
@@ -359,27 +449,95 @@ export class V2Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       transactionHistoryService,
     });
   }
 
-  withKeysDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  withKeysDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState> {
     return this.withKeys(makeDefaultKeysCapability);
+  }
+
+  /**
+   * Uses the default migration: an empty wallet built from nothing.
+   *
+   * @remarks
+   *   This is what an unconfigured builder already does, so calling it changes no behaviour — it states the choice rather
+   *   than inheriting it. Registering this variant as the target of a real fork means calling
+   *   {@link V2Builder.withMigration} with {@link makeCrossLedgerMigration} instead.
+   */
+  withMigrationDefaults(
+    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, null>,
+  ): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, null> {
+    return this.withMigration((configuration: EmptyWalletMigrationConfiguration) =>
+      makeEmptyWalletMigration(configuration),
+    );
+  }
+
+  /**
+   * Chooses how this variant produces its first state from the state that preceded it.
+   *
+   * @remarks
+   *   The strategy's input type becomes the variant's `TPreviousState`, which is what the runtime type-checks a
+   *   registration against: a variant declaring it migrates from a ledger-v8 wallet cannot be registered after one that
+   *   produces something else.
+   * @example
+   *   ```typescript
+   *   const forkTarget = new V2Builder().withDefaults().withMigration(makeCrossLedgerMigration);
+   *   ```;
+   *
+   * @param migration Builds the migration from the configuration and the sibling capabilities.
+   */
+  withMigration<TMigrationConfig, TPrevious>(
+    migration: (configuration: TMigrationConfig, getContext: () => TContext) => StateMigration<TPrevious>,
+  ): V2Builder<TConfig & TMigrationConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, TPrevious> {
+    const capabilities: V2Builder.CapabilityBuildState<
+      TConfig,
+      TContext,
+      TSerialized,
+      TSyncUpdate,
+      TTransaction,
+      TStartAux
+    > = this.#buildState;
+
+    return new V2Builder<
+      TConfig & TMigrationConfig,
+      TContext,
+      TSerialized,
+      TSyncUpdate,
+      TTransaction,
+      TStartAux,
+      TPrevious
+    >({
+      // Only the capability half crosses: the strategy being replaced is typed against the *old* previous-state
+      // parameter, so it cannot ride along even though it is about to be overwritten.
+      ...capabilities,
+      migration,
+    });
   }
 
   withKeys<TKeysConfig, TKeysContext extends Partial<RunningV2Variant.AnyContext>>(
     keysCapability: (configuration: TKeysConfig, getContext: () => TKeysContext) => KeysCapability<CoreWallet>,
-  ): V2Builder<TConfig & TKeysConfig, TContext & TKeysContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  ): V2Builder<
+    TConfig & TKeysConfig,
+    TContext & TKeysContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return new V2Builder<
       TConfig & TKeysConfig,
       TContext & TKeysContext,
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       keysCapability,
@@ -393,12 +551,13 @@ export class V2Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >,
     configuration: TConfig,
-  ): V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  ): V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState> {
     const v2Context = this.#buildContextFromBuildState(configuration);
-    const { networkId } = configuration;
+    const migration = this.#resolveMigration(configuration, () => v2Context);
 
     return {
       __polyTag__: V2Tag,
@@ -418,18 +577,40 @@ export class V2Builder<
           return new RunningV2Variant(scope, context, v2Context);
         });
       },
-      migrateState(_previousState) {
-        const seed = WalletSeed.fromString('0000000000000000000000000000000000000000000000000000000000000001');
-
-        return Effect.succeed(
-          CoreWallet.empty(PublicKeys.fromSecretKeys(ledger.ZswapSecretKeys.fromSeed(seed)), networkId),
-        );
-      },
+      // An unconfigured builder keeps producing an empty wallet, which is what `startEmpty` has always relied on.
+      // Anything else — carrying state within a ledger version, or projecting it across one — is the injected
+      // strategy's business, and its failures are reported on the runtime's state stream rather than thrown.
+      migrateState: (previousState: TPreviousState) =>
+        migration.migrate(previousState).pipe(
+          Effect.mapError(
+            (error) =>
+              new WalletRuntimeError({
+                message: 'Failed to migrate shielded wallet state into this variant',
+                cause: error,
+              }),
+          ),
+        ),
 
       deserializeState: (serialized: TSerialized): Either.Either<CoreWallet, WalletError> => {
         return v2Context.serializationCapability.deserialize(null, serialized);
       },
     };
+  }
+
+  /**
+   * Resolves the configured migration, or the empty-wallet fallback when none was configured.
+   *
+   * @remarks
+   *   The fallback is written as a nullary function on purpose. It ignores whatever preceded it — it builds an empty
+   *   wallet from nothing — which makes it a valid migration from _any_ previous state, but a `StateMigration<null>`
+   *   value could only be widened to `StateMigration<TPreviousState>` through a cast. Declaring no parameter says the
+   *   same thing to the type system without one.
+   */
+  #resolveMigration(configuration: TConfig, getContext: () => TContext): StateMigration<TPreviousState> {
+    const configured = this.#buildState.migration;
+    return configured === undefined
+      ? { migrate: () => makeEmptyWalletMigration(configuration).migrate(null) }
+      : configured(configuration, getContext);
   }
 
   #buildContextFromBuildState(
@@ -439,7 +620,8 @@ export class V2Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >,
     configuration: TConfig,
   ): RunningV2Variant.Context<TSerialized, TSyncUpdate, TTransaction, TStartAux> {
@@ -537,7 +719,17 @@ declare namespace V2Builder {
       HasKeys<TConfig, TContext> &
       HasTransactionHistory<TConfig, TContext>
   >;
-  type PartialBuildState<
+  /**
+   * The migration entry, kept out of {@link FullBuildState} on purpose: absent means "empty wallet", which is the
+   * behaviour every builder had before migrations were configurable, so a builder that never mentions migration must
+   * still be considered complete.
+   */
+  type HasMigration<TConfig, TContext, TPreviousState> = {
+    readonly migration: (configuration: TConfig, getContext: () => TContext) => StateMigration<TPreviousState>;
+  };
+
+  /** The capability half of the build state — everything that does not depend on the previous-state parameter. */
+  type CapabilityBuildState<
     TConfig = object,
     TContext = object,
     TSerialized = never,
@@ -549,6 +741,21 @@ declare namespace V2Builder {
       FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux>[K] | undefined;
   };
 
+  type PartialBuildState<
+    TConfig = object,
+    TContext = object,
+    TSerialized = never,
+    TSyncUpdate = never,
+    TTransaction = never,
+    TStartAux = object,
+    TPreviousState = null,
+  > = {
+    [K in keyof (FullBuildState<never, never, never, never, never, never> & HasMigration<never, never, never>)]?:
+      | (FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> &
+          HasMigration<TConfig, TContext, TPreviousState>)[K]
+      | undefined;
+  };
+
   /** Utility interface that manages the type variance of {@link V2Builder}. */
   interface Variance<R> {
     readonly [V2BuilderSymbol.typeId]: {
@@ -557,8 +764,16 @@ declare namespace V2Builder {
   }
 }
 
-const isBuildStateFull = <TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux>(
-  buildState: V2Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux>,
+const isBuildStateFull = <TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState>(
+  buildState: V2Builder.PartialBuildState<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  >,
 ): buildState is V2Builder.FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> => {
   const allBuildStateKeys = [
     'syncService',

--- a/packages/shielded-wallet/src/v2/index.ts
+++ b/packages/shielded-wallet/src/v2/index.ts
@@ -15,6 +15,7 @@ export * as Sync from './Sync.js';
 export * as Transacting from './Transacting.js';
 export * as TransactionHistory from './TransactionHistory.js';
 export * as Serialization from './Serialization.js';
+export * as Migration from './Migration.js';
 export * as CoinsAndBalances from './CoinsAndBalances.js';
 export * as Keys from './Keys.js';
 export * from './RunningV2Variant.js';

--- a/packages/shielded-wallet/src/v2/test/migration.test.ts
+++ b/packages/shielded-wallet/src/v2/test/migration.test.ts
@@ -1,0 +1,147 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * How this variant builds its first state from whatever preceded it.
+ *
+ * @remarks
+ *   The three strategies differ in exactly one thing — how much of the previous wallet is allowed to survive — so that is
+ *   what these pin down: everything (same ledger version), nothing (no previous wallet at all), and, across a ledger
+ *   version boundary, identity only.
+ */
+
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { CoreWallet, PublicKeys } from '../CoreWallet.js';
+import {
+  type PreviousLedgerWallet,
+  makeCarryOverMigration,
+  makeCrossLedgerMigration,
+  makeEmptyWalletMigration,
+} from '../Migration.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+const seed = Buffer.alloc(32, 7);
+const keys = (): ledger.ZswapSecretKeys => ledger.ZswapSecretKeys.fromSeed(seed);
+
+/** The version that triggered the hand-over: the first one the previous variant saw outside its own range. */
+const forkVersion = ProtocolVersion.ProtocolVersion(7n);
+
+/**
+ * A wallet of the previous ledger version, as plain data.
+ *
+ * @remarks
+ *   Deliberately wider than {@link PreviousLedgerWallet}: it also carries the coins and the cursor that a real pre-fork
+ *   wallet would be holding, so that "those do not cross" is something this file can actually observe rather than
+ *   merely fail to mention. Structural because the real thing is built on the other ledger's WASM module, and a
+ *   projection that reads no ledger object out of it has no reason to load one.
+ */
+type PreviousWalletStandIn = PreviousLedgerWallet & {
+  readonly state: {
+    readonly coins: readonly Readonly<{ type: string; nonce: string; value: bigint; mt_index: bigint }>[];
+  };
+};
+
+const previousWallet = (): PreviousWalletStandIn => {
+  const secretKeys = keys();
+  return {
+    publicKeys: {
+      coinPublicKey: secretKeys.coinPublicKey,
+      encryptionPublicKey: secretKeys.encryptionPublicKey,
+    },
+    networkId,
+    protocolVersion: forkVersion,
+    progress: {
+      appliedIndex: 4321n,
+      highestRelevantWalletIndex: 4400n,
+      highestIndex: 4400n,
+      highestRelevantIndex: 4400n,
+      isConnected: true,
+    },
+    state: {
+      coins: [
+        { type: 'aa'.repeat(32), nonce: 'bb'.repeat(32), value: 100n, mt_index: 0n },
+        { type: 'aa'.repeat(32), nonce: 'cc'.repeat(32), value: 200n, mt_index: 4n },
+      ],
+    },
+  };
+};
+
+describe('the empty-wallet migration', () => {
+  it('produces a wallet with no coins on the configured network', async () => {
+    const wallet = await Effect.runPromise(makeEmptyWalletMigration({ networkId }).migrate(null));
+
+    expect(wallet.networkId).toBe(networkId);
+    expect([...wallet.state.coins]).toEqual([]);
+    expect(wallet.coinHashes).toEqual({});
+    expect(wallet.progress.appliedIndex).toBe(0n);
+    expect(wallet.protocolVersion).toBe(ProtocolVersion.MinSupportedVersion);
+  });
+});
+
+describe('the carry-over migration', () => {
+  it('hands the previous state through untouched', async () => {
+    const previous = CoreWallet.init(new ledger.ZswapLocalState(), keys(), networkId);
+
+    const wallet = await Effect.runPromise(makeCarryOverMigration().migrate(previous));
+
+    expect(wallet).toBe(previous);
+  });
+});
+
+describe('the cross-ledger migration', () => {
+  it('carries the public keys, so the replayed timeline can be decrypted into the same coins', async () => {
+    const previous = previousWallet();
+
+    const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+    expect(wallet.publicKeys).toEqual(PublicKeys.fromSecretKeys(keys()));
+    expect(wallet.networkId).toBe(networkId);
+  });
+
+  it('records the version that triggered the hand-over, so the new variant starts inside its own range', async () => {
+    const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previousWallet()));
+
+    expect(wallet.protocolVersion).toBe(forkVersion);
+  });
+
+  it('starts from an empty local state rather than carrying the previous version coins', async () => {
+    // The indexer replays the timeline after the fork, so these coins arrive again as events of this ledger version.
+    // Carrying them as well would double-count them, and rebuilding the tree would need secret keys this has none of.
+    const previous = previousWallet();
+    expect(previous.state.coins.length).toBeGreaterThan(0);
+
+    const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+    expect([...wallet.state.coins]).toEqual([]);
+    expect(wallet.state.firstFree).toBe(0n);
+    expect(wallet.coinHashes).toEqual({});
+  });
+
+  it('resets sync progress, so the replayed timeline is read from its start', async () => {
+    // The assumption this encodes: replayed events restart their ids. Were they to continue past the boundary, the
+    // migration would park progress at the fork instead — and this expectation would be the one that changed.
+    const previous = previousWallet();
+    expect(previous.progress.appliedIndex).toBeGreaterThan(0n);
+
+    const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+    expect(wallet.progress.appliedIndex).toBe(0n);
+    expect(wallet.progress.highestIndex).toBe(0n);
+    expect(wallet.progress.highestRelevantIndex).toBe(0n);
+    expect(wallet.progress.highestRelevantWalletIndex).toBe(0n);
+    expect(wallet.progress.isConnected).toBe(false);
+  });
+});

--- a/packages/shielded-wallet/src/v2/test/migration.test.ts
+++ b/packages/shielded-wallet/src/v2/test/migration.test.ts
@@ -43,10 +43,11 @@ const forkVersion = ProtocolVersion.ProtocolVersion(7n);
  * A wallet of the previous ledger version, as plain data.
  *
  * @remarks
- *   Deliberately wider than {@link PreviousLedgerWallet}: it also carries the coins and the cursor that a real pre-fork
- *   wallet would be holding, so that "those do not cross" is something this file can actually observe rather than
- *   merely fail to mention. Structural because the real thing is built on the other ledger's WASM module, and a
- *   projection that reads no ledger object out of it has no reason to load one.
+ *   Deliberately wider than {@link PreviousLedgerWallet}: it also carries the coins a real pre-fork wallet would be
+ *   holding, so that "those do not cross" is something this file can actually observe rather than merely fail to
+ *   mention. Its cursor is non-zero for the opposite reason — what does cross has to be seen crossing. Structural
+ *   because the real thing is built on the other ledger's WASM module, and a projection that reads no ledger object out
+ *   of it has no reason to load one.
  */
 type PreviousWalletStandIn = PreviousLedgerWallet & {
   readonly state: {
@@ -130,18 +131,23 @@ describe('the cross-ledger migration', () => {
     expect(wallet.coinHashes).toEqual({});
   });
 
-  it('resets sync progress, so the replayed timeline is read from its start', async () => {
-    // The assumption this encodes: replayed events restart their ids. Were they to continue past the boundary, the
-    // migration would park progress at the fork instead — and this expectation would be the one that changed.
+  it('parks sync progress at the fork, because the replayed timeline continues the ids it left off at', async () => {
+    // The confirmed semantics: after the hard fork the indexer replays the events again, numbering them onwards from
+    // whatever id it had reached when the fork happened — never from zero. So the migrated wallet resumes from where
+    // its predecessor stopped. Rewinding to zero would point it at a stretch of the timeline the replay does not
+    // occupy, and it would sit there waiting for events that already went by under the previous ledger version.
     const previous = previousWallet();
     expect(previous.progress.appliedIndex).toBeGreaterThan(0n);
 
     const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
 
-    expect(wallet.progress.appliedIndex).toBe(0n);
-    expect(wallet.progress.highestIndex).toBe(0n);
-    expect(wallet.progress.highestRelevantIndex).toBe(0n);
-    expect(wallet.progress.highestRelevantWalletIndex).toBe(0n);
+    expect(wallet.progress.appliedIndex).toBe(previous.progress.appliedIndex);
+    expect(wallet.progress.highestIndex).toBe(previous.progress.highestIndex);
+    expect(wallet.progress.highestRelevantIndex).toBe(previous.progress.highestRelevantIndex);
+    expect(wallet.progress.highestRelevantWalletIndex).toBe(previous.progress.highestRelevantWalletIndex);
+    // The position crosses; being connected does not. This state has no running sync behind it yet — the restart that
+    // follows the migration is what reconnects it — and claiming otherwise would report a gap that nothing is closing.
+    expect(previous.progress.isConnected).toBe(true);
     expect(wallet.progress.isConnected).toBe(false);
   });
 });

--- a/packages/shielded-wallet/src/v2/test/runningV2Variant.test.ts
+++ b/packages/shielded-wallet/src/v2/test/runningV2Variant.test.ts
@@ -12,8 +12,21 @@
 // limitations under the License.
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Duration, Effect, Exit, Ref, Scope, Stream, SubscriptionRef, TestClock, TestContext } from 'effect';
+import {
+  Chunk,
+  Duration,
+  Effect,
+  Exit,
+  Fiber,
+  Ref,
+  Scope,
+  Stream,
+  SubscriptionRef,
+  TestClock,
+  TestContext,
+} from 'effect';
 import { describe, expect, it } from 'vitest';
+import { StateChange, VersionChangeType } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { makeDefaultCoinsAndBalancesCapability } from '../CoinsAndBalances.js';
 import { CoreWallet } from '../CoreWallet.js';
 import { makeDefaultKeysCapability } from '../Keys.js';
@@ -146,5 +159,86 @@ describe('RunningV2Variant.startSync tx-history fan-out', () => {
     expect(result.maxInFlight).toBe(8);
     // The cap only queues work, it never drops it.
     expect(result.recorded).toBe(12);
+  });
+});
+
+describe('RunningV2Variant.state protocol version signalling', () => {
+  /** The variant under test owns `[0, 7)`; 7 and above belong to whatever variant comes next. */
+  const activationRange = ProtocolVersion.makeRange(
+    ProtocolVersion.MinSupportedVersion,
+    ProtocolVersion.ProtocolVersion(7n),
+  );
+
+  const walletAtVersion = (protocolVersion: bigint): CoreWallet =>
+    CoreWallet.restore(
+      new ledger.ZswapLocalState(),
+      ledger.ZswapSecretKeys.fromSeed(Buffer.alloc(32, 1)),
+      { appliedIndex: 0n, highestRelevantWalletIndex: 0n, highestIndex: 0n, highestRelevantIndex: 0n },
+      protocolVersion,
+      networkId,
+    );
+
+  const versionChangesOf = (changes: Chunk.Chunk<StateChange.StateChange<CoreWallet>>): readonly bigint[] =>
+    Chunk.toArray(changes)
+      .filter(StateChange.isVersionChange)
+      .map(({ change }) => {
+        expect(VersionChangeType.isVersion(change)).toBe(true);
+        return VersionChangeType.isVersion(change) ? change.version : -1n;
+      });
+
+  /**
+   * Drains the variant's state stream for a fixed window and returns everything it emitted. A bounded window rather
+   * than `Stream.take(n)` on purpose: the point of these tests is *how many* version changes appear, so a missing one
+   * has to surface as a failed assertion, not as a hang.
+   */
+  const emissionsWithin = (
+    initialState: CoreWallet,
+    act: (stateRef: SubscriptionRef.SubscriptionRef<CoreWallet>) => Effect.Effect<void> = () => Effect.void,
+  ): Promise<Chunk.Chunk<StateChange.StateChange<CoreWallet>>> =>
+    Effect.gen(function* () {
+      const stateRef = yield* SubscriptionRef.make(initialState);
+      const scope = yield* Scope.make();
+      const variant = new RunningV2Variant(
+        scope,
+        { stateRef, activationRange },
+        variantContextOf([], trackingHistoryService({
+          inFlight: yield* Ref.make(0),
+          maxInFlight: yield* Ref.make(0),
+          recorded: yield* Ref.make(0),
+        })),
+      );
+
+      const collector = yield* Effect.fork(
+        variant.state.pipe(Stream.interruptAfter(Duration.millis(300)), Stream.runCollect),
+      );
+      yield* Effect.sleep(Duration.millis(50));
+      yield* act(stateRef);
+      const collected = yield* Fiber.join(collector);
+      yield* Scope.close(scope, Exit.void);
+      return collected;
+    }).pipe(Effect.runPromise);
+
+  it('emits exactly one VersionChange when the state transitions to a new protocol version', async () => {
+    const collected = await emissionsWithin(walletAtVersion(0n), (stateRef) =>
+      SubscriptionRef.set(stateRef, walletAtVersion(5n)),
+    );
+
+    expect(versionChangesOf(collected)).toEqual([5n]);
+  });
+
+  it('emits an immediate healing VersionChange when the initial state is outside the activation range', async () => {
+    // A snapshot serialized after the version was annotated but before the runtime migrated restores here. Without a
+    // healing emission the wallet would sit on a version it does not own and never hand over.
+    const collected = await emissionsWithin(walletAtVersion(9n));
+
+    expect(versionChangesOf(collected)).toEqual([9n]);
+  });
+
+  it('emits no VersionChange when the initial state is inside the activation range', async () => {
+    const collected = await emissionsWithin(walletAtVersion(3n));
+
+    expect(versionChangesOf(collected)).toEqual([]);
+    // The stream still reports the state itself, so an empty result would be a false pass.
+    expect(Chunk.toArray(collected).filter(StateChange.isState).length).toBeGreaterThan(0);
   });
 });

--- a/packages/shielded-wallet/src/v2/test/runningV2Variant.test.ts
+++ b/packages/shielded-wallet/src/v2/test/runningV2Variant.test.ts
@@ -188,7 +188,7 @@ describe('RunningV2Variant.state protocol version signalling', () => {
 
   /**
    * Drains the variant's state stream for a fixed window and returns everything it emitted. A bounded window rather
-   * than `Stream.take(n)` on purpose: the point of these tests is *how many* version changes appear, so a missing one
+   * than `Stream.take(n)` on purpose: the point of these tests is _how many_ version changes appear, so a missing one
    * has to surface as a failed assertion, not as a hang.
    */
   const emissionsWithin = (
@@ -201,11 +201,14 @@ describe('RunningV2Variant.state protocol version signalling', () => {
       const variant = new RunningV2Variant(
         scope,
         { stateRef, activationRange },
-        variantContextOf([], trackingHistoryService({
-          inFlight: yield* Ref.make(0),
-          maxInFlight: yield* Ref.make(0),
-          recorded: yield* Ref.make(0),
-        })),
+        variantContextOf(
+          [],
+          trackingHistoryService({
+            inFlight: yield* Ref.make(0),
+            maxInFlight: yield* Ref.make(0),
+            recorded: yield* Ref.make(0),
+          }),
+        ),
       );
 
       const collector = yield* Effect.fork(

--- a/packages/shielded-wallet/src/v2/test/sync.test.ts
+++ b/packages/shielded-wallet/src/v2/test/sync.test.ts
@@ -98,6 +98,11 @@ const createMockSubscriptionFn = (
   totalRecords: number,
   mockEventHex: string,
   timingOptions?: TimingOptions,
+  /**
+   * The protocol version the indexer reports for each event id. Defaults to a constant 1. Per-item versions are what
+   * the boundary split in `applyUpdate` keys off, so they have to survive batching intact.
+   */
+  protocolVersionOf: (id: number) => number = () => 1,
 ): ((
   _variables: ZswapEventsSubscriptionVariables,
 ) => Stream.Stream<ZswapEventsSubscription, ClientError | ServerError, SubscriptionClient>) => {
@@ -110,7 +115,7 @@ const createMockSubscriptionFn = (
         zswapLedgerEvents: {
           id,
           raw: mockEventHex,
-          protocolVersion: 1,
+          protocolVersion: protocolVersionOf(id),
           maxId: totalRecords,
         },
       })),
@@ -420,6 +425,52 @@ describe('Wallet subscription', () => {
       const variables = await cursorFor(state, secretKeys);
 
       expect(variables).toEqual({ id: 4 });
+    });
+  });
+
+  describe('per-item protocol version decoding', () => {
+    // The version reported for a single event is what decides which side of the fork boundary that event falls on, so
+    // it has to arrive at `applyUpdate` per item — a batch-level summary would erase exactly the transition being
+    // looked for.
+    const versionOf = (id: number): number => (id <= 3 ? 3 : id <= 5 ? 9 : 11);
+
+    const collectUpdates = async (eventCount: number, batchSize: number) => {
+      const mockEventHex = await createMockEventHex();
+      const mockSubscriptionFn = createMockSubscriptionFn(eventCount, mockEventHex, undefined, versionOf);
+      const secretKeys = ledger.ZswapSecretKeys.fromSeed(Buffer.alloc(32, 0));
+      const initialState = CoreWallet.initEmpty(secretKeys, NetworkId.NetworkId.Undeployed);
+
+      return await Effect.gen(function* () {
+        const syncService = makeEventsSyncService({
+          indexerClientConnection: {
+            indexerHttpUrl: 'http://localhost:8088/api/v4/graphql',
+            indexerWsUrl: 'ws://localhost:8088/api/v4/graphql/ws',
+          },
+          batchUpdates: { size: batchSize, spacing: 0 },
+        });
+
+        return yield* syncService.updates(initialState, secretKeys).pipe(Stream.runCollect);
+      }).pipe(Effect.provideService(ZswapEvents.tag, mockSubscriptionFn), Effect.scoped, Effect.runPromise);
+    };
+
+    it('carries the indexer-reported version of every event through a single batch', async () => {
+      const updates = await collectUpdates(6, 10);
+
+      expect(Chunk.size(updates)).toBe(1);
+      const batch = updates.pipe(Chunk.unsafeHead);
+      expect(batch.updates.map((u) => u.id)).toEqual([1, 2, 3, 4, 5, 6]);
+      expect(batch.updates.map((u) => u.protocolVersion)).toEqual([3, 3, 3, 9, 9, 11]);
+    });
+
+    it('keeps each event paired with its own version when the batch boundary splits them', async () => {
+      const updates = await collectUpdates(6, 2);
+
+      expect(Chunk.size(updates)).toBe(3);
+      expect(Chunk.toArray(updates).map((batch) => batch.updates.map((u) => u.protocolVersion))).toEqual([
+        [3, 3],
+        [3, 9],
+        [9, 11],
+      ]);
     });
   });
 });

--- a/packages/shielded-wallet/src/v2/test/syncCapability.test.ts
+++ b/packages/shielded-wallet/src/v2/test/syncCapability.test.ts
@@ -1,0 +1,279 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Simulator, type SimulatorState, getLastBlockEvents } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { Effect, Option, Scope, Stream } from 'effect';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { CoreWallet } from '../CoreWallet.js';
+import {
+  type EventsSyncUpdate,
+  WalletSyncUpdate,
+  makeEventsSyncCapability,
+  makeSimulatorSyncCapability,
+} from '../Sync.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+
+/**
+ * The boundary under test. The variant owns `[0, 7)`; anything reported at 7 or beyond belongs to the next variant and
+ * must not be applied here.
+ */
+const activeRange = ProtocolVersion.makeRange(ProtocolVersion.ProtocolVersion(0n), ProtocolVersion.ProtocolVersion(7n));
+
+const secretKeys = (): ledger.ZswapSecretKeys => ledger.ZswapSecretKeys.fromSeed(Buffer.alloc(32, 7));
+
+/** The six genesis mints, in ascending amount order: 100, 200, ..., 600 — 2100 in total. */
+const MINT_COUNT = 6;
+const MINT_TOTAL = 2100n;
+
+const mintingSimulator = (protocolVersion?: ProtocolVersion.ProtocolVersion) =>
+  Simulator.init({
+    ...(protocolVersion === undefined ? {} : { protocolVersion }),
+    genesisMints: Array.from({ length: MINT_COUNT }, (_, i) => ({
+      type: 'shielded' as const,
+      tokenType: ledger.shieldedToken().raw,
+      amount: BigInt((i + 1) * 100),
+      recipient: secretKeys(),
+    })) as never,
+  });
+
+const simulatorStateAt = (protocolVersion?: ProtocolVersion.ProtocolVersion): Promise<SimulatorState> =>
+  Effect.gen(function* () {
+    const simulator = yield* mintingSimulator(protocolVersion);
+    return Option.getOrThrow(yield* simulator.state$.pipe(Stream.take(1), Stream.runHead));
+  }).pipe(Effect.scoped, Effect.runPromise);
+
+/**
+ * Serialized bytes of the six real `zswapOutput` events the genesis mints emit, in chain order.
+ *
+ * They are kept as bytes rather than as `ledger.Event` instances on purpose: `replayEventsWithChanges` consumes the
+ * event objects it is handed (wasm-bindgen moves ownership), so a second use of the same instance throws. Every test
+ * deserializes its own instances.
+ */
+let eventBytes: readonly Uint8Array[];
+
+beforeAll(async () => {
+  const state = await simulatorStateAt();
+  eventBytes = getLastBlockEvents(state).map((event) => event.serialize());
+  expect(eventBytes.length).toBe(MINT_COUNT);
+});
+
+/** Builds a batch of sync updates, one per `(id, protocolVersion)` pair, each carrying its own fresh event instance. */
+const batch = (items: readonly (readonly [id: number, protocolVersion: number])[]): WalletSyncUpdate =>
+  WalletSyncUpdate.create(
+    items.map(
+      ([id, protocolVersion]): EventsSyncUpdate => ({
+        _tag: 'EventsSyncUpdate',
+        id,
+        protocolVersion,
+        maxId: MINT_COUNT,
+        event: ledger.Event.deserialize(eventBytes[id - 1]!),
+      }),
+    ),
+    secretKeys(),
+  );
+
+const freshWallet = (): CoreWallet => CoreWallet.initEmpty(secretKeys(), networkId);
+
+const coinIndices = (wallet: CoreWallet): readonly bigint[] =>
+  [...wallet.state.coins].map((coin) => coin.mt_index).sort((a, b) => Number(a - b));
+
+const totalValue = (wallet: CoreWallet): bigint => [...wallet.state.coins].reduce((sum, coin) => sum + coin.value, 0n);
+
+describe('makeEventsSyncCapability.applyUpdate boundary handling', () => {
+  const capability = makeEventsSyncCapability();
+
+  it('applies every update and annotates the state when the whole batch is inside the active range', () => {
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 3],
+        [2, 3],
+        [3, 3],
+        [4, 3],
+        [5, 3],
+        [6, 3],
+      ]),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(6n);
+    expect(state.progress.highestRelevantWalletIndex).toBe(BigInt(MINT_COUNT));
+    expect(state.progress.isConnected).toBe(true);
+    expect(state.protocolVersion).toBe(3n);
+    expect(coinIndices(state)).toEqual([0n, 1n, 2n, 3n, 4n, 5n]);
+    expect(totalValue(state)).toBe(MINT_TOTAL);
+    expect(state.state.firstFree).toBe(6n);
+    expect(result.changes.length).toBe(1);
+    expect(result.changes[0]!.receivedCoins.length).toBe(MINT_COUNT);
+    expect(result.protocolVersion).toBe(3);
+  });
+
+  it('re-annotates the state on a version bump that stays inside the active range', () => {
+    const [afterFirst] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 3],
+        [2, 3],
+        [3, 3],
+      ]),
+      activeRange,
+    );
+    expect(afterFirst.protocolVersion).toBe(3n);
+
+    const [state, result] = capability.applyUpdate(
+      afterFirst,
+      batch([
+        [4, 5],
+        [5, 5],
+        [6, 5],
+      ]),
+      activeRange,
+    );
+
+    expect(state.protocolVersion).toBe(5n);
+    expect(state.progress.appliedIndex).toBe(6n);
+    expect(coinIndices(state)).toEqual([0n, 1n, 2n, 3n, 4n, 5n]);
+    expect(totalValue(state)).toBe(MINT_TOTAL);
+    expect(result.changes.length).toBe(1);
+    expect(result.changes[0]!.receivedCoins.length).toBe(3);
+  });
+
+  it('applies only the prefix of a straddling batch and takes the version from the first suffix item', () => {
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 3],
+        [2, 3],
+        [3, 3],
+        [4, 9],
+        [5, 9],
+        [6, 11],
+      ]),
+      activeRange,
+    );
+
+    // Prefix only: the last applied id is 3, so the next variant resumes there and re-fetches ids 4-6.
+    expect(state.progress.appliedIndex).toBe(3n);
+    // The suffix's first version is what makes the variant hand over — not the batch's last version.
+    expect(state.protocolVersion).toBe(9n);
+    expect(coinIndices(state)).toEqual([0n, 1n, 2n]);
+    expect(state.state.firstFree).toBe(3n);
+    // Changes come from the prefix alone.
+    expect(result.changes.length).toBe(1);
+    expect(result.changes[0]!.receivedCoins.length).toBe(3);
+    // The reported version tags the applied changes, so it is the prefix's version.
+    expect(result.protocolVersion).toBe(3);
+    // The tip is a property of the source, so it still comes from the batch tail.
+    expect(state.progress.highestRelevantWalletIndex).toBe(BigInt(MINT_COUNT));
+  });
+
+  it('applies nothing when the whole batch is at or beyond the end of the active range', () => {
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 7],
+        [2, 7],
+        [3, 9],
+        [4, 9],
+        [5, 9],
+        [6, 9],
+      ]),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(0n);
+    expect(state.protocolVersion).toBe(7n);
+    expect(coinIndices(state)).toEqual([]);
+    expect(state.state.firstFree).toBe(0n);
+    expect(result.changes).toEqual([]);
+    expect(state.progress.highestRelevantWalletIndex).toBe(BigInt(MINT_COUNT));
+  });
+
+  it('never lowers the recorded protocol version when a later batch reports a stale lower one', () => {
+    const [afterFirst] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 5],
+        [2, 5],
+        [3, 5],
+      ]),
+      activeRange,
+    );
+    expect(afterFirst.protocolVersion).toBe(5n);
+
+    const [state] = capability.applyUpdate(
+      afterFirst,
+      batch([
+        [4, 2],
+        [5, 2],
+        [6, 2],
+      ]),
+      activeRange,
+    );
+
+    // The batch still applies; only the version annotation is held at its high-water mark.
+    expect(state.protocolVersion).toBe(5n);
+    expect(state.progress.appliedIndex).toBe(6n);
+    expect(coinIndices(state)).toEqual([0n, 1n, 2n, 3n, 4n, 5n]);
+  });
+
+  it('leaves the state untouched for an empty batch', () => {
+    const initial = freshWallet();
+    const [state, result] = capability.applyUpdate(initial, WalletSyncUpdate.create([], secretKeys()), activeRange);
+
+    expect(state.progress.appliedIndex).toBe(0n);
+    expect(state.protocolVersion).toBe(ProtocolVersion.MinSupportedVersion);
+    expect(coinIndices(state)).toEqual([]);
+    expect(result.changes).toEqual([]);
+    expect(result.protocolVersion).toBe(Number(initial.protocolVersion));
+  });
+});
+
+describe('makeSimulatorSyncCapability.applyUpdate boundary handling', () => {
+  const capability = makeSimulatorSyncCapability();
+
+  it('applies an in-range block and annotates the state with the block version', async () => {
+    const simulatorState = await simulatorStateAt(ProtocolVersion.ProtocolVersion(3n));
+
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      { update: simulatorState, secretKeys: secretKeys() },
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(1n);
+    expect(state.protocolVersion).toBe(3n);
+    expect(coinIndices(state)).toEqual([0n, 1n, 2n, 3n, 4n, 5n]);
+    expect(totalValue(state)).toBe(MINT_TOTAL);
+    expect(result.changes.length).toBe(1);
+  });
+
+  it('applies no block at or beyond the end of the active range, but still annotates the version', async () => {
+    const simulatorState = await simulatorStateAt(ProtocolVersion.ProtocolVersion(9n));
+
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      { update: simulatorState, secretKeys: secretKeys() },
+      activeRange,
+    );
+
+    // The block carries six real mint events; none of them may be applied by this variant.
+    expect(state.progress.appliedIndex).toBe(0n);
+    expect(state.protocolVersion).toBe(9n);
+    expect(coinIndices(state)).toEqual([]);
+    expect(state.state.firstFree).toBe(0n);
+    expect(result.changes).toEqual([]);
+  });
+});

--- a/packages/shielded-wallet/src/v2/test/syncCapability.test.ts
+++ b/packages/shielded-wallet/src/v2/test/syncCapability.test.ts
@@ -13,7 +13,7 @@
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Simulator, type SimulatorState, getLastBlockEvents } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
-import { Effect, Option, Scope, Stream } from 'effect';
+import { Effect, Option, Stream } from 'effect';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { CoreWallet } from '../CoreWallet.js';
 import {
@@ -72,15 +72,13 @@ beforeAll(async () => {
 /** Builds a batch of sync updates, one per `(id, protocolVersion)` pair, each carrying its own fresh event instance. */
 const batch = (items: readonly (readonly [id: number, protocolVersion: number])[]): WalletSyncUpdate =>
   WalletSyncUpdate.create(
-    items.map(
-      ([id, protocolVersion]): EventsSyncUpdate => ({
-        _tag: 'EventsSyncUpdate',
-        id,
-        protocolVersion,
-        maxId: MINT_COUNT,
-        event: ledger.Event.deserialize(eventBytes[id - 1]!),
-      }),
-    ),
+    items.map(([id, protocolVersion]): EventsSyncUpdate => ({
+      _tag: 'EventsSyncUpdate',
+      id,
+      protocolVersion,
+      maxId: MINT_COUNT,
+      event: ledger.Event.deserialize(eventBytes[id - 1]),
+    })),
     secretKeys(),
   );
 
@@ -116,7 +114,7 @@ describe('makeEventsSyncCapability.applyUpdate boundary handling', () => {
     expect(totalValue(state)).toBe(MINT_TOTAL);
     expect(state.state.firstFree).toBe(6n);
     expect(result.changes.length).toBe(1);
-    expect(result.changes[0]!.receivedCoins.length).toBe(MINT_COUNT);
+    expect(result.changes[0].receivedCoins.length).toBe(MINT_COUNT);
     expect(result.protocolVersion).toBe(3);
   });
 
@@ -147,7 +145,7 @@ describe('makeEventsSyncCapability.applyUpdate boundary handling', () => {
     expect(coinIndices(state)).toEqual([0n, 1n, 2n, 3n, 4n, 5n]);
     expect(totalValue(state)).toBe(MINT_TOTAL);
     expect(result.changes.length).toBe(1);
-    expect(result.changes[0]!.receivedCoins.length).toBe(3);
+    expect(result.changes[0].receivedCoins.length).toBe(3);
   });
 
   it('applies only the prefix of a straddling batch and takes the version from the first suffix item', () => {
@@ -172,7 +170,7 @@ describe('makeEventsSyncCapability.applyUpdate boundary handling', () => {
     expect(state.state.firstFree).toBe(3n);
     // Changes come from the prefix alone.
     expect(result.changes.length).toBe(1);
-    expect(result.changes[0]!.receivedCoins.length).toBe(3);
+    expect(result.changes[0].receivedCoins.length).toBe(3);
     // The reported version tags the applied changes, so it is the prefix's version.
     expect(result.protocolVersion).toBe(3);
     // The tip is a property of the source, so it still comes from the batch tail.


### PR DESCRIPTION
Phase 4 of the hard-fork plan: the foundation wiring (design decisions D1–D5) on both shielded variants, plus the cross-version v8→v9 `migrateState`. Stacked on #652. TDD structure preserved: red-test commits precede each implementation commit.

> **Design notes.** History was rewritten once (2026-08-12) when the wallet team confirmed the indexer **replays events after the hard fork**, replacing an earlier carried-coin/re-anchoring approach. The cursor semantics were then confirmed the same day — **ids continue from whatever id the indexer was at when the fork happened, never from 0** — and landed as the final three additive commits (red-first): the migration **parks progress at the fork** instead of resetting it.

## What this delivers

**Boundary wiring (D2/D3/D5), both variants.** `SyncCapability.applyUpdate` gains an `activeRange` parameter; the split/annotate/monotone logic lives in pure exported helpers (`splitAtVersionBoundary`, `annotateVersion`) shared by the indexer capability (per event) and the simulator capability (per block), so the two paths cannot drift. State now records the indexer-reported `protocolVersion` monotonically (`CoreWallet.withProtocolVersion`); a batch straddling the boundary applies only the prefix and records the first deferred item's version, which is what triggers `VersionChange` → migration. This closes **Gap 3**.

**Variant stream.** `RunningV1Variant`/`RunningV2Variant` store `context.activationRange`, thread it into both `applyUpdate` call sites, and emit an immediate healing `VersionChange` when a restored state is already outside the variant's range.

**Migration seam (D4).** New `Migration.ts` per variant — `StateMigration` dictionary with `makeEmptyWalletMigration`, `makeCarryOverMigration`, and `makeCrossLedgerMigration`; the builder gains a defaulted `TPreviousState` generic plus `withMigration`/`withMigrationDefaults`, and `build()` wires `migrateState` through it.

**Cross-version migration = fresh-state projection with a parked cursor (the replay design, confirmed semantics).** The indexer replays events post-fork continuing from its fork-time position, so nothing coin-shaped crosses the migration: `CoreWallet.fromPreviousVersion` carries publicKeys, networkId, and **the previous sync progress** (parked at the fork; `isConnected` deliberately does not cross) into a fresh empty v9 `ZswapLocalState`. The new variant resumes at the parked cursor and re-discovers its coins by ordinary sync of the replayed v9 events, decrypting with the keys that arrive via the restart path. Keys never enter `migrateState` or serialized state.

**Restart wiring (D1), closing Gaps 1+2.** `ShieldedWallet.start()` retains the start-aux in a private `Option` and registers the Phase-1 `onVariantActivation` watcher once; the watcher re-dispatches `startSyncInBackground(retainedAux)` on the new variant; `stop()` clears the aux.

## Tests

Baseline 130 tests → 28 confirmed red at the red-test commits → 150 passed / 22 pre-existing skips at the tip (19 files), none weakened. The park-at-fork flip followed the same discipline: the flipped expectation went red against the reset implementation (`expected 0n to be 4321n` on both variant twins) before the one-line implementation change.

## Notable decisions

- `ChangesResult.protocolVersion` reports the last **applied** item's version, not the batch tail's — tx-history tags changes with the version they were applied under.
- The v1 twin carries the identical `Migration.ts` (inert there) to keep the trees mechanically comparable.
- No two-variant factory here — the watcher tests stub the 5-member `Runtime` interface directly; the factory lives in #656 with its consumers.

## Verification (branch tip, standalone)

`yarn dist --force` 17/17 · `typecheck --force` 37/37 · `lint` 58/58 · `test:unit --force` 53/53 · shielded suite 19 files / 150 passed / 22 skipped · Effect diagnostics 0/0/0 on all 22 changed files · `format:check` · changeset status clean. All commits GPG-signed.