### PR TITLE
feat(unshielded-wallet): cross-check the indexer's reported tip against the node's finalized head

### DIFF
--- a/.changeset/indexer-liveness-cross-check.md
+++ b/.changeset/indexer-liveness-cross-check.md
@@ -21,7 +21,8 @@ is reported as `Skipped` (`no-liveness-feed`), so it can still reach "synced". T
 
 ### Fixes
 
-- `isConnected` on the sync progress clears when the indexer subscription drops; it previously latched `true`.
+- `isConnected` on the sync progress clears when the indexer subscription drops or is completed by the indexer, and the
+  subscription is rebuilt in both cases; it previously latched `true`, and a completed subscription was never rebuilt.
 - `api.rpc` calls (`getGenesis()`) work after client creation; they previously failed as disconnected.
 - Node connection failures are typed errors reachable by `catchTag`/`catchAll`, no longer defects.
 - A finite `reconnectionTimeout` also bounds the initial connection; no timeout (submission) stays unbounded.

--- a/.changeset/indexer-liveness-cross-check.md
+++ b/.changeset/indexer-liveness-cross-check.md
@@ -25,6 +25,9 @@ is reported as `Skipped` (`no-liveness-feed`), so it can still reach "synced". T
 - `api.rpc` calls (`getGenesis()`) work after client creation; they previously failed as disconnected.
 - Node connection failures are typed errors reachable by `catchTag`/`catchAll`, no longer defects.
 - A finite `reconnectionTimeout` also bounds the initial connection; no timeout (submission) stays unbounded.
+- The sync streams' retry backoff is genuinely capped at two minutes. The cap was applied to the schedule's output
+  rather than its interval, so retries kept doubling — half an hour apart by the twelfth — until the timer overflowed
+  and the stream stopped retrying.
 
 BREAKING CHANGE (`wallet-sdk`, `wallet-sdk-facade`, `wallet-sdk-unshielded-wallet`): `isStrictlyComplete()`,
 `isCompleteWithin()`, `FacadeState.isSynced` and `waitForSyncedState()` now also require the indexer not to trail the

--- a/.changeset/indexer-liveness-cross-check.md
+++ b/.changeset/indexer-liveness-cross-check.md
@@ -25,7 +25,9 @@ is reported as `Skipped` (`no-liveness-feed`), so it can still reach "synced". T
   subscription is rebuilt in both cases; it previously latched `true`, and a completed subscription was never rebuilt.
 - `api.rpc` calls (`getGenesis()`) work after client creation; they previously failed as disconnected.
 - Node connection failures are typed errors reachable by `catchTag`/`catchAll`, no longer defects.
-- A finite `reconnectionTimeout` also bounds the initial connection; no timeout (submission) stays unbounded.
+- A finite `reconnectionTimeout` also bounds the initial connection — the handshake and the close that follows it — and
+  the liveness poll's own timeout is hard even when a read is stuck in that build; no timeout (submission) stays
+  unbounded.
 - The sync streams' retry backoff is genuinely capped at two minutes. The cap was applied to the schedule's output
   rather than its interval, so retries kept doubling — half an hour apart by the twelfth — until the timer overflowed
   and the stream stopped retrying.

--- a/.changeset/indexer-liveness-cross-check.md
+++ b/.changeset/indexer-liveness-cross-check.md
@@ -30,8 +30,9 @@ first reached (`IndexerLiveness.equivalent` is the predicate). Tune with `livene
 - Node connection failures are typed errors reachable by `catchTag`/`catchAll`, no longer defects.
 - A finite `reconnectionTimeout` also bounds the initial connection — the handshake and the close that follows it — and
   the whole window is used: a node that is restarting connects on a later attempt rather than failing the build on the
-  first socket error. The liveness poll's own timeout is hard even when a read is stuck in that build; no timeout
-  (submission) stays unbounded.
+  first socket error. The same wait for the close, under the same bound, runs when the last in-flight call releases the
+  socket, so the next call does not start on a stale connection flag. The liveness poll's own timeout is hard even when
+  a read is stuck in that build; no timeout (submission) stays unbounded.
 - The sync streams' retry backoff is genuinely capped at two minutes. The cap was applied to the schedule's output
   rather than its interval, so retries kept doubling — half an hour apart by the twelfth — until the timer overflowed
   and the stream stopped retrying.

--- a/.changeset/indexer-liveness-cross-check.md
+++ b/.changeset/indexer-liveness-cross-check.md
@@ -26,8 +26,9 @@ is reported as `Skipped` (`no-liveness-feed`), so it can still reach "synced". T
 - `api.rpc` calls (`getGenesis()`) work after client creation; they previously failed as disconnected.
 - Node connection failures are typed errors reachable by `catchTag`/`catchAll`, no longer defects.
 - A finite `reconnectionTimeout` also bounds the initial connection — the handshake and the close that follows it — and
-  the liveness poll's own timeout is hard even when a read is stuck in that build; no timeout (submission) stays
-  unbounded.
+  the whole window is used: a node that is restarting connects on a later attempt rather than failing the build on the
+  first socket error. The liveness poll's own timeout is hard even when a read is stuck in that build; no timeout
+  (submission) stays unbounded.
 - The sync streams' retry backoff is genuinely capped at two minutes. The cap was applied to the schedule's output
   rather than its interval, so retries kept doubling — half an hour apart by the twelfth — until the timer overflowed
   and the stream stopped retrying.

--- a/.changeset/indexer-liveness-cross-check.md
+++ b/.changeset/indexer-liveness-cross-check.md
@@ -15,8 +15,9 @@ head (every 30 seconds by default) and, once, checks that both endpoints name th
 result is an `IndexerLiveness` verdict on `SyncProgress`: `Behind`, `Unknown` and `WrongNetwork` block completion; the
 other four (`InSync`, `Ahead`, `Unavailable`, `Skipped`) do not. A poll that fails after a `Behind` or `WrongNetwork`
 verdict leaves that verdict in place — an unreachable endpoint disproves nothing — so a node outage cannot release a
-caller waiting on a stale indexer. Tune with `livenessConfiguration` and `livenessPollInterval`. This detects
-staleness, not withholding.
+caller waiting on a stale indexer. A custom sync service supplied through `withSync` that exposes no `livenessUpdates`
+is reported as `Skipped` (`no-liveness-feed`), so it can still reach "synced". Tune with `livenessConfiguration` and
+`livenessPollInterval`. This detects staleness, not withholding.
 
 ### Fixes
 

--- a/.changeset/indexer-liveness-cross-check.md
+++ b/.changeset/indexer-liveness-cross-check.md
@@ -1,0 +1,35 @@
+---
+'@midnightntwrk/wallet-sdk': major
+'@midnightntwrk/wallet-sdk-facade': major
+'@midnightntwrk/wallet-sdk-unshielded-wallet': major
+'@midnightntwrk/wallet-sdk-node-client': major
+'@midnightntwrk/wallet-sdk-abstractions': minor
+'@midnightntwrk/wallet-sdk-capabilities': minor
+---
+
+feat(unshielded-wallet): cross-check the indexer's reported tip against the node's finalized head
+
+The wallet now verifies "synced" against the chain instead of the indexer's self-report: it polls a node's finalized
+head (every 30 seconds by default) and, once, checks that both endpoints name the same genesis block. The node is
+`nodeClientConnection` on the configuration, falling back to `relayURL`; a wallet naming neither is not checked. The
+result is an `IndexerLiveness` verdict on `SyncProgress`: `Behind`, `Unknown` and `WrongNetwork` block completion; the
+other four (`InSync`, `Ahead`, `Unavailable`, `Skipped`) do not. Tune with `livenessConfiguration` and
+`livenessPollInterval`. This detects staleness, not withholding.
+
+### Fixes
+
+- `isConnected` on the sync progress clears when the indexer subscription drops; it previously latched `true`.
+- `api.rpc` calls (`getGenesis()`) work after client creation; they previously failed as disconnected.
+- Node connection failures are typed errors reachable by `catchTag`/`catchAll`, no longer defects.
+- A finite `reconnectionTimeout` also bounds the initial connection; no timeout (submission) stays unbounded.
+
+BREAKING CHANGE (`wallet-sdk`, `wallet-sdk-facade`, `wallet-sdk-unshielded-wallet`): `isStrictlyComplete()`,
+`isCompleteWithin()`, `FacadeState.isSynced` and `waitForSyncedState()` now also require the indexer not to trail the
+finalized head, a matching genesis, and a first verdict (`Skipped` — no node, or a simulation — does not block). On by
+default for every wallet with a `relayURL`. Against a stale indexer, `waitForSyncedState()` waits — it neither rejects
+nor times out; race it against a deadline of your own and read `progress.indexerLiveness` and `progress.isConnected`
+(the `indexer-liveness` docs snippet shows the pattern). `SyncProgressData` gains a required `indexerLiveness` field,
+defaulted by `createSyncProgress()`; sync types are parameterised on `SyncUpdate`, a superset of `WalletSyncUpdate`.
+
+BREAKING CHANGE (`wallet-sdk-node-client`): `NodeClient.Service` gains required `getFinalizedBlock()` and
+`getGenesisHash()` methods. Callers are unaffected; implementers must add them.

--- a/.changeset/indexer-liveness-cross-check.md
+++ b/.changeset/indexer-liveness-cross-check.md
@@ -16,7 +16,10 @@ result is an `IndexerLiveness` verdict on `SyncProgress`: `Behind`, `Unknown` an
 other four (`InSync`, `Ahead`, `Unavailable`, `Skipped`) do not. A poll that fails after a `Behind` or `WrongNetwork`
 verdict leaves that verdict in place — an unreachable endpoint disproves nothing — so a node outage cannot release a
 caller waiting on a stale indexer. A custom sync service supplied through `withSync` that exposes no `livenessUpdates`
-is reported as `Skipped` (`no-liveness-feed`), so it can still reach "synced". Tune with `livenessConfiguration` and
+is reported as `Skipped` (`no-liveness-feed`), so it can still reach "synced". A verdict is republished only when it
+says something new — its kind, a `Behind`'s lag, an `Unavailable`'s failure count — not because the chain advanced, so
+an idle wallet's state does not change once per poll; the heights on a published `InSync` are those at which it was
+first reached (`IndexerLiveness.equivalent` is the predicate). Tune with `livenessConfiguration` and
 `livenessPollInterval`. This detects staleness, not withholding.
 
 ### Fixes

--- a/.changeset/indexer-liveness-cross-check.md
+++ b/.changeset/indexer-liveness-cross-check.md
@@ -9,7 +9,7 @@
 
 feat(unshielded-wallet): cross-check the indexer's reported tip against the node's finalized head
 
-The wallet now verifies "synced" against the chain instead of the indexer's self-report: it polls a node's finalized
+The unshielded wallet now verifies "synced" against the chain instead of the indexer's self-report: it polls a node's finalized
 head (every 30 seconds by default) and, once, checks that both endpoints name the same genesis block. The node is
 `nodeClientConnection` on the configuration, falling back to `relayURL`; a wallet naming neither is not checked. The
 result is an `IndexerLiveness` verdict on `SyncProgress`: `Behind`, `Unknown` and `WrongNetwork` block completion; the
@@ -20,12 +20,15 @@ is reported as `Skipped` (`no-liveness-feed`), so it can still reach "synced". A
 says something new — its kind, a `Behind`'s lag, an `Unavailable`'s failure count — not because the chain advanced, so
 an idle wallet's state does not change once per poll; the heights on a published `InSync` are those at which it was
 first reached (`IndexerLiveness.equivalent` is the predicate). Tune with `livenessConfiguration` and
-`livenessPollInterval`. This detects staleness, not withholding.
+`livenessPollInterval`. This detects staleness, not withholding. The shielded and dust wallets are not gated: their
+shared `SyncProgress` carries no verdict, and `FacadeState.isSynced` gates only through the unshielded wallet's progress
+(#743).
 
 ### Fixes
 
-- `isConnected` on the sync progress clears when the indexer subscription drops or is completed by the indexer, and the
-  subscription is rebuilt in both cases; it previously latched `true`, and a completed subscription was never rebuilt.
+- `isConnected` on the unshielded wallet's sync progress clears when the indexer subscription drops or is completed by
+  the indexer, and the subscription is rebuilt in both cases; it previously latched `true`, and a completed
+  subscription was never rebuilt. The shielded and dust wallets still latch it (#743).
 - `api.rpc` calls (`getGenesis()`) work after client creation; they previously failed as disconnected.
 - Node connection failures are typed errors reachable by `catchTag`/`catchAll`, no longer defects.
 - A finite `reconnectionTimeout` also bounds the initial connection — the handshake and the close that follows it — and
@@ -33,13 +36,14 @@ first reached (`IndexerLiveness.equivalent` is the predicate). Tune with `livene
   first socket error. The same wait for the close, under the same bound, runs when the last in-flight call releases the
   socket, so the next call does not start on a stale connection flag. The liveness poll's own timeout is hard even when
   a read is stuck in that build; no timeout (submission) stays unbounded.
-- The sync streams' retry backoff is genuinely capped at two minutes. The cap was applied to the schedule's output
-  rather than its interval, so retries kept doubling — half an hour apart by the twelfth — until the timer overflowed
-  and the stream stopped retrying.
+- The unshielded wallet's sync streams' retry backoff is genuinely capped at two minutes. The cap was applied to the
+  schedule's output rather than its interval, so retries kept doubling — half an hour apart by the twelfth — until the
+  timer overflowed and the stream stopped retrying. The shielded and dust wallets still carry the old schedule (#742).
 
-BREAKING CHANGE (`wallet-sdk`, `wallet-sdk-facade`, `wallet-sdk-unshielded-wallet`): `isStrictlyComplete()`,
-`isCompleteWithin()`, `FacadeState.isSynced` and `waitForSyncedState()` now also require the indexer not to trail the
-finalized head, a matching genesis, and a first verdict (`Skipped` — no node, or a simulation — does not block). On by
+BREAKING CHANGE (`wallet-sdk`, `wallet-sdk-facade`, `wallet-sdk-unshielded-wallet`): the unshielded wallet's
+`isStrictlyComplete()` and `isCompleteWithin()`, and through its progress `FacadeState.isSynced` and the facade's
+`waitForSyncedState()`, now also require the indexer not to trail the finalized head, a matching genesis, and a first
+verdict (`Skipped` — no node, or a simulation — does not block). On by
 default for every wallet with a `relayURL`. Against a stale indexer, `waitForSyncedState()` waits — it neither rejects
 nor times out; race it against a deadline of your own and read `progress.indexerLiveness` and `progress.isConnected`
 (the `indexer-liveness` docs snippet shows the pattern). `SyncProgressData` gains a required `indexerLiveness` field,

--- a/.changeset/indexer-liveness-cross-check.md
+++ b/.changeset/indexer-liveness-cross-check.md
@@ -13,8 +13,10 @@ The wallet now verifies "synced" against the chain instead of the indexer's self
 head (every 30 seconds by default) and, once, checks that both endpoints name the same genesis block. The node is
 `nodeClientConnection` on the configuration, falling back to `relayURL`; a wallet naming neither is not checked. The
 result is an `IndexerLiveness` verdict on `SyncProgress`: `Behind`, `Unknown` and `WrongNetwork` block completion; the
-other four (`InSync`, `Ahead`, `Unavailable`, `Skipped`) do not. Tune with `livenessConfiguration` and
-`livenessPollInterval`. This detects staleness, not withholding.
+other four (`InSync`, `Ahead`, `Unavailable`, `Skipped`) do not. A poll that fails after a `Behind` or `WrongNetwork`
+verdict leaves that verdict in place — an unreachable endpoint disproves nothing — so a node outage cannot release a
+caller waiting on a stale indexer. Tune with `livenessConfiguration` and `livenessPollInterval`. This detects
+staleness, not withholding.
 
 ### Fixes
 

--- a/.claude/rules/code-review.md
+++ b/.claude/rules/code-review.md
@@ -1,0 +1,29 @@
+# Code review — hard rules
+
+Always loaded (no path filter): these govern how a review finding becomes a change, whichever files it touches.
+
+## Turning a finding into a fix
+
+- **Translate first.** Before writing anything, restate the finding as the invariant it protects ("a failed poll must
+  not clear a proven `Behind`"), not as the reviewer's sentence. The invariant is what the test, the code and the
+  comments express; the reviewer's wording never appears in the repo.
+- **One finding, one TDD cycle** (`tdd` skill): design the test from the invariant, observe it fail for that reason,
+  stop for the user's review, then implement. A finding with no failing test is not fixed — it is asserted.
+- **Verify before agreeing.** Read the code the finding points at and confirm the claim holds; a review can be wrong or
+  half-right. Report what was confirmed, what was refuted, and any gap the suggested fix leaves open — but do not widen
+  the change to close that gap without the user's decision.
+- **Never weaken a test to satisfy a finding**, and never trade one guard for another silently. If the fix cannot pass
+  the test as written, present the gap to the user (`.claude/rules/testing.md` → TDD contract).
+
+## Where the trail lives
+
+- **Code and test comments state the invariant, for a reader with only the file open.** They never cite a review, a
+  reviewer, a PR thread, a ticket, or a conversation ("the reviewer flagged…", "as discussed in #659", "review
+  finding"). That context cannot be recovered from the file and ages into noise. `no-warning-comments` in
+  `eslint.config.mjs` fails the lint on these phrases as a backstop.
+- **Test names describe behaviour**, in the file's existing `should …, so/because …` style — not "regression for review
+  comment".
+- **History goes where history is kept:** the commit message may say what it addresses; the reply to the reviewer goes
+  in the PR thread, as a refinement loop with the user like any other GitHub content (CLAUDE.md → Git & GitHub
+  Conventions).
+- **Never resolve a review thread.** The reviewer resolves their own thread once they have seen the fix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ spec's test vectors — live in this repository, at `docs/spec/` and `packages/s
 
 Hard rules load automatically from `.claude/rules/` when matching files are touched: `functional-style.md` (SDK code),
 `testing.md` (tests), `transactions.md` (transaction-handling packages), `spec-reference.md` (key derivation / address
-formatting), `claude-config.md` (`.claude/**`).
+formatting), `claude-config.md` (`.claude/**`). `code-review.md` has no path filter and is always loaded: it governs how
+review findings are turned into fixes.
 
 **Specs over guesses:** never guess protocol or API semantics — consult the wallet spec (`docs/spec/Specification.md`,
 in-repo), the ledger spec (`midnightntwrk/midnight-ledger` → `spec/`), or the DApp Connector API

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,16 @@ export const defaultConfig = defineConfig(
       'eol-last': ['error', 'always'],
       'brace-style': ['error', 'stroustrup'],
       'no-console': 'warn',
+      // A comment must stand on its own for a reader with only the file open. One that cites a review, reviewer or PR
+      // thread as its justification carries context nobody can recover later — that history lives in the commit
+      // message and the PR. Backstop for `.claude/rules/code-review.md`.
+      'no-warning-comments': [
+        'error',
+        {
+          terms: ['reviewer', 'review finding', 'review comment', 'per review', 'as discussed', 'addresses comment'],
+          location: 'anywhere',
+        },
+      ],
       'no-unused-vars': 'off',
       'object-curly-newline': [
         'error',

--- a/packages/abstractions/src/IndexerLiveness.ts
+++ b/packages/abstractions/src/IndexerLiveness.ts
@@ -1,0 +1,288 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { Data } from 'effect';
+
+/**
+ * Why an indexer liveness check did not produce a verdict.
+ *
+ * @remarks
+ *   Modelled as a union rather than a bare boolean so that additional skip conditions can be introduced without a
+ *   breaking change to {@link IndexerLiveness}.
+ */
+export type SkipReason = 'no-node-configured' | 'simulation';
+
+/**
+ * The result of cross-checking an indexer's reported position against a node's finalized head.
+ *
+ * @remarks
+ *   An indexer reports its own progress, and nothing in that report is derived from consensus. A wallet that treats the
+ *   report as authoritative reports itself fully synchronized over a stale view when the indexer is stalled, lagging,
+ *   or withholding data. This type carries the outcome of an independent check against a node, so that "the indexer
+ *   says it is caught up" can be told apart from "the indexer agrees with the finalized chain".
+ *
+ *   Only {@link IndexerLiveness.Behind} and {@link IndexerLiveness.WrongNetwork} are negative verdicts.
+ *   {@link IndexerLiveness.Skipped} and {@link IndexerLiveness.Unknown} both mean "no verdict was reached", and must not
+ *   gate sync completion — a caller that configured no node endpoint would otherwise never observe a synchronized
+ *   wallet.
+ */
+export type IndexerLiveness = Data.TaggedEnum<{
+  /** The check could not run at all. Carries no judgement about the indexer. */
+  Skipped: { readonly reason: SkipReason };
+
+  /** The check can run but has not yet produced its first verdict. */
+  Unknown: {}; // eslint-disable-line @typescript-eslint/no-empty-object-type
+
+  /**
+   * The check is configured, but its most recent poll could not complete.
+   *
+   * @remarks
+   *   Either read may be the one that failed — the node's finalized head or the indexer's latest block — or the poll as a
+   *   whole may have timed out; `lastError` says which. A failed poll proves nothing about the indexer's own progress,
+   *   so this verdict does not gate sync completion — a node outage must not make a wallet whose indexer is healthy
+   *   report itself unsynchronized. It is a distinct variant rather than a reuse of {@link IndexerLiveness.Unknown} so
+   *   that a misconfigured or dead endpoint is visible to the caller instead of being indistinguishable from a check
+   *   that has not yet run. The protection this check provides degrades while polls fail, and this variant is how that
+   *   degradation announces itself.
+   */
+  Unavailable: {
+    /** How many consecutive polls have failed. */
+    readonly consecutiveFailures: number;
+    /** The message from the most recent failure. It names the read that failed, for diagnosis. */
+    readonly lastError: string;
+  };
+
+  /** The indexer's position is within the accepted tolerance of the node's finalized head. */
+  InSync: {
+    /** The height of the latest block the indexer reports having processed. */
+    readonly indexerHeight: bigint;
+    /** The height of the node's highest finalized block. */
+    readonly finalizedHeight: bigint;
+  };
+
+  /** The indexer's position trails the node's finalized head by more than the accepted tolerance. */
+  Behind: {
+    /** The height of the latest block the indexer reports having processed. */
+    readonly indexerHeight: bigint;
+    /** The height of the node's highest finalized block. */
+    readonly finalizedHeight: bigint;
+    /** How far the indexer trails the finalized head, in blocks. Always greater than the accepted tolerance. */
+    readonly lag: bigint;
+  };
+
+  /**
+   * The indexer claims a position further ahead of the node's finalized head than read skew can explain.
+   *
+   * @remarks
+   *   The indexer ingests finalized blocks only — `subscribe_finalized_blocks` is its sole chain subscription — so its
+   *   reported block is a finalized one and cannot legitimately run far ahead of a node's finalized head. The chains
+   *   are already known to match by the time heights are compared (a mismatch is {@link IndexerLiveness.WrongNetwork}
+   *   and pre-empts every height verdict), so a large overshoot means either a node endpoint whose finality lags — one
+   *   restarting or resyncing — or an indexer reporting a height it cannot support. Without this variant,
+   *   over-reporting would be a cost-free way to pass a liveness check.
+   */
+  Ahead: {
+    /** The height of the latest block the indexer reports having processed. */
+    readonly indexerHeight: bigint;
+    /** The height of the node's highest finalized block. */
+    readonly finalizedHeight: bigint;
+    /** How far the indexer leads the finalized head, in blocks. Always greater than the accepted tolerance. */
+    readonly overshoot: bigint;
+  };
+
+  /**
+   * The indexer and the node report different genesis blocks: they are on different chains.
+   *
+   * @remarks
+   *   Unlike {@link IndexerLiveness.Unavailable}, this cannot be transient. Both hashes were read successfully and differ,
+   *   which proves at least one of the two endpoints points at another chain — and it will keep pointing there until
+   *   reconfigured. Every height the indexer reports therefore describes a different chain, so height comparison is
+   *   meaningless and this verdict gates sync completion (see {@link IndexerLiveness.blocksSyncCompletion}): an
+   *   application waiting for sync must not proceed — and then submit — over data from the wrong network. Both hashes
+   *   are carried as reported, so a diagnostic can show the operator exactly what each endpoint answered.
+   */
+  WrongNetwork: {
+    /** The hash of the indexer's block at height zero, as the indexer reported it. */
+    readonly indexerGenesisHash: string;
+    /** The node's genesis hash, as the node reported it. */
+    readonly nodeGenesisHash: string;
+  };
+}>;
+
+const IndexerLiveness = Data.taggedEnum<IndexerLiveness>();
+
+/** A type predicate that determines if a given value is an {@link IndexerLiveness.Skipped} enum variant. */
+export const isSkipped = IndexerLiveness.$is('Skipped');
+
+/** A type predicate that determines if a given value is an {@link IndexerLiveness.Unknown} enum variant. */
+export const isUnknown = IndexerLiveness.$is('Unknown');
+
+/** A type predicate that determines if a given value is an {@link IndexerLiveness.InSync} enum variant. */
+export const isInSync = IndexerLiveness.$is('InSync');
+
+/** A type predicate that determines if a given value is an {@link IndexerLiveness.Behind} enum variant. */
+export const isBehind = IndexerLiveness.$is('Behind');
+
+/** A type predicate that determines if a given value is an {@link IndexerLiveness.Ahead} enum variant. */
+export const isAhead = IndexerLiveness.$is('Ahead');
+
+/** A type predicate that determines if a given value is an {@link IndexerLiveness.Unavailable} enum variant. */
+export const isUnavailable = IndexerLiveness.$is('Unavailable');
+
+/** A type predicate that determines if a given value is an {@link IndexerLiveness.WrongNetwork} enum variant. */
+export const isWrongNetwork = IndexerLiveness.$is('WrongNetwork');
+
+export const { $match: match, Skipped, Unknown, InSync, Behind, Ahead, Unavailable, WrongNetwork } = IndexerLiveness;
+
+/**
+ * Decides whether two genesis-block hashes name the same chain.
+ *
+ * @remarks
+ *   Presentation differs by source — a node reports its genesis hash `0x`-prefixed and lowercase, an indexer serves a
+ *   plain hex string with no guaranteed prefix or case — so only the bytes may decide. A formatting difference reported
+ *   as a wrong network would gate a correctly configured wallet forever.
+ * @param left - One genesis-block hash, in any hex presentation.
+ * @param right - The other genesis-block hash, in any hex presentation.
+ * @returns `true` when both hashes carry the same bytes.
+ */
+export const sameGenesis = (left: string, right: string): boolean => normalizeHash(left) === normalizeHash(right);
+
+/** Reduces a hex hash to bare lowercase digits, so presentation cannot influence a comparison. */
+const normalizeHash = (hash: string): string => hash.toLowerCase().replace(/^0x/, '');
+
+/**
+ * Determines whether a verdict shows the indexer to be serving a stale view of the chain.
+ *
+ * @remarks
+ *   It holds for {@link IndexerLiveness.Behind} alone. Only that verdict proves something about the data the wallet is
+ *   using: the indexer is missing finalized blocks, so the wallet's view is genuinely out of date. Sync-completion
+ *   checks gate on {@link blocksSyncCompletion} instead, which additionally holds for {@link IndexerLiveness.Unknown} —
+ *   staleness proven and staleness not-yet-ruled-out are different statements, and this predicate makes only the
+ *   first.
+ * @example
+ *   ```ts
+ *   const knownStale = IndexerLiveness.indicatesStaleView(progress.indexerLiveness);
+ *   ```;
+ *
+ * @param liveness - The verdict to test.
+ * @returns `true` when the indexer is known to trail the finalized head beyond the accepted tolerance.
+ */
+export const indicatesStaleView = (liveness: IndexerLiveness): boolean => isBehind(liveness);
+
+/**
+ * Determines whether a verdict must keep a wallet from reporting itself synchronized.
+ *
+ * @remarks
+ *   This is the predicate that sync-completion checks gate on, rather than testing for individual variants.
+ *
+ *   It holds for {@link IndexerLiveness.Behind}, which proves the wallet's view is out of date, and for
+ *   {@link IndexerLiveness.Unknown}, which records that a check exists but has not yet reached its first verdict. The
+ *   second matters because the first verdict needs a node connection and a metadata download — seconds — while the
+ *   indexer's first progress update lands in well under one. If `Unknown` did not block, a wallet with a stalled
+ *   indexer would report itself synchronized in exactly that window, over exactly the stale view the check exists to
+ *   catch.
+ *
+ *   It deliberately does not hold for {@link IndexerLiveness.Skipped}: that variant means no verdict is ever coming, so
+ *   blocking on it would leave every wallet without a node endpoint permanently unsynchronized — which is why `Skipped`
+ *   and `Unknown` are distinct variants. Nor does it hold for {@link IndexerLiveness.Unavailable} — a failed poll proves
+ *   nothing about the indexer's progress — or for {@link IndexerLiveness.Ahead}, which cannot distinguish a wrong
+ *   indexer from a lagging node endpoint. Wrong-network deployments do gate, but through
+ *   {@link IndexerLiveness.WrongNetwork}, whose genesis-hash comparison is deterministic where a height threshold could
+ *   never be.
+ * @example
+ *   ```ts
+ *   const canReportSynced = !IndexerLiveness.blocksSyncCompletion(progress.indexerLiveness);
+ *   ```;
+ *
+ * @param liveness - The verdict to test.
+ * @returns `true` when the wallet must not report itself synchronized under this verdict.
+ */
+export const blocksSyncCompletion = (liveness: IndexerLiveness): boolean =>
+  isBehind(liveness) || isUnknown(liveness) || isWrongNetwork(liveness);
+
+/**
+ * Compares an indexer's reported block height against a node's finalized block height.
+ *
+ * @remarks
+ *   The two tolerances are separate because they bound different things. `maxBehindBlocks` is a staleness allowance — how
+ *   out-of-date a view a caller is willing to treat as current — and can be generous. `maxAheadBlocks` bounds read
+ *   skew: the indexer ingests finalized blocks only, so it cannot legitimately lead a node's finalized head by more
+ *   than the time between the two reads accounts for, and this value should stay small. A single shared tolerance would
+ *   force a generous staleness allowance to also admit a large fabricated overshoot.
+ * @example
+ *   ```ts
+ *   const verdict = IndexerLiveness.evaluate({
+ *     indexerHeight: 1_000n,
+ *     finalizedHeight: 1_030n,
+ *     maxBehindBlocks: 10n,
+ *     maxAheadBlocks: 2n,
+ *   });
+ *   // IndexerLiveness.Behind({ indexerHeight: 1000n, finalizedHeight: 1030n, lag: 30n })
+ *   ```;
+ *
+ * @param params - The two heights to compare, and the tolerances to allow in each direction.
+ * @param params.indexerHeight - The height of the latest block the indexer reports having processed.
+ * @param params.finalizedHeight - The height of the node's highest finalized block.
+ * @param params.maxBehindBlocks - How many blocks the indexer may trail the finalized head by and still count as in
+ *   sync. `0n` requires the indexer to have reached the finalized head exactly.
+ * @param params.maxAheadBlocks - How many blocks the indexer may lead the finalized head by and still count as in sync.
+ *   `0n` admits no overshoot at all.
+ * @returns {@link IndexerLiveness.Behind} When the indexer trails by more than `maxBehindBlocks`,
+ *   {@link IndexerLiveness.Ahead} when it leads by more than `maxAheadBlocks`, and {@link IndexerLiveness.InSync}
+ *   otherwise. Never {@link IndexerLiveness.Skipped} or {@link IndexerLiveness.Unknown}, which describe the absence of a
+ *   check rather than its outcome.
+ */
+export const evaluate = ({
+  indexerHeight,
+  finalizedHeight,
+  maxBehindBlocks,
+  maxAheadBlocks,
+}: {
+  readonly indexerHeight: bigint;
+  readonly finalizedHeight: bigint;
+  readonly maxBehindBlocks: bigint;
+  readonly maxAheadBlocks: bigint;
+}): IndexerLiveness => {
+  const lag = finalizedHeight - indexerHeight;
+  const overshoot = -lag;
+
+  return lag > maxBehindBlocks
+    ? Behind({ indexerHeight, finalizedHeight, lag })
+    : overshoot > maxAheadBlocks
+      ? Ahead({ indexerHeight, finalizedHeight, overshoot })
+      : InSync({ indexerHeight, finalizedHeight });
+};
+
+/**
+ * Produces the verdict that follows an attempt to read the node failing.
+ *
+ * @remarks
+ *   The consecutive-failure count is the only state a liveness check carries between polls, and this function is where it
+ *   advances. It counts up while failures continue, so a caller can tell a single missed poll from a node that has been
+ *   unreachable for a long time, and resets once any other verdict has intervened, so a fresh outage is not reported as
+ *   a continuing one.
+ * @example
+ *   ```ts
+ *   const next = IndexerLiveness.afterFailedPoll(previous, 'websocket closed');
+ *   ```;
+ *
+ * @param previous - The verdict before this poll.
+ * @param lastError - The message from the failure that just occurred.
+ * @returns An {@link IndexerLiveness.Unavailable} verdict whose count continues the previous run of failures, or starts
+ *   a new one.
+ */
+export const afterFailedPoll = (previous: IndexerLiveness, lastError: string): IndexerLiveness =>
+  Unavailable({
+    // Any other verdict means the node was reachable since the last failure, so this outage starts a fresh count.
+    consecutiveFailures: isUnavailable(previous) ? previous.consecutiveFailures + 1 : 1,
+    lastError,
+  });

--- a/packages/abstractions/src/IndexerLiveness.ts
+++ b/packages/abstractions/src/IndexerLiveness.ts
@@ -71,7 +71,13 @@ export type IndexerLiveness = Data.TaggedEnum<{
     readonly lastError: string;
   };
 
-  /** The indexer's position is within the accepted tolerance of the node's finalized head. */
+  /**
+   * The indexer's position is within the accepted tolerance of the node's finalized head.
+   *
+   * @remarks
+   *   The heights are those at which this verdict was first reached, not the chain's current position: a publisher that
+   *   deduplicates with {@link equivalent} does not republish an `InSync` for the chain merely advancing.
+   */
   InSync: {
     /** The height of the latest block the indexer reports having processed. */
     readonly indexerHeight: bigint;
@@ -305,3 +311,41 @@ export const afterFailedPoll = (previous: IndexerLiveness, lastError: string): I
         consecutiveFailures: isUnavailable(previous) ? previous.consecutiveFailures + 1 : 1,
         lastError,
       });
+
+/**
+ * Decides whether two verdicts say the same thing to a caller.
+ *
+ * @remarks
+ *   Structural equality is the wrong test for "has anything changed": {@link IndexerLiveness.InSync},
+ *   {@link IndexerLiveness.Behind} and {@link IndexerLiveness.Ahead} carry the two heights they were computed from, and
+ *   on a live chain both advance about five blocks per poll, so consecutive verdicts are never structurally equal. A
+ *   publisher deduplicating on structure would fan a new wallet state out to every subscriber once per poll, forever,
+ *   with nothing about the wallet changed.
+ *
+ *   What a caller acts on is the kind of verdict and, where the variant carries one, its magnitude: a `Behind` whose lag
+ *   has grown is news, a lengthening outage keeps counting, and a different reason or a different pair of hashes is a
+ *   different statement. The heights alone are not: an `InSync` at a later height is the same report as the one before
+ *   it. A publisher that deduplicates with this predicate therefore leaves the heights on a published verdict as they
+ *   were when that verdict was first reached.
+ * @example
+ *   ```ts
+ *   const quiet = verdicts.pipe(Stream.changesWith(IndexerLiveness.equivalent));
+ *   ```;
+ *
+ * @param left - One verdict.
+ * @param right - The other.
+ * @returns `true` when a caller would learn nothing new from `right` after `left`.
+ */
+export const equivalent = (left: IndexerLiveness, right: IndexerLiveness): boolean =>
+  match(left, {
+    Skipped: ({ reason }) => isSkipped(right) && right.reason === reason,
+    Unknown: () => isUnknown(right),
+    Unavailable: ({ consecutiveFailures }) => isUnavailable(right) && right.consecutiveFailures === consecutiveFailures,
+    InSync: () => isInSync(right),
+    Behind: ({ lag }) => isBehind(right) && right.lag === lag,
+    Ahead: () => isAhead(right),
+    WrongNetwork: ({ indexerGenesisHash, nodeGenesisHash }) =>
+      isWrongNetwork(right) &&
+      right.indexerGenesisHash === indexerGenesisHash &&
+      right.nodeGenesisHash === nodeGenesisHash,
+  });

--- a/packages/abstractions/src/IndexerLiveness.ts
+++ b/packages/abstractions/src/IndexerLiveness.ts
@@ -18,8 +18,13 @@ import { Data } from 'effect';
  * @remarks
  *   Modelled as a union rather than a bare boolean so that additional skip conditions can be introduced without a
  *   breaking change to {@link IndexerLiveness}.
+ *
+ *   - `no-node-configured`: the default sync service found no node endpoint to compare the indexer against.
+ *   - `simulation`: the wallet syncs from an in-memory simulator, which has no node and never will.
+ *   - `no-liveness-feed`: the wallet's sync service exposes no liveness feed at all — a custom source supplied through the
+ *       builder — so no check can exist for it to run.
  */
-export type SkipReason = 'no-node-configured' | 'simulation';
+export type SkipReason = 'no-node-configured' | 'simulation' | 'no-liveness-feed';
 
 /**
  * The result of cross-checking an indexer's reported position against a node's finalized head.

--- a/packages/abstractions/src/IndexerLiveness.ts
+++ b/packages/abstractions/src/IndexerLiveness.ts
@@ -53,6 +53,11 @@ export type IndexerLiveness = Data.TaggedEnum<{
    *   that a misconfigured or dead endpoint is visible to the caller instead of being indistinguishable from a check
    *   that has not yet run. The protection this check provides degrades while polls fail, and this variant is how that
    *   degradation announces itself.
+   *
+   *   A failed poll never replaces a verdict that gates. {@link IndexerLiveness.Behind} and
+   *   {@link IndexerLiveness.WrongNetwork} are proofs about the indexer, and an endpoint going quiet disproves neither —
+   *   only a successful comparison can. Were they replaced, one timeout would open the sync gate over the same stale
+   *   view the previous poll caught; see {@link afterFailedPoll}.
    */
   Unavailable: {
     /** How many consecutive polls have failed. */
@@ -263,13 +268,19 @@ export const evaluate = ({
 };
 
 /**
- * Produces the verdict that follows an attempt to read the node failing.
+ * Produces the verdict that follows a poll failing.
  *
  * @remarks
- *   The consecutive-failure count is the only state a liveness check carries between polls, and this function is where it
- *   advances. It counts up while failures continue, so a caller can tell a single missed poll from a node that has been
- *   unreachable for a long time, and resets once any other verdict has intervened, so a fresh outage is not reported as
- *   a continuing one.
+ *   A verdict that gates sync completion on the strength of a successful comparison — {@link IndexerLiveness.Behind} or
+ *   {@link IndexerLiveness.WrongNetwork} — is kept as it is. A failed poll proves nothing, so it cannot disprove what an
+ *   earlier poll established; only another successful comparison can. Replacing such a verdict with
+ *   {@link IndexerLiveness.Unavailable}, which does not gate, would let a single timeout release a caller waiting on a
+ *   stale indexer.
+ *
+ *   Every other verdict becomes `Unavailable`. Its consecutive-failure count is the only state a liveness check carries
+ *   between polls, and this function is where it advances. It counts up while failures continue, so a caller can tell a
+ *   single missed poll from a node that has been unreachable for a long time, and resets once any other verdict has
+ *   intervened, so a fresh outage is not reported as a continuing one.
  * @example
  *   ```ts
  *   const next = IndexerLiveness.afterFailedPoll(previous, 'websocket closed');
@@ -277,12 +288,15 @@ export const evaluate = ({
  *
  * @param previous - The verdict before this poll.
  * @param lastError - The message from the failure that just occurred.
- * @returns An {@link IndexerLiveness.Unavailable} verdict whose count continues the previous run of failures, or starts
- *   a new one.
+ * @returns `previous` unchanged when it is {@link IndexerLiveness.Behind} or {@link IndexerLiveness.WrongNetwork};
+ *   otherwise an {@link IndexerLiveness.Unavailable} verdict whose count continues the previous run of failures, or
+ *   starts a new one.
  */
 export const afterFailedPoll = (previous: IndexerLiveness, lastError: string): IndexerLiveness =>
-  Unavailable({
-    // Any other verdict means the node was reachable since the last failure, so this outage starts a fresh count.
-    consecutiveFailures: isUnavailable(previous) ? previous.consecutiveFailures + 1 : 1,
-    lastError,
-  });
+  isBehind(previous) || isWrongNetwork(previous)
+    ? previous
+    : Unavailable({
+        // Any other verdict means the node was reachable since the last failure, so this outage starts a fresh count.
+        consecutiveFailures: isUnavailable(previous) ? previous.consecutiveFailures + 1 : 1,
+        lastError,
+      });

--- a/packages/abstractions/src/index.ts
+++ b/packages/abstractions/src/index.ts
@@ -17,6 +17,7 @@ export * as ProtocolState from './ProtocolState.js';
 export * as ProtocolVersion from './ProtocolVersion.js';
 export * as NetworkId from './NetworkId.js';
 export * as SyncProgress from './SyncProgress.js';
+export * as IndexerLiveness from './IndexerLiveness.js';
 export * from './InMemoryTransactionHistoryStorage.js';
 export * from './NoOpTransactionHistoryStorage.js';
 export * as TransactionHistoryStorage from './TransactionHistoryStorage.js';

--- a/packages/abstractions/src/test/indexerLiveness.test.ts
+++ b/packages/abstractions/src/test/indexerLiveness.test.ts
@@ -1,0 +1,280 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { describe, expect, it } from 'vitest';
+import * as IndexerLiveness from '../IndexerLiveness.js';
+
+/** Tolerances used throughout: a generous staleness allowance, and a tight bound on read skew. */
+const tolerances = { maxBehindBlocks: 10n, maxAheadBlocks: 2n };
+
+describe('IndexerLiveness', () => {
+  describe('evaluate', () => {
+    describe('when the indexer agrees with the finalized head', () => {
+      it('should report InSync when the indexer is exactly at the finalized head', () => {
+        const result = IndexerLiveness.evaluate({ indexerHeight: 1_000n, finalizedHeight: 1_000n, ...tolerances });
+
+        expect(result).toStrictEqual(IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n }));
+      });
+
+      it('should report InSync when the indexer trails by less than maxBehindBlocks', () => {
+        const result = IndexerLiveness.evaluate({ indexerHeight: 995n, finalizedHeight: 1_000n, ...tolerances });
+
+        expect(result).toStrictEqual(IndexerLiveness.InSync({ indexerHeight: 995n, finalizedHeight: 1_000n }));
+      });
+
+      it('should report InSync when the indexer trails by exactly maxBehindBlocks', () => {
+        const result = IndexerLiveness.evaluate({ indexerHeight: 990n, finalizedHeight: 1_000n, ...tolerances });
+
+        expect(result).toStrictEqual(IndexerLiveness.InSync({ indexerHeight: 990n, finalizedHeight: 1_000n }));
+      });
+
+      it('should report InSync when the indexer leads by exactly maxAheadBlocks, which read skew can explain', () => {
+        // The indexer height and the finalized height are read at different moments, so a small lead is expected.
+        const result = IndexerLiveness.evaluate({ indexerHeight: 1_002n, finalizedHeight: 1_000n, ...tolerances });
+
+        expect(result).toStrictEqual(IndexerLiveness.InSync({ indexerHeight: 1_002n, finalizedHeight: 1_000n }));
+      });
+    });
+
+    describe('when the indexer trails the finalized head', () => {
+      it('should report Behind when the lag exceeds maxBehindBlocks by one block', () => {
+        const result = IndexerLiveness.evaluate({ indexerHeight: 989n, finalizedHeight: 1_000n, ...tolerances });
+
+        expect(result).toStrictEqual(
+          IndexerLiveness.Behind({ indexerHeight: 989n, finalizedHeight: 1_000n, lag: 11n }),
+        );
+      });
+
+      it('should report Behind carrying both heights and the lag, so a caller can surface how stale the view is', () => {
+        const result = IndexerLiveness.evaluate({ indexerHeight: 1_000n, finalizedHeight: 5_000n, ...tolerances });
+
+        expect(result).toStrictEqual(
+          IndexerLiveness.Behind({ indexerHeight: 1_000n, finalizedHeight: 5_000n, lag: 4_000n }),
+        );
+      });
+    });
+
+    describe('when the indexer leads the finalized head', () => {
+      it('should report Ahead when the overshoot exceeds maxAheadBlocks by one block', () => {
+        const result = IndexerLiveness.evaluate({ indexerHeight: 1_003n, finalizedHeight: 1_000n, ...tolerances });
+
+        expect(result).toStrictEqual(
+          IndexerLiveness.Ahead({ indexerHeight: 1_003n, finalizedHeight: 1_000n, overshoot: 3n }),
+        );
+      });
+
+      it('should report Ahead for a height the finalized chain cannot support, rather than waving it through', () => {
+        // The indexer ingests finalized blocks only, so it cannot legitimately be this far ahead. Reporting InSync here
+        // would make over-reporting a cost-free way to pass the check.
+        const result = IndexerLiveness.evaluate({
+          indexerHeight: 999_999_999n,
+          finalizedHeight: 1_000n,
+          ...tolerances,
+        });
+
+        expect(result).toStrictEqual(
+          IndexerLiveness.Ahead({ indexerHeight: 999_999_999n, finalizedHeight: 1_000n, overshoot: 999_998_999n }),
+        );
+      });
+
+      it('should report Ahead when indexer and node are on different networks, a likely misconfiguration', () => {
+        const result = IndexerLiveness.evaluate({ indexerHeight: 4_200_000n, finalizedHeight: 12_500n, ...tolerances });
+
+        expect(result).toStrictEqual(
+          IndexerLiveness.Ahead({ indexerHeight: 4_200_000n, finalizedHeight: 12_500n, overshoot: 4_187_500n }),
+        );
+      });
+    });
+
+    describe('with zero tolerance in both directions', () => {
+      const strict = { maxBehindBlocks: 0n, maxAheadBlocks: 0n };
+
+      it('should report InSync only on exact agreement', () => {
+        const result = IndexerLiveness.evaluate({ indexerHeight: 1_000n, finalizedHeight: 1_000n, ...strict });
+
+        expect(result).toStrictEqual(IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n }));
+      });
+
+      it('should report Behind when the indexer trails by a single block', () => {
+        const result = IndexerLiveness.evaluate({ indexerHeight: 999n, finalizedHeight: 1_000n, ...strict });
+
+        expect(result).toStrictEqual(IndexerLiveness.Behind({ indexerHeight: 999n, finalizedHeight: 1_000n, lag: 1n }));
+      });
+
+      it('should report Ahead when the indexer leads by a single block', () => {
+        const result = IndexerLiveness.evaluate({ indexerHeight: 1_001n, finalizedHeight: 1_000n, ...strict });
+
+        expect(result).toStrictEqual(
+          IndexerLiveness.Ahead({ indexerHeight: 1_001n, finalizedHeight: 1_000n, overshoot: 1n }),
+        );
+      });
+    });
+
+    it('should never report Skipped or Unknown, which describe the absence of a check rather than its result', () => {
+      const result = IndexerLiveness.evaluate({ indexerHeight: 1_000n, finalizedHeight: 1_000n, ...tolerances });
+
+      expect(IndexerLiveness.isSkipped(result)).toBe(false);
+      expect(IndexerLiveness.isUnknown(result)).toBe(false);
+    });
+  });
+
+  describe('indicatesStaleView', () => {
+    it('should hold for Behind, the one verdict that proves the wallet is looking at out-of-date data', () => {
+      const verdict = IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_000n, lag: 100n });
+
+      expect(IndexerLiveness.indicatesStaleView(verdict)).toBe(true);
+    });
+
+    it('should not hold for Ahead, which cannot distinguish a wrong indexer from a lagging node', () => {
+      // Gating on this would report a healthy wallet as unsynchronized whenever its node endpoint fell behind. The
+      // verdict is still surfaced to callers; it just does not decide completion.
+      const verdict = IndexerLiveness.Ahead({ indexerHeight: 5_000n, finalizedHeight: 1_000n, overshoot: 4_000n });
+
+      expect(IndexerLiveness.indicatesStaleView(verdict)).toBe(false);
+    });
+
+    it('should not hold for InSync', () => {
+      const verdict = IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n });
+
+      expect(IndexerLiveness.indicatesStaleView(verdict)).toBe(false);
+    });
+
+    it('should not hold when the check was skipped, so a caller with no node endpoint is never judged', () => {
+      const verdict = IndexerLiveness.Skipped({ reason: 'no-node-configured' });
+
+      expect(IndexerLiveness.indicatesStaleView(verdict)).toBe(false);
+    });
+
+    it('should not hold before the first verdict arrives, so startup is not treated as staleness', () => {
+      expect(IndexerLiveness.indicatesStaleView(IndexerLiveness.Unknown())).toBe(false);
+    });
+
+    it('should not hold when the node cannot be reached, so a node outage never stalls a healthy wallet', () => {
+      // An unreachable node says nothing about the indexer. Gating here would make `waitForSyncedState` hang on a
+      // wallet whose indexer data is correct.
+      const verdict = IndexerLiveness.Unavailable({ consecutiveFailures: 12, lastError: 'websocket closed' });
+
+      expect(IndexerLiveness.indicatesStaleView(verdict)).toBe(false);
+    });
+  });
+
+  describe('blocksSyncCompletion', () => {
+    it('should hold for Behind, which proves the wallet is looking at out-of-date data', () => {
+      const verdict = IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_000n, lag: 100n });
+
+      expect(IndexerLiveness.blocksSyncCompletion(verdict)).toBe(true);
+    });
+
+    it('should hold for Unknown, so a check that has not run yet cannot be passed by racing it', () => {
+      // The first verdict needs a node connection and a metadata download — seconds — while the indexer's first
+      // progress update lands in well under one. If Unknown did not block, a wallet with a stalled indexer would
+      // report itself synchronized in exactly that window, over exactly the stale view the check exists to catch.
+      expect(IndexerLiveness.blocksSyncCompletion(IndexerLiveness.Unknown())).toBe(true);
+    });
+
+    it('should not hold when the check was skipped, so a caller with no node endpoint still completes', () => {
+      // Skipped means no verdict is ever coming. Blocking on it would leave every node-less wallet permanently
+      // unsynchronized — which is why Skipped and Unknown are distinct variants.
+      const verdict = IndexerLiveness.Skipped({ reason: 'no-node-configured' });
+
+      expect(IndexerLiveness.blocksSyncCompletion(verdict)).toBe(false);
+    });
+
+    it('should not hold when the node cannot be reached, so a node outage never stalls a healthy wallet', () => {
+      const verdict = IndexerLiveness.Unavailable({ consecutiveFailures: 3, lastError: 'websocket closed' });
+
+      expect(IndexerLiveness.blocksSyncCompletion(verdict)).toBe(false);
+    });
+
+    it('should not hold for InSync or Ahead', () => {
+      expect(
+        IndexerLiveness.blocksSyncCompletion(
+          IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n }),
+        ),
+      ).toBe(false);
+      expect(
+        IndexerLiveness.blocksSyncCompletion(
+          IndexerLiveness.Ahead({ indexerHeight: 5_000n, finalizedHeight: 1_000n, overshoot: 4_000n }),
+        ),
+      ).toBe(false);
+    });
+
+    it('should hold for WrongNetwork, because every height the indexer reports describes a different chain', () => {
+      // Unlike Unavailable, a genesis mismatch cannot be transient: the hashes are read successfully and differ, which
+      // proves one of the two endpoints points at another chain and will keep pointing there until reconfigured. An
+      // application waiting for sync must not proceed — and then submit — over data from the wrong network.
+      const verdict = IndexerLiveness.WrongNetwork({
+        indexerGenesisHash: 'aa'.repeat(32),
+        nodeGenesisHash: `0x${'bb'.repeat(32)}`,
+      });
+
+      expect(IndexerLiveness.blocksSyncCompletion(verdict)).toBe(true);
+    });
+  });
+
+  describe('indicatesStaleView for WrongNetwork', () => {
+    it('should not hold, because wrong-network data is not stale — it is from another chain entirely', () => {
+      // `indicatesStaleView` answers "may this balance be missing recent funds?". Wrong-network data deserves its own,
+      // louder message, which callers write by matching the variant — not the staleness one.
+      const verdict = IndexerLiveness.WrongNetwork({
+        indexerGenesisHash: 'aa'.repeat(32),
+        nodeGenesisHash: `0x${'bb'.repeat(32)}`,
+      });
+
+      expect(IndexerLiveness.indicatesStaleView(verdict)).toBe(false);
+    });
+  });
+
+  describe('sameGenesis', () => {
+    it('should tolerate presentation differences, so a formatting mismatch is never reported as a wrong network', () => {
+      // The node reports its genesis hash 0x-prefixed and lowercase; the indexer serves a plain hex string with no
+      // guaranteed prefix or case. Only the bytes may decide.
+      expect(IndexerLiveness.sameGenesis(`0x${'Ab'.repeat(32)}`, 'aB'.repeat(32))).toBe(true);
+      expect(IndexerLiveness.sameGenesis('ab'.repeat(32), 'ab'.repeat(32))).toBe(true);
+    });
+
+    it('should reject different hashes regardless of formatting', () => {
+      expect(IndexerLiveness.sameGenesis(`0x${'aa'.repeat(32)}`, `0x${'bb'.repeat(32)}`)).toBe(false);
+      expect(IndexerLiveness.sameGenesis('aa'.repeat(32), 'bb'.repeat(32))).toBe(false);
+    });
+  });
+
+  describe('afterFailedPoll', () => {
+    it('should report a single failure when no failure preceded it', () => {
+      const result = IndexerLiveness.afterFailedPoll(IndexerLiveness.Unknown(), 'websocket closed');
+
+      expect(result).toStrictEqual(
+        IndexerLiveness.Unavailable({ consecutiveFailures: 1, lastError: 'websocket closed' }),
+      );
+    });
+
+    it('should count consecutive failures up, so a long outage is distinguishable from a missed poll', () => {
+      const previous = IndexerLiveness.Unavailable({ consecutiveFailures: 11, lastError: 'websocket closed' });
+
+      const result = IndexerLiveness.afterFailedPoll(previous, 'websocket closed');
+
+      expect(result).toStrictEqual(
+        IndexerLiveness.Unavailable({ consecutiveFailures: 12, lastError: 'websocket closed' }),
+      );
+    });
+
+    it('should restart the count when another verdict intervened, so a fresh outage is not reported as a continuing one', () => {
+      const previous = IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n });
+
+      const result = IndexerLiveness.afterFailedPoll(previous, 'connection refused');
+
+      expect(result).toStrictEqual(
+        IndexerLiveness.Unavailable({ consecutiveFailures: 1, lastError: 'connection refused' }),
+      );
+    });
+  });
+});

