### PR TITLE
feat(shielded): byte-faithful fork-simulation proof and carried-coin re-anchoring

### DIFF
--- a/.changeset/shielded-fork-simulation-proof.md
+++ b/.changeset/shielded-fork-simulation-proof.md
@@ -1,0 +1,32 @@
+---
+'@midnightntwrk/wallet-sdk-shielded': patch
+---
+
+Prove the hard-fork crossing end to end, against real ledger bytes.
+
+A ledger-v8 chain pays a wallet, the pre-fork variant syncs it, the chain reaches the boundary height, and the wallet
+hands over to the ledger-v9 variant with a fresh state — then finds the same coins again by syncing the indexer's
+replayed timeline, and spends them. That is the corrected design stated as a test: nothing about the coins crosses the
+boundary, and everything the wallet ends up holding it re-earned through the sync path it uses every day. The two
+negatives are covered too: a version bump inside the running variant's range does not migrate, and a wallet whose very
+first sync already contains the fork reaches the same end state as one that lived through it.
+
+The replay is modelled with the thing the wallet's sync path already consumes — a second chain that re-announces every
+pre-fork commitment as a post-fork transaction. A commitment is a function of the coin and its owner's public key, so
+re-paying the same coin reproduces it exactly, and replaying the whole sequence in order reproduces the tree. No state
+translation is needed to model that, so the crossing is proven **unit tier**, with no toolchain.
+
+**The fidelity link is integration tier.** What a unit test cannot say is whether the model is faithful. So the same
+crossing runs again with the pre-fork chain handing its own serialized ledger to the ledger team's real v8-to-v9 state
+translation, and the two reconstructions are checked against each other: the tree the wallet rebuilds from replayed
+events has the same Merkle root as the tree the translation produced, and the chain holding the translated ledger
+accepts a spend whose Merkle path the wallet built from a tree it learned entirely from the replay. Both hold.
+
+That proof is integration tier because the translation is a WASM artifact built from `packages/state-translation`. This
+package's `turbo.json` now declares `test:integration` dependent on that package's `build:wasm`, mirroring
+`packages/capabilities` — so **running this package's integration tests requires a Rust toolchain**, while `dist`,
+`typecheck`, `lint` and `test:unit` do not. The package also gains `@midnightntwrk/wallet-sdk-state-translation` as a
+devDependency; nothing shipped depends on it.
+
+No shipped code changes: the wiring this exercises landed with the boundary-wiring change, and the corrected design
+needs nothing beyond it.

--- a/.changeset/shielded-fork-simulation-proof.md
+++ b/.changeset/shielded-fork-simulation-proof.md
@@ -16,6 +16,12 @@ pre-fork commitment as a post-fork transaction. A commitment is a function of th
 re-paying the same coin reproduces it exactly, and replaying the whole sequence in order reproduces the tree. No state
 translation is needed to model that, so the crossing is proven **unit tier**, with no toolchain.
 
+That chain is numbered as a continuation of the pre-fork one, opening at the boundary height rather than at zero,
+because block numbers stand in for the indexer's event ids and the indexer counts its replay on from the id the fork
+found it at. The migrated wallet's cursor is parked on that same height, and the proof pins it there — on the state the
+migration produced, before any sync has touched it. The pairing is what makes the timeline work: a wallet parked at the
+fork in front of a replay numbered from zero syncs nothing at all.
+
 **The fidelity link is integration tier.** What a unit test cannot say is whether the model is faithful. So the same
 crossing runs again with the pre-fork chain handing its own serialized ledger to the ledger team's real v8-to-v9 state
 translation, and the two reconstructions are checked against each other: the tree the wallet rebuilds from replayed

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -115,16 +115,16 @@ jobs:
           name: build-artifacts-${{ github.run_id }}
           path: .
 
-      # `test:integration` in `capabilities` and `state-translation` declares a turbo dependency on the translation
-      # WASM, so those files — and only those — need the Rust toolchain and the build's turbo cache. Three of the
-      # thirteen integration files, so this is gated rather than paid everywhere.
+      # `test:integration` in `capabilities`, `state-translation` and `shielded-wallet` declares a turbo dependency on
+      # the translation WASM, so those files — and only those — need the Rust toolchain and the build's turbo cache.
+      # A minority of the integration files, so this is gated rather than paid everywhere.
       - name: Does this file need the translation WASM?
         id: wasm
         env:
           WALLET_TEST_FILE: ${{ matrix.test-file }}
         run: |
           case "$WALLET_TEST_FILE" in
-            packages/capabilities/*|packages/state-translation/*) needed=true ;;
+            packages/capabilities/*|packages/state-translation/*|packages/shielded-wallet/*) needed=true ;;
             *) needed=false ;;
           esac
           echo "needed=$needed" >> "$GITHUB_OUTPUT"

--- a/packages/shielded-wallet/package.json
+++ b/packages/shielded-wallet/package.json
@@ -45,6 +45,9 @@
     "effect": "^3.19.19",
     "rxjs": "^7.8.2"
   },
+  "devDependencies": {
+    "@midnightntwrk/wallet-sdk-state-translation": "workspace:^"
+  },
   "scripts": {
     "typecheck": "tsc -b ./tsconfig.json --noEmit --force",
     "test": "vitest run",

--- a/packages/shielded-wallet/src/test/forkReplay.ts
+++ b/packages/shielded-wallet/src/test/forkReplay.ts
@@ -28,13 +28,19 @@
  *
  *   Two modelling choices are load-bearing and deliberate:
  *
- *   - **The replayed chain is numbered from zero.** Block numbers stand in for the indexer's event ids, and the migration
- *       resets sync progress on the assumption that a replayed timeline restarts them. Numbering the replay from zero
- *       is what makes that reset observable: a wallet that instead parked its cursor at the fork height would skip the
- *       replayed prefix and come out short. Should the indexer turn out to continue ids past the boundary, this genesis
- *       number becomes the fork height and the migration parks instead of resetting — the same one-line pair.
- *   - **It carries the post-fork protocol version**, so every replayed block sits inside the new variant's activation range
- *       and none of it is deferred back.
+ *   - **The replayed chain continues the pre-fork chain's numbering.** Block numbers stand in for the indexer's event ids,
+ *       and the indexer numbers its replay onwards from whatever id it had reached when the fork happened — never from
+ *       zero. So the replay opens at the boundary height, the same convention the {@link ForkSimulator}'s own post-fork
+ *       chain follows, and a migrated wallet parks its cursor there and meets the replay head-on. This is the half of
+ *       the design that is behaviourally load-bearing in the harness: number the replay from zero while the migration
+ *       parks and every replayed event falls behind the cursor, leaving the wallet with nothing. (The mirror image is
+ *       not symmetric — a cursor behind the replay reads all of it anyway — so what separates parking from resetting is
+ *       the migrated cursor itself, asserted where the migration produced it.)
+ *   - **Every replayed block carries the post-fork protocol version**, the genesis one included. That block sits at the
+ *       boundary height, which the pre-fork variant observed, annotated and deliberately left unapplied; re-delivering
+ *       it as post-fork content is what hands that height to the new variant. Tagging the whole replay inside the new
+ *       variant's activation range is what keeps any of it from being deferred back to a variant that has already
+ *       handed over.
  *
  *   The chain the _ledger_ continues as is a different object: the {@link ForkSimulator}'s post-fork side, which holds the
  *   translated state and announces nothing. Sync reads the replay; spends are validated against the translation.
@@ -98,6 +104,13 @@ export type ReplayChainConfig = Readonly<{
   networkId: NetworkId.NetworkId;
   /** The version the post-fork variant is registered at: every replayed block must sit inside its range. */
   protocolVersion: ProtocolVersion.ProtocolVersion;
+  /**
+   * The boundary height — the replay continues the pre-fork chain's numbering rather than restarting it.
+   *
+   * Block numbers stand in for the indexer's event ids here, and the indexer's replay counts on from the id it had
+   * reached at the fork. This is therefore where a migrated wallet's parked cursor expects to find it.
+   */
+  genesisBlockNumber: bigint;
   /** The pre-fork chain's clock at the boundary — the replay continues time rather than restarting it. */
   genesisTime: Date;
   blockProducer: BlockProducer;
