### PR TITLE
chore(deps): route dependabot/renovate PRs to canonical bot:* labels

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "labels": ["bot:renovate"],
   "nix": {
     "enabled": true
   },


### PR DESCRIPTION
Per-ecosystem `labels` added to `.github/dependabot.yml` (github-actions → `bot:github-actions`, everything else → `bot:dependencies`); `renovate.json` gains `labels: ["bot:renovate"]`. Tool-default labels stop accumulating; existing history untouched.

Closes #660