--- a/packages/abstractions/src/test/indexerLiveness.test.ts
+++ b/packages/abstractions/src/test/indexerLiveness.test.ts
@@ -298,4 +298,71 @@ describe('IndexerLiveness', () => {
       expect(IndexerLiveness.blocksSyncCompletion(result)).toBe(true);
     });
   });
+
+  describe('equivalent', () => {
+    // The heights on InSync, Behind and Ahead advance with the chain — about five blocks per poll — so two consecutive
+    // verdicts are never structurally equal on a live network. A dedup keyed on structure therefore never dedups, and a
+    // healthy idle wallet republishes its whole state to every subscriber once per poll, forever. What a caller acts on
+    // is the kind of verdict and, where the variant carries one, its magnitude: the lag, the failure count, the hashes.
+    it('should treat InSync verdicts at different heights as the same report', () => {
+      const earlier = IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n });
+      const later = IndexerLiveness.InSync({ indexerHeight: 1_005n, finalizedHeight: 1_005n });
+
+      expect(IndexerLiveness.equivalent(earlier, later)).toBe(true);
+    });
+
+    it('should treat Ahead verdicts as the same report whatever the heights, since only the kind is acted on', () => {
+      const earlier = IndexerLiveness.Ahead({ indexerHeight: 1_020n, finalizedHeight: 1_000n, overshoot: 20n });
+      const later = IndexerLiveness.Ahead({ indexerHeight: 1_030n, finalizedHeight: 1_005n, overshoot: 25n });
+
+      expect(IndexerLiveness.equivalent(earlier, later)).toBe(true);
+    });
+
+    it('should distinguish verdicts of different kinds', () => {
+      const inSync = IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n });
+      const behind = IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_000n, lag: 100n });
+
+      expect(IndexerLiveness.equivalent(inSync, behind)).toBe(false);
+    });
+
+    it('should treat Behind verdicts with the same lag at different heights as the same report', () => {
+      const earlier = IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_000n, lag: 100n });
+      const later = IndexerLiveness.Behind({ indexerHeight: 905n, finalizedHeight: 1_005n, lag: 100n });
+
+      expect(IndexerLiveness.equivalent(earlier, later)).toBe(true);
+    });
+
+    it('should distinguish Behind verdicts whose lag changed, because a growing lag is news', () => {
+      const earlier = IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_000n, lag: 100n });
+      const later = IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_005n, lag: 105n });
+
+      expect(IndexerLiveness.equivalent(earlier, later)).toBe(false);
+    });
+
+    it('should distinguish Unavailable verdicts by their failure count, so a lengthening outage keeps reporting', () => {
+      const first = IndexerLiveness.Unavailable({ consecutiveFailures: 1, lastError: 'websocket closed' });
+      const second = IndexerLiveness.Unavailable({ consecutiveFailures: 2, lastError: 'websocket closed' });
+
+      expect(IndexerLiveness.equivalent(first, first)).toBe(true);
+      expect(IndexerLiveness.equivalent(first, second)).toBe(false);
+    });
+
+    it('should distinguish Skipped verdicts by reason and WrongNetwork verdicts by their hashes', () => {
+      const noNode = IndexerLiveness.Skipped({ reason: 'no-node-configured' });
+      const simulation = IndexerLiveness.Skipped({ reason: 'simulation' });
+      const mismatch = IndexerLiveness.WrongNetwork({
+        indexerGenesisHash: 'aa'.repeat(32),
+        nodeGenesisHash: 'bb'.repeat(32),
+      });
+      const otherMismatch = IndexerLiveness.WrongNetwork({
+        indexerGenesisHash: 'aa'.repeat(32),
+        nodeGenesisHash: 'cc'.repeat(32),
+      });
+
+      expect(IndexerLiveness.equivalent(noNode, noNode)).toBe(true);
+      expect(IndexerLiveness.equivalent(noNode, simulation)).toBe(false);
+      expect(IndexerLiveness.equivalent(mismatch, mismatch)).toBe(true);
+      expect(IndexerLiveness.equivalent(mismatch, otherMismatch)).toBe(false);
+    });
+  });
 });

--- a/packages/abstractions/src/test/indexerLiveness.test.ts
+++ b/packages/abstractions/src/test/indexerLiveness.test.ts
@@ -276,5 +276,26 @@ describe('IndexerLiveness', () => {
         IndexerLiveness.Unavailable({ consecutiveFailures: 1, lastError: 'connection refused' }),
       );
     });
+
+    it('should keep a proven Behind, because a failed poll disproves nothing and Unavailable would open the sync gate', () => {
+      const previous = IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_000n, lag: 100n });
+
+      const result = IndexerLiveness.afterFailedPoll(previous, 'websocket closed');
+
+      expect(result).toStrictEqual(previous);
+      expect(IndexerLiveness.blocksSyncCompletion(result)).toBe(true);
+    });
+
+    it('should keep a proven WrongNetwork, because a chain mismatch cannot be undone by an unreachable endpoint', () => {
+      const previous = IndexerLiveness.WrongNetwork({
+        indexerGenesisHash: 'aa'.repeat(32),
+        nodeGenesisHash: `0x${'bb'.repeat(32)}`,
+      });
+
+      const result = IndexerLiveness.afterFailedPoll(previous, 'websocket closed');
+
+      expect(result).toStrictEqual(previous);
+      expect(IndexerLiveness.blocksSyncCompletion(result)).toBe(true);
+    });
   });
 });

--- a/packages/capabilities/src/liveness/index.ts
+++ b/packages/capabilities/src/liveness/index.ts
@@ -10,10 +10,5 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-export * from './balancer/index.js';
-export * from './liveness/index.js';
-export * from './pendingTransactions/index.js';
-export * from './proving/index.js';
-export * from './simulation/index.js';
-export * from './submission/index.js';
-export * from './validation/index.js';
+export * from './livenessReads.js';
+export * from './livenessService.js';

--- a/packages/capabilities/src/liveness/livenessReads.ts
+++ b/packages/capabilities/src/liveness/livenessReads.ts
@@ -1,0 +1,290 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { BlockHash } from '@midnightntwrk/wallet-sdk-indexer-client';
+import { HttpQueryClient } from '@midnightntwrk/wallet-sdk-indexer-client/effect';
+import {
+  type NodeClient,
+  type NodeClientError,
+  PolkadotNodeClient,
+} from '@midnightntwrk/wallet-sdk-node-client/effect';
+import { Duration, Effect, Option, Scope, SynchronizedRef } from 'effect';
+import { type LivenessReads, LivenessReadError } from './livenessService.js';
+
+/**
+ * How long to spend trying to reach the node before giving up on a poll.
+ *
+ * @remarks
+ *   `PolkadotNodeClient` defaults to `Duration.infinity`, which suits transaction submission — a caller waiting to submit
+ *   wants to keep trying. It is wrong here: a liveness check that waits forever on an unreachable node never publishes
+ *   the {@link IndexerLiveness.Unavailable} verdict that exists to report exactly that condition, and its poll fibre
+ *   hangs instead. This bound must stay well under the poll interval so a failing read cannot outlive the tick that
+ *   started it.
+ */
+const NODE_CONNECTION_TIMEOUT = Duration.seconds(10);
+
+/**
+ * Flattens a chain of wrapped errors into one line.
+ *
+ * @remarks
+ *   Both sources wrap their failures — the node client reports "Failed to retrieve the finalized block" over whatever the
+ *   RPC actually said. Only the outermost message would otherwise reach `Unavailable.lastError`, which names the
+ *   operation that failed but not the reason, and so cannot be acted on.
+ */
+const describeCause = (error: unknown): string =>
+  error instanceof Error
+    ? error.cause === undefined || error.cause === null
+      ? error.message
+      : `${error.message}: ${describeCause(error.cause)}`
+    : String(error);
+
+/**
+ * Parses a block height reported by the indexer.
+ *
+ * @remarks
+ *   `BigInt` throws a `RangeError` on a non-integral number, and the indexer's payload is not validated against a schema
+ *   anywhere on this path. A misbehaving indexer answering `1.5` would therefore raise a defect inside the poll and
+ *   stop it permanently — letting the very party this check exists to catch switch it off. Parsing here keeps that a
+ *   typed failure, which becomes an `Unavailable` verdict like any other unreadable answer.
+ * @param height - The value the indexer reported.
+ * @returns The height, or `Option.none` when it is not a whole non-negative number.
+ */
+export const parseIndexerHeight = (height: unknown): Option.Option<bigint> =>
+  typeof height === 'number' && Number.isSafeInteger(height) && height >= 0
+    ? Option.some(BigInt(height))
+    : Option.none();
+
+/**
+ * Parses a node endpoint.
+ *
+ * @remarks
+ *   `new URL` throws on a malformed string — omitting the scheme, for instance — and a throw while constructing a read
+ *   escapes before any Effect can catch it.
+ * @param nodeURL - The configured endpoint.
+ * @returns The parsed URL, or `Option.none` when it cannot be parsed.
+ */
+const parseNodeURL = (nodeURL: string): Option.Option<URL> => {
+  try {
+    return Option.some(new URL(nodeURL));
+  } catch {
+    return Option.none();
+  }
+};
+
+/** Describes a failure in a way that is useful when it surfaces as `Unavailable.lastError`. */
+const readError = (what: string, cause: unknown) =>
+  new LivenessReadError({
+    message: cause === undefined ? what : `${what}: ${describeCause(cause)}`,
+    cause,
+  });
+
+export type LivenessReadsConfiguration = {
+  readonly indexerClientConnection: { readonly indexerHttpUrl: string };
+  readonly nodeClientConnection: { readonly nodeURL: string };
+};
+
+/**
+ * The two calls the liveness check makes on a node client.
+ *
+ * @remarks
+ *   Narrowed to what the check uses so that a test double answers those methods rather than the whole of
+ *   `NodeClient.Service`, and so that this module depends on no more of the node client's surface than it reads.
+ */
+export type LivenessNodeReader = Pick<NodeClient.Service, 'getFinalizedBlock' | 'getGenesisHash'>;
+
+/** Builds a client for the liveness check's node reads, scoped so the connection is released with its caller. */
+export type NodeClientFactory = (
+  nodeURL: URL,
+) => Effect.Effect<LivenessNodeReader, NodeClientError.NodeClientError, Scope.Scope>;
+
+/**
+ * Connects to the node with a bounded initial connection.
+ *
+ * @remarks
+ *   Separated from {@link makeDefaultLivenessReads} so the caching around it can be tested without a node.
+ */
+const connectToNode: NodeClientFactory = (nodeURL) =>
+  PolkadotNodeClient.make({ nodeURL, reconnectionTimeout: NODE_CONNECTION_TIMEOUT });
+
+/**
+ * Builds the pair of block-height reads a liveness check compares.
+ *
+ * @remarks
+ *   This is the only place the two sources meet, and it exists in `capabilities` rather than in a wallet package so that
+ *   no wallet has to depend on `node-client` directly.
+ *
+ *   The node client is built once, on the first read that needs it, and then reused. Building one per read repeated the
+ *   full `ApiPromise` handshake — including the runtime metadata download — on every poll, against a node the wallet
+ *   does not own, to fetch two numbers. polkadot-js re-fetches metadata only when the api is not already ready
+ *   (`_loadMeta`), so a reused client pays that cost once per wallet rather than once per poll. The socket itself is
+ *   still closed between reads by `getFinalizedBlock`, so nothing is held open on the node's behalf.
+ *
+ *   Creation is deferred to the first read rather than done here, because a connection failure at construction must
+ *   become an {@link IndexerLiveness.Unavailable} verdict. Connecting while the sync stream is being assembled would put
+ *   that failure in the stream's acquire instead, so an unreachable node would stop the wallet syncing — the one
+ *   outcome this check must never cause.
+ *
+ *   A failed read leaves the cached client in place. It recovers by itself: `getFinalizedBlock` reconnects through
+ *   `ensureConnection`, and polkadot-js retries the metadata load on the next connect whenever an earlier one did not
+ *   complete. Only construction failing leaves nothing cached, and the next read then starts over — so a node that is
+ *   down when the first poll runs does not switch the check off for the rest of the session.
+ *
+ *   Both failures are flattened into {@link LivenessReadError} so the service is coupled to neither the indexer's GraphQL
+ *   errors nor the node client's error type.
+ * @example
+ *   ```ts
+ *   const reads = yield* makeDefaultLivenessReads({
+ *     indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v1/graphql' },
+ *     nodeClientConnection: { nodeURL: 'ws://localhost:9944' },
+ *   });
+ *   ```;
+ *
+ * @param config - Where to reach the indexer and the node.
+ * @param makeNodeClient - How to build the node client. Defaults to a real connection; supplying this is how a test
+ *   exercises the caching without a node.
+ * @returns An effect yielding reads suitable for {@link LivenessServiceImpl.make}. Scoped, because the client they share
+ *   is released when that scope closes.
+ */
+export const makeDefaultLivenessReads = (
+  config: LivenessReadsConfiguration,
+  makeNodeClient: NodeClientFactory = connectToNode,
+): Effect.Effect<LivenessReads, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    // The scope the reads are built in, so the shared client is released when sync stops rather than when a read ends.
+    const scope = yield* Effect.scope;
+
+    // `SynchronizedRef`, not `Ref`: filling the cache is itself an effect, and two concurrent first reads must not race
+    // into building two clients — the second would replace the first, whose socket nothing would then close until the
+    // scope did.
+    const cachedClient = yield* SynchronizedRef.make(Option.none<LivenessNodeReader>());
+
+    /**
+     * Yields the shared client, connecting on the first call.
+     *
+     * @remarks
+     *   A failure to build leaves the cache empty, so the next read tries again rather than inheriting a verdict taken
+     *   once.
+     *
+     *   Uninterruptible, because the poll fails fast: when the sibling indexer read fails, the in-flight node read is
+     *   interrupted. The client's acquire is uninterruptible on its own, so without this the interrupt would land
+     *   between the acquire completing and the cache write — stranding a fully-built client on the sync-lifetime scope
+     *   with the cache still empty, once per poll for as long as the indexer stays down. Deferring the interrupt past
+     *   the write costs at most the build's own ten-second connection bound.
+     */
+    const client = (nodeURL: URL): Effect.Effect<LivenessNodeReader, NodeClientError.NodeClientError> =>
+      Effect.uninterruptible(
+        SynchronizedRef.modifyEffect(cachedClient, (current) =>
+          Option.match(current, {
+            onSome: (existing) => Effect.succeed([existing, current] as const),
+            onNone: () =>
+              makeNodeClient(nodeURL).pipe(
+                // Extended into the outer scope, not the read's: the client has to outlive the read that built it.
+                Scope.extend(scope),
+                Effect.map((built) => [built, Option.some(built)] as const),
+              ),
+          }),
+        ),
+      );
+
+    /** Resolves the shared client from the configured endpoint — the step both node reads start with. */
+    const nodeReader = (): Effect.Effect<LivenessNodeReader, LivenessReadError | NodeClientError.NodeClientError> =>
+      Option.match(parseNodeURL(config.nodeClientConnection.nodeURL), {
+        onNone: (): Effect.Effect<URL, LivenessReadError> =>
+          Effect.fail(readError(`Node endpoint is not a valid URL: ${config.nodeClientConnection.nodeURL}`, undefined)),
+        onSome: Effect.succeed,
+      }).pipe(Effect.flatMap((nodeURL) => client(nodeURL)));
+
+    return {
+      indexerHeight: () =>
+        Effect.gen(function* () {
+          const query = yield* BlockHash;
+          const { block } = yield* query({ offset: null });
+
+          // A freshly started indexer has ingested nothing, so there is no block to compare against.
+          if (block === null || block === undefined) {
+            return yield* new LivenessReadError({ message: 'Indexer reported no latest block' });
+          }
+
+          return yield* Option.match(parseIndexerHeight(block.height), {
+            onNone: () =>
+              Effect.fail(
+                new LivenessReadError({
+                  message: `Indexer reported an unusable block height: ${String(block.height)}`,
+                }),
+              ),
+            onSome: Effect.succeed,
+          });
+        }).pipe(
+          Effect.provide(HttpQueryClient.layer({ url: config.indexerClientConnection.indexerHttpUrl })),
+          Effect.scoped,
+          Effect.catchAll((cause) =>
+            cause instanceof LivenessReadError
+              ? Effect.fail(cause)
+              : Effect.fail(readError('Failed to read the indexer’s latest block', cause)),
+          ),
+        ),
+
+      finalizedHeight: () =>
+        nodeReader().pipe(
+          Effect.flatMap((reader) => reader.getFinalizedBlock()),
+          Effect.map(({ height }) => height),
+          // A bound on the whole read, not just the connection: a node that accepts a socket and then never answers would
+          // otherwise stall the poll just as effectively as one that refuses it.
+          Effect.timeoutFail({
+            duration: NODE_CONNECTION_TIMEOUT,
+            onTimeout: () => readError('Timed out reading the node’s finalized head', undefined),
+          }),
+          Effect.catchAll((cause) =>
+            cause instanceof LivenessReadError
+              ? Effect.fail(cause)
+              : Effect.fail(readError('Failed to read the node’s finalized head', cause)),
+          ),
+        ),
+
+      indexerGenesisHash: () =>
+        Effect.gen(function* () {
+          const query = yield* BlockHash;
+          const { block } = yield* query({ offset: { height: 0 } });
+
+          // An indexer that has ingested nothing has no genesis block to name — which chain it is on is not yet known.
+          if (block === null || block === undefined) {
+            return yield* new LivenessReadError({ message: 'Indexer reported no genesis block' });
+          }
+
+          return block.hash;
+        }).pipe(
+          Effect.provide(HttpQueryClient.layer({ url: config.indexerClientConnection.indexerHttpUrl })),
+          Effect.scoped,
+          Effect.catchAll((cause) =>
+            cause instanceof LivenessReadError
+              ? Effect.fail(cause)
+              : Effect.fail(readError('Failed to read the indexer’s genesis block', cause)),
+          ),
+        ),
+
+      nodeGenesisHash: () =>
+        nodeReader().pipe(
+          Effect.flatMap((reader) => reader.getGenesisHash()),
+          // The hash itself is served from client state, but the first call builds the client — a connection that
+          // must stay bounded like every other node read.
+          Effect.timeoutFail({
+            duration: NODE_CONNECTION_TIMEOUT,
+            onTimeout: () => readError('Timed out reading the node’s genesis hash', undefined),
+          }),
+          Effect.catchAll((cause) =>
+            cause instanceof LivenessReadError
+              ? Effect.fail(cause)
+              : Effect.fail(readError('Failed to read the node’s genesis hash', cause)),
+          ),
+        ),
+    };
+  });

--- a/packages/capabilities/src/liveness/livenessReads.ts
+++ b/packages/capabilities/src/liveness/livenessReads.ts
@@ -27,8 +27,12 @@ import { type LivenessReads, LivenessReadError } from './livenessService.js';
  *   `PolkadotNodeClient` defaults to `Duration.infinity`, which suits transaction submission — a caller waiting to submit
  *   wants to keep trying. It is wrong here: a liveness check that waits forever on an unreachable node never publishes
  *   the {@link IndexerLiveness.Unavailable} verdict that exists to report exactly that condition, and its poll fibre
- *   hangs instead. This bound must stay well under the poll interval so a failing read cannot outlive the tick that
- *   started it.
+ *   hangs instead.
+ *
+ *   The bound applies twice within one connection build — once to the handshake, once to the close that follows it — so
+ *   the build's worst case is double this value, and the build runs uninterruptibly. That is why the poll's own
+ *   deadline does not depend on it: the service disconnects the read before applying its timeout, so a slow build
+ *   finishes in the background and its client is cached for the next poll, while the verdict still lands on time.
  */
 const NODE_CONNECTION_TIMEOUT = Duration.seconds(10);
 