@@ -112,7 +125,8 @@ export type ReplayChainConfig = Readonly<{
  *   Submitted one at a time and awaited, so each transaction gets a block of its own and the commitments land in exactly
  *   the order they did before the fork. Batching them would leave the within-block ordering to the block producer, and
  *   the Merkle indices are the whole point.
- * @param config The network, the post-fork version, the inherited clock, the producer and the coins to replay.
+ * @param config The network, the post-fork version, the inherited numbering and clock, the producer and the coins to
+ *   replay.
  * @returns The chain, once every coin has been re-announced.
  */
 export const makeReplayChain = (
@@ -122,8 +136,9 @@ export const makeReplayChain = (
     const chain = yield* Simulator.init({
       networkId: config.networkId,
       protocolVersion: config.protocolVersion,
-      // Zero, not the fork height: see the file's remarks — this is an event-id cursor, and the replay restarts it.
-      genesisBlockNumber: 0n,
+      // The fork height, not zero: see the file's remarks — this is an event-id cursor, and the replay counts on from
+      // where the fork found it.
+      genesisBlockNumber: config.genesisBlockNumber,
       genesisTime: config.genesisTime,
       blockProducer: config.blockProducer,
     });

--- a/packages/shielded-wallet/src/test/forkReplay.ts
+++ b/packages/shielded-wallet/src/test/forkReplay.ts
@@ -1,0 +1,136 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The indexer's post-fork replay, modelled as a chain — test scaffolding only.
+ *
+ * @remarks
+ *   After the hard fork the indexer replays the timeline: the history a wallet already synced is served again, this time
+ *   as events of the new ledger version. That is why a migrated wallet starts empty and simply syncs — it re-discovers
+ *   its own coins from the replay rather than carrying them across.
+ *
+ *   Nothing simulates an indexer, so the replay is modelled with the thing the wallet's simulator sync path already
+ *   consumes: a second chain that re-creates every pre-fork commitment as a post-fork transaction. A coin commitment is
+ *   a function of the coin and its owner's public key alone, so re-paying _the same_ coin — same token type, same
+ *   nonce, same value, same recipient — reproduces the pre-fork commitment exactly. Replay the whole pre-fork sequence
+ *   in order and the resulting tree is the pre-fork tree, which is precisely what the integration proof checks against
+ *   the ledger team's real v8-to-v9 translation.
+ *
+ *   Two modelling choices are load-bearing and deliberate:
+ *
+ *   - **The replayed chain is numbered from zero.** Block numbers stand in for the indexer's event ids, and the migration
+ *       resets sync progress on the assumption that a replayed timeline restarts them. Numbering the replay from zero
+ *       is what makes that reset observable: a wallet that instead parked its cursor at the fork height would skip the
+ *       replayed prefix and come out short. Should the indexer turn out to continue ids past the boundary, this genesis
+ *       number becomes the fork height and the migration parks instead of resetting — the same one-line pair.
+ *   - **It carries the post-fork protocol version**, so every replayed block sits inside the new variant's activation range
+ *       and none of it is deferred back.
+ *
+ *   The chain the _ledger_ continues as is a different object: the {@link ForkSimulator}'s post-fork side, which holds the
+ *   translated state and announces nothing. Sync reads the replay; spends are validated against the translation.
+ */
+
+import * as v8 from '@midnight-ntwrk/ledger-v8';
+import * as v9 from '@midnightntwrk/ledger-v9';
+import { type NetworkId, type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type BlockProducer, Simulator } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { type LedgerOps } from '@midnightntwrk/wallet-sdk-utilities';
+import { Effect, type Scope } from 'effect';
+
+/** Public keys as both ledger versions express them: hex strings, identical for identical seeds. */
+export type Recipient = Readonly<{ coinPublicKey: string; encryptionPublicKey: string }>;
+
+/**
+ * One coin, as it exists on the pre-fork chain and again in the replay.
+ *
+ * @remarks
+ *   The nonce is sampled once, by the pre-fork ledger, and then reused verbatim: that is what makes the replayed
+ *   commitment the pre-fork commitment rather than merely a commitment of the same value.
+ */
+export type ReplayedCoin = Readonly<{
+  type: string;
+  nonce: string;
+  value: bigint;
+  recipient: Recipient;
+}>;
+
+/** Samples a coin of `value` for `recipient`, using the pre-fork ledger's own nonce sampling. */
+export const mintable = (tokenType: string, value: bigint, recipient: Recipient): ReplayedCoin => {
+  const sampled = v8.createShieldedCoinInfo(tokenType, value);
+  return { type: sampled.type, nonce: sampled.nonce, value: sampled.value, recipient };
+};
+
+/** The pre-fork transaction that creates `coin`: one output, therefore one commitment, therefore one Merkle index. */
+export const preForkPayment = (networkId: NetworkId.NetworkId, coin: ReplayedCoin): v8.ProofErasedTransaction => {
+  const output = v8.ZswapOutput.new(
+    { type: coin.type, nonce: coin.nonce, value: coin.value },
+    0,
+    coin.recipient.coinPublicKey,
+    coin.recipient.encryptionPublicKey,
+  );
+  const offer = v8.ZswapOffer.fromOutput<v8.PreProof>(output, coin.type, coin.value);
+  return v8.Transaction.fromParts(networkId, offer).eraseProofs();
+};
+
+/** The replayed transaction for `coin` — the same coin, re-announced by the post-fork ledger version. */
+export const replayPayment = (networkId: NetworkId.NetworkId, coin: ReplayedCoin): v9.ProofErasedTransaction => {
+  const output = v9.ZswapOutput.new(
+    { type: coin.type, nonce: coin.nonce, value: coin.value },
+    0,
+    coin.recipient.coinPublicKey,
+    coin.recipient.encryptionPublicKey,
+  );
+  const offer = v9.ZswapOffer.fromOutput<v9.PreProof>(output, coin.type, coin.value);
+  return v9.Transaction.fromParts(networkId, offer).eraseProofs();
+};
+
+export type ReplayChainConfig = Readonly<{
+  networkId: NetworkId.NetworkId;
+  /** The version the post-fork variant is registered at: every replayed block must sit inside its range. */
+  protocolVersion: ProtocolVersion.ProtocolVersion;
+  /** The pre-fork chain's clock at the boundary — the replay continues time rather than restarting it. */
+  genesisTime: Date;
+  blockProducer: BlockProducer;
+  /** Every pre-fork commitment, in the order the pre-fork chain created them. */
+  coins: readonly ReplayedCoin[];
+}>;
+
+/**
+ * Builds the replayed post-fork timeline: one block per replayed coin, in pre-fork order.
+ *
+ * @remarks
+ *   Submitted one at a time and awaited, so each transaction gets a block of its own and the commitments land in exactly
+ *   the order they did before the fork. Batching them would leave the within-block ordering to the block producer, and
+ *   the Merkle indices are the whole point.
+ * @param config The network, the post-fork version, the inherited clock, the producer and the coins to replay.
+ * @returns The chain, once every coin has been re-announced.
+ */
+export const makeReplayChain = (
+  config: ReplayChainConfig,
+): Effect.Effect<Simulator, LedgerOps.LedgerError, Scope.Scope> =>
+  Effect.gen(function* () {
+    const chain = yield* Simulator.init({
+      networkId: config.networkId,
+      protocolVersion: config.protocolVersion,
+      // Zero, not the fork height: see the file's remarks — this is an event-id cursor, and the replay restarts it.
+      genesisBlockNumber: 0n,
+      genesisTime: config.genesisTime,
+      blockProducer: config.blockProducer,
+    });
+
+    yield* Effect.forEach(config.coins, (coin) => chain.submitTransaction(replayPayment(config.networkId, coin)), {
+      discard: true,
+    });
+
+    return chain;
+  });

--- a/packages/shielded-wallet/src/test/forkReplay.ts
+++ b/packages/shielded-wallet/src/test/forkReplay.ts
@@ -43,7 +43,7 @@
 import * as v8 from '@midnight-ntwrk/ledger-v8';
 import * as v9 from '@midnightntwrk/ledger-v9';
 import { type NetworkId, type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
-import { type BlockProducer, Simulator } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { type BlockProducer, Simulator, type SimulatorState } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import { type LedgerOps } from '@midnightntwrk/wallet-sdk-utilities';
 import { Effect, type Scope } from 'effect';
 
@@ -134,3 +134,13 @@ export const makeReplayChain = (
 
     return chain;
   });
+
+/** The Merkle root of a chain's commitment tree, read through a local state — the chain state does not expose one. */
+export const chainMerkleRoot = (chain: v9.ZswapChainState): bigint | undefined =>
+  chain.firstFree === 0n
+    ? new v9.ZswapLocalState().merkleTreeRoot
+    : new v9.ZswapLocalState().applyCollapsedUpdate(new v9.MerkleTreeCollapsedUpdate(chain, 0n, chain.firstFree - 1n))
+        .merkleTreeRoot;
+
+/** The commitment tree of a simulated chain, as a root. */
+export const simulatedChainRoot = (state: SimulatorState): bigint | undefined => chainMerkleRoot(state.ledger.zswap);

--- a/packages/shielded-wallet/src/test/forkSimulation.integration.test.ts
+++ b/packages/shielded-wallet/src/test/forkSimulation.integration.test.ts
@@ -181,9 +181,12 @@ describe('a shielded wallet crossing a byte-faithful hard fork', () => {
       expect(yield* translated.query((state) => state.ledger.zswap.firstFree)).toBe(treeSizeAtFork);
 
       // --- the indexer replays the timeline ---------------------------------------------------------------------
+      // Numbered and clocked from the boundary, exactly as the translated chain beside it is: the two reconstructions
+      // are two accounts of one timeline continuing, not of two timelines starting.
       const replayChain = yield* makeReplayChain({
         networkId,
         protocolVersion: forkVersion,
+        genesisBlockNumber: forkBlock,
         genesisTime: yield* fork.preFork.query((state) => state.currentTime),
         blockProducer: immediateBlockProducer(undefined, genesisStrictness),
         coins,
@@ -200,7 +203,8 @@ describe('a shielded wallet crossing a byte-faithful hard fork', () => {
       expect(migration.from.appliedIndex).toBe(forkBlock);
       expect(migration.to.coinCount).toBe(0);
       expect(migration.to.firstFree).toBe(0n);
-      expect(migration.to.appliedIndex).toBe(0n);
+      // Parked on the boundary, not rewound: the replay continues the indexer's event ids rather than restarting them.
+      expect(migration.to.appliedIndex).toBe(forkBlock);
 
       const postFork = yield* wallet.awaitState(
         (state) => state.version >= forkVersion && totalValue(state.state) === walletTotal,
@@ -233,6 +237,8 @@ describe('a shielded wallet crossing a byte-faithful hard fork', () => {
       // both chains: applying it neither consumes nor mutates it.
       const onReplay = yield* replayChain.submitTransaction(spend);
       expect(onReplay.transactions[0].result.type).toBe('success');
+      // Past the boundary on the replay too — both accounts of the timeline count on from the fork height.
+      expect(onReplay.number).toBeGreaterThan(forkBlock);
 
       const afterSpend = yield* wallet.awaitState((state) => state.state.progress.appliedIndex > onReplay.number);
       expect(totalValue(afterSpend.state)).toBe(walletTotal - transferred);

--- a/packages/shielded-wallet/src/test/forkSimulation.integration.test.ts
+++ b/packages/shielded-wallet/src/test/forkSimulation.integration.test.ts
@@ -1,0 +1,240 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The fidelity link: what a wallet rebuilds from the replay is what the real translation produces.
+ *
+ * @remarks
+ *   `forkSimulation.test.ts` proves the crossing — hand-over, fresh state, re-discovery by sync, spend — and needs no
+ *   ledger translation to do it. What it cannot prove is that the modelling is faithful: its wallet learns its coins
+ *   from a replayed timeline and spends against that same timeline, so it is self-consistent by construction.
+ *
+ *   This closes that gap against the ledger team's real v8-to-v9 state translation. The pre-fork chain hands its own
+ *   serialized ledger to the translation and the post-fork chain continues from the result — the chain's own account of
+ *   what survived the fork — while the wallet syncs the replayed timeline, which is the indexer's account of the same
+ *   thing. Two independent reconstructions of one tree, checked against each other two ways:
+ *
+ *   - **The roots agree.** The tree the wallet rebuilds from replayed events has the same Merkle root as the tree the
+ *       translation produced. A single number, and a byte-level claim: commitments are a function of coin and owner, so
+ *       equality here means the two ledger versions computed every one of them identically.
+ *   - **The translated chain accepts the wallet's spend.** A spend carries a Merkle path built from the wallet's tree, and
+ *       the post-fork ledger recognises it only if that path resolves to a root the translated state holds. So the
+ *       wallet — which never saw the translated tree — transacts against it.
+ *
+ *   **Integration tier because of a build step, not infra.** The translation is a WASM artifact built from
+ *   `packages/state-translation/wasm`, so it has to be compiled first; this package's `turbo.json` declares
+ *   `test:integration` dependent on that package's `build:wasm`, exactly as `capabilities` does. Nothing here needs
+ *   Docker or a network, and nothing is skipped — if the artifact were missing these tests would fail rather than pass
+ *   vacuously.
+ */
+
+import * as v8 from '@midnight-ntwrk/ledger-v8';
+import * as v9 from '@midnightntwrk/ledger-v9';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  ShieldedAddress,
+  ShieldedCoinPublicKey,
+  ShieldedEncryptionPublicKey,
+} from '@midnightntwrk/wallet-sdk-address-format';
+import {
+  ForkSimulator,
+  type Simulator,
+  V8,
+  genesisStrictness,
+  immediateBlockProducer,
+  translatorFromAsync,
+} from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { translateLedgerState } from '@midnightntwrk/wallet-sdk-state-translation';
+import { Deferred, Effect } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { V1Tag } from '../v1/index.js';
+import { V2Tag } from '../v2/index.js';
+import { type ReplayedCoin, makeReplayChain, mintable, preForkPayment, simulatedChainRoot } from './forkReplay.js';
+import { makeForkWallet } from './forkWallet.js';
+import { coinIndices, coinValues, merkleRoot, totalValue, treeSize } from './forkWalletAssertions.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+
+const forkVersion = ProtocolVersion.ProtocolVersion(7n);
+const forkBlock = 8n;
+
+const seed = Buffer.alloc(32, 42);
+const otherSeed = Buffer.alloc(32, 43);
+
+const walletValues = [100n, 200n, 300n, 400n] as const;
+const walletTotal = walletValues.reduce((sum, value) => sum + value, 0n);
+const walletIndices = [0n, 1n, 2n, 4n];
+const treeSizeAtFork = 6n;
+
+const walletRecipient = () => {
+  const keys = v9.ZswapSecretKeys.fromSeed(seed);
+  return { coinPublicKey: keys.coinPublicKey, encryptionPublicKey: keys.encryptionPublicKey };
+};
+
+const strangerRecipient = () => {
+  const keys = v9.ZswapSecretKeys.fromSeed(otherSeed);
+  return { coinPublicKey: keys.coinPublicKey, encryptionPublicKey: keys.encryptionPublicKey };
+};
+
+const recipientAddress = (): ShieldedAddress => {
+  const stranger = strangerRecipient();
+  return new ShieldedAddress(
+    ShieldedCoinPublicKey.fromHexString(stranger.coinPublicKey),
+    ShieldedEncryptionPublicKey.fromHexString(stranger.encryptionPublicKey),
+  );
+};
+
+/** The pre-fork commitment sequence: three to us, a stranger's, ours, a stranger's again. */
+const chainCoins = (): readonly ReplayedCoin[] => {
+  const tokenType = v8.shieldedToken().raw;
+  const us = walletRecipient();
+  const them = strangerRecipient();
+  return [
+    mintable(tokenType, 100n, us),
+    mintable(tokenType, 200n, us),
+    mintable(tokenType, 300n, us),
+    mintable(tokenType, 50n, them),
+    mintable(tokenType, 400n, us),
+    mintable(tokenType, 50n, them),
+  ];
+};
+
+const baseConfig = {
+  networkId,
+  forkBlock,
+  forkVersion,
+  // Genesis strictness throughout: the transfer below pays no fees, which a fee-enforcing chain would reject for
+  // reasons that have nothing to do with the fork.
+  preForkBlockProducer: V8.immediateBlockProducer(undefined, V8.genesisStrictness),
+  postForkBlockProducer: immediateBlockProducer(undefined, genesisStrictness),
+  translator: translatorFromAsync(translateLedgerState),
+};
+
+describe('the two ledger versions agree on what the wallet owns', () => {
+  it('derives the same public keys from one seed, which is what makes a replayed coin the same coin', () => {
+    // The lemma everything below rests on. A commitment is computed from the coin and its owner's coin public key; if
+    // the two ledger versions derived different keys from one seed, a replayed payment would be a payment to somebody
+    // else and no tree could ever line up.
+    const preFork = v8.ZswapSecretKeys.fromSeed(seed);
+    const postFork = v9.ZswapSecretKeys.fromSeed(seed);
+
+    expect(postFork.coinPublicKey).toBe(preFork.coinPublicKey);
+    expect(postFork.encryptionPublicKey).toBe(preFork.encryptionPublicKey);
+    expect(v9.shieldedToken().raw).toBe(v8.shieldedToken().raw);
+  });
+
+  it('computes identical coin commitments for identical coins', () => {
+    const coin = mintable(v8.shieldedToken().raw, 100n, walletRecipient());
+    const plain = { type: coin.type, nonce: coin.nonce, value: coin.value };
+
+    expect(v9.coinCommitment(plain, coin.recipient.coinPublicKey)).toBe(
+      v8.coinCommitment(plain, coin.recipient.coinPublicKey),
+    );
+  });
+});
+
+describe('a shielded wallet crossing a byte-faithful hard fork', () => {
+  it('rebuilds the translated commitment tree from the replay, and spends against the translation', async () =>
+    Effect.gen(function* () {
+      const coins = chainCoins();
+      const fork = yield* ForkSimulator.init(baseConfig);
+      const replayed = yield* Deferred.make<Simulator>();
+
+      const wallet = makeForkWallet({
+        preFork: fork.preFork,
+        replayed: Deferred.await(replayed),
+        networkId,
+        forkVersion,
+        seed,
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      yield* wallet.start;
+
+      // --- pre-fork: a real ledger-v8 chain, synced by the ledger-v8 variant ------------------------------------
+      yield* Effect.forEach(coins, (coin) => fork.preFork.submitTransaction(preForkPayment(networkId, coin)), {
+        discard: true,
+      });
+      const preFork = yield* wallet.awaitState((state) => totalValue(state.state) === walletTotal);
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+      expect(coinIndices(preFork.state)).toEqual(walletIndices);
+      expect(treeSize(preFork.state)).toBe(treeSizeAtFork);
+      const preForkRoot = merkleRoot(preFork.state);
+      expect(preForkRoot).toBeDefined();
+
+      // --- the chain forks: its ledger goes through the real v8-to-v9 translation --------------------------------
+      const translated = yield* fork.advanceToFork();
+      const translatedRoot = yield* translated.query(simulatedChainRoot);
+
+      // The translation preserved the tree the pre-fork wallet was looking at. Asserted before the wallet is involved
+      // so that a translation regression is distinguishable from a wallet one.
+      expect(translatedRoot).toBe(preForkRoot);
+      expect(yield* translated.query((state) => state.ledger.zswap.firstFree)).toBe(treeSizeAtFork);
+
+      // --- the indexer replays the timeline ---------------------------------------------------------------------
+      const replayChain = yield* makeReplayChain({
+        networkId,
+        protocolVersion: forkVersion,
+        genesisTime: yield* fork.preFork.query((state) => state.currentTime),
+        blockProducer: immediateBlockProducer(undefined, genesisStrictness),
+        coins,
+      });
+      // The replay is a faithful stand-in for the translation precisely because these agree: the same commitments, in
+      // the same order, therefore the same tree — reached by re-announcing coins rather than by converting bytes.
+      expect(yield* replayChain.query(simulatedChainRoot)).toBe(translatedRoot);
+      yield* Deferred.succeed(replayed, replayChain);
+
+      // --- the wallet hands over with nothing, then re-earns it all ---------------------------------------------
+      const migration = yield* wallet.awaitMigration;
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+      expect(migration.from.protocolVersion).toBe(forkVersion);
+      expect(migration.from.appliedIndex).toBe(forkBlock);
+      expect(migration.to.coinCount).toBe(0);
+      expect(migration.to.firstFree).toBe(0n);
+      expect(migration.to.appliedIndex).toBe(0n);
+
+      const postFork = yield* wallet.awaitState(
+        (state) => state.version >= forkVersion && totalValue(state.state) === walletTotal,
+      );
+      expect(coinValues(postFork.state)).toEqual([...walletValues]);
+      expect(coinIndices(postFork.state)).toEqual(walletIndices);
+      expect(treeSize(postFork.state)).toBe(treeSizeAtFork);
+
+      // **The fidelity link.** The wallet has never seen the translated state; it read replayed events and rebuilt a
+      // tree from them. That tree is the translated tree, down to its root.
+      expect(merkleRoot(postFork.state)).toBe(translatedRoot);
+
+      // --- and it can transact against the translation ----------------------------------------------------------
+      const transferred = 150n;
+      const transfer = yield* wallet.onPostForkVariant((variant) =>
+        variant.transferTransaction(wallet.keys.postFork, [
+          { amount: transferred, type: v9.shieldedToken().raw, receiverAddress: recipientAddress() },
+        ]),
+      );
+      const spend = transfer.eraseProofs();
+
+      // Submitted to the chain that holds the *translated* ledger, not to the replay the wallet learned from. The
+      // Merkle path in this spend was built from the wallet's own tree; the translated chain recognises it only if
+      // that root is one it holds. This is the claim in full, and nothing short of a real translation can support it.
+      const onTranslatedChain = yield* translated.submitTransaction(spend);
+      expect(onTranslatedChain.transactions[0].result.type).toBe('success');
+      expect(onTranslatedChain.number).toBeGreaterThan(forkBlock);
+
+      // The indexer reports the same spend, which is how the wallet learns of it. The same transaction object serves
+      // both chains: applying it neither consumes nor mutates it.
+      const onReplay = yield* replayChain.submitTransaction(spend);
+      expect(onReplay.transactions[0].result.type).toBe('success');
+
+      const afterSpend = yield* wallet.awaitState((state) => state.state.progress.appliedIndex > onReplay.number);
+      expect(totalValue(afterSpend.state)).toBe(walletTotal - transferred);
+    }).pipe(Effect.scoped, Effect.runPromise));
+});

--- a/packages/shielded-wallet/src/test/forkSimulation.test.ts
+++ b/packages/shielded-wallet/src/test/forkSimulation.test.ts
@@ -21,8 +21,8 @@
  *   — then spends them.
  *
  *   Which is the whole point of the corrected design: nothing about the coins crosses the boundary. The migration is
- *   allowed to carry identity and nothing else, and everything else is re-earned by ordinary synchronization. If the
- *   wallet ends up whole here, it did so through the sync path it uses every day.
+ *   allowed to carry identity and a place in the timeline, and the coins are re-earned by ordinary synchronization. If
+ *   the wallet ends up whole here, it did so through the sync path it uses every day.
  *
  *   **Unit tier, and complete.** Modelling the replay needs no state translation — the pre-fork coins are re-announced as
  *   post-fork transactions, which is what an indexer replay is — so every assertion here is earned without a WASM
@@ -140,12 +140,21 @@ const driveTo = (chain: V8.Simulator, height: bigint): Effect.Effect<void, Ledge
     yield* driveTo(chain, height);
   });
 
+/**
+ * The indexer's replay of `coins`, numbered and clocked as a continuation of `chain`.
+ *
+ * @remarks
+ *   Both continuations matter and for the same reason: the replay is the pre-fork timeline carrying on, not a second one
+ *   starting. Its event ids — block numbers here — resume at the boundary height, which is where a migrated wallet's
+ *   parked cursor is waiting for them.
+ */
 const replayOf = (coins: readonly ReplayedCoin[], chain: V8.Simulator) =>
   Effect.gen(function* () {
     const genesisTime = yield* chain.query((state) => state.currentTime);
     return yield* makeReplayChain({
       networkId,
       protocolVersion: forkVersion,
+      genesisBlockNumber: forkBlock,
       genesisTime,
       blockProducer: replayProducer(),
       coins,
@@ -193,12 +202,17 @@ describe('a shielded wallet crossing a hard fork', () => {
       expect(migration.from.protocolVersion).toBe(forkVersion);
       expect(migration.from.appliedIndex).toBe(forkBlock);
 
-      // And what it produced: a wallet holding nothing at all. No coins, no tree, no coin hashes, no progress — the
-      // coins are about to arrive again as replayed events, so carrying them would double-count them.
+      // And what it produced: a wallet holding no coins at all — no tree, no coin hashes — because they are about to
+      // arrive again as replayed events, and carrying them would double-count what the replay is delivering.
       expect(migration.to.coinCount).toBe(0);
       expect(migration.to.firstFree).toBe(0n);
       expect(migration.to.coinHashCount).toBe(0);
-      expect(migration.to.appliedIndex).toBe(0n);
+      // **Parked, not rewound.** The one place the two cursor semantics are directly distinguishable: the state the
+      // migration produced, before any sync has touched it. The replayed timeline continues the indexer's event ids
+      // from where the fork found them, so this wallet resumes on the cursor its predecessor stopped at. A migration
+      // that reset to zero fails here — and only here, because a cursor behind the replay still reads all of it.
+      expect(migration.to.appliedIndex).toBe(migration.from.appliedIndex);
+      expect(migration.to.appliedIndex).toBe(forkBlock);
       // Identity is the one thing that does cross: without these keys the replay decrypts into nothing.
       expect(migration.to.coinPublicKey).toBe(v9.ZswapSecretKeys.fromSeed(seed).coinPublicKey);
       expect(migration.to.encryptionPublicKey).toBe(v9.ZswapSecretKeys.fromSeed(seed).encryptionPublicKey);
@@ -213,8 +227,9 @@ describe('a shielded wallet crossing a hard fork', () => {
       expect(coinIndices(postFork.state)).toEqual(walletIndices);
       // And the whole tree, not just the leaves it owns: the stranger's commitments were replayed and skipped over.
       expect(treeSize(postFork.state)).toBe(treeSizeAtFork);
-      // Read from the start of the replayed timeline, which is what resetting progress at migration buys.
-      expect(postFork.state.progress.appliedIndex).toBe(BigInt(coins.length) + 1n);
+      // Read onwards from the boundary rather than from the start of anything: the replay opens at the fork height and
+      // runs one block per coin, so a wallet that consumed all of it lands that many blocks past where it parked.
+      expect(postFork.state.progress.appliedIndex).toBe(forkBlock + BigInt(coins.length) + 1n);
 
       // --- the re-discovered coins are spendable ----------------------------------------------------------------
       const transferred = 150n;
@@ -288,6 +303,9 @@ describe('a shielded wallet crossing a hard fork', () => {
       const migration = yield* wallet.awaitMigration;
       expect(migration.from.appliedIndex).toBe(forkBlock);
       expect(migration.to.coinCount).toBe(0);
+      // Reached in one batch rather than two, and the cursor still parks on the boundary: where the split happened
+      // does not change what the next variant inherits.
+      expect(migration.to.appliedIndex).toBe(forkBlock);
 
       // The end state is the same as the live transition reaches, which is the point: how the timeline was delivered
       // is not supposed to change what the wallet ends up holding.
@@ -296,6 +314,6 @@ describe('a shielded wallet crossing a hard fork', () => {
       expect(coinValues(postFork.state).toSorted(ascending)).toEqual([...walletValues]);
       expect(coinIndices(postFork.state)).toEqual(walletIndices);
       expect(treeSize(postFork.state)).toBe(treeSizeAtFork);
-      expect(postFork.state.progress.appliedIndex).toBe(BigInt(coins.length) + 1n);
+      expect(postFork.state.progress.appliedIndex).toBe(forkBlock + BigInt(coins.length) + 1n);
     }).pipe(Effect.scoped, Effect.runPromise));
 });

--- a/packages/shielded-wallet/src/test/forkSimulation.test.ts
+++ b/packages/shielded-wallet/src/test/forkSimulation.test.ts
@@ -1,0 +1,301 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * A shielded wallet crossing a hard fork and re-discovering its coins from the replayed timeline.
+ *
+ * @remarks
+ *   Every other test of this machinery specifies one seam. This drives all of them at once: a ledger-v8 chain pays the
+ *   wallet, the pre-fork variant syncs it, the chain reaches the boundary height, the wallet hands over to the
+ *   ledger-v9 variant with a _fresh_ state, and that variant finds the same coins again by syncing the indexer's replay
+ *   — then spends them.
+ *
+ *   Which is the whole point of the corrected design: nothing about the coins crosses the boundary. The migration is
+ *   allowed to carry identity and nothing else, and everything else is re-earned by ordinary synchronization. If the
+ *   wallet ends up whole here, it did so through the sync path it uses every day.
+ *
+ *   **Unit tier, and complete.** Modelling the replay needs no state translation — the pre-fork coins are re-announced as
+ *   post-fork transactions, which is what an indexer replay is — so every assertion here is earned without a WASM
+ *   artifact. `forkSimulation.integration.test.ts` adds the one claim this tier cannot make: that the tree the wallet
+ *   rebuilds from the replay is the tree the ledger team's real v8-to-v9 translation produces.
+ */
+
+import * as v8 from '@midnight-ntwrk/ledger-v8';
+import * as v9 from '@midnightntwrk/ledger-v9';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  ShieldedAddress,
+  ShieldedCoinPublicKey,
+  ShieldedEncryptionPublicKey,
+} from '@midnightntwrk/wallet-sdk-address-format';
+import {
+  type Simulator,
+  V8,
+  genesisStrictness,
+  immediateBlockProducer,
+} from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { type LedgerOps } from '@midnightntwrk/wallet-sdk-utilities';
+import { Deferred, Effect, Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { V1Tag } from '../v1/index.js';
+import { V2Tag } from '../v2/index.js';
+import { type ReplayedCoin, makeReplayChain, mintable, preForkPayment } from './forkReplay.js';
+import { type ForkWallet, makeForkWallet } from './forkWallet.js';
+import { ascending, coinIndices, coinValues, totalValue, treeSize } from './forkWalletAssertions.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+
+/**
+ * The boundary, stated once.
+ *
+ * `forkVersion` is where the post-fork variant is registered _and_ what the chain activates at `forkBlock` — the same
+ * number reaching the runtime through registration and through the timeline, which is the whole point of D5. It is
+ * deliberately an arbitrary number: the real fork's protocol version is not final, and nothing here may depend on it.
+ */
+const forkVersion = ProtocolVersion.ProtocolVersion(7n);
+const forkBlock = 8n;
+
+/** A version bump the pre-fork variant owns: inside `[MinSupportedVersion, forkVersion)`, so it must not migrate. */
+const withinRangeVersion = ProtocolVersion.ProtocolVersion(5n);
+
+const seed = Buffer.alloc(32, 42);
+const otherSeed = Buffer.alloc(32, 43);
+
+const preForkProducer = () => V8.immediateBlockProducer(undefined, V8.genesisStrictness);
+const replayProducer = () => immediateBlockProducer(undefined, genesisStrictness);
+
+const walletRecipient = () => {
+  const keys = v9.ZswapSecretKeys.fromSeed(seed);
+  return { coinPublicKey: keys.coinPublicKey, encryptionPublicKey: keys.encryptionPublicKey };
+};
+
+const strangerRecipient = () => {
+  const keys = v9.ZswapSecretKeys.fromSeed(otherSeed);
+  return { coinPublicKey: keys.coinPublicKey, encryptionPublicKey: keys.encryptionPublicKey };
+};
+
+const recipientAddress = (): ShieldedAddress => {
+  const stranger = strangerRecipient();
+  return new ShieldedAddress(
+    ShieldedCoinPublicKey.fromHexString(stranger.coinPublicKey),
+    ShieldedEncryptionPublicKey.fromHexString(stranger.encryptionPublicKey),
+  );
+};
+
+const walletValues = [100n, 200n, 300n, 400n] as const;
+const walletTotal = walletValues.reduce((sum, value) => sum + value, 0n);
+/**
+ * Where the wallet's coins sit in the commitment tree.
+ *
+ * @remarks
+ *   Non-contiguous and short of the tip on purpose: a stranger is paid at index 3 and again at 5, so the wallet has to
+ *   skip commitments it cannot decrypt while replaying, both in the middle of its own run and after it. A densely
+ *   minted wallet would exercise neither.
+ */
+const walletIndices = [0n, 1n, 2n, 4n];
+const treeSizeAtFork = 6n;
+
+/** The pre-fork commitment sequence, sampled once per chain: three to us, a stranger's, ours, a stranger's again. */
+const chainCoins = (): readonly ReplayedCoin[] => {
+  const tokenType = v8.shieldedToken().raw;
+  const us = walletRecipient();
+  const them = strangerRecipient();
+  return [
+    mintable(tokenType, 100n, us),
+    mintable(tokenType, 200n, us),
+    mintable(tokenType, 300n, us),
+    mintable(tokenType, 50n, them),
+    mintable(tokenType, 400n, us),
+    mintable(tokenType, 50n, them),
+  ];
+};
+
+/** A ledger-v8 chain that will activate `version` at `forkBlock`, with `coins` already paid out one per block. */
+const preForkChain = (coins: readonly ReplayedCoin[], version: ProtocolVersion.ProtocolVersion) =>
+  Effect.gen(function* () {
+    const chain = yield* V8.Simulator.init({ networkId, blockProducer: preForkProducer() });
+    yield* chain.scheduleFork(forkBlock, version);
+    yield* Effect.forEach(coins, (coin) => chain.submitTransaction(preForkPayment(networkId, coin)), {
+      discard: true,
+    });
+    return chain;
+  });
+
+/** Produces empty blocks until the chain stands at `height`, which is where the scheduled version change bites. */
+const driveTo = (chain: V8.Simulator, height: bigint): Effect.Effect<void, LedgerOps.LedgerError> =>
+  Effect.gen(function* () {
+    const current = yield* chain.query(V8.getCurrentBlockNumber);
+    if (current >= height) return;
+    yield* chain.produceEmptyBlock();
+    yield* driveTo(chain, height);
+  });
+
+const replayOf = (coins: readonly ReplayedCoin[], chain: V8.Simulator) =>
+  Effect.gen(function* () {
+    const genesisTime = yield* chain.query((state) => state.currentTime);
+    return yield* makeReplayChain({
+      networkId,
+      protocolVersion: forkVersion,
+      genesisTime,
+      blockProducer: replayProducer(),
+      coins,
+    });
+  });
+
+/** The wallet has handed over and finished reading the replay. */
+const rediscovered = (wallet: ForkWallet) =>
+  wallet.awaitState((state) => state.version >= forkVersion && totalValue(state.state) === walletTotal);
+
+describe('a shielded wallet crossing a hard fork', () => {
+  it('starts the new variant empty and re-discovers its coins from the replayed timeline', async () =>
+    Effect.gen(function* () {
+      const coins = chainCoins();
+      const chain = yield* preForkChain(coins, forkVersion);
+      const replayed = yield* Deferred.make<Simulator>();
+
+      const wallet = makeForkWallet({
+        preFork: chain,
+        replayed: Deferred.await(replayed),
+        networkId,
+        forkVersion,
+        seed,
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      yield* wallet.start;
+
+      // --- pre-fork: the ledger-v8 variant syncs the ledger-v8 chain --------------------------------------------
+      const preFork = yield* wallet.awaitState((state) => totalValue(state.state) === walletTotal);
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+      expect(coinValues(preFork.state)).toEqual([...walletValues]);
+      expect(coinIndices(preFork.state)).toEqual(walletIndices);
+      expect(treeSize(preFork.state)).toBe(treeSizeAtFork);
+
+      // --- the chain reaches the boundary, and the indexer starts replaying -------------------------------------
+      yield* driveTo(chain, forkBlock);
+      yield* Deferred.succeed(replayed, yield* replayOf(coins, chain));
+
+      const migration = yield* wallet.awaitMigration;
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+
+      // What the pre-fork variant handed over: its identity, the version that triggered the hand-over, and a cursor
+      // parked on the boundary height — observed and annotated, deliberately not applied.
+      expect(migration.from.coinPublicKey).toBe(v8.ZswapSecretKeys.fromSeed(seed).coinPublicKey);
+      expect(migration.from.protocolVersion).toBe(forkVersion);
+      expect(migration.from.appliedIndex).toBe(forkBlock);
+
+      // And what it produced: a wallet holding nothing at all. No coins, no tree, no coin hashes, no progress — the
+      // coins are about to arrive again as replayed events, so carrying them would double-count them.
+      expect(migration.to.coinCount).toBe(0);
+      expect(migration.to.firstFree).toBe(0n);
+      expect(migration.to.coinHashCount).toBe(0);
+      expect(migration.to.appliedIndex).toBe(0n);
+      // Identity is the one thing that does cross: without these keys the replay decrypts into nothing.
+      expect(migration.to.coinPublicKey).toBe(v9.ZswapSecretKeys.fromSeed(seed).coinPublicKey);
+      expect(migration.to.encryptionPublicKey).toBe(v9.ZswapSecretKeys.fromSeed(seed).encryptionPublicKey);
+      expect(migration.to.networkId).toBe(networkId);
+      // Kept so the restarted variant sits inside its own activation range instead of signalling backwards at once.
+      expect(migration.to.protocolVersion).toBe(forkVersion);
+
+      // --- post-fork: the coins are re-discovered, not carried --------------------------------------------------
+      const postFork = yield* rediscovered(wallet);
+      expect(coinValues(postFork.state)).toEqual([...walletValues]);
+      // At the same indices, because the replay re-announces the same commitments in the same order.
+      expect(coinIndices(postFork.state)).toEqual(walletIndices);
+      // And the whole tree, not just the leaves it owns: the stranger's commitments were replayed and skipped over.
+      expect(treeSize(postFork.state)).toBe(treeSizeAtFork);
+      // Read from the start of the replayed timeline, which is what resetting progress at migration buys.
+      expect(postFork.state.progress.appliedIndex).toBe(BigInt(coins.length) + 1n);
+
+      // --- the re-discovered coins are spendable ----------------------------------------------------------------
+      const transferred = 150n;
+      const transfer = yield* wallet.onPostForkVariant((variant) =>
+        variant.transferTransaction(wallet.keys.postFork, [
+          { amount: transferred, type: v9.shieldedToken().raw, receiverAddress: recipientAddress() },
+        ]),
+      );
+
+      const replayChain = yield* Deferred.await(replayed);
+      const block = yield* replayChain.submitTransaction(transfer.eraseProofs());
+      // The chain accepting this is the claim: a spend carries a Merkle path built from the wallet's own tree, and is
+      // only recognised if that path resolves to a root the chain holds. A tree rebuilt one index off would not.
+      expect(block.transactions[0].result.type).toBe('success');
+
+      const afterSpend = yield* wallet.awaitState((state) => state.state.progress.appliedIndex > block.number);
+      expect(totalValue(afterSpend.state)).toBe(walletTotal - transferred);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('does not migrate on a version bump that stays inside the running variant range', async () =>
+    Effect.gen(function* () {
+      // Same chain, same registration, one number different: the timeline activates a version the pre-fork variant
+      // still owns. The version is written into state either way — what must not happen is a hand-over.
+      const coins = chainCoins();
+      const chain = yield* preForkChain(coins, withinRangeVersion);
+      const replayed = yield* Deferred.make<Simulator>();
+
+      const wallet = makeForkWallet({
+        preFork: chain,
+        replayed: Deferred.await(replayed),
+        networkId,
+        forkVersion,
+        seed,
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      yield* wallet.start;
+      yield* driveTo(chain, forkBlock);
+
+      const state = yield* wallet.awaitState((current) => current.state.progress.appliedIndex > forkBlock);
+
+      // Seen and annotated on the wallet's own state — the annotation the runtime reads — and, being inside the
+      // range, it decided nothing. (Asserted here rather than on `ProtocolState.version`, which the runtime publishes
+      // one state emission behind a within-range bump.)
+      expect(state.state.protocolVersion).toBe(withinRangeVersion);
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+      expect(yield* wallet.migration).toStrictEqual(Option.none());
+      // The bumped block was applied rather than deferred, so nothing was left behind for a variant that never ran.
+      expect(state.state.progress.appliedIndex).toBe(forkBlock + 1n);
+      expect(totalValue(state.state)).toBe(walletTotal);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('migrates a wallet whose first sync already contains the fork', async () =>
+    Effect.gen(function* () {
+      // Scenario 2: a wallet started from seed after the fork has happened. Its pre-fork variant meets the whole
+      // pre-fork history in a single batch, so the boundary is split *within* one update rather than across two.
+      const coins = chainCoins();
+      const chain = yield* preForkChain(coins, forkVersion);
+      yield* driveTo(chain, forkBlock);
+      const replayChain = yield* replayOf(coins, chain);
+
+      const wallet = makeForkWallet({
+        preFork: chain,
+        replayed: Effect.succeed(replayChain),
+        networkId,
+        forkVersion,
+        seed,
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      yield* wallet.start;
+
+      const migration = yield* wallet.awaitMigration;
+      expect(migration.from.appliedIndex).toBe(forkBlock);
+      expect(migration.to.coinCount).toBe(0);
+
+      // The end state is the same as the live transition reaches, which is the point: how the timeline was delivered
+      // is not supposed to change what the wallet ends up holding.
+      const postFork = yield* rediscovered(wallet);
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+      expect(coinValues(postFork.state).toSorted(ascending)).toEqual([...walletValues]);
+      expect(coinIndices(postFork.state)).toEqual(walletIndices);
+      expect(treeSize(postFork.state)).toBe(treeSizeAtFork);
+      expect(postFork.state.progress.appliedIndex).toBe(BigInt(coins.length) + 1n);
+    }).pipe(Effect.scoped, Effect.runPromise));
+});

--- a/packages/shielded-wallet/src/test/forkWallet.ts
+++ b/packages/shielded-wallet/src/test/forkWallet.ts
@@ -1,0 +1,317 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * A shielded wallet registered over _both_ variants, syncing a chain that forks under it — test scaffolding only.
+ *
+ * @remarks
+ *   The shipped `ShieldedWallet` registers exactly one variant and its type is a one-element HList throughout, so it
+ *   cannot express a wallet that crosses a fork. Rather than widen the public surface ahead of the API redesign this
+ *   builds the two-variant wallet the way `packages/e2e-tests` builds its custom wallets: `WalletBuilder.init()` with
+ *   both variant builders registered directly. Nothing here is exported from the package.
+ *
+ *   The two sides read different sources, which is the shape the real thing has: before the fork the pre-fork chain,
+ *   after it the indexer's replayed timeline (see `forkReplay.ts`). The post-fork source does not exist when the wallet
+ *   is built, so it is supplied as an effect the post-fork variant awaits at its first sync.
+ *
+ *   Three things it has to work around, each of which is a real question the public API will have to answer eventually:
+ *
+ *   - **Configuration collides.** `WalletBuilder` intersects every variant's configuration, and both variants name their
+ *       simulator `simulator` — with different, incompatible ledger types. So the sync services are passed as closures
+ *       that ignore configuration entirely, leaving the merged configuration as just `networkId`.
+ *   - **Start-aux does not cross the boundary.** The pre-fork variant's aux is a ledger-v8 `ZswapSecretKeys`, the post-fork
+ *       variant's a ledger-v9 one. A single retained value cannot serve both, so what is retained here is the _seed_,
+ *       and each variant is handed keys derived from it — the same public keys either way (asserted by
+ *       `forkSimulation.integration.test.ts`), just built by the ledger that variant speaks.
+ *   - **The post-fork source does not exist yet** when the wallet is built, hence the effect above.
+ */
+
+import * as v8 from '@midnight-ntwrk/ledger-v8';
+import * as v9 from '@midnightntwrk/ledger-v9';
+import { type NetworkId, type ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type Simulator, type V8 } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
+import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { Deferred, Effect, FiberId, Option, Stream, pipe } from 'effect';
+import * as V1 from '../v1/index.js';
+import * as V2 from '../v2/index.js';
+
+// =============================================================================
+// Observation channels
+// =============================================================================
+
+/**
+ * Both ends of a migration, as plain data, taken at the moment it happened.
+ *
+ * @remarks
+ *   Recorded as plain data rather than by keeping the wallets themselves: the pre-fork state is built on the other
+ *   ledger's wasm objects, whose lifetime ends with the variant scope the migration closes.
+ *
+ *   The `from` side is what the projection was allowed to see; the `to` side is what it produced. Under the replay design
+ *   the interesting claim is on the `to` side — that a wallet crossing a fork starts _empty_, and re-earns its coins by
+ *   syncing.
+ */
+export type CapturedMigration = Readonly<{
+  from: Readonly<{
+    coinPublicKey: string;
+    encryptionPublicKey: string;
+    networkId: string;
+    protocolVersion: bigint;
+    appliedIndex: bigint;
+  }>;
+  to: Readonly<{
+    coinPublicKey: string;
+    encryptionPublicKey: string;
+    networkId: string;
+    protocolVersion: bigint;
+    appliedIndex: bigint;
+    coinCount: number;
+    firstFree: bigint;
+    coinHashCount: number;
+  }>;
+}>;
+
+const captureInput = (previousState: V2.Migration.PreviousLedgerWallet): CapturedMigration['from'] => ({
+  coinPublicKey: previousState.publicKeys.coinPublicKey,
+  encryptionPublicKey: previousState.publicKeys.encryptionPublicKey,
+  networkId: previousState.networkId,
+  protocolVersion: previousState.protocolVersion,
+  appliedIndex: previousState.progress.appliedIndex,
+});
+
+const captureOutput = (migrated: V2.CoreWallet): CapturedMigration['to'] => ({
+  coinPublicKey: migrated.publicKeys.coinPublicKey,
+  encryptionPublicKey: migrated.publicKeys.encryptionPublicKey,
+  networkId: migrated.networkId,
+  protocolVersion: migrated.protocolVersion,
+  appliedIndex: migrated.progress.appliedIndex,
+  coinCount: [...migrated.state.coins].length,
+  firstFree: migrated.state.firstFree,
+  coinHashCount: Object.keys(migrated.coinHashes).length,
+});
+
+/** The real cross-ledger migration, with both ends recorded on the way through. */
+const capturingCrossLedgerMigration = (
+  captured: Deferred.Deferred<CapturedMigration>,
+): V2.Migration.StateMigration<V2.Migration.PreviousLedgerWallet> => {
+  const inner = V2.Migration.makeCrossLedgerMigration();
+  return {
+    migrate: (previousState) =>
+      pipe(
+        inner.migrate(previousState),
+        Effect.tap((migrated) =>
+          Deferred.succeed(captured, { from: captureInput(previousState), to: captureOutput(migrated) }),
+        ),
+      ),
+  };
+};
+
+// =============================================================================
+// Stand-ins for services the proof does not exercise
+// =============================================================================
+
+const transactionDetails = (hash: string) => ({
+  hash,
+  block: { hash: '', height: 0, timestamp: 0 },
+  status: 'SUCCESS' as const,
+  identifiers: [] as readonly string[],
+});
+
+/**
+ * Transaction history reduced to nothing.
+ *
+ * @remarks
+ *   The real services need indexer configuration or a storage instance, neither of which says anything about crossing a
+ *   fork. Written out once per variant because the two `TransactionHistoryService` types name their own ledger's
+ *   `ZswapStateChanges`.
+ */
+const noOpPreForkHistory: V1.TransactionHistory.TransactionHistoryService = {
+  put: () => Effect.void,
+  getTransactionDetails: (hash) => Effect.succeed(transactionDetails(hash)),
+};
+
+const noOpPostForkHistory: V2.TransactionHistory.TransactionHistoryService = {
+  put: () => Effect.void,
+  getTransactionDetails: (hash) => Effect.succeed(transactionDetails(hash)),
+};
+
+/**
+ * The post-fork sync source, deferred until it exists.
+ *
+ * @remarks
+ *   A source that never arrives is a broken harness rather than a wallet error — there is no `WalletError` that means
+ *   "the simulated replay did not happen" — so failures are raised as defects instead of being folded into the sync
+ *   error channel.
+ */
+const postForkSyncService = (
+  replayed: Effect.Effect<Simulator, never>,
+): V2.Sync.SyncService<V2.CoreWallet, v9.ZswapSecretKeys, V2.Sync.SimulatorSyncUpdate> => ({
+  updates: (state, secretKeys) =>
+    Stream.unwrap(
+      pipe(
+        replayed,
+        Effect.orDie,
+        Effect.map((chain) => V2.Sync.makeSimulatorSyncService({ simulator: chain }).updates(state, secretKeys)),
+      ),
+    ),
+});
+
+// =============================================================================
+// The wallet
+// =============================================================================
+
+/** Everything needed to build a two-variant shielded wallet over a chain that forks. */
+export type ForkWalletConfig = Readonly<{
+  /** The pre-fork chain, available immediately. */
+  preFork: V8.Simulator;
+  /** The post-fork source — the indexer's replayed timeline — which only exists once the fork has happened. */
+  replayed: Effect.Effect<Simulator, never>;
+  networkId: NetworkId.NetworkId;
+  /**
+   * The version at which the post-fork variant is registered.
+   *
+   * The single source of truth for the boundary (D5): the pre-fork variant's activation range ends here, and so does
+   * the point at which its sync stops applying. Deliberately not a production constant — the real fork version is not
+   * final.
+   */
+  forkVersion: ProtocolVersion.ProtocolVersion;
+  /** The seed both variants derive their keys from. */
+  seed: Uint8Array;
+}>;
+
+/** A running two-variant shielded wallet, plus the channels a fork proof needs to observe it. */
+export type ForkWallet = Readonly<{
+  /** Keys of each ledger version, derived from the same seed. */
+  keys: Readonly<{ preFork: v8.ZswapSecretKeys; postFork: v9.ZswapSecretKeys }>;
+  /** Starts background sync, having first registered the activation watcher that restarts it after a migration. */
+  start: Effect.Effect<void, WalletRuntimeError>;
+  /** Resolves when the hand-over happens, with both ends of it. */
+  awaitMigration: Effect.Effect<CapturedMigration>;
+  /** Both ends of the migration, or `None` if none has happened yet. */
+  migration: Effect.Effect<Option.Option<CapturedMigration>>;
+  /** The tag of the variant currently running — `V1Tag` before a migration, `V2Tag` after one. */
+  activeTag: Effect.Effect<string | symbol>;
+  /** The wallet's current state, whichever variant produced it. */
+  currentState: Effect.Effect<ProtocolState.ProtocolState<V1.CoreWallet | V2.CoreWallet>, WalletRuntimeError>;
+  /**
+   * Resolves once the wallet's state satisfies `predicate`, failing the test's timeout if it never does.
+   *
+   * Use monotone predicates only: the runtime's state stream keeps just the latest value, so a state that satisfies a
+   * transient predicate can legitimately be skipped.
+   */
+  awaitState: (
+    predicate: (state: ProtocolState.ProtocolState<V1.CoreWallet | V2.CoreWallet>) => boolean,
+  ) => Effect.Effect<ProtocolState.ProtocolState<V1.CoreWallet | V2.CoreWallet>, WalletRuntimeError>;
+  /** Runs `use` against the running post-fork variant. Fails if the wallet has not migrated. */
+  onPostForkVariant: <A, E>(
+    use: (
+      variant: V2.RunningV2Variant<string, V2.Sync.SimulatorSyncUpdate, v9.FinalizedTransaction, v9.ZswapSecretKeys>,
+    ) => Effect.Effect<A, E>,
+  ) => Effect.Effect<A, E | WalletRuntimeError>;
+  /** Tears the wallet down. */
+  stop: Effect.Effect<void>;
+}>;
+
+/**
+ * Builds and starts a shielded wallet registered over both variants.
+ *
+ * @param config - The two sources, the boundary version, the network and the seed.
+ * @returns The running wallet and its observation channels.
+ */
+export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
+  const { preFork, replayed, networkId, forkVersion, seed } = config;
+
+  const preForkKeys = v8.ZswapSecretKeys.fromSeed(seed);
+  const postForkKeys = v9.ZswapSecretKeys.fromSeed(seed);
+
+  const captured = Deferred.unsafeMake<CapturedMigration>(FiberId.none);
+
+  const preForkBuilder = new V1.V1Builder()
+    .withDefaultTransactionType()
+    .withSync(() => V1.Sync.makeSimulatorSyncService({ simulator: preFork }), V1.Sync.makeSimulatorSyncCapability)
+    .withSerializationDefaults()
+    .withTransactingDefaults()
+    .withCoinsAndBalancesDefaults()
+    .withTransactionHistory(() => noOpPreForkHistory)
+    .withKeysDefaults()
+    .withCoinSelectionDefaults();
+
+  const postForkBuilder = new V2.V2Builder()
+    .withDefaultTransactionType()
+    .withSync(() => postForkSyncService(replayed), V2.Sync.makeSimulatorSyncCapability)
+    .withSerializationDefaults()
+    .withTransactingDefaults()
+    .withCoinsAndBalancesDefaults()
+    .withTransactionHistory(() => noOpPostForkHistory)
+    .withKeysDefaults()
+    .withCoinSelectionDefaults()
+    .withMigration(() => capturingCrossLedgerMigration(captured));
+
+  const WalletClass = WalletBuilder.init()
+    .withVariant(ProtocolVersion.MinSupportedVersion, preForkBuilder)
+    .withVariant(forkVersion, postForkBuilder)
+    .build({ networkId });
+
+  const wallet = WalletClass.startFirst(WalletClass, V1.CoreWallet.initEmpty(preForkKeys, networkId));
+  const runtime = wallet.runtime;
+
+  const currentState = pipe(runtime.stateChanges, Stream.take(1), Stream.runHead, Effect.map(Option.getOrThrow));
+
+  return {
+    keys: { preFork: preForkKeys, postFork: postForkKeys },
+
+    start: Effect.gen(function* () {
+      // Registered before the first dispatch and only once, exactly as `ShieldedWallet.start` does it: the returned
+      // effect resolves only once the subscription is live, so the migration cannot outrun the watcher.
+      yield* runtime.onVariantActivation({
+        [V1.V1Tag]: (v1) => v1.startSyncInBackground(preForkKeys),
+        [V2.V2Tag]: (v2) => v2.startSyncInBackground(postForkKeys),
+      });
+      yield* runtime.dispatch({
+        [V1.V1Tag]: (v1) => v1.startSyncInBackground(preForkKeys),
+        [V2.V2Tag]: (v2) => v2.startSyncInBackground(postForkKeys),
+      });
+    }),
+
+    awaitMigration: Deferred.await(captured),
+
+    migration: Deferred.poll(captured).pipe(
+      Effect.flatMap(Option.match({ onNone: () => Effect.succeedNone, onSome: Effect.asSome })),
+    ),
+
+    activeTag: pipe(
+      runtime.currentVariant,
+      Effect.map((current) => current.runningVariant.__polyTag__),
+    ),
+
+    currentState,
+
+    awaitState: (predicate) =>
+      pipe(
+        runtime.stateChanges,
+        Stream.filter(predicate),
+        Stream.take(1),
+        Stream.runHead,
+        Effect.map(Option.getOrThrow),
+      ),
+
+    onPostForkVariant: (use) =>
+      runtime.dispatch({
+        [V1.V1Tag]: () =>
+          Effect.die(new Error('The wallet is still running its pre-fork variant; it has not migrated')),
+        [V2.V2Tag]: use,
+      }),
+
+    stop: Effect.promise(() => wallet.stop()),
+  };
+};

--- a/packages/shielded-wallet/src/test/forkWallet.ts
+++ b/packages/shielded-wallet/src/test/forkWallet.ts
@@ -58,8 +58,10 @@ import * as V2 from '../v2/index.js';
  *   ledger's wasm objects, whose lifetime ends with the variant scope the migration closes.
  *
  *   The `from` side is what the projection was allowed to see; the `to` side is what it produced. Under the replay design
- *   the interesting claim is on the `to` side — that a wallet crossing a fork starts _empty_, and re-earns its coins by
- *   syncing.
+ *   the interesting claim is on the `to` side — that a wallet crossing a fork starts with no coins at all and re-earns
+ *   them by syncing, keeping only its identity and the cursor it inherited. `appliedIndex` is captured on both sides
+ *   because comparing them is the only place the parked cursor is directly observable: once sync runs, a wallet that
+ *   had rewound instead would read the same replay anyway and converge on the same state.
  */
 export type CapturedMigration = Readonly<{
   from: Readonly<{

--- a/packages/shielded-wallet/src/test/forkWalletAssertions.ts
+++ b/packages/shielded-wallet/src/test/forkWalletAssertions.ts
@@ -57,3 +57,13 @@ export const totalValue = (wallet: EitherWallet): bigint =>
  * reconstructed and not merely populated with the leaves the wallet cares about.
  */
 export const treeSize = (wallet: EitherWallet): bigint => wallet.state.firstFree;
+
+/**
+ * The root of the wallet's own commitment tree.
+ *
+ * @remarks
+ *   The single value that says whether a wallet's tree is the chain's tree. Comparing it to a root taken from a chain
+ *   state is how a proof states that what the wallet rebuilt from replayed events is byte-for-byte the tree the ledger
+ *   translation produced — not merely a tree with the same leaves in it.
+ */
+export const merkleRoot = (wallet: EitherWallet): bigint | undefined => wallet.state.merkleTreeRoot;

--- a/packages/shielded-wallet/src/test/forkWalletAssertions.ts
+++ b/packages/shielded-wallet/src/test/forkWalletAssertions.ts
@@ -1,0 +1,59 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Reading a shielded wallet's coins without caring which ledger version holds them.
+ *
+ * @remarks
+ *   A wallet crossing a fork is a `CoreWallet` of one ledger version before the boundary and of the other after it.
+ *   Everything a fork proof asserts about coins — how many, worth what, at which Merkle indices — is plain data that
+ *   both versions express identically, so these read the union rather than being written twice.
+ */
+
+import { type CoreWallet as PreForkWallet } from '../v1/CoreWallet.js';
+import { type CoreWallet as PostForkWallet } from '../v2/CoreWallet.js';
+
+/** A wallet on either side of the boundary. */
+export type EitherWallet = PreForkWallet | PostForkWallet;
+
+/** Ascending order for bigints, which `Array.prototype.sort`'s default (string) comparison gets wrong. */
+export const ascending = (left: bigint, right: bigint): number => (left < right ? -1 : left > right ? 1 : 0);
+
+const spendableCoins = (wallet: EitherWallet): readonly Readonly<{ value: bigint; mt_index: bigint }>[] => [
+  ...wallet.state.coins,
+];
+
+/** The values of the wallet's spendable coins, ascending. */
+export const coinValues = (wallet: EitherWallet): readonly bigint[] =>
+  spendableCoins(wallet)
+    .map((coin) => coin.value)
+    .sort(ascending);
+
+/** The Merkle indices the wallet's spendable coins occupy, ascending. */
+export const coinIndices = (wallet: EitherWallet): readonly bigint[] =>
+  spendableCoins(wallet)
+    .map((coin) => coin.mt_index)
+    .sort(ascending);
+
+/** Everything the wallet can spend, summed. */
+export const totalValue = (wallet: EitherWallet): bigint =>
+  spendableCoins(wallet).reduce((sum, coin) => sum + coin.value, 0n);
+
+/**
+ * How far the wallet's local commitment tree reaches — its `firstFree`.
+ *
+ * Distinct from how many coins it holds: the tree also covers everybody else's commitments, which a wallet skips over
+ * rather than stores. Comparing it to the chain's own tree size is how a proof states that the local tree was fully
+ * reconstructed and not merely populated with the leaves the wallet cares about.
+ */
+export const treeSize = (wallet: EitherWallet): bigint => wallet.state.firstFree;

--- a/packages/shielded-wallet/turbo.json
+++ b/packages/shielded-wallet/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "test:integration": {
+      // forkSimulation.integration.test.ts drives a wallet across a fork whose handover is the real v8-to-v9
+      // translation, a WASM artifact built from packages/state-translation/wasm. Declared so turbo builds it first
+      // rather than leaving the ordering to CI — which is why running any integration test in this package needs a
+      // Rust toolchain. Same trade-off, and same wiring, as packages/capabilities/turbo.json.
+      "dependsOn": ["$TURBO_EXTENDS$", "@midnightntwrk/wallet-sdk-state-translation#build:wasm"]
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2708,6 +2708,7 @@ __metadata:
     "@midnightntwrk/wallet-sdk-capabilities": "npm:4.0.0-beta.2"
     "@midnightntwrk/wallet-sdk-indexer-client": "npm:1.3.0-beta.1"
     "@midnightntwrk/wallet-sdk-runtime": "npm:1.0.6-beta.0"
+    "@midnightntwrk/wallet-sdk-state-translation": "workspace:^"
     "@midnightntwrk/wallet-sdk-utilities": "npm:1.2.1"
     effect: "npm:^3.19.19"
     rxjs: "npm:^7.8.2"


### PR DESCRIPTION
Phase 5 of the hard-fork plan — the proof. A shielded wallet is driven through a simulated v8→v9 hard fork: it syncs the pre-fork chain, observes the version signal, migrates to a **fresh** v9 state with its **cursor parked at the fork**, restarts with retained keys, **re-discovers its coins from the replayed post-fork events**, and spends them. Stacked on #655.

> **Design notes.** The real indexer **replays events after the hard fork, continuing from whatever id it was at when the fork happened — never from 0** (wallet-team confirmed). The simulator has no indexer, so the harness models the replay by **transferring the coins on the post-fork timeline**: each pre-fork coin is re-paid as a v9 transaction with the exact same type/nonce/value/recipient (`src/test/forkReplay.ts`), on a chain **numbered as a continuation of the pre-fork chain** (block numbers stand in for indexer event ids — the same convention `ForkSimulator`'s translated chain already follows). A migrated wallet parked at the fork consumes exactly the replayed suffix.

## What the proof shows (per test)

**The crossing (unit tier — no toolchain needed, 3 tests):** v8 mints → v8 variant syncs → fork at block F → `VersionChange` → `migrateState` captured with the exact pre-fork state → the migrated state's cursor **equals the pre-fork cursor** (the park assertion, checked on the captured migration before any sync runs) → v2 restarts with retained keys → coins re-discovered from the replayed events above the boundary (asserted: the first consumed replay block is `> forkBlock`) → post-fork spend → balances correct. Negatives: a within-range version bump does not migrate; a fresh post-fork wallet syncs through the boundary and consumes the replay (scenario 2).

**The fidelity link (integration tier, real WASM translation, 3 tests):** the replay model and the ledger-team translation vouch for each other — translated-chain root == pre-fork wallet root; replay-chain root == translated root; **post-fork wallet root == translated root** (a wallet that never saw the translated state rebuilt that exact tree from replayed events), and its spend — Merkle path derived entirely from replay — is **accepted by the chain holding the translated ledger**.

## Mutation verification (all caught)

Force reset-to-0 in the migration → the park assertion fails on both migrating tests; corrupt a replayed coin's value → integration fails on root equality, unit strands below balance; replay numbered from 0 while parked → the wallet consumes nothing (this was the natural red when the confirmed semantics landed); corrupt a coin with structural checks stripped → the translated chain reports the spend as `'failure'`; swap the real translation for a blank one → the oracle equality itself fails (the fidelity test cannot pass vacuously).

**Honest limit, documented in `forkReplay.ts`:** beyond the captured-migration cursor assertion, this harness cannot behaviorally separate park from reset — the simulator capability filters `blocks.number >= appliedIndex`, so a cursor *behind* the replay still reads all of it, and the real-world harm of a reset (being re-served the pre-fork v8 events) is not representable against a post-fork source that has no blocks below the boundary. The state assertion is the discriminator, and forcing a reset fails it.

## Supporting work

- **Two-variant test factory** (`src/test/forkWallet.ts`, NOT exported): V1Builder at `MinSupportedVersion`, V2Builder at a per-test fork version. Its three documented workarounds (colliding merged variant configs; start-aux that cannot cross ledger versions — the harness retains the *seed* and derives per-variant keys, verified to yield identical commitments/nullifiers across v8/v9; the post-fork source not existing at build time) are direct input to the deferred public-API redesign.
- **This branch adds no production code** — under the replay design Phase 5 is purely proof. Its changeset is a patch (integration-tier plumbing only: `state-translation` devDependency + `turbo.json` `build:wasm` dependency + the integration workflow's toolchain gate extended to `packages/shielded-wallet/*`, so running shielded integration tests requires the Rust toolchain, mirroring capabilities).
- Consequence recorded in the plan: the indexer `zswapMerkleTreeCollapsedUpdate` codegen idea is moot for the wallet path — it only existed to serve re-anchoring.

## Verification (branch tip)

`yarn dist --force` · `typecheck --force` 37/37 · `lint` 58/58 · `test:unit --force` 53/53 · shielded suite 21 files / 156 passed / 22 pre-existing skips · integration 3/3 with the built artifact (re-run independently before pushing) · Effect diagnostics 0/0/0 on all 27 changed files · `format:check` · changeset status clean. All commits GPG-signed.