@@ -178,7 +182,10 @@ export const makeDefaultLivenessReads = (
      *   interrupted. The client's acquire is uninterruptible on its own, so without this the interrupt would land
      *   between the acquire completing and the cache write — stranding a fully-built client on the sync-lifetime scope
      *   with the cache still empty, once per poll for as long as the indexer stays down. Deferring the interrupt past
-     *   the write costs at most the build's own ten-second connection bound.
+     *   the write costs at most the build's worst case: the connection bound for the handshake plus the same again for
+     *   the close, twenty seconds with the current value. The poll does not wait that long for its verdict — the
+     *   service disconnects the read before applying its own timeout — but the build itself runs to completion or to
+     *   that bound.
      */
     const client = (nodeURL: URL): Effect.Effect<LivenessNodeReader, NodeClientError.NodeClientError> =>
       Effect.uninterruptible(

--- a/packages/capabilities/src/liveness/livenessService.ts
+++ b/packages/capabilities/src/liveness/livenessService.ts
@@ -1,0 +1,300 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { IndexerLiveness } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Cause, Data, Duration, Effect, Option, Ref, Stream, SubscriptionRef } from 'effect';
+
+/**
+ * A block height could not be read.
+ *
+ * @remarks
+ *   The indexer and the node fail in their own vocabularies — a GraphQL error and a `NodeClientError` respectively. Each
+ *   caller adapts its failure into this one type, so the service depends on neither and needs only what it actually
+ *   uses: a message to report on an {@link IndexerLiveness.Unavailable} verdict.
+ */
+export class LivenessReadError extends Data.TaggedError('LivenessReadError')<{
+  /** A short description of why the read failed, surfaced to callers for diagnosis. */
+  readonly message: string;
+  /** The underlying failure, retained for logging. */
+  readonly cause?: unknown;
+}> {}
+
+/**
+ * The reads a liveness check runs, supplied as a dictionary so that callers decide where each comes from: the two block
+ * heights it compares every poll, and the two genesis hashes it compares once to establish that the heights describe
+ * the same chain.
+ *
+ * @remarks
+ *   Both reads are required. A service is only started when a node endpoint is configured — when none is, no service runs
+ *   at all and the progress keeps its {@link IndexerLiveness.Skipped} default. That is why neither read is optional: a
+ *   service that might have no node would have to represent, and handle, a state it should never be in.
+ */
+export type LivenessReads = {
+  /** Reads the height of the latest block the indexer reports having processed. */
+  readonly indexerHeight: () => Effect.Effect<bigint, LivenessReadError>;
+  /** Reads the height of the node's highest finalized block. */
+  readonly finalizedHeight: () => Effect.Effect<bigint, LivenessReadError>;
+  /** Reads the hash of the indexer's block at height zero — the chain the indexer is indexing. */
+  readonly indexerGenesisHash: () => Effect.Effect<string, LivenessReadError>;
+  /** Reads the hash of the node's genesis block — the chain the node is on. */
+  readonly nodeGenesisHash: () => Effect.Effect<string, LivenessReadError>;
+};
+
+/** How far apart the indexer and the node may be before the difference is reported. */
+export type LivenessConfiguration = {
+  /** How many blocks the indexer may trail the finalized head by and still count as in sync. */
+  readonly maxBehindBlocks: bigint;
+  /** How many blocks the indexer may lead the finalized head by and still count as in sync. */
+  readonly maxAheadBlocks: bigint;
+  /**
+   * How long a single poll may run before it is abandoned and reported as {@link IndexerLiveness.Unavailable}.
+   *
+   * @remarks
+   *   Defaults to {@link DEFAULT_POLL_TIMEOUT}. Polls run one at a time, so without this bound a read that hangs — an
+   *   endpoint that accepts a connection and never answers — would stop the loop forever, freezing the verdict at
+   *   whatever was published last. A hung read must not be able to switch the check off.
+   */
+  readonly pollTimeout?: Duration.Duration;
+};
+
+/**
+ * The default bound on a single poll.
+ *
+ * @remarks
+ *   Comfortably above the node read's own ten-second connection bound, and below the default poll interval, so an
+ *   abandoned poll never delays the tick that follows it.
+ */
+export const DEFAULT_POLL_TIMEOUT = Duration.seconds(20);
+
+/**
+ * Tolerances sized against Midnight's 6-second block slots (the indexer pins `SLOT_DURATION` at 6000 ms).
+ *
+ * @remarks
+ *   `maxBehindBlocks` is a staleness allowance: ten blocks is about a minute of chain time, generous enough that an
+ *   indexer briefly catching up is not reported as stale. `maxAheadBlocks` absorbs read skew — the two heights are read
+ *   at different moments — while staying far below the thousands of blocks that separate two different networks.
+ */
+export const DEFAULT_LIVENESS_CONFIGURATION: LivenessConfiguration = {
+  maxBehindBlocks: 10n,
+  maxAheadBlocks: 10n,
+};
+
+/**
+ * How often to compare the indexer against the node, by default.
+ *
+ * @remarks
+ *   Deliberately unhurried. Each poll costs a request to a node the wallet does not own, a stalled indexer is a
+ *   slow-developing condition, and polling faster than blocks are produced only re-reads the same block. At Midnight's
+ *   6-second slots, half a minute is about five blocks, and it surfaces a stalled indexer well within the time any
+ *   caller would notice.
+ */
+export const DEFAULT_POLL_INTERVAL = Duration.seconds(30);
+
+export type LivenessService = {
+  /**
+   * Consumes `ticks`, comparing the indexer against the node once per tick and publishing the verdict.
+   *
+   * @remarks
+   *   Ticks are supplied by the caller rather than generated here, so that tests drive the loop directly instead of
+   *   waiting on a clock. The returned effect cannot fail: a read that fails becomes an
+   *   {@link IndexerLiveness.Unavailable} verdict, because a check that gave up on its first network error would be
+   *   useless against exactly the conditions it exists to detect.
+   */
+  readonly startPolling: (ticks: Stream.Stream<unknown>) => Effect.Effect<void>;
+  /** The current verdict, followed by each subsequent one. */
+  readonly state: () => Stream.Stream<IndexerLiveness.IndexerLiveness>;
+};
+
+/**
+ * Reduces a failed poll to one line for {@link IndexerLiveness.Unavailable}'s `lastError`.
+ *
+ * @remarks
+ *   That string is shown to whoever is diagnosing a stalled wallet, so it stays a message rather than a rendered cause: a
+ *   stack trace is noise at that surface. Defects are labelled as unexpected, because unlike a read failure they
+ *   indicate a bug rather than an unreachable node.
+ */
+const describeFailure = (cause: Cause.Cause<LivenessReadError>): string =>
+  Option.match(Cause.failureOption(cause), {
+    onSome: (error) => error.message,
+    onNone: () =>
+      Option.match(Cause.dieOption(cause), {
+        onSome: (defect) =>
+          `Unexpected failure while reading: ${defect instanceof Error ? defect.message : String(defect)}`,
+        onNone: () => 'Unexpected failure while reading',
+      }),
+  });
+
+/**
+ * What the one-time genesis comparison has established.
+ *
+ * @remarks
+ *   `Mismatch` carries its verdict rather than the hashes, so it is built exactly once — at the moment of proof — and
+ *   every later poll republishes the same value, which the state stream's deduplication then collapses.
+ */
+type GenesisCheck = Data.TaggedEnum<{
+  /** No successful comparison yet: the hashes have not both been read. */
+  Unverified: {}; // eslint-disable-line @typescript-eslint/no-empty-object-type
+  /** Both endpoints reported the same genesis block; heights are comparable. */
+  SameChain: {}; // eslint-disable-line @typescript-eslint/no-empty-object-type
+  /** The endpoints are on different chains; the verdict is pinned for the service's lifetime. */
+  Mismatch: { readonly verdict: IndexerLiveness.IndexerLiveness };
+}>;
+const GenesisCheck = Data.taggedEnum<GenesisCheck>();
+
+export class LivenessServiceImpl implements LivenessService {
+  readonly #state: SubscriptionRef.SubscriptionRef<IndexerLiveness.IndexerLiveness>;
+  readonly #reads: LivenessReads;
+  readonly #configuration: LivenessConfiguration;
+  // A plain `Ref` read at the top of a poll and written mid-poll — not a race, because polls run strictly one at a
+  // time: `startPolling` awaits each poll before taking the next tick.
+  readonly #genesisCheck: Ref.Ref<GenesisCheck>;
+
+  /**
+   * Creates a service whose verdict starts as {@link IndexerLiveness.Unknown} — a check exists but has not yet run.
+   *
+   * @param reads - Where the two heights come from.
+   * @param configuration - The tolerances to apply, and the bound on a single poll.
+   * @param initialVerdict - The verdict to start from. Callers that rebuild the service mid-session pass the verdict
+   *   they already hold, so a reconnect does not erase a `Behind` the check had already reached — starting afresh at
+   *   `Unknown` would hand back a stale-view answer the moment the gate re-opened.
+   * @returns An effect yielding the service.
+   */
+  static make(
+    reads: LivenessReads,
+    configuration: LivenessConfiguration = DEFAULT_LIVENESS_CONFIGURATION,
+    initialVerdict: IndexerLiveness.IndexerLiveness = IndexerLiveness.Unknown(),
+  ): Effect.Effect<LivenessServiceImpl> {
+    return Effect.all([
+      SubscriptionRef.make<IndexerLiveness.IndexerLiveness>(initialVerdict),
+      Ref.make<GenesisCheck>(GenesisCheck.Unverified()),
+    ]).pipe(Effect.map(([state, genesisCheck]) => new LivenessServiceImpl(state, reads, configuration, genesisCheck)));
+  }
+
+  private constructor(
+    state: SubscriptionRef.SubscriptionRef<IndexerLiveness.IndexerLiveness>,
+    reads: LivenessReads,
+    configuration: LivenessConfiguration,
+    genesisCheck: Ref.Ref<GenesisCheck>,
+  ) {
+    this.#state = state;
+    this.#reads = reads;
+    this.#configuration = configuration;
+    this.#genesisCheck = genesisCheck;
+  }
+
+  state(): Stream.Stream<IndexerLiveness.IndexerLiveness> {
+    // `changes` already replays the current value before subsequent ones, under the ref's own semaphore. Prepending a
+    // separate `get` would emit the first verdict twice — and read it outside that semaphore.
+    //
+    // `Stream.changes` then drops consecutive equal verdicts. Every poll writes unconditionally, and each write fans
+    // out into the wallet's full state stream — without this, a healthy idle wallet re-notified every subscriber once
+    // per poll, forever. Verdicts are structural data, so a lengthening outage still reports: `Unavailable`'s failure
+    // count climbs, which makes consecutive verdicts unequal.
+    return this.#state.changes.pipe(Stream.changes);
+  }
+
+  startPolling(ticks: Stream.Stream<unknown>): Effect.Effect<void> {
+    return Stream.runForEach(ticks, () => this.#poll());
+  }
+
+  /**
+   * Compares the two heights once and publishes the result.
+   *
+   * @remarks
+   *   The whole poll is folded into the verdict: `catchAll` converts a failed read into an `Unavailable` verdict, so the
+   *   returned effect has no error channel and the polling loop survives an unreachable node. `SubscriptionRef.update`
+   *   reads the previous verdict inside the callback, which is what lets `afterFailedPoll` continue a run of failures
+   *   without a separate get-then-write race.
+   */
+  #poll(): Effect.Effect<void> {
+    return this.#compareOnce().pipe(
+      Effect.map((verdict) => () => verdict),
+      // A bound on the whole poll, not only on the reads' own deadlines: polls run one at a time, so a read that hangs
+      // — an endpoint that accepts a connection and never answers — would otherwise stop the loop forever, freezing
+      // the verdict at whatever was published last. A hung read must not be able to switch the check off.
+      Effect.timeoutFail({
+        duration: this.#configuration.pollTimeout ?? DEFAULT_POLL_TIMEOUT,
+        onTimeout: () => new LivenessReadError({ message: 'Poll abandoned: a read did not complete in time' }),
+      }),
+      // `catchAllCause`, not `catchAll`: a read can die as well as fail — an unparsed URL, a payload that is not the
+      // shape it claims — and a defect would kill the poll fibre outright. The verdict would then freeze at whatever
+      // was written last, which at start-up is `Unknown` and never gates, leaving an indexer able to switch off the
+      // check simply by answering badly.
+      Effect.catchAllCause((cause) =>
+        Effect.succeed((previous: IndexerLiveness.IndexerLiveness) =>
+          IndexerLiveness.afterFailedPoll(previous, describeFailure(cause)),
+        ),
+      ),
+      Effect.flatMap((nextVerdict) => SubscriptionRef.update(this.#state, nextVerdict)),
+    );
+  }
+
+  /**
+   * Runs one comparison: the chain identity first, then the heights.
+   *
+   * @remarks
+   *   Height comparison is meaningful only between endpoints on the same chain, so no height verdict is published until
+   *   the genesis hashes have been read once and found to match. A mismatch pins {@link IndexerLiveness.WrongNetwork}
+   *   for the service's lifetime — neither endpoint changes chain until reconfigured, and reconfiguring builds a new
+   *   wallet — while a match is cached so the hashes are read exactly once. A _failed_ hash read proves nothing about
+   *   which chain anyone is on, so it caches nothing: it surfaces through the ordinary `Unavailable` path and the next
+   *   poll tries the hashes again.
+   */
+  #compareOnce(): Effect.Effect<IndexerLiveness.IndexerLiveness, LivenessReadError> {
+    return Ref.get(this.#genesisCheck).pipe(
+      Effect.flatMap(
+        GenesisCheck.$match({
+          Mismatch: ({ verdict }) => Effect.succeed(verdict),
+          SameChain: () => this.#compareHeights(),
+          Unverified: () =>
+            this.#verifyGenesis().pipe(
+              Effect.flatMap(
+                GenesisCheck.$match({
+                  Mismatch: ({ verdict }) => Effect.succeed(verdict),
+                  SameChain: () => this.#compareHeights(),
+                  // Unreachable: #verifyGenesis only ever returns a settled check. Comparing heights anyway keeps the
+                  // match total without inventing an error for a state that cannot occur.
+                  Unverified: () => this.#compareHeights(),
+                }),
+              ),
+            ),
+        }),
+      ),
+    );
+  }
+
+  /** Reads both genesis hashes, settles the check, and caches the outcome. */
+  #verifyGenesis(): Effect.Effect<GenesisCheck, LivenessReadError> {
+    return Effect.all([this.#reads.indexerGenesisHash(), this.#reads.nodeGenesisHash()], { concurrency: 2 }).pipe(
+      Effect.map(([indexerGenesisHash, nodeGenesisHash]) =>
+        IndexerLiveness.sameGenesis(indexerGenesisHash, nodeGenesisHash)
+          ? GenesisCheck.SameChain()
+          : GenesisCheck.Mismatch({ verdict: IndexerLiveness.WrongNetwork({ indexerGenesisHash, nodeGenesisHash }) }),
+      ),
+      Effect.tap((check) => Ref.set(this.#genesisCheck, check)),
+    );
+  }
+
+  /** Reads both heights and reduces them to a verdict under the configured tolerances. */
+  #compareHeights(): Effect.Effect<IndexerLiveness.IndexerLiveness, LivenessReadError> {
+    return Effect.all([this.#reads.indexerHeight(), this.#reads.finalizedHeight()], { concurrency: 2 }).pipe(
+      Effect.map(([indexerHeight, finalizedHeight]) =>
+        IndexerLiveness.evaluate({
+          indexerHeight,
+          finalizedHeight,
+          maxBehindBlocks: this.#configuration.maxBehindBlocks,
+          maxAheadBlocks: this.#configuration.maxAheadBlocks,
+        }),
+      ),
+    );
+  }
+}

--- a/packages/capabilities/src/liveness/livenessService.ts
+++ b/packages/capabilities/src/liveness/livenessService.ts
@@ -196,11 +196,13 @@ export class LivenessServiceImpl implements LivenessService {
     // `changes` already replays the current value before subsequent ones, under the ref's own semaphore. Prepending a
     // separate `get` would emit the first verdict twice — and read it outside that semaphore.
     //
-    // `Stream.changes` then drops consecutive equal verdicts. Every poll writes unconditionally, and each write fans
+    // `changesWith` then drops a verdict that says nothing new. Every poll writes unconditionally, and each write fans
     // out into the wallet's full state stream — without this, a healthy idle wallet re-notified every subscriber once
-    // per poll, forever. Verdicts are structural data, so a lengthening outage still reports: `Unavailable`'s failure
-    // count climbs, which makes consecutive verdicts unequal.
-    return this.#state.changes.pipe(Stream.changes);
+    // per poll, forever. Structural equality would not do: the heights on `InSync`, `Behind` and `Ahead` advance with
+    // the chain every poll, so consecutive verdicts are never structurally equal. `equivalent` compares what a caller
+    // acts on — the kind, a `Behind`'s lag, `Unavailable`'s climbing count — so a lengthening outage or a growing lag
+    // still reports, and a healthy idle wallet stays quiet.
+    return this.#state.changes.pipe(Stream.changesWith(IndexerLiveness.equivalent));
   }
 
   startPolling(ticks: Stream.Stream<unknown>): Effect.Effect<void> {

--- a/packages/capabilities/src/liveness/livenessService.ts
+++ b/packages/capabilities/src/liveness/livenessService.ts
@@ -219,6 +219,12 @@ export class LivenessServiceImpl implements LivenessService {
   #poll(): Effect.Effect<void> {
     return this.#compareOnce().pipe(
       Effect.map((verdict) => () => verdict),
+      // `disconnect` makes the deadline below a hard one. A timeout interrupts its loser and then waits for it, so a
+      // read stuck inside an uninterruptible region — the node client's connection build is one, and cannot be made
+      // otherwise without leaking the client it builds — would stretch the deadline to the read's own length. Disconnected,
+      // the read is interrupted in the background instead: the verdict lands on time, and a build that does finish still
+      // caches its client for the next poll.
+      Effect.disconnect,
       // A bound on the whole poll, not only on the reads' own deadlines: polls run one at a time, so a read that hangs
       // — an endpoint that accepts a connection and never answers — would otherwise stop the loop forever, freezing
       // the verdict at whatever was published last. A hung read must not be able to switch the check off.

--- a/packages/capabilities/src/liveness/livenessService.ts
+++ b/packages/capabilities/src/liveness/livenessService.ts
@@ -105,9 +105,10 @@ export type LivenessService = {
    *
    * @remarks
    *   Ticks are supplied by the caller rather than generated here, so that tests drive the loop directly instead of
-   *   waiting on a clock. The returned effect cannot fail: a read that fails becomes an
-   *   {@link IndexerLiveness.Unavailable} verdict, because a check that gave up on its first network error would be
-   *   useless against exactly the conditions it exists to detect.
+   *   waiting on a clock. The returned effect cannot fail: a read that fails is folded into the verdict by
+   *   {@link IndexerLiveness.afterFailedPoll} — {@link IndexerLiveness.Unavailable}, or a gating verdict kept as it is —
+   *   because a check that gave up on its first network error would be useless against exactly the conditions it exists
+   *   to detect.
    */
   readonly startPolling: (ticks: Stream.Stream<unknown>) => Effect.Effect<void>;
   /** The current verdict, followed by each subsequent one. */
@@ -210,10 +211,10 @@ export class LivenessServiceImpl implements LivenessService {
    * Compares the two heights once and publishes the result.
    *
    * @remarks
-   *   The whole poll is folded into the verdict: `catchAll` converts a failed read into an `Unavailable` verdict, so the
+   *   The whole poll is folded into the verdict: `catchAllCause` hands a failed read to `afterFailedPoll`, so the
    *   returned effect has no error channel and the polling loop survives an unreachable node. `SubscriptionRef.update`
-   *   reads the previous verdict inside the callback, which is what lets `afterFailedPoll` continue a run of failures
-   *   without a separate get-then-write race.
+   *   reads the previous verdict inside the callback, which is what lets `afterFailedPoll` continue a run of failures —
+   *   or keep a `Behind` that a failed poll cannot disprove — without a separate get-then-write race.
    */
   #poll(): Effect.Effect<void> {
     return this.#compareOnce().pipe(

--- a/packages/capabilities/src/liveness/test/livenessReads.integration.test.ts
+++ b/packages/capabilities/src/liveness/test/livenessReads.integration.test.ts
@@ -1,0 +1,199 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { IndexerLiveness } from '@midnightntwrk/wallet-sdk-abstractions';
+import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnightntwrk/wallet-sdk-utilities/testing';
+import { Cause, Duration, Effect, Exit, Option, Schedule } from 'effect';
+import { randomUUID } from 'node:crypto';
+import { DockerComposeEnvironment, type StartedDockerComposeEnvironment, Wait } from 'testcontainers';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { makeDefaultLivenessReads } from '../livenessReads.js';
+import { DEFAULT_LIVENESS_CONFIGURATION } from '../livenessService.js';
+
+const timeoutMinutes = (minutes: number) => 1_000 * 60 * minutes;
+
+const environmentId = randomUUID();
+
+const environmentVars = buildTestEnvironmentVariables(['APP_INFRA_SECRET'], {
+  additionalVars: { TESTCONTAINERS_UID: environmentId },
+});
+
+const environment = new DockerComposeEnvironment(getComposeDirectory(), 'docker-compose.yml')
+  // Waiting for an indexed block matters: heights are only meaningful once the indexer has ingested something.
+  .withWaitStrategy(`indexer_${environmentId}`, Wait.forLogMessage(/block indexed/))
+  .withEnvironment(environmentVars);
+
+describe('makeDefaultLivenessReads', () => {
+  let startedEnvironment: StartedDockerComposeEnvironment | undefined = undefined;
+
+  const liveReads = () => {
+    const indexerPort = startedEnvironment?.getContainer(`indexer_${environmentId}`)?.getMappedPort(8088) ?? 8088;
+    const nodePort = startedEnvironment?.getContainer(`node_${environmentId}`)?.getMappedPort(9944) ?? 9944;
+
+    return makeDefaultLivenessReads({
+      indexerClientConnection: { indexerHttpUrl: `http://127.0.0.1:${indexerPort}/api/v4/graphql` },
+      nodeClientConnection: { nodeURL: `ws://127.0.0.1:${nodePort}` },
+    });
+  };
+
+  beforeAll(async () => {
+    startedEnvironment = await environment.up();
+  }, timeoutMinutes(3));
+
+  afterAll(async () => {
+    await startedEnvironment?.down();
+  }, timeoutMinutes(1));
+
+  it(
+    'should read the latest block height from a real indexer',
+    async () => {
+      // The wait strategy fires on the first indexed block, which is genesis at height 0, so the read is retried until
+      // the chain has advanced. Retrying rather than accepting 0 keeps the assertion meaningful: a read that always
+      // returned 0 would be indistinguishable from a broken one.
+      const height = await Effect.runPromise(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const reads = yield* liveReads();
+
+            // `Effect.repeat` yields the schedule's output — a repetition count — so the height is read again afterwards
+            // rather than taken from the repeat, which would assert on the count instead.
+            yield* reads
+              .indexerHeight()
+              .pipe(
+                Effect.repeat({ until: (height) => height > 0n, schedule: Schedule.spaced(Duration.seconds(1)) }),
+                Effect.timeout(Duration.seconds(45)),
+              );
+            return yield* reads.indexerHeight();
+          }),
+        ),
+      );
+
+      expect(height).toBeGreaterThan(0n);
+    },
+    timeoutMinutes(1),
+  );
+
+  it(
+    'should read genesis hashes from both endpoints that compare as the same chain',
+    async () => {
+      // The comparison the WrongNetwork verdict rests on, run against real presentation: the node reports its genesis
+      // hash 0x-prefixed, the indexer serves a plain hex string, and both containers share one chain — so
+      // `sameGenesis` must hold. A unit test cannot prove the format assumptions; only the real services can.
+      const hashes = await Effect.runPromise(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const reads = yield* liveReads();
+            const indexerGenesisHash = yield* reads.indexerGenesisHash();
+            const nodeGenesisHash = yield* reads.nodeGenesisHash();
+            return { indexerGenesisHash, nodeGenesisHash };
+          }),
+        ),
+      );
+
+      expect(hashes.indexerGenesisHash).toMatch(/^(0x)?[0-9a-fA-F]{64}$/);
+      expect(hashes.nodeGenesisHash).toMatch(/^0x[0-9a-f]{64}$/);
+      expect(IndexerLiveness.sameGenesis(hashes.indexerGenesisHash, hashes.nodeGenesisHash)).toBe(true);
+    },
+    timeoutMinutes(1),
+  );
+
+  it(
+    'should read the finalized block height from a real node',
+    async () => {
+      // Proves the two-step read works against a real node: `chain_getFinalizedHead`, then `chain_getHeader` at that
+      // hash. A unit test with a stubbed api cannot show that the call shape is accepted.
+      const exit = await Effect.runPromiseExit(
+        Effect.scoped(Effect.flatMap(liveReads(), (reads) => reads.finalizedHeight())),
+      );
+
+      // Printing the cause on failure: "Failed to read the node's finalized head" alone is not diagnosable from CI.
+      expect(Exit.isSuccess(exit) ? 'ok' : Cause.pretty(exit.cause)).toBe('ok');
+      expect(Exit.isSuccess(exit) ? exit.value : 0n).toBeGreaterThan(0n);
+    },
+    timeoutMinutes(1),
+  );
+
+  it(
+    'should read twice from one reused client, reconnecting between the reads',
+    async () => {
+      // The reason a cached client is safe at all. `getFinalizedBlock` disconnects when it finishes, so the second poll
+      // reaches a client whose socket is closed and has to reconnect through `ensureConnection`. The unit tests stub the
+      // client and so cannot exercise that path — this is the only check that a reused client survives its own
+      // disconnect, which is what the whole caching change rests on.
+      const exit = await Effect.runPromiseExit(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const reads = yield* liveReads();
+            const first = yield* reads.finalizedHeight();
+            const second = yield* reads.finalizedHeight();
+            return { first, second };
+          }),
+        ),
+      );
+
+      expect(Exit.isSuccess(exit) ? 'ok' : Cause.pretty(exit.cause)).toBe('ok');
+      const heights = Exit.isSuccess(exit) ? exit.value : { first: 0n, second: 0n };
+      expect(heights.first).toBeGreaterThan(0n);
+      // The chain advances, so the second read is at least the first. Equality is fine — two reads can land in one block.
+      expect(heights.second).toBeGreaterThanOrEqual(heights.first);
+    },
+    timeoutMinutes(1),
+  );
+
+  it(
+    'should find a healthy indexer and node in sync under the default tolerances',
+    async () => {
+      // The end-to-end claim. This is the only test that shows the two heights are on the same scale and describe the
+      // same chain, and that the shipped tolerances suit a real network rather than only the numbers in the unit tests.
+      const verdict = await Effect.runPromise(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const { indexerHeight, finalizedHeight } = yield* liveReads();
+            const [indexer, finalized] = yield* Effect.all([indexerHeight(), finalizedHeight()]);
+
+            return IndexerLiveness.evaluate({
+              indexerHeight: indexer,
+              finalizedHeight: finalized,
+              ...DEFAULT_LIVENESS_CONFIGURATION,
+            });
+          }),
+        ),
+      );
+
+      // Asserting the tag rather than a predicate, so a failure reports which verdict was reached.
+      expect(verdict._tag).toBe('InSync');
+    },
+    timeoutMinutes(1),
+  );
+
+  it(
+    'should adapt a real node connection failure into a LivenessReadError',
+    async () => {
+      // The unit tests construct `LivenessReadError` by hand. This is the only check that a genuine `NodeClientError`
+      // is adapted into one, which is the path that runs during an actual outage.
+      const unreachable = makeDefaultLivenessReads({
+        indexerClientConnection: { indexerHttpUrl: 'http://127.0.0.1:1/api/v4/graphql' },
+        nodeClientConnection: { nodeURL: 'ws://127.0.0.1:1' },
+      });
+
+      const exit = await Effect.runPromiseExit(
+        Effect.scoped(Effect.flatMap(unreachable, (reads) => reads.finalizedHeight())),
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      const failure = Exit.isFailure(exit) ? Cause.failureOption(exit.cause) : Option.none();
+      expect(Option.isSome(failure)).toBe(true);
+      expect(Option.getOrThrow(failure)._tag).toBe('LivenessReadError');
+    },
+    timeoutMinutes(1),
+  );
+});

--- a/packages/capabilities/src/liveness/test/livenessReads.test.ts
+++ b/packages/capabilities/src/liveness/test/livenessReads.test.ts
@@ -1,0 +1,239 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { NodeClientError } from '@midnightntwrk/wallet-sdk-node-client/effect';
+import { Cause, Duration, Effect, Exit, Option, Ref } from 'effect';
+import { describe, expect, it } from 'vitest';
+import {
+  type LivenessNodeReader,
+  makeDefaultLivenessReads,
+  type NodeClientFactory,
+  parseIndexerHeight,
+} from '../livenessReads.js';
+
+const failureTagOf = (exit: Exit.Exit<unknown, unknown>) =>
+  Exit.isFailure(exit)
+    ? Option.map(Cause.failureOption(exit.cause), (error) => (error as { _tag?: string })._tag)
+    : Option.none();
+
+const reachableNode = {
+  indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
+  nodeClientConnection: { nodeURL: 'ws://localhost:9944' },
+};
+
+/** A node client that answers the one call the liveness check makes, and nothing else. */
+const stubReader: LivenessNodeReader = {
+  getFinalizedBlock: () => Effect.succeed({ hash: '0xfinalized', height: 1_000n }),
+  getGenesisHash: () => Effect.succeed(`0x${'ab'.repeat(32)}`),
+};
+
+describe('makeDefaultLivenessReads', () => {
+  describe('reusing the node client across polls', () => {
+    it('should build the client once and reuse it for every later read', async () => {
+      // A client was built per read, repeating the full `ApiPromise` handshake — including the runtime metadata
+      // download — every poll, to fetch two numbers. polkadot-js skips the metadata fetch on reconnect when the api is
+      // already ready (`_loadMeta`), so one client reused across polls pays that cost once per wallet instead of once
+      // every thirty seconds.
+      const program = Effect.gen(function* () {
+        const built = yield* Ref.make(0);
+        const factory: NodeClientFactory = () => Ref.update(built, (n) => n + 1).pipe(Effect.as(stubReader));
+
+        const reads = yield* makeDefaultLivenessReads(reachableNode, factory);
+        const heights = yield* Effect.all([reads.finalizedHeight(), reads.finalizedHeight(), reads.finalizedHeight()]);
+
+        return { built: yield* Ref.get(built), heights };
+      });
+
+      const result = await Effect.runPromise(Effect.scoped(program));
+
+      expect(result).toStrictEqual({ built: 1, heights: [1_000n, 1_000n, 1_000n] });
+    });
+
+    it('should not build a client until the first read', async () => {
+      // Building it where the sync stream is assembled would put a connection failure in that stream's acquire, so an
+      // unreachable node at start-up would stop the wallet syncing instead of producing an `Unavailable` verdict — the
+      // one thing this check must never do.
+      const program = Effect.gen(function* () {
+        const built = yield* Ref.make(0);
+        const factory: NodeClientFactory = () => Ref.update(built, (n) => n + 1).pipe(Effect.as(stubReader));
+
+        yield* makeDefaultLivenessReads(reachableNode, factory);
+
+        return yield* Ref.get(built);
+      });
+
+      expect(await Effect.runPromise(Effect.scoped(program))).toBe(0);
+    });
+
+    it('should try again on a later read when building the client failed', async () => {
+      // A node that is down when the first poll runs must not switch the check off for the rest of the session. Caching
+      // the failure would do exactly that: every later poll would report `Unavailable` from a decision taken once,
+      // never noticing the node come back.
+      const program = Effect.gen(function* () {
+        const attempts = yield* Ref.make(0);
+        const factory: NodeClientFactory = () =>
+          Ref.updateAndGet(attempts, (n) => n + 1).pipe(
+            Effect.flatMap((attempt) =>
+              attempt === 1
+                ? Effect.fail(new NodeClientError.ConnectionError({ message: 'node down' }))
+                : Effect.succeed(stubReader),
+            ),
+          );
+
+        const reads = yield* makeDefaultLivenessReads(reachableNode, factory);
+        const first = yield* Effect.exit(reads.finalizedHeight());
+        const second = yield* Effect.exit(reads.finalizedHeight());
+
+        return { attempts: yield* Ref.get(attempts), firstFailed: Exit.isFailure(first), second };
+      });
+
+      const result = await Effect.runPromise(Effect.scoped(program));
+
+      expect(result.attempts).toBe(2);
+      expect(result.firstFailed).toBe(true);
+      expect(result.second).toStrictEqual(Exit.succeed(1_000n));
+    });
+
+    it('should keep a client whose build outlived an abandoned poll, rather than stranding it and rebuilding', async () => {
+      // The poll fails fast: when the indexer read fails, the in-flight node read is interrupted. A client build is
+      // uninterruptible once its acquire has started, so the interrupt lands *between* the acquire completing and the
+      // cache write — leaving the built client stranded (its release parked on the sync-lifetime scope, the cache
+      // still empty) and the next poll building another. During an indexer outage that is one full handshake and one
+      // stranded client per poll, without bound.
+      const program = Effect.gen(function* () {
+        const builds = yield* Ref.make(0);
+        const factory: NodeClientFactory = () =>
+          Effect.acquireRelease(
+            // The sleep sits inside the acquire, which `acquireRelease` runs uninterruptibly — the same shape as the
+            // real client's bounded connect. The interrupt below therefore arrives once the build is already done.
+            Ref.update(builds, (n) => n + 1).pipe(
+              Effect.zipRight(Effect.sleep(Duration.millis(50))),
+              Effect.as(stubReader),
+            ),
+            () => Effect.void,
+          );
+
+        const reads = yield* makeDefaultLivenessReads(reachableNode, factory);
+
+        // Interrupt the read mid-build, as the poll's fail-fast does when the indexer read errors first.
+        yield* reads.finalizedHeight().pipe(Effect.timeout(Duration.millis(10)), Effect.ignore);
+        yield* reads.finalizedHeight();
+
+        return yield* Ref.get(builds);
+      });
+
+      expect(await Effect.runPromise(Effect.scoped(program))).toBe(1);
+    });
+
+    it('should release the client when the scope closes, rather than holding a socket open for the process', async () => {
+      // The client now outlives a single read, so the scope it is created in is what bounds its life. Without a
+      // finalizer the WebSocket would stay open after sync stopped.
+      const program = Effect.gen(function* () {
+        const released = yield* Ref.make(false);
+        const factory: NodeClientFactory = () =>
+          Effect.acquireRelease(Effect.succeed(stubReader), () => Ref.set(released, true));
+
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const reads = yield* makeDefaultLivenessReads(reachableNode, factory);
+            yield* reads.finalizedHeight();
+          }),
+        );
+
+        return yield* Ref.get(released);
+      });
+
+      expect(await Effect.runPromise(program)).toBe(true);
+    });
+  });
+
+  it('should serve the genesis hash through the same cached client as the finalized head', async () => {
+    // The genesis hash is read once per wallet, on the first poll. Building a second client for it would repeat the
+    // connection handshake the cache exists to avoid — both node reads must share the one client.
+    const observed = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const built = yield* Ref.make(0);
+          const factory: NodeClientFactory = () => Ref.update(built, (n) => n + 1).pipe(Effect.as(stubReader));
+
+          const reads = yield* makeDefaultLivenessReads(reachableNode, factory);
+          yield* reads.finalizedHeight();
+          const genesisHash = yield* reads.nodeGenesisHash();
+
+          return { genesisHash, clientsBuilt: yield* Ref.get(built) };
+        }),
+      ),
+    );
+
+    expect(observed.genesisHash).toBe(`0x${'ab'.repeat(32)}`);
+    expect(observed.clientsBuilt).toBe(1);
+  });
+
+  describe('when the node URL cannot be parsed', () => {
+    it('should fail with a LivenessReadError rather than throwing, so a typo does not kill the poll loop', async () => {
+      // `new URL('127.0.0.1:9944')` throws — omitting the scheme is an easy mistake. Thrown synchronously from the read,
+      // it becomes a defect that stops the check permanently, which is the opposite of the visibility `Unavailable`
+      // exists to provide.
+      const exit = await Effect.runPromiseExit(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const reads = yield* makeDefaultLivenessReads({
+              indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
+              nodeClientConnection: { nodeURL: '127.0.0.1:9944' },
+            });
+
+            return yield* reads.finalizedHeight();
+          }),
+        ),
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(Option.getOrThrow(failureTagOf(exit))).toBe('LivenessReadError');
+    });
+
+    it('should not throw when the reads are merely constructed', () => {
+      // Construction is once per wallet now rather than once per poll, but it is still where a `new URL` throw would
+      // escape before any Effect could catch it.
+      expect(() =>
+        makeDefaultLivenessReads({
+          indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
+          nodeClientConnection: { nodeURL: 'not a url at all' },
+        }),
+      ).not.toThrow();
+    });
+  });
+});
+
+describe('parseIndexerHeight', () => {
+  it('should accept a whole number', () => {
+    expect(parseIndexerHeight(1_234)).toStrictEqual(Option.some(1_234n));
+  });
+
+  it('should accept zero, which is genesis and a legitimate answer', () => {
+    expect(parseIndexerHeight(0)).toStrictEqual(Option.some(0n));
+  });
+
+  it('should reject a non-integral height, which BigInt would otherwise throw on', () => {
+    // A hostile or broken indexer answering `1.5` would otherwise raise a RangeError inside the poll, killing it. The
+    // check exists to catch a misbehaving indexer, so a misbehaving indexer must not be able to switch it off.
+    expect(parseIndexerHeight(1.5)).toStrictEqual(Option.none());
+  });
+
+  it('should reject a negative height', () => {
+    expect(parseIndexerHeight(-1)).toStrictEqual(Option.none());
+  });
+
+  it('should reject a value that is not a number at all', () => {
+    expect(parseIndexerHeight(undefined)).toStrictEqual(Option.none());
+    expect(parseIndexerHeight('12')).toStrictEqual(Option.none());
+  });
+});

--- a/packages/capabilities/src/liveness/test/livenessService.test.ts
+++ b/packages/capabilities/src/liveness/test/livenessService.test.ts
@@ -1,0 +1,314 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { IndexerLiveness } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Deferred, Duration, Effect, Fiber, Option, Ref, Stream, TestClock, TestContext } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { type LivenessReads, LivenessReadError, LivenessServiceImpl } from '../livenessService.js';
+
+const tolerances = { maxBehindBlocks: 10n, maxAheadBlocks: 10n };
+
+/** Reads that always report the same two heights. */
+// The same genesis bytes in each side's own presentation — the node 0x-prefixed, the indexer bare — so every test
+// that uses these stubs also exercises the normalisation a real pairing depends on.
+const INDEXER_GENESIS = 'ab'.repeat(32);
+const NODE_GENESIS = `0x${'ab'.repeat(32)}`;
+
+/** Reads on one chain: matching genesis hashes and the given heights. */
+const sameChainReads = (overrides: Partial<LivenessReads>): LivenessReads => ({
+  indexerHeight: () => Effect.succeed(1_000n),
+  finalizedHeight: () => Effect.succeed(1_000n),
+  indexerGenesisHash: () => Effect.succeed(INDEXER_GENESIS),
+  nodeGenesisHash: () => Effect.succeed(NODE_GENESIS),
+  ...overrides,
+});
+
+const fixedReads = (indexerHeight: bigint, finalizedHeight: bigint): LivenessReads =>
+  sameChainReads({
+    indexerHeight: () => Effect.succeed(indexerHeight),
+    finalizedHeight: () => Effect.succeed(finalizedHeight),
+  });
+
+/** The verdict currently published by the service. */
+const currentVerdict = (service: LivenessServiceImpl) => Stream.runHead(service.state());
+
+describe('LivenessServiceImpl', () => {
+  it('should report Unknown before any tick, because a check exists but has not run', async () => {
+    const program = Effect.gen(function* () {
+      const service = yield* LivenessServiceImpl.make(fixedReads(1_000n, 1_000n), tolerances);
+
+      return yield* currentVerdict(service);
+    });
+
+    const verdict = await Effect.runPromise(program);
+
+    expect(verdict).toStrictEqual(Option.some(IndexerLiveness.Unknown()));
+  });
+
+  it('should publish a verdict on each tick', async () => {
+    const program = Effect.gen(function* () {
+      const service = yield* LivenessServiceImpl.make(fixedReads(1_000n, 1_000n), tolerances);
+
+      yield* service.startPolling(Stream.make(1));
+
+      return yield* currentVerdict(service);
+    });
+
+    const verdict = await Effect.runPromise(program);
+
+    expect(verdict).toStrictEqual(
+      Option.some(IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n })),
+    );
+  });
+
+  it('should publish Unavailable when a read fails, rather than failing the polling loop', async () => {
+    // A liveness check that gave up on its first network error would be useless against exactly the conditions it
+    // exists to detect, so `startPolling` cannot fail.
+    const program = Effect.gen(function* () {
+      const reads = sameChainReads({
+        finalizedHeight: () => Effect.fail(new LivenessReadError({ message: 'websocket closed' })),
+      });
+      const service = yield* LivenessServiceImpl.make(reads, tolerances);
+
+      yield* service.startPolling(Stream.make(1));
+
+      return yield* currentVerdict(service);
+    });
+
+    const verdict = await Effect.runPromise(program);
+
+    expect(verdict).toStrictEqual(
+      Option.some(IndexerLiveness.Unavailable({ consecutiveFailures: 1, lastError: 'websocket closed' })),
+    );
+  });
+
+  it('should survive a read that dies, because a defect must not silently disable the check', async () => {
+    // `catchAll` folds only the typed channel. A read can also die — a malformed indexer payload, an unparsed URL — and
+    // if that kills the poll fibre the verdict freezes at whatever was last written, which at start-up is `Unknown` and
+    // never gates. An indexer able to disable the check by returning bad data defeats the point of having one.
+    const program = Effect.gen(function* () {
+      const diesOnce = yield* Ref.make(1);
+      const reads = sameChainReads({
+        indexerHeight: () => Effect.succeed(1_000n),
+        finalizedHeight: () =>
+          Ref.getAndUpdate(diesOnce, (remaining) => (remaining > 0 ? remaining - 1 : 0)).pipe(
+            Effect.flatMap((remaining) =>
+              remaining > 0 ? Effect.die(new RangeError('not an integer')) : Effect.succeed(1_000n),
+            ),
+          ),
+      });
+      const service = yield* LivenessServiceImpl.make(reads, tolerances);
+
+      yield* service.startPolling(Stream.make(1));
+      const afterDefect = yield* currentVerdict(service);
+
+      // The second tick proves the loop is still running, not merely that the first defect was caught.
+      yield* service.startPolling(Stream.make(2));
+      const afterRecovery = yield* currentVerdict(service);
+
+      return { afterDefect, afterRecovery };
+    });
+
+    const { afterDefect, afterRecovery } = await Effect.runPromise(program);
+
+    expect(Option.getOrThrow(afterDefect)._tag).toBe('Unavailable');
+    expect(afterRecovery).toStrictEqual(
+      Option.some(IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n })),
+    );
+  });
+
+  it('should bound the whole poll, so a read that hangs becomes Unavailable instead of freezing the loop', async () => {
+    // Only the node read carried its own deadline. An indexer endpoint that accepts a connection and never answers
+    // hung the poll forever: `startPolling` runs one poll at a time, so the loop stopped, the verdict froze at
+    // whatever was published last — and if that was `InSync`, a wallet reported itself synchronized indefinitely
+    // while its indexer stalled. A hung read must not be able to switch the check off.
+    const program = Effect.gen(function* () {
+      const reads = sameChainReads({
+        indexerHeight: () => Effect.never,
+        finalizedHeight: () => Effect.succeed(1_000n),
+      });
+      const service = yield* LivenessServiceImpl.make(reads, {
+        ...tolerances,
+        pollTimeout: Duration.seconds(5),
+      });
+
+      const polling = yield* Effect.fork(service.startPolling(Stream.make(1)));
+      yield* TestClock.adjust(Duration.seconds(5));
+      yield* Fiber.join(polling);
+
+      return yield* currentVerdict(service);
+    });
+
+    const verdict = await Effect.runPromise(program.pipe(Effect.provide(TestContext.TestContext)));
+
+    expect(Option.getOrThrow(verdict)._tag).toBe('Unavailable');
+  });
+
+  it('should publish a verdict only when it changes, so an idle wallet is not re-notified every poll', async () => {
+    // Every poll wrote its verdict unconditionally, and that write fans out into the wallet's full state stream — so
+    // a healthy, idle wallet re-published its entire state to every subscriber once per poll, forever. Verdicts are
+    // structural data, so consecutive equals are dropped; `Unavailable`'s climbing failure count still differs poll
+    // to poll, so a lengthening outage keeps reporting.
+    const program = Effect.gen(function* () {
+      const service = yield* LivenessServiceImpl.make(fixedReads(1_000n, 1_000n), tolerances);
+      const seen = yield* Ref.make<readonly IndexerLiveness.IndexerLiveness[]>([]);
+      const subscribed = yield* Deferred.make<void>();
+
+      const subscriber = yield* Effect.fork(
+        service.state().pipe(
+          Stream.tap(() => Deferred.succeed(subscribed, undefined)),
+          Stream.runForEach((verdict) => Ref.update(seen, (all) => [...all, verdict])),
+        ),
+      );
+      // The replayed initial verdict proves the subscription is live before any poll runs.
+      yield* Deferred.await(subscribed);
+
+      yield* service.startPolling(Stream.make(1, 2, 3));
+      // Let the subscriber drain everything the three polls enqueued before reading the log.
+      yield* Effect.sleep(Duration.millis(20));
+      yield* Fiber.interrupt(subscriber);
+
+      return yield* Ref.get(seen);
+    });
+
+    const seen = await Effect.runPromise(program);
+
+    expect(seen).toStrictEqual([
+      IndexerLiveness.Unknown(),
+      IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n }),
+    ]);
+  });
+
+  it('should recover once a read succeeds again, so a transient outage leaves no trace', async () => {
+    const program = Effect.gen(function* () {
+      // Mutable only as test setup: the node read fails once, then succeeds.
+      const failuresRemaining = yield* Ref.make(1);
+      const reads = sameChainReads({
+        indexerHeight: () => Effect.succeed(1_000n),
+        finalizedHeight: () =>
+          Ref.getAndUpdate(failuresRemaining, (remaining) => (remaining > 0 ? remaining - 1 : 0)).pipe(
+            Effect.flatMap((remaining) =>
+              remaining > 0
+                ? Effect.fail(new LivenessReadError({ message: 'websocket closed' }))
+                : Effect.succeed(1_000n),
+            ),
+          ),
+      });
+      const service = yield* LivenessServiceImpl.make(reads, tolerances);
+
+      yield* service.startPolling(Stream.make(1, 2));
+
+      return yield* currentVerdict(service);
+    });
+
+    const verdict = await Effect.runPromise(program);
+
+    expect(verdict).toStrictEqual(
+      Option.some(IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n })),
+    );
+  });
+
+  describe('genesis cross-check', () => {
+    it('should pin WrongNetwork when the genesis hashes differ, never comparing heights on any poll', async () => {
+      // A mismatch cannot heal: both hashes were read successfully and differ, and neither endpoint changes chain
+      // until reconfigured. So the verdict is pinned — later polls neither re-read the hashes nor read heights, whose
+      // comparison would be between two different chains and therefore meaningless.
+      const calls = { heights: 0, genesis: 0 };
+      const reads = sameChainReads({
+        indexerHeight: () => {
+          calls.heights += 1;
+          return Effect.succeed(1_000n);
+        },
+        indexerGenesisHash: () => {
+          calls.genesis += 1;
+          return Effect.succeed('aa'.repeat(32));
+        },
+        nodeGenesisHash: () => Effect.succeed(`0x${'bb'.repeat(32)}`),
+      });
+
+      const verdict = await Effect.runPromise(
+        Effect.gen(function* () {
+          const service = yield* LivenessServiceImpl.make(reads, tolerances);
+          yield* service.startPolling(Stream.make('tick', 'tick', 'tick'));
+          return yield* currentVerdict(service);
+        }),
+      );
+
+      expect(verdict).toStrictEqual(
+        Option.some(
+          IndexerLiveness.WrongNetwork({
+            indexerGenesisHash: 'aa'.repeat(32),
+            nodeGenesisHash: `0x${'bb'.repeat(32)}`,
+          }),
+        ),
+      );
+      expect(calls.genesis).toBe(1);
+      expect(calls.heights).toBe(0);
+    });
+
+    it('should verify the chain identity once, then compare only heights on later polls', async () => {
+      const calls = { genesis: 0 };
+      const reads = sameChainReads({
+        indexerGenesisHash: () => {
+          calls.genesis += 1;
+          return Effect.succeed(INDEXER_GENESIS);
+        },
+      });
+
+      const verdict = await Effect.runPromise(
+        Effect.gen(function* () {
+          const service = yield* LivenessServiceImpl.make(reads, tolerances);
+          yield* service.startPolling(Stream.make('tick', 'tick', 'tick'));
+          return yield* currentVerdict(service);
+        }),
+      );
+
+      expect(verdict).toStrictEqual(
+        Option.some(IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n })),
+      );
+      expect(calls.genesis).toBe(1);
+    });
+
+    it('should report a failed genesis read as Unavailable and retry it on the next poll', async () => {
+      // Failing to read a hash proves nothing about which chain anyone is on, so it must not pin anything — unlike a
+      // successful read of two different hashes.
+      const attempts = { count: 0 };
+      const reads = sameChainReads({
+        indexerGenesisHash: () => {
+          attempts.count += 1;
+          return attempts.count === 1
+            ? Effect.fail(new LivenessReadError({ message: 'indexer answered garbage' }))
+            : Effect.succeed(INDEXER_GENESIS);
+        },
+      });
+
+      const verdicts = await Effect.runPromise(
+        Effect.gen(function* () {
+          const service = yield* LivenessServiceImpl.make(reads, tolerances);
+          yield* service.startPolling(Stream.make('tick'));
+          const afterFailure = yield* currentVerdict(service);
+          yield* service.startPolling(Stream.make('tick'));
+          const afterRecovery = yield* currentVerdict(service);
+          return { afterFailure, afterRecovery };
+        }),
+      );
+
+      expect(verdicts.afterFailure).toStrictEqual(
+        Option.some(IndexerLiveness.Unavailable({ consecutiveFailures: 1, lastError: 'indexer answered garbage' })),
+      );
+      expect(verdicts.afterRecovery).toStrictEqual(
+        Option.some(IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n })),
+      );
+      expect(attempts.count).toBe(2);
+    });
+  });
+});

--- a/packages/capabilities/src/liveness/test/livenessService.test.ts
+++ b/packages/capabilities/src/liveness/test/livenessService.test.ts
@@ -214,6 +214,40 @@ describe('LivenessServiceImpl', () => {
     ]);
   });
 
+  it('should not republish InSync as the chain advances, so a healthy idle wallet is quiet between real changes', async () => {
+    // On a live network both heights climb about five blocks per poll, so consecutive InSync verdicts are never
+    // structurally equal — and a dedup keyed on structure let every poll fan a new wallet state out to every subscriber.
+    const program = Effect.gen(function* () {
+      // Mutable only as test setup: the chain advances five blocks between polls, indexer and node in step.
+      const polls = yield* Ref.make(0n);
+      const advancing = sameChainReads({
+        indexerHeight: () => Ref.getAndUpdate(polls, (n) => n + 1n).pipe(Effect.map((n) => 1_000n + 5n * n)),
+        finalizedHeight: () => Ref.get(polls).pipe(Effect.map((n) => 1_000n + 5n * n)),
+      });
+      const service = yield* LivenessServiceImpl.make(advancing, tolerances);
+      const seen = yield* Ref.make<readonly IndexerLiveness.IndexerLiveness[]>([]);
+      const subscribed = yield* Deferred.make<void>();
+
+      const subscriber = yield* Effect.fork(
+        service.state().pipe(
+          Stream.tap(() => Deferred.succeed(subscribed, undefined)),
+          Stream.runForEach((verdict) => Ref.update(seen, (all) => [...all, verdict])),
+        ),
+      );
+      yield* Deferred.await(subscribed);
+
+      yield* service.startPolling(Stream.make(1, 2, 3));
+      yield* Effect.sleep(Duration.millis(20));
+      yield* Fiber.interrupt(subscriber);
+
+      return yield* Ref.get(seen);
+    });
+
+    const seen = await Effect.runPromise(program);
+
+    expect(seen.map((verdict) => verdict._tag)).toStrictEqual(['Unknown', 'InSync']);
+  });
+
   it('should recover once a read succeeds again, so a transient outage leaves no trace', async () => {
     const program = Effect.gen(function* () {
       // Mutable only as test setup: the node read fails once, then succeeds.

--- a/packages/capabilities/src/liveness/test/livenessService.test.ts
+++ b/packages/capabilities/src/liveness/test/livenessService.test.ts
@@ -153,6 +153,32 @@ describe('LivenessServiceImpl', () => {
     expect(Option.getOrThrow(verdict)._tag).toBe('Unavailable');
   });
 
+  it('should publish Unavailable at the poll timeout even when the hung read cannot be interrupted', async () => {
+    // A read that hangs inside an uninterruptible region — the node client's connection build is one — cannot be cut
+    // short, and a timeout that interrupts and then awaits its loser inherits that wait: the bound becomes as soft as
+    // the read is long. The verdict must still land at the deadline, with the read left to finish in the background.
+    const program = Effect.gen(function* () {
+      const reads = sameChainReads({
+        finalizedHeight: () => Effect.uninterruptible(Effect.sleep(Duration.minutes(1)).pipe(Effect.as(1_000n))),
+      });
+      const service = yield* LivenessServiceImpl.make(reads, { ...tolerances, pollTimeout: Duration.seconds(5) });
+
+      // A daemon, not a child: the test program must not wait on a poll that is still stuck at its end.
+      const polling = yield* Effect.forkDaemon(service.startPolling(Stream.make(1)));
+      yield* TestClock.adjust(Duration.seconds(5));
+      // Let the timed-out poll run through to its verdict. The clock has not moved far enough for the read to finish.
+      yield* Effect.yieldNow();
+      yield* Effect.yieldNow();
+
+      return { settled: yield* Fiber.poll(polling), verdict: yield* currentVerdict(service) };
+    });
+
+    const { settled, verdict } = await Effect.runPromise(program.pipe(Effect.provide(TestContext.TestContext)));
+
+    expect(Option.isSome(settled)).toBe(true);
+    expect(Option.getOrThrow(verdict)._tag).toBe('Unavailable');
+  });
+
   it('should publish a verdict only when it changes, so an idle wallet is not re-notified every poll', async () => {
     // Every poll wrote its verdict unconditionally, and that write fans out into the wallet's full state stream — so
     // a healthy, idle wallet re-published its entire state to every subscriber once per poll, forever. Verdicts are

--- a/packages/capabilities/src/liveness/test/livenessService.test.ts
+++ b/packages/capabilities/src/liveness/test/livenessService.test.ts
@@ -217,6 +217,38 @@ describe('LivenessServiceImpl', () => {
     );
   });
 
+  it('should keep gating on Behind when a later poll fails, so a node outage cannot clear a proven stale view', async () => {
+    // A Behind verdict is proof the indexer is stale; a failed poll after it proves nothing.
+    // Replacing it with Unavailable, which does not gate, would let a pending waitForSyncedState() resolve over the
+    // same stale indexer the first poll caught.
+    const program = Effect.gen(function* () {
+      // Mutable only as test setup: the node read answers once, then the endpoint goes away.
+      const answersRemaining = yield* Ref.make(1);
+      const reads = sameChainReads({
+        indexerHeight: () => Effect.succeed(900n),
+        finalizedHeight: () =>
+          Ref.getAndUpdate(answersRemaining, (remaining) => (remaining > 0 ? remaining - 1 : 0)).pipe(
+            Effect.flatMap((remaining) =>
+              remaining > 0
+                ? Effect.succeed(1_000n)
+                : Effect.fail(new LivenessReadError({ message: 'websocket closed' })),
+            ),
+          ),
+      });
+      const service = yield* LivenessServiceImpl.make(reads, tolerances);
+
+      yield* service.startPolling(Stream.make(1, 2));
+
+      return yield* currentVerdict(service);
+    });
+
+    const verdict = await Effect.runPromise(program);
+
+    expect(verdict).toStrictEqual(
+      Option.some(IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_000n, lag: 100n })),
+    );
+  });
+
   describe('genesis cross-check', () => {
     it('should pin WrongNetwork when the genesis hashes differ, never comparing heights on any poll', async () => {
       // A mismatch cannot heal: both hashes were read successfully and differ, and neither endpoint changes chain

--- a/packages/docs-snippets/src/snippets/indexer-liveness.no-net.ts
+++ b/packages/docs-snippets/src/snippets/indexer-liveness.no-net.ts
@@ -1,0 +1,155 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Reading the indexer liveness verdict.
+//
+// The wallet compares the indexer's latest block against the node's highest finalized block — after establishing,
+// once, that both report the same genesis block. Three verdicts make the wallet report itself incomplete: `Behind`,
+// which proves its view is stale; `Unknown`, which lasts the few seconds until the first comparison lands; and
+// `WrongNetwork`, which proves the two endpoints are on different chains. The rest are informational. All seven are
+// readable at any time, so an application can explain a wallet's state to a user rather than only showing a boolean.
+
+import {
+  type DefaultConfiguration,
+  type FacadeState,
+  IndexerLiveness,
+  type UnshieldedWalletState,
+  type WalletFacade,
+} from '@midnightntwrk/wallet-sdk';
+import { Duration } from 'effect';
+import { firstValueFrom, type Subscription } from 'rxjs';
+
+// Turning a verdict into something worth showing a user. `$match` is exhaustive: adding a verdict later fails to compile
+// here until it is handled.
+const describeLiveness = IndexerLiveness.match({
+  InSync: ({ indexerHeight, finalizedHeight }) =>
+    `Indexer is up to date (block ${indexerHeight} against a finalized head of ${finalizedHeight}).`,
+
+  Behind: ({ lag, indexerHeight, finalizedHeight }) =>
+    `Indexer is ${lag} block(s) behind the chain (${indexerHeight} against ${finalizedHeight}). ` +
+    `Balances may be missing recent funds.`,
+
+  Ahead: ({ overshoot, indexerHeight, finalizedHeight }) =>
+    `Indexer reports block ${indexerHeight}, which is ${overshoot} ahead of this node's finalized head ` +
+    `(${finalizedHeight}). Check that both point at the same network.`,
+
+  // The detail worth surfacing: how long the check has been failing, and what failed most recently. Either side may be
+  // the one that failed — the node read, the indexer read, or the whole poll timing out — and `lastError` says which.
+  Unavailable: ({ consecutiveFailures, lastError }) =>
+    `The indexer cannot be verified right now — ${consecutiveFailures} poll(s) have failed. ` +
+    `Most recently: ${lastError}`,
+
+  Skipped: ({ reason }) => `Indexer is not being verified against a node (${reason}).`,
+
+  Unknown: () => 'Indexer has not been verified against a node yet.',
+
+  // The loudest verdict: the two endpoints disagree about the genesis block, so one of them points at another chain
+  // and every balance shown is suspect. This pins until the configuration is fixed — it cannot heal on its own.
+  WrongNetwork: ({ indexerGenesisHash, nodeGenesisHash }) =>
+    `The indexer and the node are on different networks (indexer genesis ${indexerGenesisHash}, ` +
+    `node genesis ${nodeGenesisHash}). Check the configured endpoints.`,
+});
+
+// The verdict lives on the wallet's state, so it is read wherever that state is read.
+export const describeUnshieldedLiveness = (state: UnshieldedWalletState): string =>
+  describeLiveness(state.progress.indexerLiveness);
+
+// The facade's state carries the same unshielded progress.
+export const describeFacadeLiveness = (state: FacadeState): string =>
+  describeLiveness(state.unshielded.progress.indexerLiveness);
+
+// Both are observables, so in practice a verdict is read as the state changes.
+export const reportLivenessChanges = (facade: WalletFacade): Subscription =>
+  facade.state().subscribe((state) => {
+    console.log(describeFacadeLiveness(state));
+  });
+
+// Or read once, for a one-off check.
+export const currentLiveness = async (facade: WalletFacade): Promise<string> =>
+  describeFacadeLiveness(await firstValueFrom(facade.state()));
+
+// Acting on one case in particular, rather than describing them all.
+export const failedAttemptsToReachNode = (state: UnshieldedWalletState): number | undefined => {
+  const verdict = state.progress.indexerLiveness;
+
+  return IndexerLiveness.isUnavailable(verdict) ? verdict.consecutiveFailures : undefined;
+};
+
+// A wallet can report itself complete while still having something worth saying about the indexer: only `Behind`,
+// `Unknown` and `WrongNetwork` affect the boolean — plus the connection flag, which is a different statement again. `isConnected: false`
+// means this wallet's own subscription to the indexer is down (it clears when the sync stream fails and returns with
+// the next update), whereas a `Behind` verdict means the subscription works but the indexer itself is stale. An
+// application that shows both can tell a user "reconnecting" apart from "your balance may be out of date".
+export const summarise = (
+  state: UnshieldedWalletState,
+): { complete: boolean; subscribed: boolean; liveness: string } => ({
+  complete: state.progress.isStrictlyComplete(),
+  subscribed: state.progress.isConnected,
+  liveness: describeLiveness(state.progress.indexerLiveness),
+});
+
+// Tuning the check. Both fields are optional, and the defaults — 10 blocks of tolerance either way, polled every 30
+// seconds — allow about a minute of staleness at Midnight's 6-second blocks, re-checked every five blocks or so. Add
+// these to the configuration passed to `WalletFacade.init`.
+export const tunedLiveness: Pick<DefaultConfiguration, 'livenessConfiguration' | 'livenessPollInterval'> = {
+  livenessConfiguration: {
+    // The staleness allowance: how out-of-date a view the application is willing to treat as current. This is what
+    // decides `Behind`, and so what decides whether the wallet reports itself complete.
+    maxBehindBlocks: 4n,
+
+    // Read skew only. The indexer ingests finalized blocks, so it cannot legitimately lead the node's finalized head by
+    // more than the gap between the two reads accounts for — keep this small, or a fabricated height passes as `InSync`
+    // instead of `Ahead`.
+    maxAheadBlocks: 2n,
+
+    // How long one comparison may run before it is abandoned and reported as `Unavailable` (default 20 seconds).
+    // Polls run one at a time, so without this bound a read that hangs would stop the check silently.
+    pollTimeout: Duration.seconds(10),
+  },
+
+  // Accepts a `Duration`, a millisecond count, or a string such as '15 seconds'. Each poll costs one request to the
+  // indexer and one to the node, so this trades load against how quickly a stalled indexer is noticed. Polls do not
+  // overlap, and a node read is abandoned after ten seconds, so an interval below that buys nothing.
+  livenessPollInterval: '15 seconds',
+};
+
+// Naming the verification node explicitly. Without this, the check reads the node already named by `relayURL` for
+// transaction submission — the right default, since both point at the same chain. Set it to verify against a node you
+// trust more than the submission relay, or on a wallet built without submission configuration, which has no `relayURL`
+// to borrow. A wallet naming neither runs no check and reports `Skipped`.
+export const ownVerificationNode: Pick<DefaultConfiguration, 'nodeClientConnection'> = {
+  nodeClientConnection: { nodeURL: 'wss://my-own-node.example:9944' },
+};
+
+// Gating start-up on a synchronized wallet, without hanging silently.
+//
+// `waitForSyncedState()` resolves only when the wallet is genuinely synchronized: it does not reject and does not time
+// out, so against an indexer that is behind the chain — or a dropped subscription — it simply waits. That is the
+// point, but a start-up gate should say *why* it is still waiting. The diagnosis is on the progress, not in the
+// promise: race the wait against a deadline of your own, and on expiry read the verdict and the connection flag.
+export const syncedStateOrExplanation = async (
+  facade: WalletFacade,
+  deadlineMillis: number,
+): Promise<FacadeState | string> => {
+  const deadline = new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), deadlineMillis));
+  const synced = await Promise.race([facade.waitForSyncedState(), deadline]);
+
+  if (synced !== undefined) {
+    return synced;
+  }
+
+  const { progress } = (await firstValueFrom(facade.state())).unshielded;
+  return progress.isConnected
+    ? describeLiveness(progress.indexerLiveness)
+    : 'The indexer subscription is down; the wallet is reconnecting.';
+};

--- a/packages/docs-snippets/src/snippets/indexer-liveness.no-net.ts
+++ b/packages/docs-snippets/src/snippets/indexer-liveness.no-net.ts
@@ -153,3 +153,21 @@ export const syncedStateOrExplanation = async (
     ? describeLiveness(progress.indexerLiveness)
     : 'The indexer subscription is down; the wallet is reconnecting.';
 };
+
+// Every verdict, described. Run as a script, this prints what a user would see in each state. It is also what the
+// snippet test snapshots, so the wording above cannot drift unnoticed — and a snippet that only exported functions
+// produced no output to snapshot at all.
+const examples: readonly IndexerLiveness.IndexerLiveness[] = [
+  IndexerLiveness.Unknown(),
+  IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_002n }),
+  IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_000n, lag: 100n }),
+  IndexerLiveness.Ahead({ indexerHeight: 1_050n, finalizedHeight: 1_000n, overshoot: 50n }),
+  IndexerLiveness.Unavailable({ consecutiveFailures: 3, lastError: 'Poll abandoned: a read did not complete in time' }),
+  IndexerLiveness.Skipped({ reason: 'no-node-configured' }),
+  IndexerLiveness.WrongNetwork({ indexerGenesisHash: 'ab'.repeat(32), nodeGenesisHash: `0x${'cd'.repeat(32)}` }),
+];
+
+examples.forEach((verdict) => {
+  console.log(`${verdict._tag} — blocks sync completion: ${IndexerLiveness.blocksSyncCompletion(verdict)}`);
+  console.log(`  ${describeLiveness(verdict)}`);
+});

--- a/packages/docs-snippets/src/snippets/initialization.ts
+++ b/packages/docs-snippets/src/snippets/initialization.ts
@@ -39,6 +39,9 @@ const configuration: DefaultConfiguration = {
   costParameters: {
     feeBlocksMargin: 5,
   },
+  // Transactions are submitted through this node. Syncing also needs a node — it cross-checks the indexer's reported
+  // position against the chain's finalized head — and rather than name the same endpoint twice, this one is used. A
+  // wallet built without submission configuration names its own under `nodeClientConnection` instead.
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
   provingServerUrl: new URL(`http://localhost:${PROOF_SERVER_PORT}`),
   indexerClientConnection: {

--- a/packages/docs-snippets/src/test/__snapshots__/test-snippets.undeployed.test.ts.snap
+++ b/packages/docs-snippets/src/test/__snapshots__/test-snippets.undeployed.test.ts.snap
@@ -1231,3 +1231,23 @@ dust:
 ",
 ]
 `;
+
+exports[`Snippet outputs > without network > should output the correct result for 'indexer-liveness' 1`] = `
+[
+  "Unknown — blocks sync completion: true
+  Indexer has not been verified against a node yet.
+InSync — blocks sync completion: false
+  Indexer is up to date (block 1000 against a finalized head of 1002).
+Behind — blocks sync completion: true
+  Indexer is 100 block(s) behind the chain (900 against 1000). Balances may be missing recent funds.
+Ahead — blocks sync completion: false
+  Indexer reports block 1050, which is 50 ahead of this node's finalized head (1000). Check that both point at the same network.
+Unavailable — blocks sync completion: false
+  The indexer cannot be verified right now — 3 poll(s) have failed. Most recently: Poll abandoned: a read did not complete in time
+Skipped — blocks sync completion: false
+  Indexer is not being verified against a node (no-node-configured).
+WrongNetwork — blocks sync completion: true
+  The indexer and the node are on different networks (indexer genesis abababababababababababababababababababababababababababababababab, node genesis 0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd). Check the configured endpoints.
+",
+]
+`;

--- a/packages/facade/test/livenessWiring.test.ts
+++ b/packages/facade/test/livenessWiring.test.ts
@@ -1,0 +1,85 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
+import {
+  createKeystore,
+  PublicKey,
+  resolveNodeEndpoint,
+  UnshieldedWallet,
+} from '@midnightntwrk/wallet-sdk-unshielded-wallet';
+import { Option } from 'effect';
+import * as crypto from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import { type DefaultConfiguration, mergeWalletEntries, WalletEntrySchema, WalletFacade } from '../src/index.js';
+
+/**
+ * A configuration of the shape an integrator actually writes: a `relayURL` for submission, and no
+ * `nodeClientConnection`.
+ */
+const configuration: DefaultConfiguration = {
+  networkId: NetworkId.NetworkId.Undeployed,
+  relayURL: new URL('ws://localhost:9944'),
+  indexerClientConnection: {
+    indexerHttpUrl: 'http://localhost:8088/api/v4/graphql',
+  },
+  provingServerUrl: new URL('http://localhost:6300'),
+  costParameters: {
+    feeBlocksMargin: 0,
+  },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
+};
+
+describe('indexer liveness wiring through the facade', () => {
+  it('should hand the unshielded wallet a configuration the liveness check can read a node from', async () => {
+    // The check was originally reachable only by setting `nodeClientConnection`, which nothing set — so no wallet built
+    // through the facade ever ran it, while the release notes implied otherwise. Nothing caught that, because every other
+    // facade test runs in simulation mode, whose sync service never consults a node at all. This asserts the wiring
+    // itself: whatever the facade passes to the unshielded initializer must yield an endpoint to check against.
+    const seed = crypto.randomBytes(32);
+    const configurations: DefaultConfiguration[] = [];
+
+    await WalletFacade.init({
+      configuration,
+      shielded: (config) => {
+        const shielded = vi.mockObject(ShieldedWallet(config).startWithSeed(seed));
+        shielded.start.mockResolvedValue(undefined);
+        return shielded;
+      },
+      unshielded: (config) => {
+        configurations.push(config);
+        const unshielded = vi.mockObject(
+          UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(createKeystore(seed, config.networkId))),
+        );
+        unshielded.start.mockResolvedValue(undefined);
+        return unshielded;
+      },
+      dust: (config) => {
+        const dust = vi.mockObject(
+          DustWallet(config).startWithSeed(seed, ledger.LedgerParameters.initialParameters().dust),
+        );
+        dust.start.mockResolvedValue(undefined);
+        return dust;
+      },
+    });
+
+    expect(configurations).toHaveLength(1);
+    expect(configurations.map((config) => Option.isSome(resolveNodeEndpoint(config)))).toStrictEqual([true]);
+  });
+
+  it('should resolve the submission node, so no second endpoint has to be configured', () => {
+    expect(resolveNodeEndpoint(configuration)).toStrictEqual(Option.some({ nodeURL: 'ws://localhost:9944/' }));
+  });
+});

--- a/packages/facade/test/livenessWiring.test.ts
+++ b/packages/facade/test/livenessWiring.test.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 import * as ledger from '@midnight-ntwrk/ledger-v8';
 import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type SubmissionService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import {
@@ -24,6 +25,15 @@ import { Option } from 'effect';
 import * as crypto from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import { type DefaultConfiguration, mergeWalletEntries, WalletEntrySchema, WalletFacade } from '../src/index.js';
+
+// Injected so `init` never builds the default submission service: that would open a real node client on `relayURL`
+// with an infinite reconnection timeout, leaving a WebSocket reconnect loop running for the rest of the worker. A unit
+// test may not touch the network, and this test is about configuration plumbing, not submission.
+const fakeSubmission: SubmissionService<ledger.FinalizedTransaction> = {
+  // `Promise<never>` satisfies every overload of the method type; a bare `Promise.reject` is typed to the last one only.
+  submitTransaction: (): Promise<never> => Promise.reject(new Error('This submission implementation does not submit')),
+  close: () => Promise.resolve(),
+};
 
 /**
  * A configuration of the shape an integrator actually writes: a `relayURL` for submission, and no
@@ -53,6 +63,7 @@ describe('indexer liveness wiring through the facade', () => {
 
     await WalletFacade.init({
       configuration,
+      submissionService: () => fakeSubmission,
       shielded: (config) => {
         const shielded = vi.mockObject(ShieldedWallet(config).startWithSeed(seed));
         shielded.start.mockResolvedValue(undefined);

--- a/packages/node-client/src/effect/NodeClient.ts
+++ b/packages/node-client/src/effect/NodeClient.ts
@@ -17,17 +17,66 @@ import { type SerializedTransaction } from '@midnightntwrk/wallet-sdk-abstractio
 
 export type Genesis = { readonly transactions: readonly SerializedTransaction.SerializedTransaction[] };
 
+/**
+ * The node's highest block that GRANDPA has finalized.
+ *
+ * @remarks
+ *   This is the reference a wallet compares an indexer's self-reported position against. It comes from consensus rather
+ *   than from the indexer, which is what makes the comparison meaningful.
+ */
+export type FinalizedBlock = {
+  /** The hash of the finalized block, hex-encoded. */
+  readonly hash: string;
+  /** The height of the finalized block. */
+  readonly height: bigint;
+};
+
 export interface Service {
   sendMidnightTransaction(
     serializedTransaction: SerializedTransaction.SerializedTransaction,
   ): Stream.Stream<SubmissionEvent.SubmissionEvent, NodeClientError.NodeClientError>;
   getGenesis(): Effect.Effect<Genesis, NodeClientError.NodeClientError>;
+  getFinalizedBlock(): Effect.Effect<FinalizedBlock, NodeClientError.NodeClientError>;
+  getGenesisHash(): Effect.Effect<string, NodeClientError.NodeClientError>;
 }
 
 export class NodeClient extends Context.Tag('@midnight-ntwrk/wallet-node-client#NodeClient')<NodeClient, Service>() {}
 
 export const getGenesisTransactions = (): Effect.Effect<Genesis, NodeClientError.NodeClientError, NodeClient> =>
   NodeClient.pipe(Effect.flatMap((client) => client.getGenesis()));
+
+/**
+ * Reads the node's highest finalized block.
+ *
+ * @remarks
+ *   Safe to interleave with other calls on the same service instance: the default implementation reference-counts its
+ *   shared connection and disconnects only when the last in-flight call finishes, so a read completing never drops an
+ *   in-flight `sendMidnightTransaction`'s status subscription.
+ * @example
+ *   ```ts
+ *   const finalized = yield* NodeClient.getFinalizedBlock();
+ *   ```;
+ *
+ * @returns An effect yielding the hash and height of the highest block GRANDPA has finalized.
+ */
+export const getFinalizedBlock = (): Effect.Effect<FinalizedBlock, NodeClientError.NodeClientError, NodeClient> =>
+  NodeClient.pipe(Effect.flatMap((client) => client.getFinalizedBlock()));
+
+/**
+ * Reads the hash of the node's genesis block.
+ *
+ * @remarks
+ *   Identifies the chain the node is on: two endpoints reporting different genesis hashes are on different networks. The
+ *   default implementation answers from state the client already holds, without opening a connection.
+ * @example
+ *   ```ts
+ *   const genesisHash = yield* NodeClient.getGenesisHash();
+ *   ```;
+ *
+ * @returns An effect yielding the genesis-block hash as a `0x`-prefixed hex string.
+ */
+export const getGenesisHash = (): Effect.Effect<string, NodeClientError.NodeClientError, NodeClient> =>
+  NodeClient.pipe(Effect.flatMap((client) => client.getGenesisHash()));
 
 export const sendMidnightTransaction = (
   serializedTransaction: SerializedTransaction.SerializedTransaction,

--- a/packages/node-client/src/effect/NodeClient.ts
+++ b/packages/node-client/src/effect/NodeClient.ts
@@ -36,7 +36,51 @@ export interface Service {
     serializedTransaction: SerializedTransaction.SerializedTransaction,
   ): Stream.Stream<SubmissionEvent.SubmissionEvent, NodeClientError.NodeClientError>;
   getGenesis(): Effect.Effect<Genesis, NodeClientError.NodeClientError>;
+
+  /**
+   * Reads the node's highest finalized block.
+   *
+   * @remarks
+   *   Finalized, not best: the wallet's liveness check compares an indexer's self-reported position against this value,
+   *   and the indexer ingests finalized blocks only. An implementation that answered with the best (latest, possibly
+   *   reverted) head would report a healthy indexer as behind by the finality gap on every poll. The default
+   *   implementation reads the finalized head's hash and then the header at that hash, so the two fields describe the
+   *   same block.
+   *
+   *   Must be safe to call while a `sendMidnightTransaction` is in flight on the same instance: the liveness check polls
+   *   on a timer and takes no lock. The default implementation reference-counts its shared connection and disconnects
+   *   only when the last in-flight call finishes, so a read completing never drops a submission's status subscription.
+   *
+   *   An unreachable node must surface as a typed `NodeClientError`, not a defect: the liveness check turns that failure
+   *   into an `Unavailable` verdict, and a defect would kill its poll instead.
+   * @example
+   *   ```ts
+   *   const { hash, height } = yield* client.getFinalizedBlock();
+   *   ```;
+   *
+   * @returns An effect yielding the hex-encoded hash and the height of the highest block GRANDPA has finalized.
+   */
   getFinalizedBlock(): Effect.Effect<FinalizedBlock, NodeClientError.NodeClientError>;
+
+  /**
+   * Reads the hash of the node's genesis block.
+   *
+   * @remarks
+   *   Identifies the chain the node is on. The wallet compares it, once, against the indexer's block at height zero, and
+   *   pins a `WrongNetwork` verdict when they differ — so this must be the hash of block zero, not of any later
+   *   checkpoint. The comparison is by bytes, tolerant of a `0x` prefix and of case, but the convention on this
+   *   interface is a lowercase, `0x`-prefixed hex string, which is what the default implementation returns.
+   *
+   *   Should not require a live connection. The default implementation answers from state the api captured when it was
+   *   created, so the check can establish the chain identity even while the node is temporarily unreachable.
+   * @example
+   *   ```ts
+   *   const genesisHash = yield* client.getGenesisHash();
+   *   // '0x1234…' — compare with IndexerLiveness.sameGenesis(indexerHash, genesisHash)
+   *   ```;
+   *
+   * @returns An effect yielding the genesis-block hash as a `0x`-prefixed hex string.
+   */
   getGenesisHash(): Effect.Effect<string, NodeClientError.NodeClientError>;
 }
 

--- a/packages/node-client/src/effect/PolkadotNodeClient.ts
+++ b/packages/node-client/src/effect/PolkadotNodeClient.ts
@@ -315,7 +315,9 @@ export class PolkadotNodeClient implements NodeClient.Service {
       () =>
         pipe(
           this.ensureConnection(),
-          Effect.andThen(() => Effect.promise(() => this.api.rpc.chain.getBlock(this.api.genesisHash))),
+          // `tryPromise` rather than `promise`: a rejected RPC has to reach the `mapError` below and the caller's
+          // `catchTag`, not arrive as a defect that bypasses both and kills the fibre as a crash.
+          Effect.andThen(() => Effect.tryPromise(() => this.api.rpc.chain.getBlock(this.api.genesisHash))),
           // https://polkadot.js.org/docs/api/cookbook/blocks/#how-do-i-view-extrinsic-information
           Effect.map(({ block }) => ({
             transactions: block.extrinsics

--- a/packages/node-client/src/effect/PolkadotNodeClient.ts
+++ b/packages/node-client/src/effect/PolkadotNodeClient.ts
@@ -123,12 +123,24 @@ export class PolkadotNodeClient implements NodeClient.Service {
       // still CLOSING. `isConnected` only flips false once #onSocketClose fires, so returning here without waiting
       // leaves ensureConnection() reading a stale `true`, skipping the reconnect, and sending on a dying socket.
       // Locally the close-ack lands fast enough to hide this; against a remote node it does not.
+      //
+      // The wait shares the caller's bound. A node that completes the handshake and then goes half-open never
+      // acknowledges the close frame, and only ws's own 30-second close timeout would end the wait — from inside this
+      // uninterruptible acquire, which no outer deadline can cut short. A caller who asked for a bound asked for it
+      // on the whole build, so the wait is abandoned once it elapses: the socket is left CLOSING for ws to finish, and
+      // a stale `isConnected` costs one failed readiness probe, since `ensureConnection` establishes readiness with a
+      // call rather than the flag.
       await new Promise<void>((resolve) => {
         if (!api.isConnected) {
           resolve();
           return;
         }
-        api.once('disconnected', () => resolve());
+        const closeTimer: { handle?: ReturnType<typeof setTimeout> } = {};
+        api.once('disconnected', () => {
+          if (closeTimer.handle !== undefined) clearTimeout(closeTimer.handle);
+          resolve();
+        });
+        if (isBounded) closeTimer.handle = setTimeout(resolve, timeoutMillis);
         void api.disconnect();
       });
       return api;

--- a/packages/node-client/src/effect/PolkadotNodeClient.ts
+++ b/packages/node-client/src/effect/PolkadotNodeClient.ts
@@ -20,10 +20,12 @@ import {
   Layer,
   type ParseResult,
   pipe,
+  Ref,
   Schedule,
   Schema,
   type Scope,
   Stream,
+  SynchronizedRef,
   type StreamEmit,
 } from 'effect';
 import * as NodeClient from './NodeClient.js';
@@ -38,6 +40,16 @@ export type Config = {
   reconnectionTimeout: Duration.Duration;
   reconnectionDelay: Duration.Duration;
 };
+
+/**
+ * How many consecutive readiness probes may fail on a connected socket before the failure is surfaced.
+ *
+ * @remarks
+ *   Small, because each failure on a connected socket already says the node is answering the transport but not RPC — more
+ *   retries only delay the verdict. Three tolerates a probe racing a reconnect that has not finished re-initialising,
+ *   without letting a genuinely broken node hide behind an unbounded retry loop.
+ */
+const MAX_CONNECTED_PROBE_FAILURES = 3;
 
 export const DEFAULT_CONFIG = {
   reconnectionTimeout: Duration.infinity,
@@ -54,34 +66,92 @@ export class PolkadotNodeClient implements NodeClient.Service {
     configInput: Partial<Config> & Pick<Config, 'nodeURL'>,
   ): Effect.Effect<PolkadotNodeClient, NodeClientError.NodeClientError, Scope.Scope> {
     const config = makeConfig(configInput);
+
+    // A finite `reconnectionTimeout` is a caller asking to be told when the node cannot be reached. Honouring it here as
+    // well as in `ensureConnection` is what makes that possible: left to its defaults, `WsProvider` retries on a timer
+    // and `throwOnConnect: false` means `ApiPromise.create` waits for a connection that may never arrive.
+    const isBounded = Duration.isFinite(config.reconnectionTimeout);
+
+    // The bound is enforced inside the promise rather than with `Effect.timeout`, because `Effect.acquireRelease` runs
+    // its acquire uninterruptibly — deliberately, so a resource cannot be acquired and then leaked — and an
+    // uninterruptible region ignores an outer timeout. Racing here also lets the half-open provider be closed, which an
+    // interruption could not do.
+    const connect = Effect.tryPromise(async () => {
+      // `autoConnectMs` keeps its default deliberately. Passing `false` does not mean "connect once without retrying" —
+      // it means "do not connect at all", leaving `ApiPromise.create` waiting on a connection nobody started. The bound
+      // below is what limits the wait; the provider's own retry behaviour is left alone.
+      const provider = new WsProvider(config.nodeURL.toString());
+
+      const created = ApiPromise.create({
+        // @ts-expect-error -- exactOptionalPropertyTypes cause an incompatibility here
+        provider,
+        // Surfacing a connection error rather than retrying past it, but only for a caller that asked to be bounded.
+        throwOnConnect: isBounded,
+        noInitWarn: true,
+      });
+
+      // Clamped to the largest delay `setTimeout` honours: a delay of 2^31ms or more overflows and fires after ~1ms,
+      // which turned a generous bound such as 30 days into an instant failure on every connection attempt. A bound
+      // that large behaves as "still waiting" on any human timescale, so the clamp loses nothing.
+      const timeoutMillis = Math.min(Duration.toMillis(config.reconnectionTimeout), 2 ** 31 - 1);
+      // Held so the timer can be cleared once the race settles. Left armed, it keeps Node's event loop alive, so a
+      // short-lived process that reads once cannot exit until it fires.
+      const timer: { handle?: ReturnType<typeof setTimeout> } = {};
+
+      const api = isBounded
+        ? await Promise.race([
+            created,
+            new Promise<never>((_resolve, reject) => {
+              timer.handle = setTimeout(() => reject(new Error(`Timed out after ${timeoutMillis}ms`)), timeoutMillis);
+            }),
+          ])
+            .catch(async (error: unknown) => {
+              // Without this the provider keeps retrying on its timer for the lifetime of the process.
+              await provider.disconnect().catch(() => undefined);
+              throw error;
+            })
+            .finally(() => {
+              if (timer.handle !== undefined) clearTimeout(timer.handle);
+            })
+        : await created;
+
+      // Disconnect immediately after loading metadata to avoid keeping the WebSocket open.
+      // The health-check timer (10s interval) and timeout handler (5s interval) are cleared on disconnect.
+      // Metadata and type registry remain cached in memory for subsequent on-demand connections.
+      //
+      // WsProvider.disconnect() is fire-and-forget: it dispatches the close frame and returns while the socket is
+      // still CLOSING. `isConnected` only flips false once #onSocketClose fires, so returning here without waiting
+      // leaves ensureConnection() reading a stale `true`, skipping the reconnect, and sending on a dying socket.
+      // Locally the close-ack lands fast enough to hide this; against a remote node it does not.
+      await new Promise<void>((resolve) => {
+        if (!api.isConnected) {
+          resolve();
+          return;
+        }
+        api.once('disconnected', () => resolve());
+        void api.disconnect();
+      });
+      return api;
+    });
+
     return Effect.acquireRelease(
-      Effect.promise(async () => {
-        const api = await ApiPromise.create({
-          // @ts-expect-error -- exactOptionalPropertyTypes cause an incompatibility here
-          provider: new WsProvider(config.nodeURL.toString()),
-          throwOnConnect: false,
-          noInitWarn: true,
-        });
-        // Disconnect immediately after loading metadata to avoid keeping the WebSocket open.
-        // The health-check timer (10s interval) and timeout handler (5s interval) are cleared on disconnect.
-        // Metadata and type registry remain cached in memory for subsequent on-demand connections.
-        //
-        // WsProvider.disconnect() is fire-and-forget: it dispatches the close frame and returns while the socket is
-        // still CLOSING. `isConnected` only flips false once #onSocketClose fires, so returning here without waiting
-        // leaves ensureConnection() reading a stale `true`, skipping the reconnect, and sending on a dying socket.
-        // Locally the close-ack lands fast enough to hide this; against a remote node it does not.
-        await new Promise<void>((resolve) => {
-          if (!api.isConnected) {
-            resolve();
-            return;
-          }
-          api.once('disconnected', () => resolve());
-          void api.disconnect();
-        });
-        return api;
-      }),
+      // `tryPromise` rather than `promise`: a rejected connection has to reach the error channel this method already
+      // declares, instead of arriving as a defect that no `catchTag` can handle.
+      connect.pipe(
+        Effect.mapError(
+          (cause) =>
+            new NodeClientError.ConnectionError({
+              message: `Could not connect to ${config.nodeURL.toString()}`,
+              cause,
+            }),
+        ),
+      ),
       (api) => Effect.promise(() => api.disconnect()),
-    ).pipe(Effect.map((api) => new PolkadotNodeClient(config, api)));
+    ).pipe(
+      Effect.flatMap((api) =>
+        SynchronizedRef.make(0).pipe(Effect.map((activeCalls) => new PolkadotNodeClient(config, api, activeCalls))),
+      ),
+    );
   }
 
   static layer(
@@ -92,73 +162,104 @@ export class PolkadotNodeClient implements NodeClient.Service {
 
   readonly config: Config;
   readonly api: ApiPromise;
-  /** Operations currently holding the shared connection open. */
-  #activeOperations = 0;
+  /**
+   * How many calls are in flight on this instance's shared `api`.
+   *
+   * @remarks
+   *   Every method used to end with an unconditional disconnect of the one shared socket, so interleaving any two calls
+   *   on the same instance let whichever finished first tear the socket down under the other — an in-flight
+   *   submission's status subscription being the costly case. The count makes the disconnect conditional: each call
+   *   registers before it connects and deregisters when it finishes, and only the last one out releases the socket.
+   *   `SynchronizedRef` serialises the transitions, so a call arriving while the last one is disconnecting waits, then
+   *   reconnects through `ensureConnection`.
+   */
+  readonly #activeCalls: SynchronizedRef.SynchronizedRef<number>;
 
-  constructor(config: Config, api: ApiPromise) {
+  constructor(config: Config, api: ApiPromise, activeCalls: SynchronizedRef.SynchronizedRef<number>) {
     this.config = config;
     this.api = api;
+    this.#activeCalls = activeCalls;
+  }
+
+  /** Registers one call on the shared connection. Must be balanced by {@link PolkadotNodeClient.#deregister}. */
+  #register(): Effect.Effect<void> {
+    return SynchronizedRef.update(this.#activeCalls, (active) => active + 1);
+  }
+
+  /** Deregisters one call, disconnecting the shared socket when it was the last one in flight. */
+  #deregister(): Effect.Effect<void> {
+    return SynchronizedRef.updateEffect(this.#activeCalls, (active) =>
+      active === 1 ? Effect.promise(() => this.api.disconnect()).pipe(Effect.as(0)) : Effect.succeed(active - 1),
+    );
   }
 
   ensureConnection(): Effect.Effect<void, NodeClientError.NodeClientError> {
-    return pipe(
-      Effect.promise(async () => {
-        if (!this.api.isConnected) {
-          try {
-            await this.api.connect();
-          } catch (error) {
-            // WsProvider.connect() rejects if a WebSocket already exists (connection in progress).
-            // This is expected when the repeat loop re-enters before the 'open' event fires.
-            if (!(error instanceof Error && error.message === 'WebSocket is already connected')) {
-              throw error;
+    // The counter distinguishes "the node is not there yet" from "the node is there and broken". Failures while the
+    // socket is down retry without limit — that is the unbounded caller's contract, and what submission relies on.
+    // Failures while the socket reports connected are a verdict about the node, and surfacing them restores the loud
+    // failure this method's probe had silently absorbed: before the probe existed, such a node failed on the first
+    // real call; with the probe swallowing every error, it span the retry loop forever under the default (infinite)
+    // reconnectionTimeout.
+    return Ref.make(0).pipe(
+      Effect.flatMap((connectedProbeFailures) =>
+        pipe(
+          // `tryPromise` + swallow, not `Effect.promise`: a rejected connect() inside `Effect.promise` is a defect that
+          // bypasses the typed ConnectionError mapping below and kills the caller's fibre as a crash. A rejection here
+          // is one failed attempt, not a verdict — the probe below decides usability and the schedule retries, with
+          // the surrounding timeout as the overall bound. This also covers WsProvider's rejection when a WebSocket
+          // already exists (a connection in progress), which the repeat loop routinely races into.
+          Effect.tryPromise(async () => {
+            if (!this.api.isConnected) {
+              await this.api.connect();
             }
-          }
-        }
-      }),
-      Effect.andThen(Effect.sync(() => this.api.isConnected)),
-      Effect.repeat({
-        until: (value) => value,
-        schedule: Schedule.spaced(this.config.reconnectionDelay),
-      }),
-      Effect.timeout(this.config.reconnectionTimeout),
-      Effect.asVoid,
-      Effect.mapError(
-        (timeout) =>
-          new NodeClientError.ConnectionError({
-            message: `Could not establish a usable connection within ${Duration.format(
-              this.config.reconnectionTimeout,
-            )}`,
-            cause: timeout,
           }),
+          Effect.catchAll(() => Effect.void),
+          // Readiness is established by making a call, not by reading `isConnected`. That flag goes true when the
+          // socket opens, which is earlier than the api can serve requests: after `make()` disconnects to release the
+          // socket, a reconnect has to re-initialise the runtime metadata and subscriptions, and any `api.rpc` call
+          // issued in the gap fails with a disconnection. A trivial call is the only honest test of "usable".
+          Effect.andThen(
+            Effect.tryPromise(() => this.api.rpc.system.chain()).pipe(
+              Effect.zipLeft(Ref.set(connectedProbeFailures, 0)),
+              Effect.as(true),
+              Effect.catchAll((probeError) =>
+                this.api.isConnected
+                  ? Ref.updateAndGet(connectedProbeFailures, (failures) => failures + 1).pipe(
+                      Effect.flatMap((failures) =>
+                        failures >= MAX_CONNECTED_PROBE_FAILURES
+                          ? Effect.fail(
+                              new NodeClientError.ConnectionError({
+                                message: 'Node accepted the connection but repeatedly failed to answer RPC',
+                                cause: probeError,
+                              }),
+                            )
+                          : Effect.succeed(false),
+                      ),
+                    )
+                  : // A failed probe on a closed socket says nothing beyond "not connected yet" — reset, keep waiting.
+                    Ref.set(connectedProbeFailures, 0).pipe(Effect.as(false)),
+              ),
+            ),
+          ),
+          Effect.repeat({
+            until: (usable) => usable,
+            schedule: Schedule.spaced(this.config.reconnectionDelay),
+          }),
+          Effect.timeout(this.config.reconnectionTimeout),
+          Effect.asVoid,
+          // `catchTag`, not `mapError`: the probe's ConnectionError must pass through unwrapped, so the caller sees
+          // "node answered the socket but not RPC" rather than a second ConnectionError blaming the timeout.
+          Effect.catchTag(
+            'TimeoutException',
+            (timeout) =>
+              new NodeClientError.ConnectionError({
+                message: 'Could not connect before the configured reconnectionTimeout elapsed',
+                cause: timeout,
+              }),
+          ),
+        ),
       ),
     );
-  }
-
-  /** Takes a hold on the shared connection for the duration of one operation. */
-  #acquire(): Effect.Effect<void, NodeClientError.NodeClientError> {
-    return pipe(
-      this.ensureConnection(),
-      Effect.tap(() =>
-        Effect.sync(() => {
-          this.#activeOperations += 1;
-        }),
-      ),
-    );
-  }
-
-  /**
-   * Drops one hold, disconnecting only once the last operation finishes.
-   *
-   * The api instance is shared, so an unconditional `disconnect()` in a per-operation finalizer closes the transport
-   * out from under any operation still in flight.
-   */
-  #release(): Effect.Effect<void> {
-    return Effect.promise(async () => {
-      this.#activeOperations = Math.max(0, this.#activeOperations - 1);
-      if (this.#activeOperations === 0) {
-        await this.api.disconnect();
-      }
-    });
   }
 
   sendMidnightTransaction(
@@ -187,9 +288,9 @@ export class PolkadotNodeClient implements NodeClient.Service {
     );
 
     return pipe(
-      Stream.fromEffect(this.#acquire()),
+      Stream.acquireRelease(this.#register(), () => this.#deregister()),
+      Stream.flatMap(() => Stream.fromEffect(this.ensureConnection())),
       Stream.flatMap(() => outputStream),
-      Stream.ensuring(this.#release()),
     );
   }
 
@@ -197,24 +298,63 @@ export class PolkadotNodeClient implements NodeClient.Service {
     { readonly transactions: readonly SerializedTransaction.SerializedTransaction[] },
     NodeClientError.NodeClientError
   > {
-    return pipe(
-      this.#acquire(),
-      Effect.andThen(() => Effect.promise(() => this.api.rpc.chain.getBlock(this.api.genesisHash))),
-      // https://polkadot.js.org/docs/api/cookbook/blocks/#how-do-i-view-extrinsic-information
-      Effect.map(({ block }) => ({
-        transactions: block.extrinsics
-          .filter(({ method }) => method.section === 'midnight' && method.method === 'sendMnTransaction')
-          .map(({ method }) => method.args[0].toU8a())
-          .map(SerializedTransaction.of),
-      })),
-      Effect.mapError(
-        (error) =>
-          new NodeClientError.ConnectionError({
-            message: 'Failed to retrieve genesis transactions',
-            cause: error,
-          }),
-      ),
-      Effect.ensuring(this.#release()),
+    return Effect.acquireUseRelease(
+      this.#register(),
+      () =>
+        pipe(
+          this.ensureConnection(),
+          Effect.andThen(() => Effect.promise(() => this.api.rpc.chain.getBlock(this.api.genesisHash))),
+          // https://polkadot.js.org/docs/api/cookbook/blocks/#how-do-i-view-extrinsic-information
+          Effect.map(({ block }) => ({
+            transactions: block.extrinsics
+              .filter(({ method }) => method.section === 'midnight' && method.method === 'sendMnTransaction')
+              .map(({ method }) => method.args[0].toU8a())
+              .map(SerializedTransaction.of),
+          })),
+          Effect.mapError(
+            (error) =>
+              new NodeClientError.ConnectionError({
+                message: 'Failed to retrieve genesis transactions',
+                cause: error,
+              }),
+          ),
+        ),
+      () => this.#deregister(),
+    );
+  }
+
+  getGenesisHash(): Effect.Effect<string, NodeClientError.NodeClientError> {
+    // Answered from the api rather than the chain: `ApiPromise.create` fetched the genesis hash once and caches it, so
+    // this read needs neither a connection nor the register/deregister dance the RPC-backed calls run.
+    return Effect.sync(() => this.api.genesisHash.toString());
+  }
+
+  getFinalizedBlock(): Effect.Effect<NodeClient.FinalizedBlock, NodeClientError.NodeClientError> {
+    return Effect.acquireUseRelease(
+      this.#register(),
+      () =>
+        pipe(
+          this.ensureConnection(),
+          Effect.andThen(() =>
+            // `tryPromise` rather than `promise`: an unreachable node has to surface as a typed failure the periodic
+            // liveness check can handle, not as a defect that tears the caller's fiber down.
+            Effect.tryPromise(async () => {
+              // The header must be read at the finalized head's hash. `getHeader()` with no argument returns the best
+              // block, whose height may not be finalized yet.
+              const hash = await this.api.rpc.chain.getFinalizedHead();
+              const header = await this.api.rpc.chain.getHeader(hash.toString());
+              return { hash: hash.toString(), height: header.number.toBigInt() };
+            }),
+          ),
+          Effect.mapError(
+            (error) =>
+              new NodeClientError.ConnectionError({
+                message: 'Failed to retrieve the finalized block',
+                cause: error,
+              }),
+          ),
+        ),
+      () => this.#deregister(),
     );
   }
 

--- a/packages/node-client/src/effect/PolkadotNodeClient.ts
+++ b/packages/node-client/src/effect/PolkadotNodeClient.ts
@@ -69,7 +69,7 @@ export class PolkadotNodeClient implements NodeClient.Service {
 
     // A finite `reconnectionTimeout` is a caller asking to be told when the node cannot be reached. Honouring it here as
     // well as in `ensureConnection` is what makes that possible: left to its defaults, `WsProvider` retries on a timer
-    // and `throwOnConnect: false` means `ApiPromise.create` waits for a connection that may never arrive.
+    // and `ApiPromise.create` waits for a connection that may never arrive.
     const isBounded = Duration.isFinite(config.reconnectionTimeout);
 
     // The bound is enforced inside the promise rather than with `Effect.timeout`, because `Effect.acquireRelease` runs
@@ -85,8 +85,11 @@ export class PolkadotNodeClient implements NodeClient.Service {
       const created = ApiPromise.create({
         // @ts-expect-error -- exactOptionalPropertyTypes cause an incompatibility here
         provider,
-        // Surfacing a connection error rather than retrying past it, but only for a caller that asked to be bounded.
-        throwOnConnect: isBounded,
+        // Off for bounded callers too. With it on, `create` returns `isReadyOrError`, which rejects on the provider's
+        // first `error` event — any socket error, such as a node restarting — although the provider would have retried
+        // and connected moments later. A bounded caller then failed within milliseconds and never used the window it
+        // asked for. The race below is the bound; the provider's retries fill the window, as `ensureConnection`'s do.
+        throwOnConnect: false,
         noInitWarn: true,
       });
 

--- a/packages/node-client/src/effect/PolkadotNodeClient.ts
+++ b/packages/node-client/src/effect/PolkadotNodeClient.ts
@@ -51,6 +51,56 @@ export type Config = {
  */
 const MAX_CONNECTED_PROBE_FAILURES = 3;
 
+/**
+ * Clamps a duration to the largest delay `setTimeout` honours.
+ *
+ * @remarks
+ *   A delay of 2^31 ms or more overflows and fires after about a millisecond, which turned a generous bound such as 30
+ *   days into an instant failure on every connection attempt. A bound that large behaves as "still waiting" on any
+ *   human timescale, so the clamp loses nothing.
+ */
+const toTimerMillis = (duration: Duration.Duration): number => Math.min(Duration.toMillis(duration), 2 ** 31 - 1);
+
+/**
+ * Disconnects the api and waits until its socket has actually closed.
+ *
+ * @remarks
+ *   `WsProvider.disconnect()` is fire-and-forget: it dispatches the close frame and returns while the socket is still
+ *   CLOSING, and `isConnected` only flips false once the close event fires. A caller that returns without waiting
+ *   leaves the next `ensureConnection()` reading a stale `true`: it skips the reconnect, drops its readiness probe on
+ *   the dying socket, sleeps `reconnectionDelay`, reconnects, and usually fails one more pre-open probe — seconds lost
+ *   on every call. Locally the close-ack lands fast enough to hide this; against a remote node it does not. Both places
+ *   that release the socket — the build in `make()` and the last call's `#deregister` — wait here, so the two cannot
+ *   drift.
+ *
+ *   The wait shares the caller's bound. A node that completes the handshake and then goes half-open never acknowledges
+ *   the close frame, and only ws's own 30-second close timeout would end the wait — from inside an uninterruptible
+ *   acquire, in `make()`'s case, which no outer deadline can cut short. A finite bound is therefore honoured here too:
+ *   the wait is abandoned once it elapses, the socket is left CLOSING for ws to finish, and a stale `isConnected` costs
+ *   one failed readiness probe. An infinite bound waits for the event, as an unbounded caller expects.
+ * @param api - The api whose socket to release.
+ * @param bound - How long to wait for the close to be acknowledged; `Duration.infinity` waits indefinitely.
+ * @returns A promise that settles once the socket has closed or the bound has elapsed.
+ */
+const disconnectAndAwaitClose = (api: ApiPromise, bound: Duration.Duration): Promise<void> =>
+  new Promise<void>((resolve) => {
+    if (!api.isConnected) {
+      resolve();
+      return;
+    }
+    const closeTimer: { handle?: ReturnType<typeof setTimeout> } = {};
+    // The handler stays registered if the bound wins: firing later, it resolves a settled promise and clears a fired
+    // timer, both no-ops. `once` returns the api, not an unsubscribe, so there is nothing cheaper to do.
+    api.once('disconnected', () => {
+      if (closeTimer.handle !== undefined) clearTimeout(closeTimer.handle);
+      resolve();
+    });
+    if (Duration.isFinite(bound)) {
+      closeTimer.handle = setTimeout(resolve, toTimerMillis(bound));
+    }
+    void api.disconnect();
+  });
+
 export const DEFAULT_CONFIG = {
   reconnectionTimeout: Duration.infinity,
   reconnectionDelay: Duration.seconds(1),
@@ -93,10 +143,7 @@ export class PolkadotNodeClient implements NodeClient.Service {
         noInitWarn: true,
       });
 
-      // Clamped to the largest delay `setTimeout` honours: a delay of 2^31ms or more overflows and fires after ~1ms,
-      // which turned a generous bound such as 30 days into an instant failure on every connection attempt. A bound
-      // that large behaves as "still waiting" on any human timescale, so the clamp loses nothing.
-      const timeoutMillis = Math.min(Duration.toMillis(config.reconnectionTimeout), 2 ** 31 - 1);
+      const timeoutMillis = toTimerMillis(config.reconnectionTimeout);
       // Held so the timer can be cleared once the race settles. Left armed, it keeps Node's event loop alive, so a
       // short-lived process that reads once cannot exit until it fires.
       const timer: { handle?: ReturnType<typeof setTimeout> } = {};
@@ -120,32 +167,9 @@ export class PolkadotNodeClient implements NodeClient.Service {
 
       // Disconnect immediately after loading metadata to avoid keeping the WebSocket open.
       // The health-check timer (10s interval) and timeout handler (5s interval) are cleared on disconnect.
-      // Metadata and type registry remain cached in memory for subsequent on-demand connections.
-      //
-      // WsProvider.disconnect() is fire-and-forget: it dispatches the close frame and returns while the socket is
-      // still CLOSING. `isConnected` only flips false once #onSocketClose fires, so returning here without waiting
-      // leaves ensureConnection() reading a stale `true`, skipping the reconnect, and sending on a dying socket.
-      // Locally the close-ack lands fast enough to hide this; against a remote node it does not.
-      //
-      // The wait shares the caller's bound. A node that completes the handshake and then goes half-open never
-      // acknowledges the close frame, and only ws's own 30-second close timeout would end the wait — from inside this
-      // uninterruptible acquire, which no outer deadline can cut short. A caller who asked for a bound asked for it
-      // on the whole build, so the wait is abandoned once it elapses: the socket is left CLOSING for ws to finish, and
-      // a stale `isConnected` costs one failed readiness probe, since `ensureConnection` establishes readiness with a
-      // call rather than the flag.
-      await new Promise<void>((resolve) => {
-        if (!api.isConnected) {
-          resolve();
-          return;
-        }
-        const closeTimer: { handle?: ReturnType<typeof setTimeout> } = {};
-        api.once('disconnected', () => {
-          if (closeTimer.handle !== undefined) clearTimeout(closeTimer.handle);
-          resolve();
-        });
-        if (isBounded) closeTimer.handle = setTimeout(resolve, timeoutMillis);
-        void api.disconnect();
-      });
+      // Metadata and type registry remain cached in memory for subsequent on-demand connections. The wait for the
+      // close, and its bound, are explained on `disconnectAndAwaitClose`.
+      await disconnectAndAwaitClose(api, config.reconnectionTimeout);
       return api;
     });
 
@@ -201,10 +225,19 @@ export class PolkadotNodeClient implements NodeClient.Service {
     return SynchronizedRef.update(this.#activeCalls, (active) => active + 1);
   }
 
-  /** Deregisters one call, disconnecting the shared socket when it was the last one in flight. */
+  /**
+   * Deregisters one call, disconnecting the shared socket when it was the last one in flight.
+   *
+   * @remarks
+   *   Waits for the close to be acknowledged, as `make()` does — see `disconnectAndAwaitClose`. Returning on
+   *   `disconnect()` alone left the next call a stale `isConnected: true` and cost it a dropped probe and a reconnect
+   *   delay.
+   */
   #deregister(): Effect.Effect<void> {
     return SynchronizedRef.updateEffect(this.#activeCalls, (active) =>
-      active === 1 ? Effect.promise(() => this.api.disconnect()).pipe(Effect.as(0)) : Effect.succeed(active - 1),
+      active === 1
+        ? Effect.promise(() => disconnectAndAwaitClose(this.api, this.config.reconnectionTimeout)).pipe(Effect.as(0))
+        : Effect.succeed(active - 1),
     );
   }
 

--- a/packages/node-client/src/effect/test/PolkadotNodeClient.boundedConnect.test.ts
+++ b/packages/node-client/src/effect/test/PolkadotNodeClient.boundedConnect.test.ts
@@ -1,0 +1,106 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { Cause, Duration, Effect, Exit, Fiber, Option, Scope } from 'effect';
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * A stub whose connection never establishes, standing in for a node that accepts nothing — the condition under which
+ * `ApiPromise.create` waits indefinitely, because `WsProvider` retries on a timer and `throwOnConnect: false` means it
+ * never rejects.
+ */
+vi.mock('@polkadot/api', () => ({
+  ApiPromise: {
+    create: vi.fn(() => new Promise(() => {})),
+  },
+  WsProvider: vi.fn(),
+}));
+
+const { PolkadotNodeClient } = await import('../PolkadotNodeClient.js');
+
+const makeClient = (reconnectionTimeout?: Duration.Duration) =>
+  Effect.gen(function* () {
+    const scope = yield* Scope.make();
+
+    return yield* PolkadotNodeClient.make({
+      nodeURL: new URL('ws://127.0.0.1:1'),
+      ...(reconnectionTimeout === undefined ? {} : { reconnectionTimeout }),
+    }).pipe(Effect.provideService(Scope.Scope, scope));
+  });
+
+/**
+ * Runs `make` against a wall clock, reporting whether it settled at all.
+ *
+ * @remarks
+ *   Racing here rather than relying on the test runner's timeout, so that a hang fails as an assertion naming what
+ *   happened instead of as an opaque "timed out in 5000ms".
+ */
+const settleWithin = (millis: number, reconnectionTimeout?: Duration.Duration) =>
+  Effect.race(
+    makeClient(reconnectionTimeout).pipe(
+      Effect.exit,
+      Effect.map((exit) => ({ outcome: 'settled' as const, exit })),
+    ),
+    Effect.sleep(Duration.millis(millis)).pipe(Effect.as({ outcome: 'hung' as const, exit: undefined })),
+  ).pipe(Effect.runPromise);
+
+describe('PolkadotNodeClient.make', () => {
+  it('should fail with a ConnectionError when a finite reconnectionTimeout elapses before the node answers', async () => {
+    const result = await settleWithin(3_000, Duration.millis(200));
+
+    expect(result.outcome).toBe('settled');
+    const exit = result.exit;
+    expect(exit !== undefined && Exit.isFailure(exit)).toBe(true);
+    const failure =
+      exit !== undefined && Exit.isFailure(exit) ? Cause.failureOption(exit.cause) : Option.none<{ _tag: string }>();
+    expect(Option.isSome(failure)).toBe(true);
+    expect(Option.getOrThrow(failure)._tag).toBe('ConnectionError');
+  });
+
+  it('should not fire a finite timeout early when it exceeds the 32-bit setTimeout range', async () => {
+    // `setTimeout` with a delay of 2^31ms or more overflows and fires after ~1ms, so a generous bound such as 30 days
+    // failed every connection attempt instantly — the opposite of what the caller asked for. The delay is clamped to
+    // the largest value `setTimeout` honours; a bound that large behaves as "still waiting" on any human timescale.
+    //
+    // Observed by polling rather than racing, for the same reason as the unbounded test below: the acquire is
+    // uninterruptible, so a race against it can never resolve.
+    const stillRunning = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.forkDaemon(makeClient(Duration.days(30)));
+        yield* Effect.sleep(Duration.millis(500));
+        return yield* Fiber.poll(fiber);
+      }).pipe(Effect.scoped),
+    );
+
+    expect(Option.isNone(stillRunning)).toBe(true);
+  });
+
+  it('should keep waiting when reconnectionTimeout is the default, so submission is unaffected', async () => {
+    // Submission passes no timeout and relies on retrying until the node appears. That behaviour must not change: this
+    // asserts the absence of a bound, which is the whole reason the bound is opt-in.
+    //
+    // Forked and polled rather than raced against a timer: `Effect.acquireRelease` acquires uninterruptibly, so a race
+    // could never resolve and would report the runner's timeout instead of this property. Polling observes "has not
+    // settled" without needing to interrupt anything. The fibre is left running, which is the point of the test.
+    const stillRunning = await Effect.runPromise(
+      Effect.gen(function* () {
+        // `forkDaemon`, not `fork`: a child fibre is interrupted when its parent completes, and
+        // interrupting an uninterruptible acquire would block the test forever.
+        const fiber = yield* Effect.forkDaemon(makeClient());
+        yield* Effect.sleep(Duration.millis(200));
+        return yield* Fiber.poll(fiber);
+      }).pipe(Effect.scoped),
+    );
+
+    expect(Option.isNone(stillRunning)).toBe(true);
+  });
+});

--- a/packages/node-client/src/effect/test/PolkadotNodeClient.boundedConnect.test.ts
+++ b/packages/node-client/src/effect/test/PolkadotNodeClient.boundedConnect.test.ts
@@ -26,6 +26,7 @@ vi.mock('@polkadot/api', () => ({
 }));
 
 const { PolkadotNodeClient } = await import('../PolkadotNodeClient.js');
+const { ApiPromise } = await import('@polkadot/api');
 
 const makeClient = (reconnectionTimeout?: Duration.Duration) =>
   Effect.gen(function* () {
@@ -54,6 +55,31 @@ const settleWithin = (millis: number, reconnectionTimeout?: Duration.Duration) =
   ).pipe(Effect.runPromise);
 
 describe('PolkadotNodeClient.make', () => {
+  it('should connect within a finite reconnectionTimeout even when the first socket attempt errors', async () => {
+    // With `throwOnConnect: true`, `ApiPromise.create` returns `isReadyOrError`, which rejects on the provider's first
+    // `error` event — any socket error, such as a node restarting — although `WsProvider` would have retried and
+    // connected a moment later. A bounded caller therefore failed within milliseconds and never used the window it
+    // asked for. The stub mirrors the library: rejection on the first error when throwing on connect, otherwise the
+    // connection lands after a retry. The api it yields is already disconnected, so `make()` has no close to wait for.
+    vi.mocked(ApiPromise).create.mockImplementationOnce((options) =>
+      options?.throwOnConnect
+        ? Promise.reject(new Error('connect ECONNREFUSED 127.0.0.1:1'))
+        : new Promise((resolve) =>
+            setTimeout(
+              // Type cast required because: the client only reads `isConnected` from the api during make(); a full
+              // ApiPromise double would drag the whole polkadot surface into a test about one connection option.
+              () => resolve({ isConnected: false } as unknown as Awaited<ReturnType<typeof ApiPromise.create>>),
+              50,
+            ),
+          ),
+    );
+
+    const result = await settleWithin(3_000, Duration.seconds(1));
+
+    expect(result.outcome).toBe('settled');
+    expect(result.exit !== undefined && Exit.isSuccess(result.exit)).toBe(true);
+  });
+
   it('should fail with a ConnectionError when a finite reconnectionTimeout elapses before the node answers', async () => {
     const result = await settleWithin(3_000, Duration.millis(200));
 

--- a/packages/node-client/src/effect/test/PolkadotNodeClient.finalizedBlock.test.ts
+++ b/packages/node-client/src/effect/test/PolkadotNodeClient.finalizedBlock.test.ts
@@ -1,0 +1,153 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { Cause, Effect, Exit, Option, Scope } from 'effect';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const FINALIZED_HASH = '0x9f1c4e2a7b3d5f6081927364a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e';
+
+/**
+ * A stub `ApiPromise`. `ApiPromise.create` is a static factory on an external module, so it cannot be replaced with a
+ * hand-written fake object the way an injected service could be.
+ */
+const mockApi = {
+  isConnected: false,
+  connect: vi.fn(() => {
+    mockApi.isConnected = true;
+    return Promise.resolve();
+  }),
+  // The close event fires synchronously here, where the real WsProvider fires it later: `make()` awaits that event
+  // before returning, and these tests assert the finalized-head read, not close-handshake timing — the lifecycle suite
+  // covers the asynchronous close.
+  disconnect: vi.fn(() => {
+    mockApi.isConnected = false;
+    mockApi.__emit('disconnected');
+    return Promise.resolve();
+  }),
+  __handlers: {} as Record<string, Array<() => void>>,
+  once: vi.fn((event: string, handler: () => void) => {
+    (mockApi.__handlers[event] ??= []).push(handler);
+    return () => {};
+  }),
+  __emit: (event: string) => {
+    const handlers = mockApi.__handlers[event] ?? [];
+    mockApi.__handlers[event] = [];
+    handlers.forEach((handler) => handler());
+  },
+  rpc: {
+    chain: {
+      getFinalizedHead: vi.fn(),
+      getHeader: vi.fn(),
+    },
+    system: {
+      // `ensureConnection` establishes readiness by making a call rather than reading `isConnected`, so a double for
+      // this client has to answer it.
+      chain: vi.fn(() => Promise.resolve('Midnight Dev')),
+    },
+  },
+  genesisHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+};
+
+vi.mock('@polkadot/api', () => ({
+  ApiPromise: {
+    create: vi.fn(() => {
+      mockApi.isConnected = true;
+      return mockApi;
+    }),
+  },
+  WsProvider: vi.fn(),
+}));
+
+const { PolkadotNodeClient } = await import('../PolkadotNodeClient.js');
+
+const makeClient = () =>
+  Effect.gen(function* () {
+    const scope = yield* Scope.make();
+    const client = yield* PolkadotNodeClient.make({ nodeURL: new URL('ws://127.0.0.1:9944') }).pipe(
+      Effect.provideService(Scope.Scope, scope),
+    );
+    return client;
+  }).pipe(Effect.runPromise);
+
+/** Point the stubbed RPC at a finalized block of the given height. */
+const stubFinalizedBlock = (height: bigint) => {
+  mockApi.rpc.chain.getFinalizedHead.mockResolvedValue({ toString: () => FINALIZED_HASH });
+  mockApi.rpc.chain.getHeader.mockResolvedValue({ number: { toBigInt: () => height } });
+};
+
+describe('PolkadotNodeClient.getFinalizedBlock', () => {
+  beforeEach(() => {
+    mockApi.isConnected = false;
+    mockApi.connect.mockClear();
+    mockApi.disconnect.mockClear();
+    mockApi.rpc.chain.getFinalizedHead.mockReset();
+    mockApi.rpc.chain.getHeader.mockReset();
+  });
+
+  it('should report the hash and height of the finalized head', async () => {
+    stubFinalizedBlock(1_234_567n);
+    const client = await makeClient();
+
+    const result = await Effect.runPromise(client.getFinalizedBlock());
+
+    expect(result).toStrictEqual({ hash: FINALIZED_HASH, height: 1_234_567n });
+  });
+
+  it('should read the header of the finalized head, not of the best block', async () => {
+    // `getHeader` with no argument returns the best block, which may be unfinalized. Passing the finalized hash is what
+    // makes the height a finalized one.
+    stubFinalizedBlock(42n);
+    const client = await makeClient();
+
+    await Effect.runPromise(client.getFinalizedBlock());
+
+    expect(mockApi.rpc.chain.getHeader).toHaveBeenCalledWith(FINALIZED_HASH);
+  });
+
+  it('should connect before reading and disconnect afterwards', async () => {
+    stubFinalizedBlock(100n);
+    const client = await makeClient();
+    mockApi.connect.mockClear();
+    mockApi.disconnect.mockClear();
+
+    await Effect.runPromise(client.getFinalizedBlock());
+
+    expect(mockApi.connect).toHaveBeenCalled();
+    expect(mockApi.disconnect).toHaveBeenCalled();
+  });
+
+  describe('when the node cannot be reached', () => {
+    it('should fail with a ConnectionError rather than dying, so callers can handle it', async () => {
+      // A liveness check runs periodically against a node that may be unreachable. That has to be a typed failure the
+      // caller can match on, not a defect that tears down the fiber.
+      mockApi.rpc.chain.getFinalizedHead.mockRejectedValue(new Error('websocket closed'));
+      const client = await makeClient();
+
+      const exit = await Effect.runPromiseExit(client.getFinalizedBlock());
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      const failure = Exit.isFailure(exit) ? Cause.failureOption(exit.cause) : Option.none();
+      expect(Option.isSome(failure)).toBe(true);
+      expect(Option.getOrThrow(failure)._tag).toBe('ConnectionError');
+    });
+
+    it('should still disconnect when the read fails, so a failed check leaks no connection', async () => {
+      mockApi.rpc.chain.getFinalizedHead.mockRejectedValue(new Error('websocket closed'));
+      const client = await makeClient();
+      mockApi.disconnect.mockClear();
+
+      await Effect.runPromiseExit(client.getFinalizedBlock());
+
+      expect(mockApi.disconnect).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/node-client/src/effect/test/PolkadotNodeClient.integration.test.ts
+++ b/packages/node-client/src/effect/test/PolkadotNodeClient.integration.test.ts
@@ -15,7 +15,21 @@ import { PolkadotNodeClient } from '../PolkadotNodeClient.js';
 import * as NodeClient from '../NodeClient.js';
 import * as SubmissionEvent from '../SubmissionEvent.js';
 import { type StartedTestContainer, Wait } from 'testcontainers';
-import { Array as EArray, Chunk, Effect, Either, Exit, Order, pipe, Random, Scope, Stream } from 'effect';
+import {
+  Array as EArray,
+  Cause,
+  Chunk,
+  Duration,
+  Effect,
+  Either,
+  Exit,
+  Order,
+  pipe,
+  Random,
+  Schedule,
+  Scope,
+  Stream,
+} from 'effect';
 import { TestTransactions } from '../../testing/index.js';
 import { TestContainers } from '@midnightntwrk/wallet-sdk-utilities/testing';
 import { NodeContext } from '@effect/platform-node';
@@ -29,8 +43,7 @@ const clientLayer = (nodePort: number) =>
 // It takes some time to pass through enough rounds of consensus, even in tests
 vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
 
-// There are issues with replaying transactions after node restart
-describe.skip('PolkadotNodeClient', () => {
+describe('PolkadotNodeClient', () => {
   let scope: Scope.CloseableScope | undefined = undefined;
   let node: StartedTestContainer | undefined = undefined;
 
@@ -61,7 +74,11 @@ describe.skip('PolkadotNodeClient', () => {
     }
   });
 
-  it('does report an error if transaction fails well-formedness check upon submission', async () => {
+  // Skipped: needs `temp-resources/test-txs.json`, which nothing produces (see the other skipped tests below). Worse
+  // than merely failing, this one passed vacuously: `Effect.either` absorbed the fixture-load failure, so the
+  // `isLeft` assertion succeeded on the missing file rather than on a node rejection — burning a node container to
+  // assert nothing.
+  it.skip('does report an error if transaction fails well-formedness check upon submission', async () => {
     const result = await pipe(
       Effect.gen(function* () {
         const transactions = yield* TestTransactions.load(TestTransactions.defaultPaths.fullPath);
@@ -88,7 +105,9 @@ describe.skip('PolkadotNodeClient', () => {
     });
   });
 
-  it('does report an error if node cannot deserialize transaction', async () => {
+  // Skipped: same missing fixture, same vacuous pass — `Stream.either` turned the fixture-load failure into a single
+  // `Left` that satisfied the per-item `isLeft` assertion.
+  it.skip('does report an error if node cannot deserialize transaction', async () => {
     const modifyTx = (txBytes: Uint8Array) => {
       return Effect.gen(function* () {
         const pickNumber = Random.nextIntBetween(0, txBytes.length - 1);
@@ -133,7 +152,51 @@ describe.skip('PolkadotNodeClient', () => {
     });
   });
 
-  it('does submit a transaction', async () => {
+  // These two cover the Effect-based read path — connect, issue an `api.rpc` call, disconnect. Nothing exercised it
+  // before, which is how it came to be broken: `make()` disconnects after loading metadata, and a subsequent reconnect
+  // has to leave the client actually usable, not merely connected. Neither test needs the transaction fixture.
+  it('does read the genesis transactions', async () => {
+    const result = await pipe(
+      NodeClient.getGenesisTransactions(),
+      Effect.provide(clientLayer(node!.getMappedPort(9944))),
+      Effect.provide(NodeContext.layer),
+      Effect.scoped,
+      Effect.runPromiseExit,
+    );
+
+    // Comparing against 'ok' so a failure reports the cause instead of just `false`.
+    expect(Exit.isSuccess(result) ? 'ok' : Cause.pretty(result.cause)).toBe('ok');
+  });
+
+  it('does read the finalized block', async () => {
+    // The container waits for block 1 to be imported, but finalization trails import by a few consensus rounds, so the
+    // read is retried until the finalized head has advanced past genesis.
+    const result = await pipe(
+      // `Effect.repeat` yields the schedule's output — a repetition count — so the value is read again afterwards
+      // rather than taken from the repeat.
+      Effect.gen(function* () {
+        yield* NodeClient.getFinalizedBlock().pipe(
+          Effect.repeat({ until: ({ height }) => height > 0n, schedule: Schedule.spaced(Duration.seconds(1)) }),
+          Effect.timeout(Duration.seconds(60)),
+        );
+        return yield* NodeClient.getFinalizedBlock();
+      }),
+      Effect.provide(clientLayer(node!.getMappedPort(9944))),
+      Effect.provide(NodeContext.layer),
+      Effect.scoped,
+      Effect.runPromiseExit,
+    );
+
+    expect(Exit.isSuccess(result) ? 'ok' : Cause.pretty(result.cause)).toBe('ok');
+    expect(Exit.isSuccess(result) ? result.value.height : 0n).toBeGreaterThan(0n);
+    expect(Exit.isSuccess(result) ? result.value.hash : '').toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  // Skipped: needs `temp-resources/test-txs.json`, which nothing produces. The generator this package points at
+  // (`gen-txs.ts`) is absent, no CI job builds the file, and `temp-resources/` is gitignored — so these three can only
+  // pass on a machine where the fixture was generated by hand. Restoring that pipeline is its own piece of work; the
+  // rest of this suite runs, rather than the whole file being skipped for their sake.
+  it.skip('does submit a transaction', async () => {
     const submitAllTransactions = TestTransactions.load(TestTransactions.defaultPaths.fullPath).pipe(
       Stream.fromEffect,
       Stream.flatMap(TestTransactions.streamAllValid),
@@ -152,7 +215,11 @@ describe.skip('PolkadotNodeClient', () => {
     expect(Exit.isSuccess(result)).toBe(true);
   });
 
-  it.concurrent('does emit subsequent events', async () => {
+  // Skipped: needs `temp-resources/test-txs.json`, which nothing produces. The generator this package points at
+  // (`gen-txs.ts`) is absent, no CI job builds the file, and `temp-resources/` is gitignored — so these three can only
+  // pass on a machine where the fixture was generated by hand. Restoring that pipeline is its own piece of work; the
+  // rest of this suite runs, rather than the whole file being skipped for their sake.
+  it.skip('does emit subsequent events', async () => {
     const submitAndCollectEvents = TestTransactions.load(TestTransactions.defaultPaths.fullPath).pipe(
       Stream.fromEffect,
       Stream.flatMap(TestTransactions.streamAllValid),
@@ -181,7 +248,11 @@ describe.skip('PolkadotNodeClient', () => {
     // );
   });
 
-  it("is able to submit transaction after node's unavailability", async () => {
+  // Skipped: needs `temp-resources/test-txs.json`, which nothing produces. The generator this package points at
+  // (`gen-txs.ts`) is absent, no CI job builds the file, and `temp-resources/` is gitignored — so these three can only
+  // pass on a machine where the fixture was generated by hand. Restoring that pipeline is its own piece of work; the
+  // rest of this suite runs, rather than the whole file being skipped for their sake.
+  it.skip("is able to submit transaction after node's unavailability", async () => {
     const first2Transactions = TestTransactions.load(TestTransactions.defaultPaths.fullPath).pipe(
       Stream.fromEffect,
       Stream.flatMap(TestTransactions.streamAllValid),

--- a/packages/node-client/src/effect/test/PolkadotNodeClient.lifecycle.test.ts
+++ b/packages/node-client/src/effect/test/PolkadotNodeClient.lifecycle.test.ts
@@ -12,8 +12,14 @@
 // limitations under the License.
 import { describe, it, vi, expect, beforeEach } from 'vitest';
 import BN from 'bn.js';
-import { Effect, pipe, Scope, Stream } from 'effect';
+import { Cause, Duration, Effect, Exit, Option, pipe, Scope, Stream } from 'effect';
 import { SerializedTransaction } from '@midnightntwrk/wallet-sdk-abstractions';
+
+// `ensureConnection` establishes readiness by making a call rather than reading `isConnected`, so a double for this
+// client has to answer it — and answer it faithfully: a probe that succeeded while disconnected would let the
+// readiness loop pass without ever connecting.
+const faithfulProbe = () =>
+  mockApi.isConnected ? Promise.resolve('Midnight Dev') : Promise.reject(new Error('disconnected'));
 
 const mockApi = {
   isConnected: false,
@@ -49,6 +55,9 @@ const mockApi = {
     chain: {
       getBlock: vi.fn(),
     },
+    system: {
+      chain: vi.fn(faithfulProbe),
+    },
   },
   genesisHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
 };
@@ -83,6 +92,24 @@ describe('PolkadotNodeClient lifecycle', () => {
     mockApi.disconnect.mockClear();
     mockApi.tx.midnight.sendMnTransaction.mockClear();
     mockApi.rpc.chain.getBlock.mockClear();
+    // Restored here rather than inside the tests that override it: a test that fails mid-override must not poison the
+    // tests after it.
+    mockApi.rpc.system.chain.mockImplementation(faithfulProbe);
+  });
+
+  it('getGenesisHash answers from the api without opening a connection', async () => {
+    // The genesis hash is fetched once by `ApiPromise.create` and cached on the api, so reading it must not run the
+    // ensure-connection dance — the liveness check calls this on every first poll and a wrong-network wallet would
+    // otherwise pay a connection round-trip to learn what the client already knows.
+    const { client } = await makeClient();
+    mockApi.connect.mockClear();
+    mockApi.disconnect.mockClear();
+
+    const hash = await Effect.runPromise(client.getGenesisHash());
+
+    expect(hash).toBe(mockApi.genesisHash);
+    expect(mockApi.connect).not.toHaveBeenCalled();
+    expect(mockApi.disconnect).not.toHaveBeenCalled();
   });
 
   it('disconnects immediately after make()', async () => {
@@ -139,6 +166,58 @@ describe('PolkadotNodeClient lifecycle', () => {
     expect(mockApi.disconnect).toHaveBeenCalled();
     expect(events).toHaveLength(1);
     expect(events[0]._tag).toBe('Finalized');
+  });
+
+  it('retries a rejected connect() until it succeeds, rather than dying on it', async () => {
+    // `Effect.promise` treated a rejected connect() as a defect: it bypassed the typed ConnectionError mapping and
+    // killed the caller's fibre as a crash — while the changeset promises connection failures reach catchTag/catchAll.
+    // A rejection is one failed attempt, not a verdict: the readiness loop retries it like any unusable probe.
+    const scope = await Effect.runPromise(Scope.make());
+    const client = await Effect.runPromise(
+      PolkadotNodeClient.make({
+        nodeURL: new URL('ws://127.0.0.1:9944'),
+        reconnectionDelay: Duration.millis(5),
+        reconnectionTimeout: Duration.seconds(5),
+      }).pipe(Effect.provideService(Scope.Scope, scope)),
+    );
+    mockApi.connect.mockClear();
+    mockApi.connect
+      .mockImplementationOnce(() => Promise.reject(new Error('boom')))
+      .mockImplementationOnce(() => {
+        mockApi.isConnected = true;
+        return Promise.resolve();
+      });
+    mockApi.rpc.chain.getBlock.mockResolvedValue({ block: { extrinsics: [] } });
+
+    const result = await pipe(client.getGenesis(), Effect.runPromiseExit);
+
+    expect(Exit.isSuccess(result)).toBe(true);
+    expect(mockApi.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces a ConnectionError when the node answers the socket but not RPC, rather than hanging forever', async () => {
+    // The readiness probe swallowed every RPC error and retried without limit. Under the default (infinite)
+    // reconnectionTimeout — what submission uses — a node whose socket connects but whose RPC persistently fails
+    // therefore turned from a loud failure into a silent hang: before the probe existed, `ensureConnection` completed
+    // on the socket flag and the first real call failed on the error channel. A connected socket whose probe keeps
+    // failing is a verdict about the node, not a connection still on its way up.
+    const scope = await Effect.runPromise(Scope.make());
+    const client = await Effect.runPromise(
+      PolkadotNodeClient.make({
+        nodeURL: new URL('ws://127.0.0.1:9944'),
+        reconnectionDelay: Duration.millis(5),
+        // Deliberately no reconnectionTimeout: the silent hang existed precisely for the unbounded default.
+      }).pipe(Effect.provideService(Scope.Scope, scope)),
+    );
+    mockApi.isConnected = true;
+    mockApi.rpc.system.chain.mockImplementation(() => Promise.reject(new Error('RPC broken')));
+
+    const exit = await Effect.runPromiseExit(client.ensureConnection());
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    const failure = Exit.isFailure(exit) ? Cause.failureOption(exit.cause) : Option.none();
+    expect(Option.isSome(failure)).toBe(true);
+    expect(Option.getOrThrow(failure)._tag).toBe('ConnectionError');
   });
 
   it('getGenesis connects before and disconnects after', async () => {

--- a/packages/node-client/src/effect/test/PolkadotNodeClient.lifecycle.test.ts
+++ b/packages/node-client/src/effect/test/PolkadotNodeClient.lifecycle.test.ts
@@ -238,6 +238,21 @@ describe('PolkadotNodeClient lifecycle', () => {
     expect(result.transactions).toEqual([]);
   });
 
+  it('getGenesis surfaces a rejected RPC as a ConnectionError rather than a defect', async () => {
+    // A rejection inside `Effect.promise` is a defect: it bypasses the `mapError` that names the failure and any
+    // `catchTag('ConnectionError')` in the caller, killing that fibre as a crash. Every other RPC on this client goes
+    // through `tryPromise` for exactly that reason; this one must too.
+    const { client } = await makeClient();
+    mockApi.rpc.chain.getBlock.mockRejectedValue(new Error('node went away mid-request'));
+
+    const exit = await Effect.runPromiseExit(client.getGenesis());
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    const failure = Exit.isFailure(exit) ? Cause.failureOption(exit.cause) : Option.none();
+    expect(Option.isSome(failure)).toBe(true);
+    expect(Option.getOrThrow(failure)._tag).toBe('ConnectionError');
+  });
+
   it('does not disconnect a shared connection while another operation is in flight', async () => {
     const { client } = await makeClient();
     mockApi.disconnect.mockClear();

--- a/packages/node-client/src/effect/test/PolkadotNodeClient.lifecycle.test.ts
+++ b/packages/node-client/src/effect/test/PolkadotNodeClient.lifecycle.test.ts
@@ -238,6 +238,20 @@ describe('PolkadotNodeClient lifecycle', () => {
     expect(result.transactions).toEqual([]);
   });
 
+  it('waits for the socket to actually close when the last call releases it', async () => {
+    // `api.disconnect()` returns while the socket is still CLOSING; `isConnected` clears only when the close event
+    // fires. A release that does not wait leaves the next call reading a stale `true`: it skips `connect()`, drops its
+    // readiness probe on the dying socket, sleeps `reconnectionDelay`, reconnects, and usually fails one more pre-open
+    // probe — two seconds or more of a liveness read's ten-second budget. `make()` already waits for the event for this
+    // reason; the release path must too.
+    const { client } = await makeClient();
+    mockApi.rpc.chain.getBlock.mockResolvedValue({ block: { extrinsics: [] } });
+
+    await Effect.runPromise(client.getGenesis());
+
+    expect(client.api.isConnected).toBe(false);
+  });
+
   it('getGenesis surfaces a rejected RPC as a ConnectionError rather than a defect', async () => {
     // A rejection inside `Effect.promise` is a defect: it bypasses the `mapError` that names the failure and any
     // `catchTag('ConnectionError')` in the caller, killing that fibre as a crash. Every other RPC on this client goes

--- a/packages/node-client/src/effect/test/PolkadotNodeClient.lifecycle.test.ts
+++ b/packages/node-client/src/effect/test/PolkadotNodeClient.lifecycle.test.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 import { describe, it, vi, expect, beforeEach } from 'vitest';
 import BN from 'bn.js';
-import { Cause, Duration, Effect, Exit, Option, pipe, Scope, Stream } from 'effect';
+import { Cause, Duration, Effect, Exit, Fiber, Option, pipe, Scope, Stream } from 'effect';
 import { SerializedTransaction } from '@midnightntwrk/wallet-sdk-abstractions';
 
 // `ensureConnection` establishes readiness by making a call rather than reading `isConnected`, so a double for this
@@ -306,5 +306,33 @@ describe('PolkadotNodeClient lifecycle', () => {
     // so a make() that does not wait leaves isConnected stale-true and ensureConnection()
     // skips the reconnect, sending on a dying socket.
     expect(client.api.isConnected).toBe(false);
+  });
+
+  it('make() stops waiting for the close once a finite reconnectionTimeout elapses', async () => {
+    // A node that completes the handshake and then goes half-open never acknowledges the close frame. Only ws's own
+    // 30-second close timeout ended that wait, from inside an uninterruptible acquire no outer deadline can cut short —
+    // so a caller who asked for a 10-second bound waited 40. The bound the caller asked for covers the whole build,
+    // the close included.
+    //
+    // Forked and polled rather than raced: interrupting an uninterruptible acquire would block the test forever.
+    mockApi.disconnect.mockImplementationOnce(() => Promise.resolve()); // never emits 'disconnected'
+
+    const settled = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.forkDaemon(
+          Effect.gen(function* () {
+            const scope = yield* Scope.make();
+            return yield* PolkadotNodeClient.make({
+              nodeURL: new URL('ws://127.0.0.1:9944'),
+              reconnectionTimeout: Duration.millis(200),
+            }).pipe(Effect.provideService(Scope.Scope, scope));
+          }),
+        );
+        yield* Effect.sleep(Duration.seconds(1));
+        return yield* Fiber.poll(fiber);
+      }).pipe(Effect.scoped),
+    );
+
+    expect(Option.isSome(settled)).toBe(true);
   });
 });

--- a/packages/node-client/src/effect/test/PolkadotNodeClient.sharedConnection.test.ts
+++ b/packages/node-client/src/effect/test/PolkadotNodeClient.sharedConnection.test.ts
@@ -1,0 +1,181 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import BN from 'bn.js';
+import { Effect, pipe, Scope, Stream } from 'effect';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SerializedTransaction } from '@midnightntwrk/wallet-sdk-abstractions';
+
+const FINALIZED_HASH = '0x9f1c4e2a7b3d5f6081927364a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e';
+
+// `ensureConnection` establishes readiness by making a call rather than reading `isConnected`, so a double for this
+// client has to answer it — and answer it faithfully: a probe that succeeded while disconnected would let the
+// readiness loop pass without ever connecting.
+const faithfulProbe = () =>
+  mockApi.isConnected ? Promise.resolve('Midnight Dev') : Promise.reject(new Error('disconnected'));
+
+/**
+ * A stub `ApiPromise`. `ApiPromise.create` is a static factory on an external module, so it cannot be replaced with a
+ * hand-written fake object the way an injected service could be.
+ */
+const mockApi = {
+  isConnected: false,
+  connect: vi.fn(() => {
+    mockApi.isConnected = true;
+    return Promise.resolve();
+  }),
+  // The close event fires synchronously here, where the real WsProvider fires it later: `make()` awaits that event
+  // before returning, and these tests assert hold-counting, not close-handshake timing — the lifecycle suite covers
+  // the asynchronous close.
+  disconnect: vi.fn(() => {
+    mockApi.isConnected = false;
+    mockApi.__emit('disconnected');
+    return Promise.resolve();
+  }),
+  __handlers: {} as Record<string, Array<() => void>>,
+  once: vi.fn((event: string, handler: () => void) => {
+    (mockApi.__handlers[event] ??= []).push(handler);
+    return () => {};
+  }),
+  __emit: (event: string) => {
+    const handlers = mockApi.__handlers[event] ?? [];
+    mockApi.__handlers[event] = [];
+    handlers.forEach((handler) => handler());
+  },
+  tx: {
+    midnight: {
+      sendMnTransaction: vi.fn(),
+    },
+  },
+  rpc: {
+    chain: {
+      getFinalizedHead: vi.fn(),
+      getHeader: vi.fn(),
+    },
+    system: {
+      chain: vi.fn(faithfulProbe),
+    },
+  },
+  genesisHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+};
+
+vi.mock('@polkadot/api', () => ({
+  ApiPromise: {
+    create: vi.fn(() => {
+      mockApi.isConnected = true;
+      return mockApi;
+    }),
+  },
+  WsProvider: vi.fn(),
+}));
+
+// Must import after vi.mock so the mock is in place
+const { PolkadotNodeClient } = await import('../PolkadotNodeClient.js');
+
+const makeClient = () =>
+  Effect.gen(function* () {
+    const scope = yield* Scope.make();
+    const client = yield* PolkadotNodeClient.make({ nodeURL: new URL('ws://127.0.0.1:9944') }).pipe(
+      Effect.provideService(Scope.Scope, scope),
+    );
+    return client;
+  }).pipe(Effect.runPromise);
+
+/** A submission result whose status is Finalized, in the shape `#handleSubmissionResult` decodes. */
+const finalizedResult = {
+  status: {
+    isReady: false,
+    isFuture: false,
+    isBroadcast: false,
+    isRetracted: false,
+    isInBlock: false,
+    isFinalized: true,
+    asFinalized: { toString: () => '0xabc' },
+    isFinalityTimeout: false,
+    isUsurped: false,
+    isDropped: false,
+    isInvalid: false,
+  },
+  txHash: { toString: () => '0xdef' },
+  blockNumber: new BN(42),
+};
+
+describe('PolkadotNodeClient shared connection', () => {
+  beforeEach(() => {
+    mockApi.isConnected = false;
+    mockApi.connect.mockClear();
+    mockApi.disconnect.mockClear();
+    mockApi.tx.midnight.sendMnTransaction.mockReset();
+    mockApi.rpc.chain.getFinalizedHead.mockReset();
+    mockApi.rpc.chain.getHeader.mockReset();
+    // Restored here rather than inside tests that override it: a test that fails mid-override must not poison the
+    // tests after it.
+    mockApi.rpc.system.chain.mockImplementation(faithfulProbe);
+  });
+
+  it('should keep the connection open under an in-flight submission when getFinalizedBlock finishes first', async () => {
+    // Every call on this client ended with an unconditional disconnect of the one shared socket. Interleaving any two
+    // calls on the same instance therefore let the first to finish tear the socket down under the other — the case the
+    // interface could only warn about. The client must instead track its in-flight calls and disconnect only when the
+    // last one finishes.
+    const client = await makeClient();
+    mockApi.disconnect.mockClear();
+    mockApi.connect.mockClear();
+
+    // A submission whose node-side callback is captured and held: the transaction stays in flight — subscription open,
+    // no terminal status — until this test finalizes it.
+    const submissionArrived = Promise.withResolvers<(result: unknown) => Promise<void>>();
+    mockApi.tx.midnight.sendMnTransaction.mockReturnValue({
+      send: vi.fn((callback: (result: unknown) => Promise<void>) => {
+        submissionArrived.resolve(callback);
+        return Promise.resolve(() => {});
+      }),
+    });
+    mockApi.rpc.chain.getFinalizedHead.mockResolvedValue({ toString: () => FINALIZED_HASH });
+    mockApi.rpc.chain.getHeader.mockResolvedValue({ number: { toBigInt: () => 1_000n } });
+
+    const submission = pipe(
+      client.sendMidnightTransaction(SerializedTransaction.of(new Uint8Array([1, 2, 3]))),
+      Stream.runCollect,
+      Effect.map((chunk) => [...chunk]),
+      Effect.scoped,
+      Effect.runPromise,
+    );
+    const reportSubmissionResult = await submissionArrived.promise;
+
+    // The overlapping read, on the same client instance, completing while the submission is still in flight.
+    const block = await Effect.runPromise(client.getFinalizedBlock());
+    expect(block.height).toBe(1_000n);
+
+    // The heart of the test: the finished read must not have torn the socket down under the live submission.
+    expect(mockApi.disconnect).not.toHaveBeenCalled();
+    expect(mockApi.isConnected).toBe(true);
+
+    // Only when the submission — the last in-flight call — finishes does the client release the connection.
+    await reportSubmissionResult(finalizedResult);
+    const events = await submission;
+    expect(events.map((event) => event._tag)).toEqual(['Finalized']);
+    expect(mockApi.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('should still disconnect after a lone getFinalizedBlock, so counting calls does not leak sockets', async () => {
+    const client = await makeClient();
+    mockApi.disconnect.mockClear();
+    mockApi.rpc.chain.getFinalizedHead.mockResolvedValue({ toString: () => FINALIZED_HASH });
+    mockApi.rpc.chain.getHeader.mockResolvedValue({ number: { toBigInt: () => 7n } });
+
+    await Effect.runPromise(client.getFinalizedBlock());
+
+    expect(mockApi.disconnect).toHaveBeenCalledTimes(1);
+    expect(mockApi.isConnected).toBe(false);
+  });
+});

--- a/packages/unshielded-wallet/src/UnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/UnshieldedWallet.ts
@@ -33,7 +33,7 @@ import {
   type UnboundTransactionBalanceResult,
   type UnprovenTransactionBalanceResult,
 } from './v1/Transacting.js';
-import { type WalletSyncUpdate } from './v1/SyncSchema.js';
+import { type SyncUpdate } from './v1/SyncSchema.js';
 import { type UtxoWithMeta } from './v1/UnshieldedState.js';
 import { type Variant, type VariantBuilder, type WalletLike } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
@@ -105,15 +105,11 @@ export class UnshieldedWalletState<TSerialized = string> {
   }
 }
 
-export type UnshieldedWallet = CustomizedUnshieldedWallet<WalletSyncUpdate, string>;
+export type UnshieldedWallet = CustomizedUnshieldedWallet<SyncUpdate, string>;
 
 export type DefaultUnshieldedConfiguration = DefaultV1Configuration;
 
-export type UnshieldedWalletClass = CustomizedUnshieldedWalletClass<
-  WalletSyncUpdate,
-  string,
-  DefaultUnshieldedConfiguration
->;
+export type UnshieldedWalletClass = CustomizedUnshieldedWalletClass<SyncUpdate, string, DefaultUnshieldedConfiguration>;
 
 export type UnshieldedWalletAPI<TSerialized = string> = {
   readonly state: rx.Observable<UnshieldedWalletState<TSerialized>>;
@@ -171,13 +167,13 @@ export type UnshieldedWalletAPI<TSerialized = string> = {
 };
 
 export type CustomizedUnshieldedWallet<
-  TSyncUpdate = WalletSyncUpdate,
+  TSyncUpdate = SyncUpdate,
   TSerialized = string,
 > = UnshieldedWalletAPI<TSerialized> &
   WalletLike.WalletLike<[Variant.VersionedVariant<V1Variant<TSerialized, TSyncUpdate>>]>;
 
 export interface CustomizedUnshieldedWalletClass<
-  TSyncUpdate = WalletSyncUpdate,
+  TSyncUpdate = SyncUpdate,
   TSerialized = string,
   TConfig extends BaseV1Configuration = DefaultV1Configuration,
 > extends WalletLike.BaseWalletClass<[Variant.VersionedVariant<V1Variant<TSerialized, TSyncUpdate>>]> {
@@ -192,7 +188,7 @@ export function UnshieldedWallet(configuration: DefaultV1Configuration): Unshiel
 
 export function CustomUnshieldedWallet<
   TConfig extends BaseV1Configuration = DefaultV1Configuration,
-  TSyncUpdate = WalletSyncUpdate,
+  TSyncUpdate = SyncUpdate,
   TSerialized = string,
 >(
   configuration: TConfig,

--- a/packages/unshielded-wallet/src/index.ts
+++ b/packages/unshielded-wallet/src/index.ts
@@ -17,3 +17,4 @@ export {
   mergeUnshieldedSections,
 } from './v1/TransactionHistory.js';
 export * from './KeyStore.js';
+export { type DefaultSyncConfiguration, type NodeClientConnection, resolveNodeEndpoint } from './v1/Sync.js';

--- a/packages/unshielded-wallet/src/v1/CoreWallet.ts
+++ b/packages/unshielded-wallet/src/v1/CoreWallet.ts
@@ -40,7 +40,9 @@ export const CoreWallet = {
   restore(
     state: UnshieldedState,
     publicKey: PublicKey,
-    syncProgress: Omit<SyncProgressData, 'isConnected'>,
+    // A restored wallet holds no live verdict: `indexerLiveness` is re-established by the running liveness check, never
+    // rehydrated from storage, so that a stale verdict cannot outlive the session that produced it.
+    syncProgress: Omit<SyncProgressData, 'isConnected' | 'indexerLiveness'>,
     protocolVersion: ProtocolVersion.ProtocolVersion,
     networkId: string,
   ): CoreWallet {
@@ -55,12 +57,13 @@ export const CoreWallet = {
 
   updateProgress(
     wallet: CoreWallet,
-    { appliedId, highestTransactionId, isConnected }: Partial<SyncProgressData>,
+    { appliedId, highestTransactionId, isConnected, indexerLiveness }: Partial<SyncProgressData>,
   ): CoreWallet {
     const progress = createSyncProgress({
       appliedId: appliedId ?? wallet.progress.appliedId,
       highestTransactionId: highestTransactionId ?? wallet.progress.highestTransactionId,
       isConnected: isConnected ?? wallet.progress.isConnected,
+      indexerLiveness: indexerLiveness ?? wallet.progress.indexerLiveness,
     });
     return { ...wallet, progress };
   },

--- a/packages/unshielded-wallet/src/v1/RetrySchedule.ts
+++ b/packages/unshielded-wallet/src/v1/RetrySchedule.ts
@@ -1,0 +1,34 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { Duration, Schedule } from 'effect';
+
+/** The longest the sync streams wait between two retries. */
+const MAX_RETRY_DELAY = Duration.minutes(2);
+
+/**
+ * Exponential backoff with jitter, capped at two minutes — shared by both sync streams.
+ *
+ * @remarks
+ *   The cap is a real bound on the recurrence interval, not on the schedule's output. `Schedule.map` over an exponential
+ *   schedule transforms only the value it emits; the interval the runtime waits keeps doubling, reaches half an hour by
+ *   the twelfth retry and overflows the timer within a day, after which the stream never retries again.
+ *   `Schedule.union` recurs whenever either schedule would, so the interval is the smaller of the two — the exponential
+ *   until it passes the cap, the cap from then on. Jitter is applied before the union so the cap is hard: applied
+ *   after, its upper band could stretch a capped wait past two minutes.
+ * @returns A schedule whose output — the pair of both schedules' outputs — carries nothing a retry loop reads.
+ */
+export const retrySchedule = (): Schedule.Schedule<readonly [Duration.Duration, number], unknown> =>
+  Schedule.exponential(Duration.seconds(1), 2).pipe(
+    Schedule.jittered,
+    Schedule.union(Schedule.spaced(MAX_RETRY_DELAY)),
+  );

--- a/packages/unshielded-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/unshielded-wallet/src/v1/RunningV1Variant.ts
@@ -21,7 +21,7 @@ import {
 import { EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
 import { type SerializationCapability } from './Serialization.js';
 import { type SyncCapability, type SyncService } from './Sync.js';
-import { type WalletSyncUpdate } from './SyncSchema.js';
+import { type SyncUpdate } from './SyncSchema.js';
 import {
   type TransactingCapability,
   type TokenTransfer,
@@ -35,7 +35,7 @@ import { type WalletError } from './WalletError.js';
 import { type CoinsAndBalancesCapability } from './CoinsAndBalances.js';
 import { type KeysCapability } from './Keys.js';
 import { type CoinSelection } from '@midnightntwrk/wallet-sdk-capabilities';
-import { type CoreWallet } from './CoreWallet.js';
+import { CoreWallet } from './CoreWallet.js';
 import { type TransactionHistoryService } from './TransactionHistory.js';
 import type * as ledger from '@midnight-ntwrk/ledger-v8';
 
@@ -78,7 +78,10 @@ export declare namespace RunningV1Variant {
 
 export const V1Tag: unique symbol = Symbol('V1');
 
-export type DefaultRunningV1 = RunningV1Variant<string, WalletSyncUpdate>;
+// `SyncUpdate`, matching `DefaultV1Variant` and `UnshieldedWallet`: the default sync stream carries liveness verdicts
+// alongside the indexer's own updates, so an alias still naming `WalletSyncUpdate` would describe no wallet the
+// default builder can produce.
+export type DefaultRunningV1 = RunningV1Variant<string, SyncUpdate>;
 
 export class RunningV1Variant<TSerialized, TSyncUpdate> implements Variant.RunningVariant<typeof V1Tag, CoreWallet> {
   readonly __polyTag__: typeof V1Tag = V1Tag;
@@ -118,10 +121,58 @@ export class RunningV1Variant<TSerialized, TSyncUpdate> implements Variant.Runni
   }
 
   startSyncInBackground(): Effect.Effect<void> {
-    return this.startSync().pipe(
-      Stream.runScoped(Sink.drain),
-      Effect.forkScoped,
-      Effect.provideService(Scope.Scope, this.#scope),
+    return Effect.zipRight(
+      this.#startLivenessInBackground(),
+      this.startSync().pipe(Stream.runScoped(Sink.drain), Effect.forkScoped),
+    ).pipe(Effect.asVoid, Effect.provideService(Scope.Scope, this.#scope));
+  }
+
+  /**
+   * Forks the sync service's liveness feed, when it has one, for the lifetime of the wallet.
+   *
+   * @remarks
+   *   Deliberately outside {@link RunningV1Variant.startSync} and its retry: rebuilding the feed on every indexer-stream
+   *   retry reconnected its node client each time and silenced verdicts during exactly the windows — indexer outages —
+   *   the liveness check exists for. The feed is built once, from the state the wallet holds at start, and lives until
+   *   the wallet's scope closes. It still retries on its own failures, which its verdict streams are built never to
+   *   produce — a failure here is a bug, and backing off beats silently losing the check.
+   */
+  #startLivenessInBackground(): Effect.Effect<void, never, Scope.Scope> {
+    const livenessUpdates = this.#v1Context.syncService.livenessUpdates;
+
+    return livenessUpdates === undefined
+      ? Effect.void
+      : pipe(
+          SubscriptionRef.get(this.#context.stateRef),
+          Stream.fromEffect,
+          Stream.flatMap((state) => livenessUpdates(state)),
+          Stream.mapEffect((update) => this.#applyUpdate(update)),
+          Stream.tapError((error) => Console.error(error)),
+          Stream.retry(RunningV1Variant.#retrySchedule()),
+          Stream.runScoped(Sink.drain),
+          Effect.forkScoped,
+          Effect.asVoid,
+        );
+  }
+
+  /** Folds one update into the wallet state through the sync capability. */
+  #applyUpdate(update: TSyncUpdate): Effect.Effect<void, WalletError> {
+    return SubscriptionRef.updateEffect(this.#context.stateRef, (state) =>
+      pipe(this.#v1Context.syncCapability.applyUpdate(state, update), EitherOps.toEffect),
+    );
+  }
+
+  /** Exponential backoff with jitter, capped at two minutes — shared by both sync streams. */
+  static #retrySchedule(): Schedule.Schedule<Duration.Duration, unknown> {
+    return pipe(
+      Schedule.exponential(Duration.seconds(1), 2),
+      Schedule.map((delay) => {
+        const maxDelay = Duration.minutes(2);
+        const jitter = Duration.millis(Math.floor(Math.random() * 1000));
+        const delayWithJitter = Duration.toMillis(delay) + Duration.toMillis(jitter);
+
+        return Duration.millis(Math.min(delayWithJitter, Duration.toMillis(maxDelay)));
+      }),
     );
   }
 
@@ -130,24 +181,20 @@ export class RunningV1Variant<TSerialized, TSyncUpdate> implements Variant.Runni
       SubscriptionRef.get(this.#context.stateRef),
       Stream.fromEffect,
       Stream.flatMap((state) => this.#v1Context.syncService.updates(state)),
-      Stream.mapEffect((update) => {
-        return SubscriptionRef.updateEffect(this.#context.stateRef, (state) =>
-          pipe(this.#v1Context.syncCapability.applyUpdate(state, update), EitherOps.toEffect),
-        );
-      }),
+      Stream.mapEffect((update) => this.#applyUpdate(update)),
       Stream.tapError((error) => Console.error(error)),
-      Stream.retry(
-        pipe(
-          Schedule.exponential(Duration.seconds(1), 2),
-          Schedule.map((delay) => {
-            const maxDelay = Duration.minutes(2);
-            const jitter = Duration.millis(Math.floor(Math.random() * 1000));
-            const delayWithJitter = Duration.toMillis(delay) + Duration.toMillis(jitter);
-
-            return Duration.millis(Math.min(delayWithJitter, Duration.toMillis(maxDelay)));
-          }),
+      // The flag is written true on every progress update and nowhere else goes false, so without this it latches: a
+      // wallet whose subscription just died would sit through the retry backoff — or an entire indexer outage — still
+      // holding isConnected: true, a caught-up cursor, and its last liveness verdict, and so still reporting itself
+      // synchronized. The liveness check cannot catch that case: the indexer itself may be healthy while this wallet's
+      // subscription is dead. The connection flag is the one truthful signal, and the stream failing is the one place
+      // that knows it.
+      Stream.tapError(() =>
+        SubscriptionRef.update(this.#context.stateRef, (state) =>
+          CoreWallet.updateProgress(state, { isConnected: false }),
         ),
       ),
+      Stream.retry(RunningV1Variant.#retrySchedule()),
     );
   }
 

--- a/packages/unshielded-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/unshielded-wallet/src/v1/RunningV1Variant.ts
@@ -32,7 +32,7 @@ import {
 } from './Transacting.js';
 import { type UtxoWithMeta } from './UnshieldedState.js';
 import { type UnboundTransaction } from './TransactionOps.js';
-import { type WalletError } from './WalletError.js';
+import { SyncWalletError, type WalletError } from './WalletError.js';
 import { type CoinsAndBalancesCapability } from './CoinsAndBalances.js';
 import { type KeysCapability } from './Keys.js';
 import { type CoinSelection } from '@midnightntwrk/wallet-sdk-capabilities';
@@ -177,6 +177,12 @@ export class RunningV1Variant<TSerialized, TSyncUpdate> implements Variant.Runni
       SubscriptionRef.get(this.#context.stateRef),
       Stream.fromEffect,
       Stream.flatMap((state) => this.#v1Context.syncService.updates(state)),
+      // A live wallet's update source has no legitimate end — the indexer subscription and the simulator's state feed
+      // are both open-ended — so a stream that completes has been dropped as surely as one that failed. The indexer
+      // does exactly this: a graphql-ws `complete` ends the stream cleanly. Left as an end, the sync fibre simply
+      // finished: no retry, no flag reset, and no further transaction could ever reach the wallet. Failing here puts
+      // an end through the same path as a failure — the log, the flag, the backoff.
+      Stream.concat(Stream.fail(new SyncWalletError({ message: 'Sync subscription ended' }))),
       Stream.mapEffect((update) => this.#applyUpdate(update)),
       Stream.tapError((error) => Console.error(error)),
       // The flag is written true on every progress update and nowhere else goes false, so without this it latches: a

--- a/packages/unshielded-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/unshielded-wallet/src/v1/RunningV1Variant.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Effect, pipe, type Record, Scope, Stream, SubscriptionRef, Schedule, Duration, Sink, Console } from 'effect';
-import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { IndexerLiveness, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import {
   type WalletRuntimeError,
   type Variant,
@@ -136,12 +136,21 @@ export class RunningV1Variant<TSerialized, TSyncUpdate> implements Variant.Runni
    *   the liveness check exists for. The feed is built once, from the state the wallet holds at start, and lives until
    *   the wallet's scope closes. It still retries on its own failures, which its verdict streams are built never to
    *   produce — a failure here is a bug, and backing off beats silently losing the check.
+   *
+   *   A service with no feed gets a verdict too. The progress defaults to `Unknown`, which gates completion until a first
+   *   verdict arrives — and for such a service none ever would, so the wallet could never report itself synchronized.
+   *   This is the one place that inspects the service, so the absence is turned into `Skipped` here, once. The write is
+   *   unconditional: a verdict restored with a serialized state came from a check this wallet no longer has.
    */
   #startLivenessInBackground(): Effect.Effect<void, never, Scope.Scope> {
     const livenessUpdates = this.#v1Context.syncService.livenessUpdates;
 
     return livenessUpdates === undefined
-      ? Effect.void
+      ? SubscriptionRef.update(this.#context.stateRef, (state) =>
+          CoreWallet.updateProgress(state, {
+            indexerLiveness: IndexerLiveness.Skipped({ reason: 'no-liveness-feed' }),
+          }),
+        )
       : pipe(
           SubscriptionRef.get(this.#context.stateRef),
           Stream.fromEffect,

--- a/packages/unshielded-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/unshielded-wallet/src/v1/RunningV1Variant.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { Effect, pipe, type Record, Scope, Stream, SubscriptionRef, Schedule, Duration, Sink, Console } from 'effect';
+import { Effect, pipe, type Record, Scope, Stream, SubscriptionRef, Sink, Console } from 'effect';
 import { IndexerLiveness, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import {
   type WalletRuntimeError,
@@ -22,6 +22,7 @@ import { EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
 import { type SerializationCapability } from './Serialization.js';
 import { type SyncCapability, type SyncService } from './Sync.js';
 import { type SyncUpdate } from './SyncSchema.js';
+import { retrySchedule } from './RetrySchedule.js';
 import {
   type TransactingCapability,
   type TokenTransfer,
@@ -157,7 +158,7 @@ export class RunningV1Variant<TSerialized, TSyncUpdate> implements Variant.Runni
           Stream.flatMap((state) => livenessUpdates(state)),
           Stream.mapEffect((update) => this.#applyUpdate(update)),
           Stream.tapError((error) => Console.error(error)),
-          Stream.retry(RunningV1Variant.#retrySchedule()),
+          Stream.retry(retrySchedule()),
           Stream.runScoped(Sink.drain),
           Effect.forkScoped,
           Effect.asVoid,
@@ -168,20 +169,6 @@ export class RunningV1Variant<TSerialized, TSyncUpdate> implements Variant.Runni
   #applyUpdate(update: TSyncUpdate): Effect.Effect<void, WalletError> {
     return SubscriptionRef.updateEffect(this.#context.stateRef, (state) =>
       pipe(this.#v1Context.syncCapability.applyUpdate(state, update), EitherOps.toEffect),
-    );
-  }
-
-  /** Exponential backoff with jitter, capped at two minutes — shared by both sync streams. */
-  static #retrySchedule(): Schedule.Schedule<Duration.Duration, unknown> {
-    return pipe(
-      Schedule.exponential(Duration.seconds(1), 2),
-      Schedule.map((delay) => {
-        const maxDelay = Duration.minutes(2);
-        const jitter = Duration.millis(Math.floor(Math.random() * 1000));
-        const delayWithJitter = Duration.toMillis(delay) + Duration.toMillis(jitter);
-
-        return Duration.millis(Math.min(delayWithJitter, Duration.toMillis(maxDelay)));
-      }),
     );
   }
 
@@ -203,7 +190,7 @@ export class RunningV1Variant<TSerialized, TSyncUpdate> implements Variant.Runni
           CoreWallet.updateProgress(state, { isConnected: false }),
         ),
       ),
-      Stream.retry(RunningV1Variant.#retrySchedule()),
+      Stream.retry(retrySchedule()),
     );
   }
 

--- a/packages/unshielded-wallet/src/v1/Sync.ts
+++ b/packages/unshielded-wallet/src/v1/Sync.ts
@@ -10,7 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { Effect, type Scope, Stream, Schema, pipe, Either, HashMap } from 'effect';
+import { type Duration, Effect, type Scope, Stream, Schema, pipe, Either, HashMap, Option } from 'effect';
+import { IndexerLiveness } from '@midnightntwrk/wallet-sdk-abstractions';
 import { CoreWallet } from './CoreWallet.js';
 import { UtxoWithMeta } from './UnshieldedState.js';
 import {
@@ -18,17 +19,38 @@ import {
   type SimulatorState,
   getCurrentBlockNumber,
 } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import {
+  DEFAULT_LIVENESS_CONFIGURATION,
+  DEFAULT_POLL_INTERVAL,
+  type DefaultSubmissionConfiguration,
+  type LivenessConfiguration,
+  type LivenessReads,
+  type LivenessReadsConfiguration,
+  LivenessServiceImpl,
+  makeDefaultLivenessReads,
+} from '@midnightntwrk/wallet-sdk-capabilities';
 import { UnshieldedTransactions } from '@midnightntwrk/wallet-sdk-indexer-client';
 import { WsSubscriptionClient, ConnectionHelper } from '@midnightntwrk/wallet-sdk-indexer-client/effect';
 import { SyncWalletError, type WalletError } from './WalletError.js';
 import { WsURL } from '@midnightntwrk/wallet-sdk-utilities/networking';
 import { type TransactionHistoryService } from './TransactionHistory.js';
 import { EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
-import { type WalletSyncUpdate, WalletSyncUpdateSchema } from './SyncSchema.js';
+import { type IndexerLivenessUpdate, type SyncUpdate, WalletSyncUpdateSchema } from './SyncSchema.js';
 import * as ledger from '@midnight-ntwrk/ledger-v8';
 
 export interface SyncService<TState, TUpdate> {
+  /** The wallet's subscription to its update source. Rebuilt by the variant's retry whenever it fails. */
   updates: (state: TState) => Stream.Stream<TUpdate, WalletError, Scope.Scope>;
+  /**
+   * Updates whose lifetime is the wallet's, not the subscription's.
+   *
+   * @remarks
+   *   Forked once at wallet scope and never rebuilt: `updates` failing and retrying must not restart this feed, so a
+   *   liveness poller keeps its node connection — and keeps publishing verdicts — while the indexer subscription is
+   *   down. Optional because not every source has such a feed: the simulator reports its skipped check through its
+   *   capability instead.
+   */
+  livenessUpdates?: (state: TState) => Stream.Stream<TUpdate, WalletError, Scope.Scope>;
 }
 
 export interface SyncCapability<TState, TUpdate> {
@@ -41,17 +63,70 @@ export type IndexerClientConnection = {
   keepAlive?: number;
 };
 
+export type NodeClientConnection = {
+  /** The node's WebSocket RPC endpoint, used only to read the finalized head. */
+  nodeURL: string;
+};
+
+/**
+ * The node transactions are submitted through, borrowed from the submission configuration as the default source of a
+ * finalized head.
+ *
+ * @remarks
+ *   Every wallet configured to submit already names a node, and demanding that same endpoint a second time would leave
+ *   the cross-check switched off for anyone who did not know to opt in.
+ *
+ *   Taken from `DefaultSubmissionConfiguration` rather than redeclared, so that renaming or retyping the field there
+ *   fails to compile here. Declared independently it would merely stop matching, and the check would go quiet — the
+ *   class of silent failure this feature exists to prevent.
+ */
+type SubmissionNodeFallback = Partial<Pick<DefaultSubmissionConfiguration, 'relayURL'>>;
+
 export type DefaultSyncConfiguration = {
   indexerClientConnection: IndexerClientConnection;
-};
+  /**
+   * Where to read the node's finalized head, for cross-checking the indexer's reported position.
+   *
+   * @remarks
+   *   Synchronizing needs a node as well as an indexer, and this is where sync says so. Optional only because a wallet
+   *   may run without one, in which case no cross-check happens and the wallet reports {@link IndexerLiveness.Skipped}.
+   *
+   *   A wallet configured for transaction submission need not set it: the endpoint named by `relayURL` is used, so the
+   *   same node is not configured twice. Set this to name the node explicitly — a wallet built without submission
+   *   configuration has no `relayURL` to borrow.
+   */
+  nodeClientConnection?: NodeClientConnection;
+  /**
+   * How far the indexer may drift from the node's finalized head before the difference is reported.
+   *
+   * @remarks
+   *   Defaults to {@link DEFAULT_LIVENESS_CONFIGURATION}, whose tolerances suit a chain producing blocks seconds apart.
+   *   Set this for a chain with a different block time, or to tighten the staleness allowance a caller is willing to
+   *   treat as current.
+   */
+  livenessConfiguration?: LivenessConfiguration;
+  /**
+   * How often to compare the indexer against the node.
+   *
+   * @remarks
+   *   Defaults to {@link DEFAULT_POLL_INTERVAL}. Each poll costs one request to the indexer and one to a node the wallet
+   *   does not own, so shortening this trades load for how quickly a stalled indexer is noticed. Polling faster than
+   *   blocks are produced only re-reads the same block.
+   *
+   *   Polls never overlap: each one is awaited before the next tick is taken. An interval shorter than the time a read
+   *   takes — a read of the node is given ten seconds before it is abandoned — therefore slows the effective cadence to
+   *   the speed of the reads rather than running two at once.
+   */
+  livenessPollInterval?: Duration.DurationInput;
+} & SubmissionNodeFallback;
 
 export type DefaultSyncContext = {
   transactionHistoryService: TransactionHistoryService;
 };
 
-export const makeDefaultSyncService = (config: DefaultSyncConfiguration): SyncService<CoreWallet, WalletSyncUpdate> => {
+export const makeDefaultSyncService = (config: DefaultSyncConfiguration): SyncService<CoreWallet, SyncUpdate> => {
   return {
-    updates: (state: CoreWallet): Stream.Stream<WalletSyncUpdate, WalletError, Scope.Scope> => {
+    updates: (state: CoreWallet): Stream.Stream<SyncUpdate, WalletError, Scope.Scope> => {
       const { indexerClientConnection } = config;
 
       const webSocketUrlResult = ConnectionHelper.createWebSocketUrl(
@@ -80,7 +155,7 @@ export const makeDefaultSyncService = (config: DefaultSyncConfiguration): SyncSe
       const { appliedId } = state.progress;
       const { address } = state.publicKey;
 
-      return pipe(
+      const indexerUpdates: Stream.Stream<SyncUpdate, WalletError, Scope.Scope> = pipe(
         UnshieldedTransactions.run({ address, transactionId: Number(appliedId) }),
         Stream.provideLayer(
           WsSubscriptionClient.layer({ url: indexerWsUrl, keepAlive: indexerClientConnection.keepAlive }),
@@ -96,17 +171,104 @@ export const makeDefaultSyncService = (config: DefaultSyncConfiguration): SyncSe
           );
         }),
       );
+
+      return indexerUpdates;
     },
+    // Both outcomes live here so the decision is made in one place — a caller choosing between them separately would
+    // leave one branch dead code, exercised only by tests.
+    livenessUpdates: (state: CoreWallet): Stream.Stream<SyncUpdate, WalletError, Scope.Scope> =>
+      Option.match(makeLivenessUpdates(config, state.progress.indexerLiveness), {
+        // Reported from the one place that can see the configuration: no node means no check, said once rather than
+        // left as `Unknown` forever. The stream then ends — there is nothing more this feed will ever say.
+        onNone: () =>
+          Stream.make({
+            type: 'IndexerLiveness' as const,
+            verdict: IndexerLiveness.Skipped({ reason: 'no-node-configured' as const }),
+          }),
+        onSome: (verdicts) => verdicts,
+      }),
   };
 };
+
+/**
+ * Decides which node endpoint the liveness check should read, if any.
+ *
+ * @remarks
+ *   `nodeClientConnection` is sync's own statement of the node it needs, so it is preferred. A wallet configured for
+ *   submission need not repeat that endpoint, so `relayURL` serves as the default. Only a wallet naming neither goes
+ *   unchecked.
+ * @param config - The sync configuration.
+ * @returns The endpoint to read the finalized head from, or `Option.none` when the wallet names no node at all.
+ */
+export const resolveNodeEndpoint = (config: DefaultSyncConfiguration): Option.Option<NodeClientConnection> =>
+  Option.orElse(Option.fromNullable(config.nodeClientConnection), () =>
+    Option.map(Option.fromNullable(config.relayURL), (relayURL) => ({ nodeURL: relayURL.toString() })),
+  );
+
+/**
+ * Builds the stream of liveness verdicts for a wallet, when one can be produced.
+ *
+ * @remarks
+ *   Returns `Option.none` when no node endpoint is configured. There is nothing to compare the indexer against in that
+ *   case, so no service is started and the wallet's progress keeps the {@link IndexerLiveness.Skipped} default set by
+ *   `createSyncProgress` — "no check ran, because you configured no node".
+ * @param config - The sync configuration, whose `nodeClientConnection` decides whether a check is possible, and whose
+ *   `livenessConfiguration` and `livenessPollInterval` override the defaults.
+ * @param initialVerdict - The verdict to start from, so a rebuilt stream does not discard what is already known.
+ * @param makeReads - Where the two block heights come from. Defaults to reading the configured indexer and node;
+ *   supplying this is how a test drives the check without either of them.
+ * @returns The stream of verdict updates to merge into the sync stream, or `Option.none` when no node is configured.
+ */
+export const makeLivenessUpdates = (
+  config: DefaultSyncConfiguration,
+  initialVerdict: IndexerLiveness.IndexerLiveness,
+  makeReads: (
+    readsConfig: LivenessReadsConfiguration,
+  ) => Effect.Effect<LivenessReads, never, Scope.Scope> = makeDefaultLivenessReads,
+): Option.Option<Stream.Stream<IndexerLivenessUpdate, WalletError, Scope.Scope>> =>
+  resolveNodeEndpoint(config).pipe(
+    Option.map((nodeClientConnection) =>
+      Stream.unwrapScoped(
+        Effect.gen(function* () {
+          // Built in the stream's scope, so the node connection the reads share is released when sync stops.
+          const reads = yield* makeReads({
+            indexerClientConnection: config.indexerClientConnection,
+            nodeClientConnection,
+          });
+
+          const service = yield* LivenessServiceImpl.make(
+            reads,
+            config.livenessConfiguration ?? DEFAULT_LIVENESS_CONFIGURATION,
+            // Seeded from what the wallet already knows. The feed lives at wallet scope and is only ever rebuilt
+            // after an unexpected failure — and starting afresh at `Unknown` there would clear a `Behind` verdict,
+            // handing back a "synchronized" answer over the stale view the check had just caught.
+            initialVerdict,
+          );
+
+          // Forked into the caller's scope so polling stops when sync does, rather than outliving the wallet.
+          yield* Effect.forkScoped(
+            service.startPolling(Stream.tick(config.livenessPollInterval ?? DEFAULT_POLL_INTERVAL)),
+          );
+
+          return service
+            .state()
+            .pipe(Stream.map((verdict): IndexerLivenessUpdate => ({ type: 'IndexerLiveness', verdict })));
+        }),
+      ),
+    ),
+  );
 
 export const makeDefaultSyncCapability = (
   _config: DefaultSyncConfiguration,
   getContext: () => DefaultSyncContext,
-): SyncCapability<CoreWallet, WalletSyncUpdate> => {
+): SyncCapability<CoreWallet, SyncUpdate> => {
   return {
-    applyUpdate: (state: CoreWallet, update: WalletSyncUpdate): Either.Either<CoreWallet, WalletError> => {
-      if (update.type === 'UnshieldedTransactionsProgress') {
+    applyUpdate: (state: CoreWallet, update: SyncUpdate): Either.Either<CoreWallet, WalletError> => {
+      if (update.type === 'IndexerLiveness') {
+        // Only the verdict is written. A verdict says nothing about which transactions have been applied, so touching
+        // the sync cursor here would let the liveness check corrupt it.
+        return Either.right(CoreWallet.updateProgress(state, { indexerLiveness: update.verdict }));
+      } else if (update.type === 'UnshieldedTransactionsProgress') {
         return Either.right(
           CoreWallet.updateProgress(state, {
             highestTransactionId: BigInt(update.highestTransactionId),
@@ -222,7 +384,14 @@ export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, Simula
 
       const blockNumber = getCurrentBlockNumber(update.update);
       const updateProgress = (wallet: CoreWallet) =>
-        CoreWallet.updateProgress(wallet, { appliedId: blockNumber, isConnected: true });
+        CoreWallet.updateProgress(wallet, {
+          appliedId: blockNumber,
+          isConnected: true,
+          // `Unknown` gates sync completion, so a wallet whose progress never left it would never report itself
+          // synchronized. A simulation has no node to cross-check against and never will — the wiring that knows
+          // says so, the same way the default sync service reports `Skipped` when no node is configured.
+          indexerLiveness: IndexerLiveness.Skipped({ reason: 'simulation' }),
+        });
 
       if (createdUtxos.length === 0 && spentUtxos.length === 0) {
         return Either.right(updateProgress(state));

--- a/packages/unshielded-wallet/src/v1/Sync.ts
+++ b/packages/unshielded-wallet/src/v1/Sync.ts
@@ -39,7 +39,14 @@ import { type IndexerLivenessUpdate, type SyncUpdate, WalletSyncUpdateSchema } f
 import * as ledger from '@midnight-ntwrk/ledger-v8';
 
 export interface SyncService<TState, TUpdate> {
-  /** The wallet's subscription to its update source. Rebuilt by the variant's retry whenever it fails. */
+  /**
+   * The wallet's subscription to its update source. Rebuilt by the variant's retry whenever it fails.
+   *
+   * @remarks
+   *   Expected to be open-ended. A stream that completes is treated by the variant exactly like one that failed — logged,
+   *   `isConnected` cleared, and rebuilt after backoff — because a wallet has no use for a source that has stopped
+   *   speaking, whatever the reason.
+   */
   updates: (state: TState) => Stream.Stream<TUpdate, WalletError, Scope.Scope>;
   /**
    * Updates whose lifetime is the wallet's, not the subscription's.

--- a/packages/unshielded-wallet/src/v1/Sync.ts
+++ b/packages/unshielded-wallet/src/v1/Sync.ts
@@ -210,8 +210,9 @@ export const resolveNodeEndpoint = (config: DefaultSyncConfiguration): Option.Op
  *
  * @remarks
  *   Returns `Option.none` when no node endpoint is configured. There is nothing to compare the indexer against in that
- *   case, so no service is started and the wallet's progress keeps the {@link IndexerLiveness.Skipped} default set by
- *   `createSyncProgress` — "no check ran, because you configured no node".
+ *   case, so no service is started. The progress defaults to {@link IndexerLiveness.Unknown}, which gates completion, so
+ *   the caller must still publish a verdict: the default sync service answers `Option.none` with a single
+ *   {@link IndexerLiveness.Skipped} — "no check ran, because you configured no node".
  * @param config - The sync configuration, whose `nodeClientConnection` decides whether a check is possible, and whose
  *   `livenessConfiguration` and `livenessPollInterval` override the defaults.
  * @param initialVerdict - The verdict to start from, so a rebuilt stream does not discard what is already known.

--- a/packages/unshielded-wallet/src/v1/SyncProgress.ts
+++ b/packages/unshielded-wallet/src/v1/SyncProgress.ts
@@ -10,10 +10,22 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import { IndexerLiveness } from '@midnightntwrk/wallet-sdk-abstractions';
+
 export interface SyncProgressData {
   readonly appliedId: bigint;
   readonly highestTransactionId: bigint;
   readonly isConnected: boolean;
+  /**
+   * The outcome of cross-checking the indexer's reported position against a node's finalized head.
+   *
+   * @remarks
+   *   `highestTransactionId` is a value the indexer reports about itself, so on its own it cannot distinguish a caught-up
+   *   indexer from a stalled or withholding one. This field carries an independent verdict, and
+   *   {@link SyncProgressOps.isCompleteWithin} refuses to report completion while that verdict blocks it — see
+   *   {@link IndexerLiveness.blocksSyncCompletion} for which verdicts do.
+   */
+  readonly indexerLiveness: IndexerLiveness.IndexerLiveness;
 }
 
 export interface SyncProgressOps {
@@ -28,7 +40,11 @@ export interface SyncProgress extends SyncProgressData {
 export const SyncProgress: SyncProgressOps = {
   isCompleteWithin(data: SyncProgressData, maxGap: bigint = 50n): boolean {
     const applyLag = BigInt(Math.abs(Number(data.highestTransactionId - data.appliedId)));
-    return data.isConnected && applyLag <= maxGap;
+    // `applyLag` only shows whether the wallet has kept up with the indexer; both of its terms come from the indexer, so
+    // it cannot reveal an indexer that is itself stale. That is what the liveness verdict adds: `Behind` blocks because
+    // staleness is proven, and `Unknown` blocks because it is not yet ruled out — the first verdict takes seconds, and
+    // an ungated `Unknown` would let start-up race past the check over exactly the stale view it exists to catch.
+    return data.isConnected && applyLag <= maxGap && !IndexerLiveness.blocksSyncCompletion(data.indexerLiveness);
   },
 };
 
@@ -37,14 +53,25 @@ export const createSyncProgress = (
     appliedId?: bigint;
     highestTransactionId?: bigint;
     isConnected?: boolean;
+    indexerLiveness?: IndexerLiveness.IndexerLiveness;
   } = {},
 ): SyncProgress => {
-  const { appliedId = 0n, highestTransactionId = 0n, isConnected = false } = params;
+  const {
+    appliedId = 0n,
+    highestTransactionId = 0n,
+    isConnected = false,
+    // `Unknown`, not `Skipped`: this constructor cannot see the sync configuration, so it does not know whether a node
+    // was configured. Claiming `no-node-configured` here would misreport a wallet that has one, right up until the
+    // first verdict arrives — and telling those apart is the entire reason the two cases are distinct. The sync wiring,
+    // which does know, sets `Skipped`.
+    indexerLiveness = IndexerLiveness.Unknown(),
+  } = params;
 
   const data: SyncProgressData = {
     appliedId,
     highestTransactionId,
     isConnected,
+    indexerLiveness,
   };
 
   return {

--- a/packages/unshielded-wallet/src/v1/SyncSchema.ts
+++ b/packages/unshielded-wallet/src/v1/SyncSchema.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Schema } from 'effect';
+import { type IndexerLiveness } from '@midnightntwrk/wallet-sdk-abstractions';
 import { SafeBigInt } from '@midnightntwrk/wallet-sdk-utilities';
 
 const DateFromMillis = Schema.transform(Schema.Number, Schema.DateFromSelf, {
@@ -152,3 +153,19 @@ export const ProgressSchema = Schema.Struct({
 export const WalletSyncUpdateSchema = Schema.Union(UnshieldedUpdateSchema, ProgressSchema);
 
 export type WalletSyncUpdate = Schema.Schema.Type<typeof WalletSyncUpdateSchema>;
+
+/**
+ * A new verdict on whether the indexer agrees with the node's finalized head.
+ *
+ * @remarks
+ *   Deliberately not part of {@link WalletSyncUpdateSchema}. That schema decodes what the indexer sends over the wire, and
+ *   a liveness verdict is produced by the wallet comparing two sources — it is never decoded from a payload, so it
+ *   would be a member that never matches.
+ */
+export type IndexerLivenessUpdate = {
+  readonly type: 'IndexerLiveness';
+  readonly verdict: IndexerLiveness.IndexerLiveness;
+};
+
+/** Everything the unshielded sync stream can carry: the indexer's own updates, plus verdicts from the liveness check. */
+export type SyncUpdate = WalletSyncUpdate | IndexerLivenessUpdate;

--- a/packages/unshielded-wallet/src/v1/V1Builder.ts
+++ b/packages/unshielded-wallet/src/v1/V1Builder.ts
@@ -28,7 +28,7 @@ import {
   makeDefaultSyncService,
   makeDefaultSyncCapability,
 } from './Sync.js';
-import { type WalletSyncUpdate } from './SyncSchema.js';
+import { type SyncUpdate } from './SyncSchema.js';
 import {
   type DefaultTransactingConfiguration,
   type DefaultTransactingContext,
@@ -78,7 +78,7 @@ export type V1Variant<TSerialized, TSyncUpdate> = Variant.Variant<
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyV1Variant = V1Variant<any, any>;
-export type DefaultV1Variant = V1Variant<string, WalletSyncUpdate>;
+export type DefaultV1Variant = V1Variant<string, SyncUpdate>;
 
 export type TransactionOf<T extends AnyV1Variant> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -92,9 +92,9 @@ export type SerializedStateOf<T extends AnyV1Variant> =
 
 export type DefaultV1Builder = V1Builder<
   DefaultV1Configuration,
-  RunningV1Variant.Context<string, WalletSyncUpdate>,
+  RunningV1Variant.Context<string, SyncUpdate>,
   string,
-  WalletSyncUpdate
+  SyncUpdate
 >;
 
 export class V1Builder<
@@ -123,7 +123,7 @@ export class V1Builder<
     TConfig & DefaultSyncConfiguration,
     TContext & DefaultSyncContext,
     TSerialized,
-    WalletSyncUpdate
+    SyncUpdate
   > {
     return this.withSync(makeDefaultSyncService, makeDefaultSyncCapability);
   }

--- a/packages/unshielded-wallet/src/v1/test/retrySchedule.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/retrySchedule.test.ts
@@ -1,0 +1,63 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { Chunk, Duration, Effect, Schedule } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { retrySchedule } from '../RetrySchedule.js';
+
+const TWO_MINUTES_MS = Duration.toMillis(Duration.minutes(2));
+
+/**
+ * The real interval between recurrences, for each of `count` consecutive retries.
+ *
+ * @remarks
+ *   A schedule's output value and its recurrence interval are different things: `Schedule.delays` reports the interval
+ *   the runtime actually waits, which is what a retry loop experiences. Asserting on the output alone would pass a
+ *   schedule whose interval is unbounded.
+ */
+const realDelaysMs = (count: number): readonly number[] =>
+  Effect.runSync(
+    Schedule.run(
+      Schedule.delays(retrySchedule()),
+      0,
+      Array.from({ length: count }, (_, i) => i),
+    ),
+  ).pipe(Chunk.map(Duration.toMillis), Chunk.toReadonlyArray);
+
+describe('retrySchedule', () => {
+  it('should never wait longer than two minutes between retries, so an outage is retried at a steady cadence', () => {
+    // An uncapped doubling reaches half an hour by the twelfth retry and overflows the runtime's timer within a day,
+    // at which point the stream stops retrying altogether — a wallet that never reconnects after a long outage.
+    const delays = realDelaysMs(30);
+
+    delays.forEach((delay) => expect(delay).toBeLessThanOrEqual(TWO_MINUTES_MS));
+  });
+
+  it('should settle at exactly the cap once the exponential has passed it', () => {
+    // From the ninth retry the un-jittered delay is 256 s and cannot dip below the cap even at minimum jitter, so
+    // every later interval is the cap itself — the steady cadence a long outage should be polled at.
+    const delays = realDelaysMs(30);
+
+    expect(delays.slice(8)).toStrictEqual(Array.from({ length: 22 }, () => TWO_MINUTES_MS));
+  });
+
+  it('should start at about one second and double, with jitter, before the cap', () => {
+    // Jitter keeps a fleet of wallets from reconnecting in lock-step after a shared outage. Effect's default band is
+    // 0.8–1.2 of the nominal delay, so the bounds below are those of the first two retries.
+    const [first, second] = realDelaysMs(2);
+
+    expect(first).toBeGreaterThanOrEqual(800);
+    expect(first).toBeLessThanOrEqual(1_200);
+    expect(second).toBeGreaterThanOrEqual(1_600);
+    expect(second).toBeLessThanOrEqual(2_400);
+  });
+});

--- a/packages/unshielded-wallet/src/v1/test/runningV1Variant.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/runningV1Variant.test.ts
@@ -1,0 +1,203 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { IndexerLiveness } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Cause, Duration, Effect, Exit, Option, Schedule, Scope, Stream, SubscriptionRef } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { type PublicKey } from '../../KeyStore.js';
+import { CoreWallet } from '../CoreWallet.js';
+import { RunningV1Variant } from '../RunningV1Variant.js';
+import { makeDefaultSyncCapability, type SyncService } from '../Sync.js';
+import { type SyncUpdate } from '../SyncSchema.js';
+import { type TransactionHistoryService } from '../TransactionHistory.js';
+import { SyncWalletError } from '../WalletError.js';
+
+const publicKey: PublicKey = {
+  publicKey: 'e6d8b9c1a2f3',
+  addressHex: '0102030405',
+  address: 'mn_addr_undeployed1testaddress',
+};
+
+const noOpHistory: TransactionHistoryService = { put: () => Effect.void };
+
+const syncCapability = makeDefaultSyncCapability(
+  { indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v1/graphql' } },
+  () => ({ transactionHistoryService: noOpHistory }),
+);
+
+/** A subscription that reports a fully synchronized wallet, then dies — an indexer WebSocket dropping mid-session. */
+const dyingSyncService: SyncService<CoreWallet, SyncUpdate> = {
+  updates: () =>
+    Stream.concat(
+      Stream.make<SyncUpdate[]>(
+        {
+          type: 'IndexerLiveness',
+          verdict: IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n }),
+        },
+        { type: 'UnshieldedTransactionsProgress', highestTransactionId: 0 },
+      ),
+      Stream.fail(new SyncWalletError({ message: 'websocket closed' })),
+    ),
+};
+
+describe('RunningV1Variant.startSync', () => {
+  it('should clear isConnected when the sync stream fails, so a dead subscription cannot keep reporting synced', async () => {
+    // `isConnected` was written true on every progress update and cleared nowhere: it latched. When the subscription
+    // dropped, the stream failed into its retry backoff with the wallet still holding isConnected: true, a caught-up
+    // cursor, and the last liveness verdict — so `isCompleteWithin()` reported a wallet connected to nothing as
+    // synchronized, for up to the full backoff (capped at two minutes) or an entire indexer outage. The liveness check
+    // cannot catch this one: the indexer itself may be healthy — it is this wallet's subscription that is dead — so
+    // the connection flag is the only truthful signal, and it must go false the moment the stream does.
+    const program = Effect.gen(function* () {
+      const stateRef = yield* SubscriptionRef.make(CoreWallet.init(publicKey, 'undeployed'));
+      const scope = yield* Scope.make();
+
+      const variant = new RunningV1Variant(
+        scope,
+        { stateRef },
+        // Type cast required because: startSync exercises only the sync service and capability; building the full
+        // context would drag transacting, serialization and key material into a test about a connection flag.
+        {
+          syncService: dyingSyncService,
+          syncCapability,
+          transactionHistoryService: noOpHistory,
+        } as unknown as RunningV1Variant.Context<string, SyncUpdate>,
+      );
+
+      // Subscribed before sync starts, so no intermediate state can slip past between replay and live changes.
+      const firstDisconnectAfterConnect = yield* Effect.fork(
+        stateRef.changes.pipe(
+          Stream.map((wallet) => wallet.progress),
+          // Drop everything up to and including the moment the update latched the flag true...
+          Stream.dropUntil((progress) => progress.isConnected),
+          // ...then wait for it to be cleared. Carrying the whole progress out, so completion is asserted on the same
+          // state the flag was observed on.
+          Stream.filter((progress) => !progress.isConnected),
+          Stream.runHead,
+        ),
+      );
+      yield* Effect.yieldNow();
+
+      yield* variant.startSyncInBackground().pipe(Effect.provideService(Scope.Scope, scope));
+
+      const progressAfterFailure = yield* firstDisconnectAfterConnect.await.pipe(
+        Effect.flatten,
+        // Both abnormal endings are defects, not expected failures: the state stream cannot end while its ref lives,
+        // and the timeout firing is precisely the bug under test.
+        Effect.flatMap(Option.match({ onNone: () => Effect.dieMessage('state stream ended'), onSome: Effect.succeed })),
+        Effect.timeoutFailCause({
+          duration: Duration.seconds(3),
+          onTimeout: () => Cause.die(new Error('isConnected was never cleared after the sync stream failed')),
+        }),
+      );
+
+      yield* Scope.close(scope, Exit.void);
+
+      return progressAfterFailure;
+    });
+
+    const progress = await Effect.runPromise(Effect.scoped(program));
+
+    expect(progress.isConnected).toBe(false);
+    // The cursor is caught up and the last verdict is InSync — without the cleared flag, this wallet would count as
+    // fully synchronized while connected to nothing. This is the assertion the whole feature's premise implies.
+    expect(progress.isStrictlyComplete()).toBe(false);
+  });
+
+  it(
+    'should build the liveness feed once at wallet scope, so an indexer-stream retry does not restart the poller',
+    { timeout: 10_000 },
+    async () => {
+      // `updates()` fails and is rebuilt by the variant's retry — that is its contract. The liveness feed must not be
+      // torn down with it: rebuilding it on every retry reconnects its node client each time and silences verdicts
+      // during exactly the windows — indexer outages — the check exists for. The feed's lifetime is the wallet's.
+      const builds = { indexer: 0, liveness: 0 };
+
+      const retryingSyncService: SyncService<CoreWallet, SyncUpdate> = {
+        updates: () => {
+          builds.indexer += 1;
+          return Stream.concat(
+            Stream.make<SyncUpdate[]>({ type: 'UnshieldedTransactionsProgress', highestTransactionId: 0 }),
+            Stream.fail(new SyncWalletError({ message: 'websocket closed' })),
+          );
+        },
+        livenessUpdates: () => {
+          builds.liveness += 1;
+          return Stream.concat(
+            Stream.make<SyncUpdate[]>({
+              type: 'IndexerLiveness',
+              verdict: IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n }),
+            }),
+            // Held open: a real verdict stream never ends, and an ending one would mask a feed that was rebuilt.
+            Stream.never,
+          );
+        },
+      };
+
+      const program = Effect.gen(function* () {
+        const stateRef = yield* SubscriptionRef.make(CoreWallet.init(publicKey, 'undeployed'));
+        const scope = yield* Scope.make();
+
+        const variant = new RunningV1Variant(
+          scope,
+          { stateRef },
+          // Type cast required because: startSync exercises only the sync service and capability; building the full
+          // context would drag transacting, serialization and key material into a test about feed ownership.
+          {
+            syncService: retryingSyncService,
+            syncCapability,
+            transactionHistoryService: noOpHistory,
+          } as unknown as RunningV1Variant.Context<string, SyncUpdate>,
+        );
+
+        const verdictArrived = yield* Effect.fork(
+          stateRef.changes.pipe(
+            Stream.filter((wallet) => IndexerLiveness.isInSync(wallet.progress.indexerLiveness)),
+            Stream.runHead,
+          ),
+        );
+        yield* Effect.yieldNow();
+
+        yield* variant.startSyncInBackground().pipe(Effect.provideService(Scope.Scope, scope));
+
+        // Wait through at least one retry of the indexer stream — the rebuild the liveness feed must survive.
+        yield* Effect.sync(() => builds.indexer).pipe(
+          Effect.repeat({ until: (count) => count >= 2, schedule: Schedule.spaced(Duration.millis(50)) }),
+          Effect.timeoutFailCause({
+            duration: Duration.seconds(8),
+            onTimeout: () => Cause.die(new Error('the indexer stream was never retried')),
+          }),
+        );
+
+        yield* verdictArrived.await.pipe(
+          Effect.flatten,
+          Effect.flatMap(
+            Option.match({ onNone: () => Effect.dieMessage('state stream ended'), onSome: Effect.succeed }),
+          ),
+          Effect.timeoutFailCause({
+            duration: Duration.seconds(3),
+            onTimeout: () => Cause.die(new Error('no liveness verdict ever reached the wallet state')),
+          }),
+        );
+
+        yield* Scope.close(scope, Exit.void);
+
+        return builds;
+      });
+
+      const observed = await Effect.runPromise(Effect.scoped(program));
+
+      expect(observed.indexer).toBeGreaterThanOrEqual(2);
+      expect(observed.liveness).toBe(1);
+    },
+  );
+});

--- a/packages/unshielded-wallet/src/v1/test/runningV1Variant.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/runningV1Variant.test.ts
@@ -200,4 +200,65 @@ describe('RunningV1Variant.startSync', () => {
       expect(observed.liveness).toBe(1);
     },
   );
+
+  it('should report Skipped when the sync service has no liveness feed, so a custom source can still report synced', async () => {
+    // `Unknown` is the progress default and gates completion; the only writers that move a wallet off it are a liveness
+    // feed and the simulator capability. A service without `livenessUpdates` — any custom source supplied through
+    // `withSync` — therefore left the wallet blocked forever, with no error and no log. The variant is the one place
+    // that inspects the service, so the absence of a feed is turned into a verdict there, once.
+    const feedlessSyncService: SyncService<CoreWallet, SyncUpdate> = {
+      updates: () =>
+        Stream.concat(
+          Stream.make<SyncUpdate[]>({ type: 'UnshieldedTransactionsProgress', highestTransactionId: 0 }),
+          // Held open: a live subscription does not end.
+          Stream.never,
+        ),
+    };
+
+    const program = Effect.gen(function* () {
+      const stateRef = yield* SubscriptionRef.make(CoreWallet.init(publicKey, 'undeployed'));
+      const scope = yield* Scope.make();
+
+      const variant = new RunningV1Variant(
+        scope,
+        { stateRef },
+        // Type cast required because: the test exercises only the sync service and capability; building the full
+        // context would drag transacting, serialization and key material into a test about the liveness default.
+        {
+          syncService: feedlessSyncService,
+          syncCapability,
+          transactionHistoryService: noOpHistory,
+        } as unknown as RunningV1Variant.Context<string, SyncUpdate>,
+      );
+
+      const connected = yield* Effect.fork(
+        stateRef.changes.pipe(
+          Stream.filter((wallet) => wallet.progress.isConnected),
+          Stream.runHead,
+        ),
+      );
+      yield* Effect.yieldNow();
+
+      yield* variant.startSyncInBackground().pipe(Effect.provideService(Scope.Scope, scope));
+
+      yield* connected.await.pipe(
+        Effect.flatten,
+        Effect.timeoutFailCause({
+          duration: Duration.seconds(3),
+          onTimeout: () => Cause.die(new Error('the progress update never reached the wallet state')),
+        }),
+      );
+
+      const wallet = yield* SubscriptionRef.get(stateRef);
+      yield* Scope.close(scope, Exit.void);
+
+      return wallet.progress;
+    });
+
+    const progress = await Effect.runPromise(Effect.scoped(program));
+
+    expect(progress.indexerLiveness).toStrictEqual(IndexerLiveness.Skipped({ reason: 'no-liveness-feed' }));
+    // The user-visible symptom: connected, caught up, and still never "synced".
+    expect(progress.isStrictlyComplete()).toBe(true);
+  });
 });

--- a/packages/unshielded-wallet/src/v1/test/runningV1Variant.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/runningV1Variant.test.ts
@@ -261,4 +261,59 @@ describe('RunningV1Variant.startSync', () => {
     // The user-visible symptom: connected, caught up, and still never "synced".
     expect(progress.isStrictlyComplete()).toBe(true);
   });
+
+  it('should treat a subscription that ends cleanly as dropped, clearing isConnected and rebuilding it', async () => {
+    // The indexer closes a subscription with a graphql-ws `complete` when its own stream ends; the client turns that
+    // into a clean stream end. A live wallet's update source has no legitimate end — every source is open-ended — so an
+    // end is a dropped connection by another name. Without this, the sync fiber simply finished: no retry, no flag
+    // reset, and the wallet went on reporting itself synchronized while no further transaction could ever reach it.
+    const builds = { indexer: 0 };
+
+    const endingSyncService: SyncService<CoreWallet, SyncUpdate> = {
+      updates: () => {
+        builds.indexer += 1;
+        return builds.indexer === 1
+          ? // The first subscription reports a caught-up wallet, then the indexer completes it.
+            Stream.make<SyncUpdate[]>({ type: 'UnshieldedTransactionsProgress', highestTransactionId: 0 })
+          : // The rebuilt one says nothing, so the flag the retry cleared stays observable.
+            Stream.never;
+      },
+    };
+
+    const program = Effect.gen(function* () {
+      const stateRef = yield* SubscriptionRef.make(CoreWallet.init(publicKey, 'undeployed'));
+      const scope = yield* Scope.make();
+
+      const variant = new RunningV1Variant(
+        scope,
+        { stateRef },
+        // Type cast required because: the test exercises only the sync service and capability; building the full
+        // context would drag transacting, serialization and key material into a test about subscription lifetime.
+        {
+          syncService: endingSyncService,
+          syncCapability,
+          transactionHistoryService: noOpHistory,
+        } as unknown as RunningV1Variant.Context<string, SyncUpdate>,
+      );
+
+      yield* variant.startSyncInBackground().pipe(Effect.provideService(Scope.Scope, scope));
+
+      // Give the retry a bounded chance to rebuild the subscription; the assertions below decide the outcome.
+      yield* Effect.sync(() => builds.indexer).pipe(
+        Effect.repeat({ until: (count) => count >= 2, schedule: Schedule.spaced(Duration.millis(50)) }),
+        Effect.timeoutOption(Duration.seconds(5)),
+      );
+
+      const wallet = yield* SubscriptionRef.get(stateRef);
+      yield* Scope.close(scope, Exit.void);
+
+      return { progress: wallet.progress, builds: builds.indexer };
+    });
+
+    const observed = await Effect.runPromise(Effect.scoped(program));
+
+    expect(observed.builds).toBeGreaterThanOrEqual(2);
+    expect(observed.progress.isConnected).toBe(false);
+    expect(observed.progress.isStrictlyComplete()).toBe(false);
+  });
 });

--- a/packages/unshielded-wallet/src/v1/test/sync.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/sync.test.ts
@@ -1,0 +1,275 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { IndexerLiveness } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type LivenessReads } from '@midnightntwrk/wallet-sdk-capabilities';
+import { Chunk, Duration, Effect, Either, Option, Ref, Stream, TestClock, TestContext } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { type PublicKey } from '../../KeyStore.js';
+import { CoreWallet } from '../CoreWallet.js';
+import { type SimulatorState } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import {
+  type DefaultSyncConfiguration,
+  makeDefaultSyncCapability,
+  makeDefaultSyncService,
+  makeLivenessUpdates,
+  makeSimulatorSyncCapability,
+  resolveNodeEndpoint,
+} from '../Sync.js';
+import { type IndexerLivenessUpdate } from '../SyncSchema.js';
+import { type TransactionHistoryService } from '../TransactionHistory.js';
+
+const indexerOnly = { indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v1/graphql' } };
+
+const withNode = {
+  ...indexerOnly,
+  nodeClientConnection: { nodeURL: 'ws://localhost:9944' },
+};
+
+/** A history service that records nothing — a liveness verdict never reaches it. */
+const noOpHistory: TransactionHistoryService = { put: () => Effect.void };
+
+const publicKey: PublicKey = {
+  publicKey: 'e6d8b9c1a2f3',
+  addressHex: '0102030405',
+  address: 'mn_addr_undeployed1testaddress',
+};
+
+const capability = () => makeDefaultSyncCapability(indexerOnly, () => ({ transactionHistoryService: noOpHistory }));
+
+const livenessUpdate = (verdict: IndexerLiveness.IndexerLiveness): IndexerLivenessUpdate => ({
+  type: 'IndexerLiveness',
+  verdict,
+});
+
+/** Reads that answer with fixed heights and matching genesis hashes, so a verdict depends only on the tolerances. */
+const fixedHeightReads = (heights: {
+  readonly indexerHeight: bigint;
+  readonly finalizedHeight: bigint;
+}): LivenessReads => ({
+  indexerHeight: () => Effect.succeed(heights.indexerHeight),
+  finalizedHeight: () => Effect.succeed(heights.finalizedHeight),
+  indexerGenesisHash: () => Effect.succeed('ab'.repeat(32)),
+  nodeGenesisHash: () => Effect.succeed(`0x${'ab'.repeat(32)}`),
+});
+
+/**
+ * Runs the liveness stream until it publishes a verdict, and returns that verdict.
+ *
+ * @remarks
+ *   Filtering on `Unknown` rather than taking the first two elements: `SubscriptionRef.changes` replays whatever the
+ *   current value is, so a poll that lands before the subscriber attaches would make the seed absent and a
+ *   `Stream.take(2)` wait forever for a second verdict that never comes.
+ */
+const firstVerdict = (
+  config: DefaultSyncConfiguration,
+  reads: LivenessReads,
+): Promise<Option.Option<IndexerLiveness.IndexerLiveness>> =>
+  Effect.runPromise(
+    Option.getOrThrow(makeLivenessUpdates(config, IndexerLiveness.Unknown(), () => Effect.succeed(reads))).pipe(
+      Stream.map((update) => update.verdict),
+      Stream.filter((verdict) => !IndexerLiveness.isUnknown(verdict)),
+      Stream.runHead,
+      Effect.timeout(Duration.seconds(5)),
+      Effect.scoped,
+    ),
+  );
+
+describe('makeDefaultSyncCapability', () => {
+  describe('applying an IndexerLiveness update', () => {
+    it('should record the verdict on the wallet progress', () => {
+      const behind = IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_000n, lag: 100n });
+      const wallet = CoreWallet.init(publicKey, 'undeployed');
+
+      const result = capability().applyUpdate(wallet, livenessUpdate(behind));
+
+      expect(Either.isRight(result)).toBe(true);
+      expect(Either.getOrThrow(result).progress.indexerLiveness).toStrictEqual(behind);
+    });
+
+    it('should leave transaction progress untouched, because staleness is orthogonal to applying transactions', () => {
+      // A verdict says nothing about which transactions the wallet has applied. Touching these would let the liveness
+      // check corrupt the sync cursor.
+      const wallet = CoreWallet.updateProgress(CoreWallet.init(publicKey, 'undeployed'), {
+        appliedId: 42n,
+        highestTransactionId: 99n,
+        isConnected: true,
+      });
+
+      const result = capability().applyUpdate(
+        wallet,
+        livenessUpdate(IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n })),
+      );
+
+      const progress = Either.getOrThrow(result).progress;
+      expect(progress.appliedId).toBe(42n);
+      expect(progress.highestTransactionId).toBe(99n);
+      expect(progress.isConnected).toBe(true);
+    });
+  });
+});
+
+describe('makeSimulatorSyncCapability', () => {
+  it('should mark the liveness check skipped, because a simulation has no node to cross-check against', () => {
+    // `Unknown` gates sync completion, so a wallet whose progress never left `Unknown` would never report itself
+    // synchronized. The simulator wiring knows no check will ever run, and says so — the same principle as the default
+    // sync service reporting `Skipped` when no node is configured.
+    const emptySimulatorState = {
+      currentTime: new Date(0),
+      blocks: [{ number: 7n }],
+      ledger: { dust: { toString: () => '' }, utxo: { filter: () => [] } },
+      // Type cast required because: the capability reads only these fields, and a real LedgerState needs the ledger
+      // WASM runtime, which a unit test must not load.
+    } as unknown as SimulatorState;
+
+    const result = makeSimulatorSyncCapability().applyUpdate(CoreWallet.init(publicKey, 'undeployed'), {
+      update: emptySimulatorState,
+    });
+
+    expect(Either.getOrThrow(result).progress.indexerLiveness).toStrictEqual(
+      IndexerLiveness.Skipped({ reason: 'simulation' }),
+    );
+  });
+});
+
+describe('makeLivenessUpdates', () => {
+  it('should seed the stream from the verdict it is given, so a reconnect does not erase what was known', async () => {
+    // `updates()` is rebuilt on every indexer-stream retry, under `Stream.retry`. Starting each new liveness stream at
+    // `Unknown` would clear a `Behind` verdict on every reconnect and let `waitForSyncedState` resolve over the stale
+    // view the check had already caught.
+    const behind = IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_000n, lag: 100n });
+
+    const first = await Effect.runPromise(
+      Stream.runHead(Option.getOrThrow(makeLivenessUpdates(withNode, behind))).pipe(Effect.scoped),
+    );
+
+    expect(first).toStrictEqual(Option.some({ type: 'IndexerLiveness', verdict: behind }));
+  });
+
+  it('should produce a stream only when a node endpoint is configured', () => {
+    // Without a node there is nothing to compare the indexer against, so no service runs and the sync stream reports
+    // `Skipped` once instead. Both directions are asserted together: either alone is satisfied by a function that
+    // ignores its configuration entirely.
+    expect(Option.isNone(makeLivenessUpdates(indexerOnly, IndexerLiveness.Unknown()))).toBe(true);
+    expect(Option.isSome(makeLivenessUpdates(withNode, IndexerLiveness.Unknown()))).toBe(true);
+  });
+
+  it('should fall back to relayURL, so a wallet configured for submission is checked without further configuration', () => {
+    // `relayURL` is a required part of the facade's configuration, so every wallet that can submit already has a node.
+    // Asking for the same endpoint twice would leave the check switched off for everyone who did not know to opt in.
+    const withRelayOnly = { ...indexerOnly, relayURL: new URL('ws://localhost:9944') };
+
+    expect(Option.isSome(makeLivenessUpdates(withRelayOnly, IndexerLiveness.Unknown()))).toBe(true);
+  });
+
+  it('should prefer an explicit nodeClientConnection over relayURL', () => {
+    // The override exists for pointing the liveness read at a different node than submission uses.
+    const both = { ...withNode, relayURL: new URL('ws://someone-elses-node:9944') };
+
+    expect(resolveNodeEndpoint(both)).toStrictEqual(Option.some({ nodeURL: 'ws://localhost:9944' }));
+  });
+
+  it('should resolve no endpoint when neither is configured', () => {
+    expect(resolveNodeEndpoint(indexerOnly)).toStrictEqual(Option.none());
+  });
+
+  it('should apply the configured tolerances rather than the defaults', async () => {
+    // Both directions are asserted, because each travels as a separate field: wiring one through and leaving the other
+    // as a literal default would pass a test that checked only the direction that was wired.
+    const tighterThanDefault = {
+      ...withNode,
+      livenessConfiguration: { maxBehindBlocks: 5n, maxAheadBlocks: 5n },
+    };
+
+    // A lag of 8 blocks: inside the default allowance of 10, outside the configured 5.
+    const behind = await firstVerdict(
+      tighterThanDefault,
+      fixedHeightReads({ indexerHeight: 992n, finalizedHeight: 1_000n }),
+    );
+
+    // An overshoot of 8 blocks: likewise inside the default allowance and outside the configured one.
+    const ahead = await firstVerdict(
+      tighterThanDefault,
+      fixedHeightReads({ indexerHeight: 1_008n, finalizedHeight: 1_000n }),
+    );
+
+    expect(behind).toStrictEqual(
+      Option.some(IndexerLiveness.Behind({ indexerHeight: 992n, finalizedHeight: 1_000n, lag: 8n })),
+    );
+    expect(ahead).toStrictEqual(
+      Option.some(IndexerLiveness.Ahead({ indexerHeight: 1_008n, finalizedHeight: 1_000n, overshoot: 8n })),
+    );
+  });
+
+  it('should poll at the configured interval rather than the default', async () => {
+    // Pinned to the moment of the second poll rather than to a count over a window: that fails whether the interval is
+    // ignored in favour of the 30-second default or applied to the wrong schedule, and it does not depend on how the
+    // first tick is timed.
+    const program = Effect.gen(function* () {
+      const polls = yield* Ref.make(0);
+      const countingReads: LivenessReads = {
+        indexerHeight: () => Ref.updateAndGet(polls, (n) => n + 1).pipe(Effect.as(1_000n)),
+        finalizedHeight: () => Effect.succeed(1_000n),
+        indexerGenesisHash: () => Effect.succeed('ab'.repeat(32)),
+        nodeGenesisHash: () => Effect.succeed(`0x${'ab'.repeat(32)}`),
+      };
+
+      const updates = Option.getOrThrow(
+        makeLivenessUpdates({ ...withNode, livenessPollInterval: Duration.seconds(5) }, IndexerLiveness.Unknown(), () =>
+          Effect.succeed(countingReads),
+        ),
+      );
+
+      yield* Effect.fork(Stream.runDrain(updates));
+
+      yield* TestClock.adjust(Duration.millis(4_999));
+      const justBeforeTheInterval = yield* Ref.get(polls);
+
+      yield* TestClock.adjust(Duration.millis(1));
+      const atTheInterval = yield* Ref.get(polls);
+
+      return { justBeforeTheInterval, atTheInterval };
+    });
+
+    const counts = await Effect.runPromise(program.pipe(Effect.scoped, Effect.provide(TestContext.TestContext)));
+
+    // The first poll runs immediately, so the second — and only the second — is what the interval governs.
+    expect(counts).toStrictEqual({ justBeforeTheInterval: 1, atTheInterval: 2 });
+  });
+});
+
+describe('makeDefaultSyncService liveness feed', () => {
+  it('should report the check skipped once when no node is configured, so progress never stays Unknown', async () => {
+    // `Unknown` gates sync completion, so a wallet with no node must be told that no check is coming. Said through the
+    // liveness feed rather than the indexer stream, because the report must not depend on the indexer answering.
+    const service = makeDefaultSyncService(indexerOnly);
+    const wallet = CoreWallet.init(publicKey, 'undeployed');
+
+    const collected = await Effect.runPromise(
+      // Non-null assertion required because: the default service always provides the feed; its absence would itself
+      // be the failure under test.
+      service.livenessUpdates!(wallet).pipe(Stream.runCollect, Effect.scoped),
+    );
+
+    const updates = Chunk.toReadonlyArray(collected);
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toStrictEqual(livenessUpdate(IndexerLiveness.Skipped({ reason: 'no-node-configured' })));
+  });
+
+  it('should keep verdicts out of the indexer subscription, whose lifetime is retry-bound', () => {
+    // The indexer stream is rebuilt by the variant's retry on every failure; the liveness feed is forked once at
+    // wallet scope. A verdict emitted through `updates()` would silently re-tie the poller to the retry loop.
+    const service = makeDefaultSyncService(withNode);
+
+    expect(service.livenessUpdates).toBeDefined();
+  });
+});

--- a/packages/unshielded-wallet/src/v1/test/sync.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/sync.test.ts
@@ -149,7 +149,15 @@ describe('makeLivenessUpdates', () => {
     const behind = IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_000n, lag: 100n });
 
     const first = await Effect.runPromise(
-      Stream.runHead(Option.getOrThrow(makeLivenessUpdates(withNode, behind))).pipe(Effect.scoped),
+      Stream.runHead(
+        Option.getOrThrow(
+          // Reads are injected, as in every sibling: the default factory opens a socket to the node and an HTTP request
+          // to the indexer, and a unit test may touch neither.
+          makeLivenessUpdates(withNode, behind, () =>
+            Effect.succeed(fixedHeightReads({ indexerHeight: 900n, finalizedHeight: 1_000n })),
+          ),
+        ),
+      ).pipe(Effect.scoped),
     );
 
     expect(first).toStrictEqual(Option.some({ type: 'IndexerLiveness', verdict: behind }));

--- a/packages/unshielded-wallet/src/v1/test/syncProgress.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/syncProgress.test.ts
@@ -1,0 +1,180 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { IndexerLiveness } from '@midnightntwrk/wallet-sdk-abstractions';
+import { describe, expect, it } from 'vitest';
+import { createSyncProgress, SyncProgress, type SyncProgressData } from '../SyncProgress.js';
+
+/** A fully caught-up, connected wallet. Only `indexerLiveness` varies across the tests below. */
+const caughtUp = (indexerLiveness: IndexerLiveness.IndexerLiveness): SyncProgressData => ({
+  appliedId: 100n,
+  highestTransactionId: 100n,
+  isConnected: true,
+  indexerLiveness,
+});
+
+describe('SyncProgress', () => {
+  describe('isCompleteWithin', () => {
+    describe('when the indexer is behind the finalized head', () => {
+      const behind = IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_000n, lag: 100n });
+
+      it('should return false even though the wallet has applied every transaction the indexer reported', () => {
+        // The whole point of the check: the indexer's own report says "caught up", the chain says otherwise.
+        const result = SyncProgress.isCompleteWithin(caughtUp(behind));
+
+        expect(result).toBe(false);
+      });
+
+      it('should return false regardless of how generous maxGap is, because maxGap bounds apply lag, not staleness', () => {
+        const result = SyncProgress.isCompleteWithin(caughtUp(behind), 1_000_000n);
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('when the indexer and the node are on different networks', () => {
+      it('should return false, because every height the indexer reports describes a different chain', () => {
+        // Guards the wiring, not the predicate: completion must keep flowing through
+        // `IndexerLiveness.blocksSyncCompletion`, where WrongNetwork gates, rather than enumerating variants here.
+        const result = SyncProgress.isCompleteWithin(
+          caughtUp(
+            IndexerLiveness.WrongNetwork({
+              indexerGenesisHash: 'aa'.repeat(32),
+              nodeGenesisHash: `0x${'bb'.repeat(32)}`,
+            }),
+          ),
+        );
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('when the indexer claims a position ahead of the finalized head', () => {
+      it('should return true, because an overshoot does not show the wallet to be looking at stale data', () => {
+        // An overshoot cannot distinguish a wrong indexer from a node endpoint that has fallen behind. Blocking here
+        // would report a healthy wallet as unsynchronized whenever its node lagged, so the verdict is surfaced on the
+        // progress rather than used to gate completion.
+        const result = SyncProgress.isCompleteWithin(
+          caughtUp(
+            IndexerLiveness.Ahead({ indexerHeight: 4_200_000n, finalizedHeight: 12_500n, overshoot: 4_187_500n }),
+          ),
+        );
+
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('when no verdict on the indexer has been reached', () => {
+      it('should return true when the check was skipped, so callers with no node endpoint still observe completion', () => {
+        // Every existing caller configures no node endpoint. Gating on a verdict that can never arrive would leave
+        // `waitForSyncedState` blocked forever.
+        const result = SyncProgress.isCompleteWithin(
+          caughtUp(IndexerLiveness.Skipped({ reason: 'no-node-configured' })),
+        );
+
+        expect(result).toBe(true);
+      });
+
+      it('should return false while the first check is still in flight, so startup cannot race past the check', () => {
+        // The reverse was true at first — Unknown did not gate — and it left a hole: the indexer's first progress
+        // update lands in under a second, while the first verdict needs a node connection and a metadata download.
+        // In that window a wallet with a stalled indexer was connected, caught up with the indexer's own report, and
+        // ungated — so `waitForSyncedState` resolved over exactly the stale view this check exists to catch. A wallet
+        // with no node configured is not affected: its wiring reports `Skipped`, which does not gate.
+        const result = SyncProgress.isCompleteWithin(caughtUp(IndexerLiveness.Unknown()));
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('when the indexer agrees with the finalized head', () => {
+      it('should return true', () => {
+        const result = SyncProgress.isCompleteWithin(
+          caughtUp(IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n })),
+        );
+
+        expect(result).toBe(true);
+      });
+
+      it('should still return false when the wallet has not applied everything the indexer reported', () => {
+        // A live indexer does not excuse the wallet from applying what it has been sent.
+        const result = SyncProgress.isCompleteWithin({
+          appliedId: 100n,
+          highestTransactionId: 200n, // applyLag = 100, beyond the default maxGap of 50
+          isConnected: true,
+          indexerLiveness: IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n }),
+        });
+
+        expect(result).toBe(false);
+      });
+
+      it('should still return false when disconnected', () => {
+        const result = SyncProgress.isCompleteWithin({
+          appliedId: 100n,
+          highestTransactionId: 100n,
+          isConnected: false,
+          indexerLiveness: IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n }),
+        });
+
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('createSyncProgress', () => {
+    it('should default to an unknown verdict, because this constructor cannot see whether a node is configured', () => {
+      // Not `Skipped`: that claims "no node was configured", which this constructor has no way of knowing. A wallet
+      // that does configure one would be misreported until its first verdict arrived, defeating the point of keeping
+      // the two cases distinct. The sync wiring reports `Skipped` because it can see the configuration.
+      const progress = createSyncProgress();
+
+      expect(progress.indexerLiveness).toStrictEqual(IndexerLiveness.Unknown());
+    });
+
+    it('should carry a supplied verdict through to the created progress', () => {
+      const verdict = IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_000n, lag: 100n });
+
+      const progress = createSyncProgress({
+        appliedId: 100n,
+        highestTransactionId: 100n,
+        isConnected: true,
+        indexerLiveness: verdict,
+      });
+
+      expect(progress.indexerLiveness).toStrictEqual(verdict);
+    });
+  });
+
+  describe('isStrictlyComplete', () => {
+    it('should return false when the indexer is behind, even with zero apply lag', () => {
+      const progress = createSyncProgress({
+        appliedId: 100n,
+        highestTransactionId: 100n,
+        isConnected: true,
+        indexerLiveness: IndexerLiveness.Behind({ indexerHeight: 900n, finalizedHeight: 1_000n, lag: 100n }),
+      });
+
+      expect(progress.isStrictlyComplete()).toBe(false);
+    });
+
+    it('should return true when the indexer agrees with the finalized head and apply lag is zero', () => {
+      const progress = createSyncProgress({
+        appliedId: 100n,
+        highestTransactionId: 100n,
+        isConnected: true,
+        indexerLiveness: IndexerLiveness.InSync({ indexerHeight: 1_000n, finalizedHeight: 1_000n }),
+      });
+
+      expect(progress.isStrictlyComplete()).toBe(true);
+    });
+  });
+});

--- a/packages/unshielded-wallet/test/UnshieldedWallet.integration.test.ts
+++ b/packages/unshielded-wallet/test/UnshieldedWallet.integration.test.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnightntwrk/wallet-sdk-utilities/testing';
+import * as rx from 'rxjs';
 import { firstValueFrom } from 'rxjs';
 import { randomUUID } from 'node:crypto';
 import { DockerComposeEnvironment, type StartedDockerComposeEnvironment, Wait } from 'testcontainers';
@@ -19,7 +20,7 @@ import { UnshieldedWallet } from '../src/index.js';
 import { getUnshieldedSeed, createWalletConfig, waitForCoins } from './testUtils.js';
 import { createKeystore, PublicKey } from '../src/KeyStore.js';
 import { UnshieldedAddress } from '@midnightntwrk/wallet-sdk-address-format';
-import { NoOpTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import { IndexerLiveness, NoOpTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
 
 vi.setConfig({ testTimeout: 100_000, hookTimeout: 100_000 });
 
@@ -38,12 +39,45 @@ const environment = new DockerComposeEnvironment(getComposeDirectory(), 'docker-
 
 describe('UnshieldedWallet', () => {
   let indexerPort: number;
+  let nodePort: number;
   let startedEnvironment: StartedDockerComposeEnvironment;
   const unshieldedSeed = getUnshieldedSeed('0000000000000000000000000000000000000000000000000000000000000002');
 
   beforeAll(async () => {
     startedEnvironment = await environment.up();
     indexerPort = startedEnvironment.getContainer(`indexer_${environmentId}`).getMappedPort(8088);
+    nodePort = startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944);
+  });
+
+  it('should cross-check the indexer against the node using only the submission relay URL', async () => {
+    // The check reads its endpoint from `relayURL` — the node a wallet already names for submission — so no second
+    // endpoint is configured here. That is the wiring that shipped switched off: it needed a `nodeClientConnection`
+    // nobody set. This runs it against a real indexer and a real node and waits for an actual verdict, which is the only
+    // way to show the poll loop runs and its result reaches the wallet's progress.
+    const config = createWalletConfig(indexerPort, {
+      relayURL: new URL(`ws://localhost:${nodePort}`),
+      // The default 30-second cadence leaves roughly three polls inside this file's 100s timeout, and the first one
+      // usually lands before the indexer has ingested anything. Two seconds makes the verdict a certainty rather than
+      // a race against the clock.
+      livenessPollInterval: '2 seconds',
+    });
+    const keystore = createKeystore(unshieldedSeed, config.networkId);
+    const wallet = UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(keystore));
+
+    await wallet.start();
+
+    try {
+      const state = await firstValueFrom(
+        wallet.state.pipe(rx.filter((state) => IndexerLiveness.isInSync(state.progress.indexerLiveness))),
+      );
+
+      const verdict = state.progress.indexerLiveness;
+      expect(IndexerLiveness.isInSync(verdict)).toBe(true);
+      // `Skipped` would mean the endpoint never resolved; `Unknown` that no poll completed.
+      expect(verdict._tag).toBe('InSync');
+    } finally {
+      await wallet.stop();
+    }
   });
 
   it('should build', async () => {


### PR DESCRIPTION
# Description

Implements #657 (item 1 of #584).

The unshielded wallet decided it was synchronized by comparing its applied transaction id against
`highestTransactionId` — a number the indexer reports about itself. Nothing reconciled that against
the chain, so a stalled, lagging or withholding indexer left the wallet reporting `isSynced === true`
over a stale view: no error, just a balance missing recently received funds.

The wallet now periodically compares the indexer's latest block against the node's highest finalized
block, and reports itself unsynchronized while the indexer trails it, until the first comparison has
landed, or — permanently — when the two endpoints prove to be on different chains.

**This is on by default.** It reads the node already named by `relayURL` for submission, which the
facade requires, so no new configuration is needed and every existing integrator is affected.

**Scope:** unshielded only — #658 covers shielded and Dust, which need cross-repo protocol work. And
this detects staleness, not withholding: an indexer reporting the true block height while withholding
transaction events still passes. That needs commitment-tree root verification, also #658.

# Proposed Solution

An `IndexerLiveness` verdict on `SyncProgress`. Three of its seven cases gate the completion result —
`isStrictlyComplete()`, `isCompleteWithin()`, and therefore `waitForSyncedState()`:

| Verdict | Gates completion? | What it means |
| --- | --- | --- |
| `Behind` | **yes** | indexer is missing finalized blocks — the view is stale |
| `Unknown` | **yes** | no verdict yet — staleness is not yet ruled out |
| `WrongNetwork` | **yes** | the endpoints report different genesis blocks — they are on different chains |
| `Ahead` | no | indexer claims more than the finalized head — read skew or a lagging node |
| `Unavailable` | no | a poll could not complete — `lastError` names the failed read |
| `Skipped` | no | no node named at all, or a simulation — no verdict is ever coming |
| `InSync` | no | indexer within tolerance of the finalized head |

`Behind` gates because staleness is proven. `Unknown` gates because it is not yet ruled out: the
first verdict needs a node connection and a metadata download — seconds — while the indexer's first
progress update lands in well under one, so an ungated `Unknown` would let start-up race past the
check over exactly the stale view it exists to catch. It cannot gate forever: every path out of it is
bounded — the poll succeeds (a verdict), fails (`Unavailable`), or is cut off by the poll timeout
(`Unavailable` again), none of which gate. `WrongNetwork` gates because it is proven and permanent:
the genesis hashes are compared once, before any height comparison — heights from two different
chains mean nothing — and a mismatch cannot heal until someone reconfigures an endpoint. A failed
hash read pins nothing; it surfaces as `Unavailable` and is retried.

A "no" means the verdict leaves completion alone: the result is decided entirely by the conditions
that existed before this feature — whether the wallet is connected, and how much of the indexer's
stream it has applied. The verdict itself is always
readable on `progress.indexerLiveness`, carrying its detail — how far ahead, how many failed attempts
and the last error, how far behind — so every case can be surfaced to a user even when the boolean
says the wallet is complete. Gating on the inconclusive ones would make a node outage report a
healthy wallet as unsynchronized.

Layered so no wallet package depends on `node-client`: the verdict type and comparison in
`abstractions`, `getFinalizedBlock()` and `getGenesisHash()` on `node-client`, the polling service and
its height and genesis-hash reads in `capabilities`, and the wiring in `unshielded-wallet` — and the node client answers the genesis hash
from state it already holds, so the once-per-wallet chain-identity check costs no extra connection. Tolerances are separate per direction —
staleness can be generous, read skew must be tight — defaulting to 10 blocks each and a 30-second
interval — about a minute of staleness allowance at Midnight's 6-second slots — overridable via `livenessConfiguration` and `livenessPollInterval` on the configuration.
Each poll is bounded (20s default), so a read that hangs becomes `Unavailable` instead of freezing the
check; verdicts are published only when they change, so an idle wallet is not re-notified every poll;
and the node client behind the check is built once per wallet and reused, not once per poll.

Three pre-existing `node-client` defects had to be fixed for any of this to work. They were invisible
because both integration suites touching that client were skipped in their entirety:

- `api.rpc` calls failed after the client was created, so `getGenesis()` had never worked against a
  real node
- connection failures arrived as defects, bypassing the error channel the signature declares
- an unreachable node hung indefinitely and unboundably, which made `Unavailable` unreachable

Review hardening on top of those: a `connect()` that rejects mid-reconnect is retried rather than
escaping as a defect; a node that accepts the socket but persistently fails RPC surfaces as a typed
`ConnectionError` instead of spinning the readiness loop forever; a finite timeout beyond
`setTimeout`'s 32-bit range is clamped rather than overflowing into an instant failure; and
`isConnected` on the sync progress is cleared when the sync stream fails — previously it latched true
on the first update, so a wallet whose subscription dropped kept reporting itself synchronized
through the whole retry backoff. The liveness check cannot catch that last case (the indexer itself
may be healthy while this wallet's subscription is dead), which is why the connection flag has to.
A fourth: `main` landed its own reference-counting of the shared connection while this PR waited
(#649). This branch keeps its `SynchronizedRef` variant, which serialises acquire/release transitions
so a call arriving while the last one disconnects cannot race the socket closed — #649's regression
tests are retained and pass against it.
A fifth: the liveness feed now runs at wallet scope, decoupled from the indexer subscription, so it
keeps publishing verdicts — and keeps its node connection — while the subscription is down or
retrying; previously it was rebuilt on every retry and went silent in exactly those windows.

# Important Changes Introduced

**Breaking — `unshielded-wallet` (major).** `isStrictlyComplete()` and `isCompleteWithin()` return
`false` while the indexer is known to be behind the node's finalized head, until the first verdict
has arrived, and — permanently — when the endpoints report different genesis blocks
(`WrongNetwork`). They previously considered only whether the wallet had applied everything the
indexer had sent it, so a wallet reading from a stalled indexer reported itself complete. Nothing is
required of the caller — the check runs by itself, and every wallet naming a `relayURL` gets it,
which the facade requires. Wallets with no node (and simulations) report `Skipped` and complete as
before.

`waitForSyncedState()` is built on the same predicate, so it does not resolve while the indexer is
behind. It does not reject or time out either; it waits until the indexer catches up. An integrator
gating start-up on it should race it against a deadline of their own and, on expiry, read
`progress.indexerLiveness` and `progress.isConnected` to say why the wallet has not settled — the
migration note in the changeset shows the pattern.

`SyncProgressData` gains a required `indexerLiveness` field, so anything building that object as a
literal must supply one — `createSyncProgress()` fills it in.

Sync updates gain one more kind: liveness verdicts, alongside the indexer's own.
The type naming its contents changed from `WalletSyncUpdate` to `SyncUpdate`, which shows up on
`UnshieldedWallet`, `UnshieldedWalletClass`, `DefaultV1Variant` and `DefaultRunningV1`. Everything
the old type described is still in the new one, so constructing or matching the indexer's updates
compiles unchanged — but code that handles every update type exhaustively will need a branch for the
new case.

**Breaking — `node-client` (major).** `NodeClient.Service` gains required `getFinalizedBlock()` and
`getGenesisHash()` methods. Callers are unaffected; implementers must add them. Connection and RPC failures are now typed rather
than defects, so `catchTag` reaches them — a caller whose `catchAll` previously let these through as
crashes will now catch them. Not flagged by the compiler: any `ApiPromise` double must now answer
`rpc.system.chain()`.

**Transaction submission is untouched.** The new connection timeout applies only when a caller asks
for one, and submission doesn't — so it still waits for an unreachable node to come back rather than
failing the submission. A test asserts that specifically, because inheriting the timeout would turn a
brief node outage into a failed transaction.

# Testing

`yarn test:unit` — the full unit suite, no infrastructure required.

`yarn test:integration` for `node-client`, `capabilities` and `unshielded-wallet` — needs Docker and
`APP_INFRA_SECRET`. The one that matters most starts a real wallet against a real indexer and node
with only `relayURL` configured, and waits for the verdict to actually become `InSync`. Another
proves the two endpoints' real genesis-hash presentations compare as the same chain — the assumption
`WrongNetwork` rests on.

## Gaps a reviewer should know about

- **Transaction submission still has no working integration coverage.** The submission tests in
  `node-client` and `capabilities` need a generated fixture that nothing produces — no generator, no
  CI job, gitignored output. Pre-existing, and the reason the `node-client` defects survived. The
  tests that passed vacuously on the missing fixture are now skipped with the reason recorded.

Refs #657, #584, #658









