### PR TITLE
feat(dust): fork boundary wiring, cross-version migration, and the crossing proof

### DIFF
--- a/.changeset/dust-fork-boundary-wiring.md
+++ b/.changeset/dust-fork-boundary-wiring.md
@@ -1,0 +1,51 @@
+---
+'@midnightntwrk/wallet-sdk-dust-wallet': minor
+---
+
+Make the dust wallet able to follow the chain across a hard fork: sync now recognises the protocol version the indexer
+reports, hands over at the variant boundary, and starts the next ledger version's variant on a fresh state.
+
+**Behavioural change: wallet state now tracks the reported protocol version.** Until now nothing wrote the indexer's
+`protocolVersion` into the wallet state, so it stayed pinned at its initial value and a protocol version change could
+never be signalled. It is now recorded on every applied batch that reports one. The value only ever increases — a source
+that briefly reports an older version (a reconnect replaying from an earlier cursor, say) cannot drag the wallet back
+below a boundary it has already crossed.
+
+**Breaking for custom `withSync` authors: `SyncCapability.applyUpdate` takes a third argument.** It is now
+`applyUpdate(state, update, activeRange)`, where `activeRange` is the half-open protocol version range the running
+variant owns. Anything the source reports at or beyond its end belongs to a later variant and must be left unapplied for
+that variant to fetch. Implementations that ignore the parameter keep their present behaviour; the exported
+`splitAtVersionBoundary` and `annotateVersion` helpers implement the rule for anyone who wants it.
+
+**`SyncEventsUpdateSchema` gains an optional `protocolVersion`.** Optional because dust's subscription does not select
+the field yet — the indexer schema defines it on `DustLedgerEvent`, but adding the selection-set line waits on
+confirmation against a deployed indexer. Until then every item arrives without it, and an absent value means "the
+indexer did not say": the event applies normally and the recorded version is left alone. Reading a missing value as zero
+would drag the version down and, on a wallet already past the boundary, look like a migration backwards.
+
+**New: the migration seam.** `Migration.ts` exports `StateMigration` with three instances — `makeEmptyWalletMigration`
+(no previous wallet), `makeCarryOverMigration` (same ledger version), and `makeCrossLedgerMigration` (across a fork).
+The builder gains `withMigration` and `withMigrationDefaults`, and `migrateState` — which until now handed the previous
+state straight back, so a ledger-v8 wallet would have been passed off as a ledger-v9 one — runs the configured strategy.
+
+The cross-ledger strategy carries the dust public key, the network, the protocol version that triggered the hand-over,
+and the sync cursor. It carries no dust. After a fork the indexer replays the timeline, so exactly the same dust is
+generated again by events of the new ledger version and re-discovered by ordinary sync; carrying it as well would
+double-count it. Sync progress is **parked at the fork** rather than rewound, because the replay continues the indexer's
+event ids from wherever it had reached rather than restarting them.
+
+**New: `dustParameters` on the builder configuration, optional.** Dust's local state is parameterised where shielded's
+is not, so an empty or migrated state cannot be constructed without dust parameters. It defaults to the ledger's initial
+parameters, so no existing `build({ ... })` call site changes.
+
+**Sync now restarts itself after a migration.** `DustWallet.start` retains the `DustSecretKey` in memory for the
+wallet's lifetime and registers a runtime activation watcher that re-dispatches `startSyncInBackground` onto the newly
+activated variant. The key never enters serialized state, and `stop` clears it so a stopped wallet cannot be resurrected
+by a late activation. A state restored from a snapshot taken between the version being recorded and the runtime acting
+on it now emits an immediate healing version change instead of stalling on a version its variant does not own.
+
+**Known limitation: the projections-based fast-sync path does not implement the boundary.** A projections update is a
+folded snapshot of dust state, not a run of version-tagged timeline items, and `BlockData` carries no protocol version —
+so there is nothing to split and nothing to record. `makeEventLessSyncCapability` accepts the activation range for
+signature parity and does not act on it, which means a wallet syncing exclusively that way will not hand over at a fork.
+Closing this needs a protocol version on the projections wire format. It is pinned by a test rather than left implicit.

--- a/.changeset/dust-fork-simulation-proof.md
+++ b/.changeset/dust-fork-simulation-proof.md
@@ -1,0 +1,43 @@
+---
+'@midnightntwrk/wallet-sdk-dust-wallet': patch
+---
+
+Prove the dust hard-fork crossing end to end, against real ledger bytes.
+
+A real ledger-v8 dust chain rewards Night and registers it for dust generation, the pre-fork variant syncs the events
+that produced, the indexer reports the boundary version, and the wallet hands over to the ledger-v9 variant with a state
+holding no dust at all — then finds the same dust again by syncing the indexer's replayed timeline. That is the
+corrected design stated as a test: nothing about the dust crosses the boundary, and everything the wallet ends up
+holding it re-discovered through the sync path it uses every day. The two negatives are covered too: a version bump
+inside the running variant's range does not migrate, and a wallet whose very first sync already contains the fork
+reaches the same end state as one that lived through it.
+
+The replay is modelled by re-framing the pre-fork events. Ledger-v8 frames an `Event` `midnight:event[v9]:` and
+ledger-v9 frames it `midnight:event[v14]:`, and each rejects the other's header outright — but everything after that
+header is byte-identical for a `dustInitialUtxo` event, so re-framing the same bytes is the whole of the model. The file
+opens by asserting exactly that, applying the original events with ledger-v8 and the re-framed ones with ledger-v9 and
+comparing the results, so a ledger release that ever changes the encoding retires the model loudly instead of quietly
+turning it into a fiction.
+
+**No integration companion, and none is warranted.** The shielded proof needs one because its replay re-mints
+_equivalent_ coins, so only the real v8-to-v9 state translation can say whether the tree it rebuilds is the tree the
+fork produced. Dust replays the _same_ event bytes, which makes the pre-fork and post-fork wallets directly comparable —
+UTXO for UTXO (nonce, backing Night, creation time, initial value, Merkle index) and root for root, on both the
+commitment and generation trees — with no WASM artifact and no Rust toolchain involved. So the whole proof is **unit
+tier**, `turbo.json` is untouched, and the integration workflow needs no new path case.
+
+Both sides sync through the events path, the one the fork design is written against: its cursor is an indexer event id,
+which is the thing the migration parks and the replay counts on from. The replay is numbered as a continuation of the
+pre-fork timeline, opening one past the last event the pre-fork variant applied, and the migrated wallet's cursor is
+parked on that same id — pinned on the state the migration produced, before any sync has touched it, which is the only
+place parking and rewinding are distinguishable.
+
+Two gaps are recorded rather than papered over. There is no dust analogue of the shielded proof's closing spend: dust is
+spent as the fee half of a transaction that a chain must validate, and an indexer replay is an event log, not a ledger —
+what stands in its place is the commitment-root equality above. And `DustLocalState` gained `commitmentTreeFirstFree`,
+`generatingTreeFirstFree` and `nullifiers` only in ledger-v9, so tree _sizes_ cannot be compared across the boundary the
+way the shielded proof compares `firstFree`.
+
+No shipped code changes: the wiring this exercises landed with the boundary-wiring change, and the corrected design
+needs nothing beyond it. The ledger-v8 dust fixture now exports the seed it derives from, because a wallet crossing the
+boundary needs the seed rather than a key — the two variants each build their own `DustSecretKey` from it.

--- a/packages/dust-wallet/src/DustWallet.ts
+++ b/packages/dust-wallet/src/DustWallet.ts
@@ -24,12 +24,12 @@ import { type DustAddress } from '@midnightntwrk/wallet-sdk-address-format';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
 import { type Variant, type VariantBuilder, type WalletLike } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type Clock } from '@midnightntwrk/wallet-sdk-utilities';
-import { Effect, Either, type Scope } from 'effect';
+import { Effect, Either, Option, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
 import { type Balance, type CoinsAndBalancesCapability, type UtxoWithFullDustDetails } from './v2/CoinsAndBalances.js';
 import { CoreWallet } from './v2/CoreWallet.js';
 import { type KeysCapability } from './v2/Keys.js';
-import { V2Tag } from './v2/RunningV2Variant.js';
+import { type RunningV2Variant, V2Tag } from './v2/RunningV2Variant.js';
 import { type SerializationCapability } from './v2/Serialization.js';
 import { type NightUtxoSplitForDustRegistration } from './v2/Transacting.js';
 import { type DustFullInfo, type UtxoWithMeta } from './v2/types/Dust.js';
@@ -303,6 +303,27 @@ export function CustomDustWallet<
 
     readonly state: rx.Observable<DustWalletState<TSerialized>>;
 
+    /**
+     * The start-aux the wallet was last started with.
+     *
+     * @remarks
+     *   Sync needs the dust secret key, and a migration starts a fresh variant whose sync has never been started. The key
+     *   cannot come from the state — it is deliberately absent from anything serialized — and it does not exist yet
+     *   when the wallet is first constructed, so it is held here, in memory, for the lifetime of the wallet. Cleared by
+     *   {@link stop} so a stopped wallet cannot be silently resurrected by a late activation.
+     */
+    readonly #retainedAux = Ref.unsafeMake<Option.Option<TStartAux>>(Option.none());
+
+    /**
+     * Whether the activation watcher has been registered.
+     *
+     * @remarks
+     *   Registration is per wallet, not per `start`: watchers accumulate, so registering on every call would restart sync
+     *   once per historical `start` on the next activation. Flipped with `getAndSet` so concurrent `start` calls cannot
+     *   both observe it unset.
+     */
+    readonly #watcherRegistered = Ref.unsafeMake(false);
+
     constructor(
       runtime: Runtime.Runtime<
         [Variant.VersionedVariant<V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>>]
@@ -319,7 +340,35 @@ export function CustomDustWallet<
     }
 
     start(secretKey: TStartAux): Promise<void> {
-      return this.runtime.dispatch({ [V2Tag]: (v2) => v2.startSyncInBackground(secretKey) }).pipe(Effect.runPromise);
+      return Effect.gen(this, function* () {
+        yield* Ref.set(this.#retainedAux, Option.some(secretKey));
+
+        // Registered before the first dispatch, and only once: `onVariantActivation` resolves only after its
+        // subscription is live, so an activation racing this call is queued rather than missed.
+        const alreadyRegistered = yield* Ref.getAndSet(this.#watcherRegistered, true);
+        if (!alreadyRegistered) {
+          yield* this.runtime.onVariantActivation({
+            [V2Tag]: (v2: RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>) =>
+              Ref.get(this.#retainedAux).pipe(
+                Effect.flatMap(
+                  Option.match({
+                    // Stopped, or never started: there is nothing to resume and no key to resume it with.
+                    onNone: () => Effect.void,
+                    onSome: (retained: TStartAux) => v2.startSyncInBackground(retained),
+                  }),
+                ),
+              ),
+          });
+        }
+
+        yield* this.runtime.dispatch({ [V2Tag]: (v2) => v2.startSyncInBackground(secretKey) });
+      }).pipe(Effect.runPromise);
+    }
+
+    override async stop(): Promise<void> {
+      // Released before the runtime is torn down: the key outlives neither the wallet nor an in-flight activation.
+      Ref.set(this.#retainedAux, Option.none()).pipe(Effect.runSync);
+      await super.stop();
     }
 
     stepSync(secretKey: TStartAux): Promise<void> {

--- a/packages/dust-wallet/src/test/forkReplay.ts
+++ b/packages/dust-wallet/src/test/forkReplay.ts
@@ -1,0 +1,149 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The indexer's post-fork replay of a dust timeline — test scaffolding only.
+ *
+ * @remarks
+ *   After the hard fork the indexer replays the timeline: the history a wallet already synced is served again, this time
+ *   as events of the new ledger version, numbered onwards from whatever event id it had reached. That is why a migrated
+ *   dust wallet starts with no dust and simply syncs — it re-discovers its own dust from the replay rather than
+ *   carrying it across.
+ *
+ *   **What the replay is here.** A ledger `Event` cannot cross a version boundary as-is: ledger-v8 frames its events
+ *   `midnight:event[v9]:` and ledger-v9 frames them `midnight:event[v14]:`, and each refuses the other's header
+ *   outright (`expected header tag 'midnight:event[v14]:', got 'midnight:event[v9]:'`). What ledger-v8 and ledger-v9
+ *   _do_ agree on is everything after that header: the payload of a `dustInitialUtxo` event is byte-identical between
+ *   them. So the replay is modelled by re-framing each pre-fork event under the post-fork header — the same event,
+ *   re-emitted by the new ledger version, which is precisely what an indexer replay is.
+ *
+ *   That agreement is not assumed. `forkSimulation.test.ts` opens by asserting it directly: a re-framed event applied by
+ *   ledger-v9 produces the same dust — same nonces, same backing Night, same values, same Merkle indices, same tree
+ *   roots — as the original applied by ledger-v8. If a future ledger release changes the dust event encoding, that
+ *   assertion fails and this whole model is retired loudly rather than quietly modelling something false.
+ *
+ *   This is where dust does better than the shielded proof: shielded re-mints equivalent coins to reproduce equivalent
+ *   commitments, and needs the real v8-to-v9 state translation to close the fidelity gap. Dust replays the same event
+ *   bytes, so the pre-fork and post-fork wallets are directly comparable without any translation at all.
+ *
+ *   **Two modelling choices are load-bearing and deliberate.**
+ *
+ *   - **The replay continues the pre-fork event numbering.** The indexer numbers its replay onwards from the id it had
+ *       reached when the fork happened, never from zero, so the replay opens just past the boundary and a migrated
+ *       wallet parks its cursor there and meets it head-on. Numbering the replay from one instead, while the migration
+ *       parks, would put most of it behind the cursor and the wallet would come back holding only the tail of its own
+ *       history. (The mirror image is not symmetric — a cursor behind the replay reads all of it anyway — so what
+ *       separates parking from resetting is the migrated cursor itself, asserted where the migration produced it.)
+ *   - **Every replayed event carries the post-fork protocol version.** Tagging the whole replay inside the new variant's
+ *       activation range is what keeps any of it from being deferred straight back to a variant that has already handed
+ *       over.
+ */
+
+import { Event as PreForkEvent } from '@midnight-ntwrk/ledger-v8';
+import { Event as PostForkEvent } from '@midnightntwrk/ledger-v9';
+import { type WalletSyncSubscription as PreForkItem } from '../v1/Sync.js';
+import { type WalletSyncSubscription as PostForkItem } from '../v2/SyncSchema.js';
+
+/** The serialization header ledger-v8 frames an `Event` with. */
+const preForkHeader = 'midnight:event[v9]:';
+
+/** The serialization header ledger-v9 frames an `Event` with. */
+const postForkHeader = 'midnight:event[v14]:';
+
+const headerBytes = (header: string): readonly number[] => [...header].map((character) => character.charCodeAt(0));
+
+const hasHeader = (bytes: Uint8Array, header: readonly number[]): boolean =>
+  header.every((byte, index) => bytes[index] === byte);
+
+/**
+ * Re-frames a pre-fork event's bytes under the post-fork ledger's header.
+ *
+ * @remarks
+ *   The whole of the modelling. Only the header is rewritten; the payload is passed through untouched, which is what
+ *   makes the replayed event the _same_ event rather than an equivalent one.
+ * @param bytes A serialized ledger-v8 `Event`.
+ * @returns The same event, framed for ledger-v9.
+ * @throws Error if `bytes` is not a ledger-v8 event — a harness that re-framed the wrong thing must not look like a
+ *   fork that went wrong.
+ */
+export const reframeAsPostFork = (bytes: Uint8Array): Uint8Array => {
+  const from = headerBytes(preForkHeader);
+  if (!hasHeader(bytes, from)) {
+    throw new Error(`Not a ledger-v8 event: expected the header ${preForkHeader}`);
+  }
+  return Uint8Array.from([...headerBytes(postForkHeader), ...bytes.subarray(from.length)]);
+};
+
+/**
+ * One event on the indexer's wire: its id, its bytes, and the protocol version it was reported under.
+ *
+ * @remarks
+ *   Bytes rather than an `Event` instance, because `replayEventsWithChanges` takes ownership of the events it is handed
+ *   (wasm-bindgen moves them) — so every delivery deserializes its own instance. Held in the pre-fork encoding
+ *   throughout: whether an item is read as a pre-fork or a post-fork event is decided by which variant is being fed,
+ *   which is the fork itself expressed as a type.
+ */
+export type TimelineEvent = Readonly<{
+  /** The indexer's event id. One id space, shared by the pre-fork timeline and the replay that continues it. */
+  id: number;
+  /** The event as ledger-v8 serialized it. */
+  bytes: Uint8Array;
+  /** The protocol version the indexer reported this event under. */
+  protocolVersion: number;
+}>;
+
+/**
+ * Numbers a run of events from `firstId`, all reported at `protocolVersion`.
+ *
+ * @param eventBytes Serialized pre-fork events, in chain order.
+ * @param firstId The id of the first event — 1 for the pre-fork timeline, the boundary id for the replay continuing it.
+ * @param protocolVersion The version every one of these events is reported under.
+ * @returns The numbered run, in the order given.
+ */
+export const numberedFrom = (
+  eventBytes: readonly Uint8Array[],
+  firstId: number,
+  protocolVersion: number,
+): readonly TimelineEvent[] => eventBytes.map((bytes, offset) => ({ id: firstId + offset, bytes, protocolVersion }));
+
+/**
+ * The tip an item is reported against: the last id in the batch it arrives in.
+ *
+ * @remarks
+ *   The indexer reports its own highest id alongside each event, and every batch this harness delivers runs to the tip
+ *   the source has reached — the pre-fork timeline up to the boundary event, the replay up to its last event — so the
+ *   batch's own last id _is_ that tip.
+ */
+const tipOf = (batch: readonly TimelineEvent[]): number => batch.at(-1)?.id ?? 0;
+
+/** The batch as the pre-fork variant's subscription sees it: events decoded by ledger-v8. */
+export const asPreForkItems = (batch: readonly TimelineEvent[]): PreForkItem[] => {
+  const maxId = tipOf(batch);
+  return batch.map((event) => ({
+    id: event.id,
+    maxId,
+    protocolVersion: event.protocolVersion,
+    raw: PreForkEvent.deserialize(event.bytes),
+  }));
+};
+
+/** The batch as the post-fork variant's subscription sees it: the same events, re-framed and decoded by ledger-v9. */
+export const asPostForkItems = (batch: readonly TimelineEvent[]): PostForkItem[] => {
+  const maxId = tipOf(batch);
+  return batch.map((event) => ({
+    id: event.id,
+    maxId,
+    protocolVersion: event.protocolVersion,
+    raw: PostForkEvent.deserialize(reframeAsPostFork(event.bytes)),
+  }));
+};

--- a/packages/dust-wallet/src/test/forkSimulation.test.ts
+++ b/packages/dust-wallet/src/test/forkSimulation.test.ts
@@ -1,0 +1,388 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * A dust wallet crossing a hard fork and re-discovering its dust from the replayed timeline.
+ *
+ * @remarks
+ *   Every other test of this machinery specifies one seam. This drives all of them at once: a real ledger-v8 dust chain
+ *   registers Night for dust generation, the pre-fork variant syncs the events it produced, the timeline reaches the
+ *   boundary version, the wallet hands over to the ledger-v9 variant with a state holding _no dust_, and that variant
+ *   finds the same dust again by syncing the indexer's replay.
+ *
+ *   Which is the whole point of the corrected design: nothing about the dust crosses the boundary. The migration is
+ *   allowed to carry identity and a place in the timeline, and the dust is re-discovered by ordinary synchronization.
+ *   If the wallet ends up whole here, it did so through the sync path it uses every day.
+ *
+ *   **Unit tier, and complete — with no integration companion.** The shielded proof needs one: its replay re-mints
+ *   equivalent coins, so only the ledger team's real v8-to-v9 state translation can say whether the tree it rebuilds is
+ *   the tree the fork actually produced. Dust needs no such thing, because the two ledger versions turn out to encode a
+ *   `dustInitialUtxo` event identically apart from its header — so the replay here is the same event bytes, and the
+ *   post-fork wallet's dust is comparable to the pre-fork wallet's directly, UTXO for UTXO and root for root. The
+ *   `describe` block below establishes exactly that, and it is the load-bearing assumption of the whole file: if a
+ *   ledger release ever changes the encoding, it fails and the model is retired rather than quietly becoming a
+ *   fiction.
+ *
+ *   **What this proof does not do, and why.** The shielded proof ends by spending the re-discovered coins into the chain
+ *   and watching it accept them, which is what ties the wallet's rebuilt Merkle path to a root the ledger holds. There
+ *   is no dust analogue available here: dust is spent as the fee half of a transaction, which a chain has to validate,
+ *   and this harness has no post-fork chain — the replay is an event log, which is what an indexer serves and all a
+ *   fork's aftermath consists of. What stands in its place is stronger than the spend on one axis and weaker on
+ *   another: the post-fork wallet's own commitment-tree root is asserted equal to the pre-fork wallet's, so the tree
+ *   the path would be built against is byte-identical, but no ledger is asked to accept anything.
+ */
+
+import {
+  DustSecretKey as PreForkSecretKey,
+  Event as PreForkEvent,
+  LedgerParameters as PreForkLedgerParameters,
+} from '@midnight-ntwrk/ledger-v8';
+import {
+  DustSecretKey as PostForkSecretKey,
+  LedgerParameters as PostForkLedgerParameters,
+  Event as PostForkEvent,
+} from '@midnightntwrk/ledger-v9';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Deferred, Effect, Option, Queue, Stream } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { CoreWallet as PreForkWallet } from '../v1/CoreWallet.js';
+import { V1Tag } from '../v1/RunningV1Variant.js';
+import {
+  DUST_EVENT_COUNT,
+  buildDustChain,
+  dustSeed,
+  freshWallet as freshPreForkWallet,
+} from '../v1/test/dustEvents.js';
+import { CoreWallet as PostForkWallet } from '../v2/CoreWallet.js';
+import { V2Tag } from '../v2/RunningV2Variant.js';
+import { dustParameters as postForkDustParameters, freshWallet as freshPostForkWallet } from '../v2/test/dustEvents.js';
+import { type TimelineEvent, numberedFrom, reframeAsPostFork } from './forkReplay.js';
+import { makeForkWallet } from './forkWallet.js';
+import {
+  balanceAt,
+  commitmentTreeRoot,
+  dustCount,
+  dustIdentities,
+  dustIndices,
+  generationTreeRoot,
+} from './forkWalletAssertions.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+
+/**
+ * The boundary, stated once.
+ *
+ * `forkVersion` is where the post-fork variant is registered _and_ the version the indexer reports the replayed events
+ * under — the same number reaching the runtime through registration and through the timeline, which is the whole point
+ * of D5. It is deliberately an arbitrary number: the real fork's protocol version is not final, and nothing here may
+ * depend on it.
+ */
+const forkVersion = ProtocolVersion.ProtocolVersion(7n);
+
+/** A version bump the pre-fork variant owns: inside `[MinSupportedVersion, forkVersion)`, so it must not migrate. */
+const withinRangeVersion = ProtocolVersion.ProtocolVersion(5n);
+
+/** What the indexer reports the pre-fork history under. */
+const preForkVersion = Number(ProtocolVersion.MinSupportedVersion);
+
+/**
+ * The event id the replay opens at.
+ *
+ * @remarks
+ *   One past the pre-fork history, because there is only one id space: the indexer numbers its replay onwards from the id
+ *   it had reached when the fork happened. This is therefore also where a migrated wallet's parked cursor is waiting.
+ */
+const boundaryId = DUST_EVENT_COUNT + 1;
+
+/** Where the replay ends, and so where a wallet that consumed all of it lands. */
+const replayEndId = boundaryId + DUST_EVENT_COUNT - 1;
+
+/** Every dust UTXO the fixture's registrations produce, in commitment order. */
+const dustIndicesAtFork = [0n, 1n, 2n, 3n];
+
+/** The pre-fork history as the indexer served it: the fixture's events, numbered from one, at the pre-fork version. */
+const preForkHistory = (eventBytes: readonly Uint8Array[]): readonly TimelineEvent[] =>
+  numberedFrom(eventBytes, 1, preForkVersion);
+
+/** The replay: the same events again, renumbered from the boundary and reported at the post-fork version. */
+const replayOf = (eventBytes: readonly Uint8Array[]): readonly TimelineEvent[] =>
+  numberedFrom(eventBytes, boundaryId, Number(forkVersion));
+
+/** Re-reports the last event of a run at `version`, which is how a timeline announces a version change. */
+const reportedAt = (events: readonly TimelineEvent[], version: ProtocolVersion.ProtocolVersion) =>
+  events.map((event, index) => (index === events.length - 1 ? { ...event, protocolVersion: Number(version) } : event));
+
+/**
+ * What a wallet that read this whole history holds, computed by the pre-fork ledger and nothing else.
+ *
+ * @remarks
+ *   The independent oracle. The fixture's dust is sampled fresh per chain — the backing Night nonces are random — so
+ *   there are no constants to write down the way the shielded proof writes down its coin values. This stands in for
+ *   them: `CoreWallet` folding the events directly, with no variant, no runtime and no fork anywhere near it. A
+ *   post-fork wallet that agrees with this agrees with a reading the fork machinery had no hand in producing.
+ */
+const walletOfHistory = (eventBytes: readonly Uint8Array[], at: Date): PreForkWallet => {
+  const [wallet] = PreForkWallet.applyEventsWithChanges(
+    freshPreForkWallet(),
+    PreForkSecretKey.fromSeed(dustSeed()),
+    eventBytes.map((bytes) => PreForkEvent.deserialize(bytes)),
+    at,
+  );
+  return wallet;
+};
+
+describe('the two ledger versions agree on what a dust event says', () => {
+  it('derives the same dust public key from one seed, which is what makes the replayed dust the same dust', () => {
+    // The lemma everything below rests on. A `dustInitialUtxo` event names its owner's dust public key, and a wallet
+    // only takes the events addressed to its own; if the two ledger versions derived different keys from one seed, the
+    // replay would be somebody else's dust and the post-fork wallet would end up empty.
+    const seed = dustSeed();
+
+    expect(PostForkSecretKey.fromSeed(seed).publicKey).toBe(PreForkSecretKey.fromSeed(seed).publicKey);
+  });
+
+  it('values dust against the same initial parameters', () => {
+    // Dust's local state is parameterised where shielded's is not, and the migration supplies the post-fork parameters
+    // rather than carrying the pre-fork ones. Comparing balances across the boundary only means something because the
+    // two sets agree.
+    const preFork = PreForkLedgerParameters.initialParameters().dust;
+    const postFork = PostForkLedgerParameters.initialParameters().dust;
+
+    expect(postFork.nightDustRatio).toBe(preFork.nightDustRatio);
+    expect(postFork.generationDecayRate).toBe(preFork.generationDecayRate);
+    expect(postFork.dustGracePeriodSeconds).toBe(preFork.dustGracePeriodSeconds);
+  });
+
+  it('refuses the other version framing, which is why a replayed event has to be re-framed at all', async () => {
+    const chain = await buildDustChain();
+
+    // Not a modelling convenience: a ledger-v9 wallet cannot be handed a ledger-v8 event, full stop. Whatever replays
+    // the timeline after a fork has to re-emit it under the new version, and this is the wall that says so.
+    expect(() => PostForkEvent.deserialize(chain.eventBytes[0])).toThrowError(/midnight:event/);
+  });
+
+  it('builds the same dust from a re-framed event as from the original', async () => {
+    const chain = await buildDustChain();
+
+    const preFork = walletOfHistory(chain.eventBytes, chain.syncTime);
+    const [postFork] = PostForkWallet.applyEventsWithChanges(
+      freshPostForkWallet(),
+      PostForkSecretKey.fromSeed(dustSeed()),
+      chain.eventBytes.map((bytes) => PostForkEvent.deserialize(reframeAsPostFork(bytes))),
+      chain.syncTime,
+    );
+
+    // The claim the replay model stands on, and the reason this package needs no state translation to prove a fork:
+    // re-framing changes the header and nothing else, so ledger-v9 reconstructs the very dust ledger-v8 did.
+    expect(dustIdentities(postFork)).toEqual(dustIdentities(preFork));
+    expect(commitmentTreeRoot(postFork)).toBe(commitmentTreeRoot(preFork));
+    expect(generationTreeRoot(postFork)).toBe(generationTreeRoot(preFork));
+    expect(balanceAt(postFork, chain.syncTime)).toBe(balanceAt(preFork, chain.syncTime));
+  });
+});
+
+describe('a dust wallet crossing a hard fork', () => {
+  it(
+    'starts the new variant with no dust and re-discovers it from the replayed timeline',
+    async () =>
+      Effect.gen(function* () {
+        const chain = yield* Effect.promise(() => buildDustChain());
+        const replay = replayOf(chain.eventBytes);
+        const wire = yield* Queue.unbounded<readonly TimelineEvent[]>();
+        const replayed = yield* Deferred.make<readonly TimelineEvent[]>();
+
+        const wallet = makeForkWallet({
+          preFork: Stream.fromQueue(wire),
+          replayed: Deferred.await(replayed),
+          networkId,
+          forkVersion,
+          seed: dustSeed(),
+          dustParameters: {
+            preFork: PreForkLedgerParameters.initialParameters().dust,
+            postFork: postForkDustParameters(),
+          },
+          syncTime: chain.syncTime,
+        });
+        yield* Effect.addFinalizer(() => wallet.stop);
+        yield* wallet.start;
+
+        // --- pre-fork: the ledger-v8 variant syncs the ledger-v8 chain's events -----------------------------------
+        yield* Queue.offer(wire, preForkHistory(chain.eventBytes));
+
+        const preFork = yield* wallet.awaitState((state) => dustCount(state.state) === DUST_EVENT_COUNT);
+        expect(yield* wallet.activeTag).toBe(V1Tag);
+        expect(dustIndices(preFork.state)).toEqual(dustIndicesAtFork);
+        expect(preFork.state.progress.appliedIndex).toBe(BigInt(DUST_EVENT_COUNT));
+        // Everything the pre-fork wallet knows, recorded before the hand-over destroys the ledger-v8 objects holding it.
+        const preForkDust = dustIdentities(preFork.state);
+        const preForkCommitmentRoot = commitmentTreeRoot(preFork.state);
+        const preForkGenerationRoot = generationTreeRoot(preFork.state);
+        const preForkBalance = balanceAt(preFork.state, chain.syncTime);
+        expect(preForkCommitmentRoot).toBeDefined();
+        expect(preForkBalance).toBeGreaterThan(0n);
+
+        // --- the fork: the indexer's first post-fork event reaches the still-open pre-fork subscription ------------
+        // It is the replay's own opening event, delivered in the encoding the pre-fork variant can read. The pre-fork
+        // variant will not apply it — it is past the end of that variant's range — so all that reaches the wallet from
+        // it is the version it was reported under.
+        yield* Queue.offer(wire, [replay[0]]);
+        yield* Deferred.succeed(replayed, replay);
+
+        const migration = yield* wallet.awaitMigration;
+        expect(yield* wallet.activeTag).toBe(V2Tag);
+
+        // What the pre-fork variant handed over: its identity, the version that triggered the hand-over, and a cursor
+        // parked on the last event it applied — the boundary event was observed and annotated, deliberately not applied.
+        expect(migration.from.dustPublicKey).toBe(PreForkSecretKey.fromSeed(dustSeed()).publicKey);
+        expect(migration.from.protocolVersion).toBe(forkVersion);
+        expect(migration.from.appliedIndex).toBe(BigInt(DUST_EVENT_COUNT));
+
+        // And what it produced: a wallet holding no dust at all — no UTXOs, nothing pending, neither tree standing —
+        // because exactly that dust is about to arrive again as replayed events, and carrying it would double-count what
+        // the replay is delivering.
+        const empty = freshPostForkWallet();
+        expect(migration.to.dustCount).toBe(0);
+        expect(migration.to.pendingDustCount).toBe(0);
+        expect(migration.to.commitmentTreeRoot).toBe(commitmentTreeRoot(empty));
+        expect(migration.to.generationTreeRoot).toBe(generationTreeRoot(empty));
+        // **Parked, not rewound.** The one place the two cursor semantics are directly distinguishable: the state the
+        // migration produced, before any sync has touched it. The replay continues the indexer's event ids from where the
+        // fork found them, so this wallet resumes on the cursor its predecessor stopped at. A migration that reset to
+        // zero fails here — and only here, because a cursor behind the replay still reads all of it.
+        expect(migration.to.appliedIndex).toBe(migration.from.appliedIndex);
+        expect(migration.to.appliedIndex).toBe(BigInt(DUST_EVENT_COUNT));
+        // Identity is the one thing that does cross: without this key the replay decrypts into nothing.
+        expect(migration.to.dustPublicKey).toBe(PostForkSecretKey.fromSeed(dustSeed()).publicKey);
+        expect(migration.to.networkId).toBe(networkId);
+        // Kept so the restarted variant sits inside its own activation range instead of signalling backwards at once.
+        expect(migration.to.protocolVersion).toBe(forkVersion);
+        // The empty state is valued against the parameters the migration was handed, not against anything carried over.
+        expect(migration.to.nightDustRatio).toBe(postForkDustParameters().nightDustRatio);
+
+        // --- post-fork: the dust is re-discovered, not carried -----------------------------------------------------
+        const postFork = yield* wallet.awaitState(
+          (state) => state.version >= forkVersion && dustCount(state.state) === DUST_EVENT_COUNT,
+        );
+        // The same dust, not merely the same amount of it: same nonces, same backing Night, same creation times, same
+        // initial values, at the same commitment indices.
+        expect(dustIdentities(postFork.state)).toEqual(preForkDust);
+        // And the same trees, which is what a spend's Merkle path would be built against.
+        expect(commitmentTreeRoot(postFork.state)).toBe(preForkCommitmentRoot);
+        expect(generationTreeRoot(postFork.state)).toBe(preForkGenerationRoot);
+        // Valued at the same instant on both sides, because dust generates and decays and a balance means nothing
+        // without one.
+        expect(balanceAt(postFork.state, chain.syncTime)).toBe(preForkBalance);
+        // Read onwards from the boundary rather than from the start of anything: the replay opens where the parked
+        // cursor is waiting and runs to its own end.
+        expect(postFork.state.progress.appliedIndex).toBe(BigInt(replayEndId));
+      }).pipe(Effect.scoped, Effect.runPromise),
+    60_000,
+  );
+
+  it(
+    'does not migrate on a version bump that stays inside the running variant range',
+    async () =>
+      Effect.gen(function* () {
+        // Same timeline, same registration, one number different: the indexer reports a version the pre-fork variant
+        // still owns. The version is written onto the state either way — what must not happen is a hand-over.
+        const chain = yield* Effect.promise(() => buildDustChain());
+        const wire = yield* Queue.unbounded<readonly TimelineEvent[]>();
+        const replayed = yield* Deferred.make<readonly TimelineEvent[]>();
+
+        const wallet = makeForkWallet({
+          preFork: Stream.fromQueue(wire),
+          replayed: Deferred.await(replayed),
+          networkId,
+          forkVersion,
+          seed: dustSeed(),
+          dustParameters: {
+            preFork: PreForkLedgerParameters.initialParameters().dust,
+            postFork: postForkDustParameters(),
+          },
+          syncTime: chain.syncTime,
+        });
+        yield* Effect.addFinalizer(() => wallet.stop);
+        yield* wallet.start;
+
+        yield* Queue.offer(wire, reportedAt(preForkHistory(chain.eventBytes), withinRangeVersion));
+
+        const state = yield* wallet.awaitState(
+          (current) =>
+            current.state.protocolVersion === withinRangeVersion && dustCount(current.state) === DUST_EVENT_COUNT,
+        );
+
+        // Seen and annotated on the wallet's own state — the annotation the runtime reads — and, being inside the range,
+        // it decided nothing. (Asserted here rather than on `ProtocolState.version`, which the runtime publishes one
+        // state emission behind a within-range bump.)
+        expect(state.state.protocolVersion).toBe(withinRangeVersion);
+        expect(yield* wallet.activeTag).toBe(V1Tag);
+        expect(yield* wallet.migration).toStrictEqual(Option.none());
+        // The bumped event was applied rather than deferred, so nothing was left behind for a variant that never ran.
+        expect(state.state.progress.appliedIndex).toBe(BigInt(DUST_EVENT_COUNT));
+        expect(dustIndices(state.state)).toEqual(dustIndicesAtFork);
+      }).pipe(Effect.scoped, Effect.runPromise),
+    60_000,
+  );
+
+  it(
+    'migrates a wallet whose first sync already contains the fork',
+    async () =>
+      Effect.gen(function* () {
+        // Scenario 2: a wallet started from seed after the fork has happened. Its pre-fork variant meets the whole
+        // pre-fork history and the boundary in a single batch, so the split happens *within* one update rather than
+        // across two.
+        const chain = yield* Effect.promise(() => buildDustChain());
+        const replay = replayOf(chain.eventBytes);
+        const wire = yield* Queue.unbounded<readonly TimelineEvent[]>();
+
+        const wallet = makeForkWallet({
+          preFork: Stream.fromQueue(wire),
+          replayed: Effect.succeed(replay),
+          networkId,
+          forkVersion,
+          seed: dustSeed(),
+          dustParameters: {
+            preFork: PreForkLedgerParameters.initialParameters().dust,
+            postFork: postForkDustParameters(),
+          },
+          syncTime: chain.syncTime,
+        });
+        yield* Effect.addFinalizer(() => wallet.stop);
+        yield* wallet.start;
+
+        yield* Queue.offer(wire, [...preForkHistory(chain.eventBytes), replay[0]]);
+
+        const migration = yield* wallet.awaitMigration;
+        expect(migration.from.appliedIndex).toBe(BigInt(DUST_EVENT_COUNT));
+        expect(migration.to.dustCount).toBe(0);
+        // Reached in one batch rather than two, and the cursor still parks on the boundary: where the split happened
+        // does not change what the next variant inherits.
+        expect(migration.to.appliedIndex).toBe(BigInt(DUST_EVENT_COUNT));
+
+        // The end state is the same as the live transition reaches, which is the point: how the timeline was delivered is
+        // not supposed to change what the wallet ends up holding.
+        const postFork = yield* wallet.awaitState(
+          (state) => state.version >= forkVersion && dustCount(state.state) === DUST_EVENT_COUNT,
+        );
+        expect(yield* wallet.activeTag).toBe(V2Tag);
+        // Compared against the history folded straight into a `CoreWallet`, because this run never exposes a pre-fork
+        // state to compare with — the boundary arrived in the wallet's very first batch.
+        const expected = walletOfHistory(chain.eventBytes, chain.syncTime);
+        expect(dustIdentities(postFork.state)).toEqual(dustIdentities(expected));
+        expect(commitmentTreeRoot(postFork.state)).toBe(commitmentTreeRoot(expected));
+        expect(balanceAt(postFork.state, chain.syncTime)).toBe(balanceAt(expected, chain.syncTime));
+        expect(postFork.state.progress.appliedIndex).toBe(BigInt(replayEndId));
+      }).pipe(Effect.scoped, Effect.runPromise),
+    60_000,
+  );
+});

--- a/packages/dust-wallet/src/test/forkSimulation.test.ts
+++ b/packages/dust-wallet/src/test/forkSimulation.test.ts
@@ -54,7 +54,7 @@ import {
 } from '@midnightntwrk/ledger-v9';
 import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Deferred, Effect, Option, Queue, Stream } from 'effect';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { CoreWallet as PreForkWallet } from '../v1/CoreWallet.js';
 import { V1Tag } from '../v1/RunningV1Variant.js';
 import {
@@ -76,6 +76,10 @@ import {
   dustIndices,
   generationTreeRoot,
 } from './forkWalletAssertions.js';
+
+// Building a real dust chain (rewards + registrations through WASM) fits vitest's 5s default on a laptop but not on
+// a CI runner — the whole file measured ~23s there. Sized like the shielded fork proof's override, with CI headroom.
+vi.setConfig({ testTimeout: 30_000 });
 
 const networkId = NetworkId.NetworkId.Undeployed;
 

--- a/packages/dust-wallet/src/test/forkWallet.ts
+++ b/packages/dust-wallet/src/test/forkWallet.ts
@@ -1,0 +1,435 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * A dust wallet registered over _both_ variants, syncing a timeline that forks under it — test scaffolding only.
+ *
+ * @remarks
+ *   The shipped `DustWallet` registers exactly one variant and its type is a one-element HList throughout, so it cannot
+ *   express a wallet that crosses a fork. Rather than widen the public surface ahead of the API redesign this builds
+ *   the two-variant wallet the way `packages/e2e-tests` builds its custom wallets: `WalletBuilder.init()` with both
+ *   variant builders registered directly. Nothing here is exported from the package.
+ *
+ *   Both sides sync through the **events** path — `makeDefaultSyncCapability`, the capability the shipped wallet uses —
+ *   because that is the path the fork design is written against: its cursor is an indexer event id, which is the thing
+ *   the migration parks and the replay counts on from. (The projections path cannot do any of this and says so in
+ *   `Sync.ts`: a projections update is a folded snapshot with no protocol version anywhere in it, so there is nothing
+ *   to split at a boundary. The simulator path could, at block granularity, but its cursor is a block number and its
+ *   updates carry a live chain that only one of the two ledger versions can hold.) What is substituted is the sync
+ *   _service_ on each side — the thing that would otherwise open a WebSocket to an indexer — while the capability that
+ *   folds an update into the wallet, boundary rule and all, is the real one.
+ *
+ *   So neither side watches a chain: each is served a numbered, version-tagged event log, which is what an indexer serves
+ *   and the only thing that exists after a fork anyway. The events in it are real, produced by a real ledger-v8 dust
+ *   chain in `v1/test/dustEvents.ts` — recorded rather than streamed, because a wallet crossing a boundary has to be
+ *   handed the same history twice, and a chain's `Event` instances are consumed the first time they are replayed.
+ *
+ *   Three things it has to work around, each of which is a real question the public API will have to answer eventually:
+ *
+ *   - **One configuration cannot carry two ledgers' dust parameters.** `WalletBuilder` intersects every variant's
+ *       configuration, and both variants declare an optional `dustParameters` — each of its own ledger's
+ *       `DustParameters`. Nothing objects: the two classes are structurally identical, so the intersection accepts
+ *       either, and whichever is supplied is then handed to _both_ variants — one of which would be building a
+ *       `DustLocalState` out of the other module's WASM object. A hazard the type system does not catch, so the field
+ *       is left unset and each side is passed its own parameters directly: the pre-fork ones into the initial state,
+ *       the post-fork ones into the migration.
+ *   - **Start-aux does not cross the boundary.** The pre-fork variant's aux is a ledger-v8 `DustSecretKey`, the post-fork
+ *       variant's a ledger-v9 one, and those two _are_ distinct to the type system — each declares a private
+ *       constructor — so a single retained value provably cannot serve both. What is retained here is therefore the
+ *       _seed_, and each variant is handed a key derived from it: the same dust public key either way (asserted by
+ *       `forkSimulation.test.ts`), just built by the ledger that variant speaks. This is exactly what `DustWallet`'s
+ *       `#retainedAux` will have to become when it is registered over two variants.
+ *   - **The replay does not exist yet** when the wallet is built — it is what the indexer starts serving once the fork has
+ *       happened — so it is supplied as an effect the post-fork variant awaits at its first sync.
+ */
+
+import {
+  type DustParameters as PreForkParameters,
+  DustSecretKey as PreForkSecretKey,
+  LedgerParameters as PreForkLedgerParameters,
+} from '@midnight-ntwrk/ledger-v8';
+import {
+  type DustParameters as PostForkParameters,
+  DustSecretKey as PostForkSecretKey,
+  LedgerParameters as PostForkLedgerParameters,
+} from '@midnightntwrk/ledger-v9';
+import { type NetworkId, type ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
+import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { Deferred, Effect, FiberId, Option, Stream, pipe } from 'effect';
+import { CoreWallet as PreForkWallet } from '../v1/CoreWallet.js';
+import { V1Tag } from '../v1/RunningV1Variant.js';
+import * as PreForkSync from '../v1/Sync.js';
+import { V1Builder } from '../v1/V1Builder.js';
+import { type CoreWallet as PostForkWallet } from '../v2/CoreWallet.js';
+import * as PostForkMigration from '../v2/Migration.js';
+import { V2Tag } from '../v2/RunningV2Variant.js';
+import * as PostForkSync from '../v2/Sync.js';
+import { type BlockData as PostForkBlockData, WalletSyncUpdate as PostForkUpdate } from '../v2/SyncSchema.js';
+import { V2Builder } from '../v2/V2Builder.js';
+import { asPostForkItems, asPreForkItems, type TimelineEvent } from './forkReplay.js';
+
+// =============================================================================
+// Observation channels
+// =============================================================================
+
+/**
+ * Both ends of a migration, as plain data, taken at the moment it happened.
+ *
+ * @remarks
+ *   Recorded as plain data rather than by keeping the wallets themselves: the pre-fork state is built on the other
+ *   ledger's WASM objects, whose lifetime ends with the variant scope the migration closes.
+ *
+ *   The `from` side is what the projection was allowed to see; the `to` side is what it produced. Under the replay design
+ *   the interesting claim is on the `to` side — that a wallet crossing a fork starts with no dust at all and re-earns
+ *   it by syncing, keeping only its identity and the cursor it inherited. `appliedIndex` is captured on both sides
+ *   because comparing them is the only place the parked cursor is directly observable: once sync runs, a wallet that
+ *   had rewound instead would read the same replay anyway and converge on the same state.
+ */
+export type CapturedMigration = Readonly<{
+  from: Readonly<{
+    dustPublicKey: bigint;
+    networkId: string;
+    protocolVersion: bigint;
+    appliedIndex: bigint;
+  }>;
+  to: Readonly<{
+    dustPublicKey: bigint;
+    networkId: string;
+    protocolVersion: bigint;
+    appliedIndex: bigint;
+    dustCount: number;
+    pendingDustCount: number;
+    commitmentTreeRoot: bigint | undefined;
+    generationTreeRoot: bigint | undefined;
+    /**
+     * The night-to-dust ratio the produced state is parameterised by.
+     *
+     * @remarks
+     *   Captured because it is the one thing dust's migration has to supply that shielded's does not: `DustLocalState`
+     *   carries the generation and decay rates it values dust against, and they belong to whichever ledger module
+     *   produced them, so the post-fork parameters are handed in rather than carried across.
+     */
+    nightDustRatio: bigint;
+  }>;
+}>;
+
+const captureInput = (previousState: PostForkMigration.PreviousLedgerWallet): CapturedMigration['from'] => ({
+  dustPublicKey: previousState.publicKey.publicKey,
+  networkId: previousState.networkId,
+  protocolVersion: previousState.protocolVersion,
+  appliedIndex: previousState.progress.appliedIndex,
+});
+
+const captureOutput = (migrated: PostForkWallet): CapturedMigration['to'] => ({
+  dustPublicKey: migrated.publicKey.publicKey,
+  networkId: migrated.networkId,
+  protocolVersion: migrated.protocolVersion,
+  appliedIndex: migrated.progress.appliedIndex,
+  dustCount: migrated.state.utxos.length,
+  pendingDustCount: migrated.pendingDust.length,
+  commitmentTreeRoot: migrated.state.commitmentTreeRoot(),
+  generationTreeRoot: migrated.state.generatingTreeRoot(),
+  nightDustRatio: migrated.state.params.nightDustRatio,
+});
+
+/** The real cross-ledger migration, with both ends recorded on the way through. */
+const capturingCrossLedgerMigration = (
+  dustParameters: PostForkParameters,
+  captured: Deferred.Deferred<CapturedMigration>,
+): PostForkMigration.StateMigration<PostForkMigration.PreviousLedgerWallet> => {
+  const inner = PostForkMigration.makeCrossLedgerMigration({ dustParameters });
+  return {
+    migrate: (previousState) =>
+      pipe(
+        inner.migrate(previousState),
+        Effect.tap((migrated) =>
+          Deferred.succeed(captured, { from: captureInput(previousState), to: captureOutput(migrated) }),
+        ),
+      ),
+  };
+};
+
+// =============================================================================
+// Stand-ins for services the proof does not exercise
+// =============================================================================
+
+const transactionDetails = (hash: string) => ({
+  hash,
+  block: { hash: '', height: 0, timestamp: 0 },
+  status: 'SUCCESS' as const,
+  identifiers: [] as readonly string[],
+  fees: null,
+});
+
+/**
+ * Transaction history reduced to nothing.
+ *
+ * @remarks
+ *   The real services need indexer configuration or a storage instance, neither of which says anything about crossing a
+ *   fork. Written out once per variant because the two `TransactionHistoryService` types name their own ledger's
+ *   `DustStateChanges`.
+ */
+const noOpPreForkHistory = {
+  put: () => Effect.void,
+  getTransactionDetails: (hash: string) => Effect.succeed(transactionDetails(hash)),
+};
+
+const noOpPostForkHistory = {
+  put: () => Effect.void,
+  getTransactionDetails: (hash: string) => Effect.succeed(transactionDetails(hash)),
+};
+
+/**
+ * Block data nothing in the proof reads.
+ *
+ * @remarks
+ *   `blockData` serves fee estimation and transaction balancing, neither of which a fork proof exercises — but it is part
+ *   of `SyncService`, so both stand-ins have to answer it. A fixed, well-formed reading is returned rather than a
+ *   failure: a defect here would surface as a sync error and read like a fork that went wrong.
+ */
+const preForkBlockData = (timestamp: Date): PreForkSync.BlockData => ({
+  hash: '',
+  height: 0,
+  ledgerParameters: PreForkLedgerParameters.initialParameters(),
+  timestamp,
+});
+
+const postForkBlockData = (timestamp: Date): PostForkBlockData => ({
+  hash: '',
+  height: 0,
+  ledgerParameters: PostForkLedgerParameters.initialParameters(),
+  timestamp,
+  zswapEndIndex: 0,
+  dustCommitmentEndIndex: 0,
+  dustGenerationEndIndex: 0,
+  dustCommitmentMerkleTreeRoot: '',
+  dustGenerationMerkleTreeRoot: '',
+});
+
+/**
+ * How far back a subscription opens, given where the wallet stopped applying.
+ *
+ * @remarks
+ *   The rule the real indexer service uses, restated over an in-memory timeline: the cursor is inclusive and must stay at
+ *   or below `appliedIndex`, so a wallet already at the tip is still delivered something and its apply loop still runs.
+ *   Modelled rather than skipped because it is what makes the migrated wallet's parked cursor _do_ anything: the replay
+ *   is filtered against it, exactly as the indexer would filter its stream.
+ */
+const resumeFrom = (appliedIndex: bigint): number => Number(appliedIndex) - 1;
+
+/**
+ * The pre-fork sync service: batches of a timeline the test controls, filtered by the wallet's cursor.
+ *
+ * @param batches The pre-fork wire, one batch per emission — which is how a test decides whether the boundary arrives
+ *   in the same batch as the history before it or in a later one.
+ * @param timestamp The instant every batch is valued at, which has to be at or after the last event's block time for
+ *   the dust it creates to be worth anything.
+ */
+const preForkSyncService = (
+  batches: Stream.Stream<readonly TimelineEvent[]>,
+  timestamp: Date,
+): PreForkSync.SyncService<PreForkWallet, PreForkSecretKey, PreForkSync.WalletSyncUpdate> => ({
+  updates: (state, secretKey) => {
+    const from = resumeFrom(state.progress.appliedIndex);
+    return pipe(
+      batches,
+      Stream.map((batch) => batch.filter((event) => event.id > from)),
+      Stream.filter((batch) => batch.length > 0),
+      Stream.map((batch) => PreForkSync.WalletSyncUpdate.create(asPreForkItems(batch), secretKey, timestamp)),
+    );
+  },
+  blockData: () => Effect.succeed(preForkBlockData(timestamp)),
+});
+
+/**
+ * The post-fork sync service: the indexer's replay, deferred until it exists.
+ *
+ * @remarks
+ *   A replay that never arrives is a broken harness rather than a wallet error — there is no `WalletError` that means
+ *   "the simulated replay did not happen" — so failures are raised as defects instead of being folded into the sync
+ *   error channel.
+ */
+const postForkSyncService = (
+  replayed: Effect.Effect<readonly TimelineEvent[], never>,
+  timestamp: Date,
+): PostForkSync.SyncService<PostForkWallet, PostForkSecretKey, PostForkUpdate> => ({
+  updates: (state, secretKey) => {
+    const from = resumeFrom(state.progress.appliedIndex);
+    return pipe(
+      replayed,
+      Effect.orDie,
+      Effect.map((replay) => replay.filter((event) => event.id > from)),
+      Effect.map((batch) => PostForkUpdate.create(asPostForkItems(batch), secretKey, timestamp)),
+      Stream.fromEffect,
+    );
+  },
+  blockData: () => Effect.succeed(postForkBlockData(timestamp)),
+});
+
+// =============================================================================
+// The wallet
+// =============================================================================
+
+/** Everything needed to build a two-variant dust wallet over a timeline that forks. */
+export type ForkWalletConfig = Readonly<{
+  /** The pre-fork wire, one batch per emission. */
+  preFork: Stream.Stream<readonly TimelineEvent[]>;
+  /** The replay — the indexer's re-emission of the timeline — which only exists once the fork has happened. */
+  replayed: Effect.Effect<readonly TimelineEvent[], never>;
+  networkId: NetworkId.NetworkId;
+  /**
+   * The version at which the post-fork variant is registered.
+   *
+   * The single source of truth for the boundary (D5): the pre-fork variant's activation range ends here, and so does
+   * the point at which its sync stops applying. Deliberately not a production constant — the real fork version is not
+   * final.
+   */
+  forkVersion: ProtocolVersion.ProtocolVersion;
+  /** The seed both variants derive their dust key from. */
+  seed: Uint8Array;
+  /**
+   * The dust parameters each side values dust against.
+   *
+   * @remarks
+   *   Two of them, because `DustLocalState` is parameterised and the parameters are a WASM object of whichever ledger
+   *   module produced them. Shielded's fork wallet needs no equivalent: its local state carries no parameters at all.
+   */
+  dustParameters: Readonly<{ preFork: PreForkParameters; postFork: PostForkParameters }>;
+  /** The instant sync updates are valued at — at or after the last event's block time. */
+  syncTime: Date;
+}>;
+
+/** A running two-variant dust wallet, plus the channels a fork proof needs to observe it. */
+export type ForkWallet = Readonly<{
+  /** A dust key of each ledger version, derived from the same seed. */
+  keys: Readonly<{ preFork: PreForkSecretKey; postFork: PostForkSecretKey }>;
+  /** Starts background sync, having first registered the activation watcher that restarts it after a migration. */
+  start: Effect.Effect<void, WalletRuntimeError>;
+  /** Resolves when the hand-over happens, with both ends of it. */
+  awaitMigration: Effect.Effect<CapturedMigration>;
+  /** Both ends of the migration, or `None` if none has happened yet. */
+  migration: Effect.Effect<Option.Option<CapturedMigration>>;
+  /** The tag of the variant currently running — `V1Tag` before a migration, `V2Tag` after one. */
+  activeTag: Effect.Effect<string | symbol>;
+  /** The wallet's current state, whichever variant produced it. */
+  currentState: Effect.Effect<ProtocolState.ProtocolState<PreForkWallet | PostForkWallet>, WalletRuntimeError>;
+  /**
+   * Resolves once the wallet's state satisfies `predicate`, failing the test's timeout if it never does.
+   *
+   * Use monotone predicates only: the runtime's state stream keeps just the latest value, so a state that satisfies a
+   * transient predicate can legitimately be skipped.
+   */
+  awaitState: (
+    predicate: (state: ProtocolState.ProtocolState<PreForkWallet | PostForkWallet>) => boolean,
+  ) => Effect.Effect<ProtocolState.ProtocolState<PreForkWallet | PostForkWallet>, WalletRuntimeError>;
+  /** Tears the wallet down. */
+  stop: Effect.Effect<void>;
+}>;
+
+/**
+ * Builds and starts a dust wallet registered over both variants.
+ *
+ * @param config - The two sources, the boundary version, the network, the seed and the parameters each side values dust
+ *   against.
+ * @returns The running wallet and its observation channels.
+ */
+export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
+  const { preFork, replayed, networkId, forkVersion, seed, dustParameters, syncTime } = config;
+
+  const preForkKey = PreForkSecretKey.fromSeed(seed);
+  const postForkKey = PostForkSecretKey.fromSeed(seed);
+
+  const captured = Deferred.unsafeMake<CapturedMigration>(FiberId.none);
+
+  const preForkBuilder = new V1Builder()
+    .withDefaultTransactionType()
+    .withSync(
+      () => preForkSyncService(preFork, syncTime),
+      () => PreForkSync.makeDefaultSyncCapability(),
+    )
+    .withSerializationDefaults()
+    .withTransactingDefaults()
+    .withCoinsAndBalancesDefaults()
+    .withTransactionHistory(() => noOpPreForkHistory)
+    .withKeysDefaults()
+    .withCoinSelectionDefaults();
+
+  const postForkBuilder = new V2Builder()
+    .withDefaultTransactionType()
+    .withSync(
+      () => postForkSyncService(replayed, syncTime),
+      () => PostForkSync.makeDefaultSyncCapability(),
+    )
+    .withSerializationDefaults()
+    .withTransactingDefaults()
+    .withCoinsAndBalancesDefaults()
+    .withTransactionHistory(() => noOpPostForkHistory)
+    .withKeysDefaults()
+    .withCoinSelectionDefaults()
+    .withMigration(() => capturingCrossLedgerMigration(dustParameters.postFork, captured));
+
+  const WalletClass = WalletBuilder.init()
+    .withVariant(ProtocolVersion.MinSupportedVersion, preForkBuilder)
+    .withVariant(forkVersion, postForkBuilder)
+    .build({ networkId, costParameters: { feeBlocksMargin: 5 } });
+
+  const wallet = WalletClass.startFirst(
+    WalletClass,
+    PreForkWallet.initEmpty(dustParameters.preFork, preForkKey, networkId),
+  );
+  const runtime = wallet.runtime;
+
+  const currentState = pipe(runtime.stateChanges, Stream.take(1), Stream.runHead, Effect.map(Option.getOrThrow));
+
+  return {
+    keys: { preFork: preForkKey, postFork: postForkKey },
+
+    start: Effect.gen(function* () {
+      // Registered before the first dispatch and only once, exactly as `DustWallet.start` does it: the returned effect
+      // resolves only once the subscription is live, so the migration cannot outrun the watcher.
+      yield* runtime.onVariantActivation({
+        [V1Tag]: (v1) => v1.startSyncInBackground(preForkKey),
+        [V2Tag]: (v2) => v2.startSyncInBackground(postForkKey),
+      });
+      yield* runtime.dispatch({
+        [V1Tag]: (v1) => v1.startSyncInBackground(preForkKey),
+        [V2Tag]: (v2) => v2.startSyncInBackground(postForkKey),
+      });
+    }),
+
+    awaitMigration: Deferred.await(captured),
+
+    migration: Deferred.poll(captured).pipe(
+      Effect.flatMap(Option.match({ onNone: () => Effect.succeedNone, onSome: Effect.asSome })),
+    ),
+
+    activeTag: pipe(
+      runtime.currentVariant,
+      Effect.map((current) => current.runningVariant.__polyTag__),
+    ),
+
+    currentState,
+
+    awaitState: (predicate) =>
+      pipe(
+        runtime.stateChanges,
+        Stream.filter(predicate),
+        Stream.take(1),
+        Stream.runHead,
+        Effect.map(Option.getOrThrow),
+      ),
+
+    stop: Effect.promise(() => wallet.stop()),
+  };
+};

--- a/packages/dust-wallet/src/test/forkWalletAssertions.ts
+++ b/packages/dust-wallet/src/test/forkWalletAssertions.ts
@@ -1,0 +1,102 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Reading a dust wallet's holdings without caring which ledger version holds them.
+ *
+ * @remarks
+ *   A wallet crossing a fork is a `CoreWallet` of one ledger version before the boundary and of the other after it.
+ *   Everything a fork proof asserts about its dust — how many UTXOs, at which Merkle indices, backed by which Night,
+ *   worth what — is plain data that both versions express identically, so these read the union rather than being
+ *   written twice.
+ *
+ *   Restricted on purpose to the members ledger-v8 and ledger-v9 both declare. `DustLocalState` gained
+ *   `commitmentTreeFirstFree`, `generatingTreeFirstFree` and `nullifiers` in v9, so a fork proof cannot compare tree
+ *   _sizes_ across the boundary the way the shielded proof compares `firstFree` — the pre-fork side has no such reading
+ *   to offer. The tree roots are declared by both, and they are the stronger statement anyway.
+ */
+
+import { type CoreWallet as PreForkWallet } from '../v1/CoreWallet.js';
+import { type CoreWallet as PostForkWallet } from '../v2/CoreWallet.js';
+
+/** A dust wallet on either side of the boundary. */
+export type EitherWallet = PreForkWallet | PostForkWallet;
+
+/** Ascending order for bigints, which `Array.prototype.sort`'s default (string) comparison gets wrong. */
+const ascending = (left: bigint, right: bigint): number => (left < right ? -1 : left > right ? 1 : 0);
+
+/**
+ * One dust UTXO, reduced to the fields that identify it.
+ *
+ * @remarks
+ *   Every one of these is a value the ledger derived rather than the wallet chose: `nonce` from the backing Night nonce
+ *   and the owner's key, `initialValue` from the Night value and the elapsed generation time, `mtIndex` from where the
+ *   commitment landed. So a wallet that ends up holding an equal set of these is holding the same dust, not merely a
+ *   similar amount of it.
+ */
+export type DustIdentity = Readonly<{
+  nonce: bigint;
+  initialValue: bigint;
+  backingNight: string;
+  ctime: number;
+  mtIndex: bigint;
+  owner: bigint;
+}>;
+
+const identify = (utxo: {
+  nonce: bigint;
+  initialValue: bigint;
+  backingNight: string;
+  ctime: Date;
+  mtIndex: bigint;
+  owner: bigint;
+}): DustIdentity => ({
+  nonce: utxo.nonce,
+  initialValue: utxo.initialValue,
+  backingNight: utxo.backingNight,
+  ctime: utxo.ctime.getTime(),
+  mtIndex: utxo.mtIndex,
+  owner: utxo.owner,
+});
+
+/** The wallet's dust UTXOs, identified and ordered by Merkle index so two wallets are directly comparable. */
+export const dustIdentities = (wallet: EitherWallet): readonly DustIdentity[] =>
+  wallet.state.utxos.map(identify).sort((left, right) => ascending(left.mtIndex, right.mtIndex));
+
+/** How many dust UTXOs the wallet holds. */
+export const dustCount = (wallet: EitherWallet): number => wallet.state.utxos.length;
+
+/** The Merkle indices the wallet's dust UTXOs occupy in the commitment tree, ascending. */
+export const dustIndices = (wallet: EitherWallet): readonly bigint[] =>
+  wallet.state.utxos.map((utxo) => utxo.mtIndex).sort(ascending);
+
+/**
+ * The root of the wallet's own dust commitment tree.
+ *
+ * @remarks
+ *   The single value that says whether two wallets rebuilt the same tree rather than merely trees with the same leaves in
+ *   them. Both ledger versions compute it, which is what makes it usable across the boundary.
+ */
+export const commitmentTreeRoot = (wallet: EitherWallet): bigint | undefined => wallet.state.commitmentTreeRoot();
+
+/** The root of the wallet's dust generation tree — the Night-side half of the same statement. */
+export const generationTreeRoot = (wallet: EitherWallet): bigint | undefined => wallet.state.generatingTreeRoot();
+
+/**
+ * Everything the wallet could pay fees with at `time`.
+ *
+ * @remarks
+ *   Time-dependent, and that is the point: dust generates and decays, so a balance is only meaningful with the instant it
+ *   was valued at. Both sides of a fork proof must be valued at the same instant for the comparison to mean anything.
+ */
+export const balanceAt = (wallet: EitherWallet, time: Date): bigint => wallet.state.walletBalance(time);

--- a/packages/dust-wallet/src/v1/CoreWallet.ts
+++ b/packages/dust-wallet/src/v1/CoreWallet.ts
@@ -94,8 +94,8 @@ export const CoreWallet = {
    *
    * @remarks
    *   Only ever raises it. A stale lower report — a late batch from behind the tip, a source that rewound — would
-   *   otherwise look like a downward version change and send the runtime migrating backwards into a variant this
-   *   wallet has already left.
+   *   otherwise look like a downward version change and send the runtime migrating backwards into a variant this wallet
+   *   has already left.
    */
   withProtocolVersion(wallet: CoreWallet, version: ProtocolVersion.ProtocolVersion): CoreWallet {
     return version > wallet.protocolVersion ? { ...wallet, protocolVersion: version } : wallet;

--- a/packages/dust-wallet/src/v1/CoreWallet.ts
+++ b/packages/dust-wallet/src/v1/CoreWallet.ts
@@ -89,6 +89,46 @@ export const CoreWallet = {
     };
   },
 
+  /**
+   * Records an observed protocol version, monotonically.
+   *
+   * @remarks
+   *   Only ever raises it. A stale lower report — a late batch from behind the tip, a source that rewound — would
+   *   otherwise look like a downward version change and send the runtime migrating backwards into a variant this
+   *   wallet has already left.
+   */
+  withProtocolVersion(wallet: CoreWallet, version: ProtocolVersion.ProtocolVersion): CoreWallet {
+    return version > wallet.protocolVersion ? { ...wallet, protocolVersion: version } : wallet;
+  },
+
+  /**
+   * The first state of this ledger version, projected from the wallet of the version it replaced.
+   *
+   * @remarks
+   *   Identity and position only. The dust itself is deliberately absent: the indexer replays the timeline after the
+   *   fork, so the same dust is generated again by events of this ledger version and re-discovered by ordinary sync.
+   *
+   *   `dustParameters` has to be supplied rather than carried, and this is where dust departs from shielded:
+   *   `DustLocalState` is parameterised by the ledger's dust parameters, and those are a WASM object belonging to
+   *   whichever ledger module produced them. The previous variant's copy cannot be handed to this one.
+   */
+  fromPreviousVersion(previous: {
+    readonly publicKey: PublicKey;
+    readonly networkId: NetworkId;
+    readonly protocolVersion: bigint;
+    readonly progress: SyncProgress.SyncProgressData;
+    readonly dustParameters: DustParameters;
+  }): CoreWallet {
+    return {
+      state: new DustLocalState(previous.dustParameters),
+      publicKey: previous.publicKey,
+      networkId: previous.networkId,
+      pendingDust: [],
+      progress: SyncProgress.createSyncProgress({ ...previous.progress, isConnected: false }),
+      protocolVersion: ProtocolVersion.ProtocolVersion(previous.protocolVersion),
+    };
+  },
+
   applyEventsWithChanges(
     wallet: CoreWallet,
     secretKey: DustSecretKey,

--- a/packages/dust-wallet/src/v1/Migration.ts
+++ b/packages/dust-wallet/src/v1/Migration.ts
@@ -13,7 +13,7 @@
 import { type DustParameters, DustSecretKey } from '@midnight-ntwrk/ledger-v8';
 import { type SyncProgress, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Effect } from 'effect';
-import { CoreWallet, PublicKey } from './CoreWallet.js';
+import { CoreWallet } from './CoreWallet.js';
 import { type NetworkId } from './types/ledger.js';
 import { type WalletError } from './WalletError.js';
 
@@ -118,16 +118,16 @@ export type CrossLedgerMigrationConfiguration = {
  *
  * @remarks
  *   The indexer replays the timeline after the hard fork, re-emitting the wallet's history as events of the new ledger
- *   version. A migrated wallet therefore does not need — and must not attempt — to carry its dust: exactly the same dust
- *   is generated again by ordinary sync, from the replayed registration events, and valued against this version's
+ *   version. A migrated wallet therefore does not need — and must not attempt — to carry its dust: exactly the same
+ *   dust is generated again by ordinary sync, from the replayed registration events, and valued against this version's
  *   parameters. Carrying it across as well would double-count what the replay is about to deliver, on top of requiring
  *   generation and commitment trees that this ledger's WASM module cannot read.
  *
  *   So what crosses is the dust public key, the network, the protocol version that triggered the hand-over, and the
- *   cursor. Sync progress is **parked at the fork** rather than rewound: the indexer numbers the replayed events onwards
- *   from whatever id it had reached when the fork happened, never from zero, so the inherited cursor is exactly where
- *   the replay begins. A wallet that rewound to zero would wait on a stretch of the timeline this ledger version's
- *   events do not occupy.
+ *   cursor. Sync progress is **parked at the fork** rather than rewound: the indexer numbers the replayed events
+ *   onwards from whatever id it had reached when the fork happened, never from zero, so the inherited cursor is exactly
+ *   where the replay begins. A wallet that rewound to zero would wait on a stretch of the timeline this ledger
+ *   version's events do not occupy.
  *
  *   If the ledger team ships a byte-level translation for wallet local state, it replaces this instance without touching
  *   anything around it — that is the point of the {@link StateMigration} seam.

--- a/packages/dust-wallet/src/v1/Migration.ts
+++ b/packages/dust-wallet/src/v1/Migration.ts
@@ -1,0 +1,150 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { type DustParameters, DustSecretKey } from '@midnight-ntwrk/ledger-v8';
+import { type SyncProgress, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect } from 'effect';
+import { CoreWallet, PublicKey } from './CoreWallet.js';
+import { type NetworkId } from './types/ledger.js';
+import { type WalletError } from './WalletError.js';
+
+/**
+ * How this variant produces its first state from whatever came before it.
+ *
+ * @remarks
+ *   The strategy is injected through the builder rather than hard-coded into the variant, because "whatever came before"
+ *   is not one thing: an empty wallet at first start, a wallet of this same ledger version, or a wallet of the ledger
+ *   version this one replaced. Those are different functions with different input types, and the runtime only ever
+ *   needs one of them per registration — so which one is a build-time decision, expressed as a dictionary in the
+ *   repository's usual dictionary-passing style.
+ * @typeParam TPreviousState The state this migration consumes.
+ */
+export type StateMigration<TPreviousState> = {
+  migrate: (previousState: TPreviousState) => Effect.Effect<CoreWallet, WalletError>;
+};
+
+export type EmptyWalletMigrationConfiguration = {
+  networkId: NetworkId;
+  /**
+   * The dust parameters the fresh state is built on.
+   *
+   * @remarks
+   *   Dust's local state is parameterised where shielded's is not: generation and decay rates live on the state itself,
+   *   so there is no such thing as a parameterless empty dust wallet.
+   */
+  dustParameters: DustParameters;
+};
+
+/**
+ * The migration used when there is no previous wallet at all.
+ *
+ * @remarks
+ *   It backs `WalletLike.startEmpty`, which builds a wallet before any key material exists. The resulting state holds no
+ *   dust and has a public key derived from a fixed placeholder seed; it is a scaffold to be replaced by a real start,
+ *   not a wallet anybody can pay fees with.
+ * @example
+ *   ```typescript
+ *   const builder = new V1Builder().withDefaults().withMigration(makeEmptyWalletMigration({ networkId, dustParameters }));
+ *   ```;
+ *
+ * @param configuration Supplies the network the scaffold state claims to be on, and the dust parameters it uses.
+ * @returns A migration from `null`.
+ */
+export const makeEmptyWalletMigration = (configuration: EmptyWalletMigrationConfiguration): StateMigration<null> => ({
+  migrate: () => {
+    const seed = WalletSeed.fromString('0000000000000000000000000000000000000000000000000000000000000001');
+    return Effect.succeed(
+      CoreWallet.initEmpty(configuration.dustParameters, DustSecretKey.fromSeed(seed), configuration.networkId),
+    );
+  },
+});
+
+/**
+ * The migration between two variants that share this ledger version.
+ *
+ * @remarks
+ *   Both sides speak the same state type, so the carry is the identity: the generation and commitment trees, the dust
+ *   UTXOs and sync progress all remain valid. This is the right strategy for a protocol bump that does not change
+ *   serialization.
+ * @returns A migration from a {@link CoreWallet} of this ledger version.
+ */
+export const makeCarryOverMigration = (): StateMigration<CoreWallet> => ({
+  migrate: (previousState) => Effect.succeed(previousState),
+});
+
+/**
+ * The shape a wallet of the _previous_ ledger version must expose to be projected across a hard fork.
+ *
+ * @remarks
+ *   Structural on purpose. The previous variant's `CoreWallet` is built on a different ledger module, and naming that
+ *   module here would drag a second multi-megabyte WASM binary into this variant for the sake of a type. Everything the
+ *   projection reads is plain data — the dust public key is a `bigint` and the network id a string — so a structural
+ *   description is both sufficient and the only version-agnostic option.
+ *
+ *   `progress` is where the migrated wallet resumes from: the replayed timeline continues the indexer's event ids rather
+ *   than restarting them, so the previous variant's cursor is the position the next one has to start at (see
+ *   {@link makeCrossLedgerMigration}).
+ */
+export type PreviousLedgerWallet = Readonly<{
+  publicKey: { readonly publicKey: bigint };
+  networkId: string;
+  protocolVersion: bigint;
+  progress: SyncProgress.SyncProgressData;
+}>;
+
+export type CrossLedgerMigrationConfiguration = {
+  /**
+   * This ledger version's dust parameters.
+   *
+   * @remarks
+   *   Supplied rather than carried, and this is where dust departs from shielded. `DustLocalState` is parameterised by
+   *   the ledger's dust parameters, and those are a WASM object belonging to whichever ledger module produced them —
+   *   the previous variant's copy cannot be handed to this one, and its values need not even still be current.
+   */
+  dustParameters: DustParameters;
+};
+
+/**
+ * The migration across a ledger-version boundary: a dustless state of this version, carrying identity and position.
+ *
+ * @remarks
+ *   The indexer replays the timeline after the hard fork, re-emitting the wallet's history as events of the new ledger
+ *   version. A migrated wallet therefore does not need — and must not attempt — to carry its dust: exactly the same dust
+ *   is generated again by ordinary sync, from the replayed registration events, and valued against this version's
+ *   parameters. Carrying it across as well would double-count what the replay is about to deliver, on top of requiring
+ *   generation and commitment trees that this ledger's WASM module cannot read.
+ *
+ *   So what crosses is the dust public key, the network, the protocol version that triggered the hand-over, and the
+ *   cursor. Sync progress is **parked at the fork** rather than rewound: the indexer numbers the replayed events onwards
+ *   from whatever id it had reached when the fork happened, never from zero, so the inherited cursor is exactly where
+ *   the replay begins. A wallet that rewound to zero would wait on a stretch of the timeline this ledger version's
+ *   events do not occupy.
+ *
+ *   If the ledger team ships a byte-level translation for wallet local state, it replaces this instance without touching
+ *   anything around it — that is the point of the {@link StateMigration} seam.
+ * @param configuration Supplies this ledger version's dust parameters for the fresh state.
+ * @returns A migration from a previous-ledger-version wallet.
+ */
+export const makeCrossLedgerMigration = (
+  configuration: CrossLedgerMigrationConfiguration,
+): StateMigration<PreviousLedgerWallet> => ({
+  migrate: (previousState) =>
+    Effect.succeed(
+      CoreWallet.fromPreviousVersion({
+        publicKey: { publicKey: previousState.publicKey.publicKey },
+        networkId: previousState.networkId,
+        protocolVersion: previousState.protocolVersion,
+        progress: previousState.progress,
+        dustParameters: configuration.dustParameters,
+      }),
+    ),
+});

--- a/packages/dust-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/dust-wallet/src/v1/RunningV1Variant.ts
@@ -68,8 +68,26 @@ const progress = (state: CoreWallet): StateChange.StateChange<CoreWallet>[] => {
   return [StateChange.ProgressUpdate({ sourceGap, applyGap })];
 };
 
-const protocolVersionChange = (previous: CoreWallet, current: CoreWallet): StateChange.StateChange<CoreWallet>[] => {
-  return previous.protocolVersion != current.protocolVersion
+/**
+ * The version signals this variant puts on its state stream.
+ *
+ * @remarks
+ *   Two of them, for two different situations. A transition is the ordinary one: the state moved to a version the variant
+ *   may or may not own, and the runtime decides. The healing emission covers restore: a snapshot taken between the
+ *   moment sync annotated an out-of-range version and the moment the runtime acted on it comes back with a version this
+ *   variant does not own and no transition to announce it, so it would sit there forever. Announcing it on the first
+ *   observation is what forward-migrates such a snapshot.
+ */
+const protocolVersionChange = (
+  previous: CoreWallet,
+  current: CoreWallet,
+  isInitial: boolean,
+  activationRange: ProtocolVersion.ProtocolVersion.Range,
+): StateChange.StateChange<CoreWallet>[] => {
+  const transitioned = previous.protocolVersion != current.protocolVersion;
+  const strandedOutsideRange = isInitial && !ProtocolVersion.withinRange(current.protocolVersion, activationRange);
+
+  return transitioned || strandedOutsideRange
     ? [
         StateChange.VersionChange({
           change: VersionChangeType.Version({
@@ -127,18 +145,27 @@ export class RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
     this.state = Stream.fromEffect(context.stateRef.get).pipe(
       Stream.flatMap((initialState) =>
         context.stateRef.changes.pipe(
-          Stream.mapAccum(initialState, (previous: CoreWallet, current: CoreWallet) => {
-            return [current, [previous, current]] as const;
-          }),
+          // The accumulator carries the "have we seen anything yet" flag alongside the previous state: the first
+          // observation is the only one that can be a restored state nobody has inspected against this variant's
+          // range yet, and `SubscriptionRef.changes` replays the current value, so it is exactly this element.
+          Stream.mapAccum(
+            { previous: initialState, isInitial: true },
+            (seen, current: CoreWallet) =>
+              [{ previous: current, isInitial: false }, [seen.previous, current, seen.isInitial] as const] as const,
+          ),
         ),
       ),
       Stream.mapConcat(
-        ([previous, current]: readonly [CoreWallet, CoreWallet]): StateChange.StateChange<CoreWallet>[] => {
+        ([previous, current, isInitial]: readonly [
+          CoreWallet,
+          CoreWallet,
+          boolean,
+        ]): StateChange.StateChange<CoreWallet>[] => {
           // TODO: emit progress only upon actual change
           return [
             StateChange.State({ state: current }),
             ...progress(current),
-            ...protocolVersionChange(previous, current),
+            ...protocolVersionChange(previous, current, isInitial, context.activationRange),
           ];
         },
       ),
@@ -197,7 +224,11 @@ export class RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
             SubscriptionRef.modifyEffect(this.#context.stateRef, (state) =>
               Effect.try({
                 try: () => {
-                  const [newState, changesResult] = this.#v1Context.syncCapability.applyUpdate(state, update);
+                  const [newState, changesResult] = this.#v1Context.syncCapability.applyUpdate(
+                    state,
+                    update,
+                    this.#context.activationRange,
+                  );
                   return [changesResult, newState] as const;
                 },
                 catch: (err) =>

--- a/packages/dust-wallet/src/v1/Sync.ts
+++ b/packages/dust-wallet/src/v1/Sync.ts
@@ -128,8 +128,7 @@ export const splitAtVersionBoundary = <T>(
     boundary < 0 ? [items, [] as readonly T[]] : [items.slice(0, boundary), items.slice(boundary)];
   // The first deferred item is the hand-over signal. Failing that, the last applied item that actually reported a
   // version — searching backwards so a trailing untagged item does not erase an earlier tagged one.
-  const signalling =
-    deferred.at(0) ?? [...applied].reverse().find((item) => versionOf(item) !== undefined);
+  const signalling = deferred.at(0) ?? [...applied].reverse().find((item) => versionOf(item) !== undefined);
   const signalledVersion = signalling === undefined ? undefined : versionOf(signalling);
 
   return {
@@ -151,7 +150,6 @@ export const annotateVersion = (
     onNone: () => state,
     onSome: (version) => CoreWallet.withProtocolVersion(state, version),
   });
-
 
 export type IndexerClientConnection = {
   indexerHttpUrl: string;

--- a/packages/dust-wallet/src/v1/Sync.ts
+++ b/packages/dust-wallet/src/v1/Sync.ts
@@ -22,7 +22,9 @@ import {
   Duration,
   Chunk,
   Schedule,
+  Option,
 } from 'effect';
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import {
   type DustSecretKey,
   type DustStateChanges,
@@ -64,8 +66,92 @@ export type ChangesResult = {
 };
 
 export interface SyncCapability<TState, TUpdate, TResult> {
-  applyUpdate: (state: TState, update: TUpdate) => [TState, TResult];
+  /**
+   * Folds a sync update into the wallet state.
+   *
+   * @param state The state to fold into.
+   * @param update The update to apply.
+   * @param activeRange The half-open protocol version range the running variant owns. Anything the source reports at or
+   *   beyond its end belongs to a later variant and must be left unapplied for that variant to fetch.
+   */
+  applyUpdate: (
+    state: TState,
+    update: TUpdate,
+    activeRange: ProtocolVersion.ProtocolVersion.Range,
+  ) => [TState, TResult];
 }
+
+/** The result of splitting a batch of version-tagged items at a variant's activation boundary. */
+export type BoundarySplit<T> = {
+  /** The leading items this variant owns, in source order. */
+  readonly applied: readonly T[];
+  /** The trailing items belonging to a later protocol version, left for the next variant to re-fetch. */
+  readonly deferred: readonly T[];
+  /**
+   * The protocol version to record on the state: the first deferred item's version when there is one — that is the
+   * signal that triggers migration — otherwise the last version any applied item reported. `None` when the batch was
+   * empty, and also when nothing in it reported a version at all.
+   */
+  readonly observedVersion: Option.Option<ProtocolVersion.ProtocolVersion>;
+};
+
+/**
+ * Splits a batch of version-tagged items at the end of a variant's activation range.
+ *
+ * @remarks
+ *   The split is positional, not a filter: everything from the first out-of-range item onwards is deferred, even if a
+ *   later item reports an in-range version again. A batch is a contiguous slice of one timeline, so applying past a
+ *   boundary and then resuming behind it would leave a hole no cursor can describe.
+ *
+ *   An item whose version is `undefined` is treated as in-range and contributes no annotation. Dust's subscription does
+ *   not report `protocolVersion` yet, so an absent value means "the indexer did not say" — which must keep today's
+ *   behaviour exactly, rather than being read as version zero and dragging the recorded version down.
+ *
+ *   This is the one place the boundary rule lives; the indexer capability (per event) and the simulator capability (per
+ *   block) both go through it, so they cannot drift apart.
+ * @param items The batch, in source order.
+ * @param versionOf Reads the protocol version an item was reported at, or `undefined` if it carries none.
+ * @param activeRange The variant's half-open activation range.
+ * @returns The applied/deferred split and the version to record.
+ */
+export const splitAtVersionBoundary = <T>(
+  items: readonly T[],
+  versionOf: (item: T) => number | undefined,
+  activeRange: ProtocolVersion.ProtocolVersion.Range,
+): BoundarySplit<T> => {
+  const [, end] = activeRange;
+  const boundary = items.findIndex((item) => {
+    const version = versionOf(item);
+    return version !== undefined && BigInt(version) >= end;
+  });
+  const [applied, deferred] =
+    boundary < 0 ? [items, [] as readonly T[]] : [items.slice(0, boundary), items.slice(boundary)];
+  // The first deferred item is the hand-over signal. Failing that, the last applied item that actually reported a
+  // version — searching backwards so a trailing untagged item does not erase an earlier tagged one.
+  const signalling =
+    deferred.at(0) ?? [...applied].reverse().find((item) => versionOf(item) !== undefined);
+  const signalledVersion = signalling === undefined ? undefined : versionOf(signalling);
+
+  return {
+    applied,
+    deferred,
+    observedVersion:
+      signalledVersion === undefined
+        ? Option.none()
+        : Option.some(ProtocolVersion.ProtocolVersion(BigInt(signalledVersion))),
+  };
+};
+
+/** Records a batch's observed protocol version on the state, monotonically. A batch that observed none is a no-op. */
+export const annotateVersion = (
+  state: CoreWallet,
+  observedVersion: Option.Option<ProtocolVersion.ProtocolVersion>,
+): CoreWallet =>
+  Option.match(observedVersion, {
+    onNone: () => state,
+    onSome: (version) => CoreWallet.withProtocolVersion(state, version),
+  });
+
 
 export type IndexerClientConnection = {
   indexerHttpUrl: string;
@@ -157,6 +243,17 @@ export const SyncEventsUpdateSchema = Schema.Struct({
   id: Schema.Number,
   raw: HexedEvent,
   maxId: Schema.Number,
+  /**
+   * The protocol version the indexer reported this event under, when it reports one at all.
+   *
+   * @remarks
+   *   Optional because dust's subscription does not select the field yet — the schema defines it on `DustLedgerEvent`,
+   *   but adding the selection-set line waits on confirmation from a deployed indexer. Until then every item arrives
+   *   without it, and an absent value means "the indexer did not say", which is treated as in-range: the event applies
+   *   normally and the wallet's recorded version is left alone. Reading it as zero instead would drag the recorded
+   *   version down and, on a wallet already past the boundary, look like a migration backwards.
+   */
+  protocolVersion: Schema.optional(Schema.Number),
 });
 
 export type WalletSyncSubscription = Schema.Schema.Type<typeof SyncEventsUpdateSchema>;
@@ -314,7 +411,11 @@ export const makeIndexerSyncService = (config: DefaultSyncConfiguration): Indexe
 
 export const makeDefaultSyncCapability = (): SyncCapability<CoreWallet, WalletSyncUpdate, ChangesResult> => {
   return {
-    applyUpdate(state: CoreWallet, wrappedUpdate: WalletSyncUpdate): [CoreWallet, ChangesResult] {
+    applyUpdate(
+      state: CoreWallet,
+      wrappedUpdate: WalletSyncUpdate,
+      activeRange: ProtocolVersion.ProtocolVersion.Range,
+    ): [CoreWallet, ChangesResult] {
       const { updates, secretKey } = wrappedUpdate;
 
       // Nothing to update yet
@@ -325,25 +426,45 @@ export const makeDefaultSyncCapability = (): SyncCapability<CoreWallet, WalletSy
       const appliedIndex = state.progress.appliedIndex;
       const freshUpdates = updates.filter((u) => BigInt(u.id) > appliedIndex);
 
+      // The tip is a property of the source, not of what this variant chose to apply, so it is read from the batch
+      // tail even when the tail belongs to the next protocol version.
       const highestRelevantWalletIndex = BigInt(updates.at(-1)!.maxId);
 
+      const { applied, observedVersion } = splitAtVersionBoundary(
+        freshUpdates,
+        (update) => update.protocolVersion,
+        activeRange,
+      );
+
       const [newState, changes]: [CoreWallet, DustStateChanges[]] =
-        freshUpdates.length === 0
+        applied.length === 0
           ? [state, []]
           : CoreWallet.applyEventsWithChanges(
               state,
               secretKey,
-              freshUpdates.map((u) => u.raw),
+              applied.map((u) => u.raw),
               wrappedUpdate.timestamp,
             );
 
-      const updatedState = CoreWallet.updateProgress(newState, {
-        appliedIndex: freshUpdates.length === 0 ? appliedIndex : BigInt(freshUpdates.at(-1)!.id),
+      // `appliedIndex` stops at the last event this variant actually replayed. The next variant resumes one below it
+      // on an inclusive cursor, so the deferred suffix is re-fetched rather than skipped.
+      const updatedState = CoreWallet.updateProgress(annotateVersion(newState, observedVersion), {
+        appliedIndex: applied.length === 0 ? appliedIndex : BigInt(applied.at(-1)!.id),
         highestRelevantWalletIndex,
         isConnected: true,
       });
 
-      return [updatedState, { changes, protocolVersion: Number(updatedState.protocolVersion) }];
+      return [
+        updatedState,
+        {
+          changes,
+          // Tags the changes that were actually produced, so tx-history records the version they were applied under
+          // rather than the one that is about to trigger the hand-over.
+          protocolVersion:
+            [...applied].reverse().find((u) => u.protocolVersion !== undefined)?.protocolVersion ??
+            Number(state.protocolVersion),
+        },
+      ];
     },
   };
 };
@@ -397,27 +518,50 @@ export const makeSimulatorSyncService = (
 
 export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, SimulatorSyncUpdate, ChangesResult> => {
   return {
-    applyUpdate: (state: CoreWallet, update: SimulatorSyncUpdate): [CoreWallet, ChangesResult] => {
+    applyUpdate: (
+      state: CoreWallet,
+      update: SimulatorSyncUpdate,
+      activeRange: ProtocolVersion.ProtocolVersion.Range,
+    ): [CoreWallet, ChangesResult] => {
       const lastBlock = V8.getLastBlock(update.update);
       // If no block exists yet (blank simulator), skip update
       if (lastBlock === undefined) {
         return [state, { changes: [], protocolVersion: Number(state.protocolVersion) }];
       }
-      // Get all events from blocks starting at appliedIndex (the next block to process).
+
       // appliedIndex semantics: the first block number we haven't processed yet.
       // Initial: appliedIndex = 0 (haven't processed any blocks)
       // After processing block N: appliedIndex = N + 1 (next block to process)
-      const events = [...V8.getBlockEventsFrom(update.update, state.progress.appliedIndex)];
-      const [newState, changes] = CoreWallet.applyEventsWithChanges(
-        state,
-        update.secretKey,
-        events,
-        lastBlock.timestamp,
+      //
+      // The boundary is applied at block granularity here — a block carries exactly one protocol version, stamped when
+      // it was produced — but it is the same rule and the same helper the indexer path uses. Blocks are walked
+      // individually rather than through `getBlockEventsFrom` so that the split has something to cut.
+      const pending = update.update.blocks.filter((block) => block.number >= state.progress.appliedIndex);
+      const { applied, observedVersion } = splitAtVersionBoundary(
+        pending,
+        (block) => Number(block.protocolVersion),
+        activeRange,
       );
-      const updatedState = CoreWallet.updateProgress(newState, {
-        appliedIndex: lastBlock.number + 1n,
+
+      const events = applied.flatMap((block) => block.transactions.flatMap((tx) => tx.result.events));
+      const lastAppliedBlock = applied.at(-1);
+
+      const [newState, changes] =
+        applied.length === 0
+          ? [state, []]
+          : CoreWallet.applyEventsWithChanges(state, update.secretKey, events, lastAppliedBlock!.timestamp);
+
+      const updatedState = CoreWallet.updateProgress(annotateVersion(newState, observedVersion), {
+        appliedIndex: lastAppliedBlock === undefined ? state.progress.appliedIndex : lastAppliedBlock.number + 1n,
       });
-      return [updatedState, { changes, protocolVersion: Number(updatedState.protocolVersion) }];
+      return [
+        updatedState,
+        {
+          changes,
+          protocolVersion:
+            lastAppliedBlock === undefined ? Number(state.protocolVersion) : Number(lastAppliedBlock.protocolVersion),
+        },
+      ];
     },
   };
 };

--- a/packages/dust-wallet/src/v1/V1Builder.ts
+++ b/packages/dust-wallet/src/v1/V1Builder.ts
@@ -12,13 +12,15 @@
 // limitations under the License.
 import { Effect, Scope, type Types, type Either } from 'effect';
 import { type Expect, type ItemType } from '@midnightntwrk/wallet-sdk-utilities/types';
-import { type DustSecretKey, type FinalizedTransaction } from '@midnight-ntwrk/ledger-v8';
 import {
-  type WalletRuntimeError,
-  type VariantBuilder,
-  type Variant,
-} from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+  type DustParameters,
+  type DustSecretKey,
+  type FinalizedTransaction,
+  LedgerParameters,
+} from '@midnight-ntwrk/ledger-v8';
+import { WalletRuntimeError, type VariantBuilder, type Variant } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type WalletError } from './WalletError.js';
+import { type EmptyWalletMigrationConfiguration, type StateMigration, makeEmptyWalletMigration } from './Migration.js';
 import {
   type SyncService,
   type SyncCapability,
@@ -56,9 +58,34 @@ import { type TotalCostParameters } from './types/transaction.js';
 export type BaseV1Configuration = {
   networkId: NetworkId;
   costParameters: TotalCostParameters;
+  /**
+   * The dust parameters a state built from nothing is valued against.
+   *
+   * @remarks
+   *   Consulted by the migration seam alone — nothing else in the variant reads it. It exists because dust's local state
+   *   is parameterised where shielded's is not: generation and decay rates live on the state, so an empty dust wallet
+   *   cannot be built without a set of them. Optional, and defaulting to `LedgerParameters.initialParameters().dust`,
+   *   because it is the empty-wallet fallback that needs it, and that fallback is what every builder written before
+   *   migrations were configurable silently relies on. A variant registered as the target of a real fork does not use
+   *   this field at all: {@link makeCrossLedgerMigration} carries its own, required, parameters.
+   */
+  dustParameters?: DustParameters;
 };
 
 export type DefaultV1Configuration = BaseV1Configuration & DefaultTransactionHistoryConfiguration;
+
+/**
+ * Completes a builder configuration into the one the empty-wallet migration asks for.
+ *
+ * @remarks
+ *   The dust parameters are optional on the builder and required on the migration, and this is the single place that gap
+ *   is closed, so the fallback the unconfigured `build` takes and the one {@link V1Builder.withMigrationDefaults} states
+ *   explicitly cannot drift apart.
+ */
+const emptyWalletMigrationConfiguration = (configuration: BaseV1Configuration): EmptyWalletMigrationConfiguration => ({
+  networkId: configuration.networkId,
+  dustParameters: configuration.dustParameters ?? LedgerParameters.initialParameters().dust,
+});
 
 const V1BuilderSymbol: {
   readonly typeId: unique symbol;
@@ -68,10 +95,10 @@ const V1BuilderSymbol: {
 
 export type DefaultV1Variant = V1Variant<string, WalletSyncUpdate, FinalizedTransaction, DustSecretKey>;
 
-export type V1Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData> = Variant.Variant<
+export type V1Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData, TPreviousState = null> = Variant.Variant<
   typeof V1Tag,
   CoreWallet,
-  CoreWallet, // null,
+  TPreviousState,
   RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData>
 > & {
   deserializeState: (serialized: TSerialized) => Either.Either<CoreWallet, WalletError>;
@@ -81,12 +108,14 @@ export type V1Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData> = Varian
   transactionHistory: TransactionHistoryService;
 };
 
-export type DefaultV1Builder = V1Builder<
+export type DefaultV1Builder<TPreviousState = null> = V1Builder<
   DefaultV1Configuration,
   RunningV1Variant.Context<string, WalletSyncUpdate, FinalizedTransaction, DustSecretKey>,
   string,
   WalletSyncUpdate,
-  FinalizedTransaction
+  FinalizedTransaction,
+  object,
+  TPreviousState
 >;
 
 export class V1Builder<
@@ -96,28 +125,66 @@ export class V1Builder<
   TSyncUpdate = never,
   TTransaction = never,
   TStartAux extends object = object,
-> implements VariantBuilder.VariantBuilder<V1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>, TConfig> {
-  #buildState: V1Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux>;
+  TPreviousState = null,
+> implements VariantBuilder.VariantBuilder<
+  V1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState>,
+  TConfig
+> {
+  #buildState: V1Builder.PartialBuildState<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  >;
 
   constructor(
-    buildState: V1Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> = {},
+    buildState: V1Builder.PartialBuildState<
+      TConfig,
+      TContext,
+      TSerialized,
+      TSyncUpdate,
+      TTransaction,
+      TStartAux,
+      TPreviousState
+    > = {},
   ) {
     this.#buildState = buildState;
   }
 
-  withDefaults(): DefaultV1Builder {
-    return this.withDefaultTransactionType()
-      .withSyncDefaults()
-      .withSerializationDefaults()
-      .withTransactingDefaults()
-      .withCoinsAndBalancesDefaults()
-      .withTransactionHistoryDefaults()
-      .withKeysDefaults()
-      .withCoinSelectionDefaults() as DefaultV1Builder;
+  withDefaults(
+    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, null>,
+  ): DefaultV1Builder {
+    return (
+      this.withDefaultTransactionType()
+        .withSyncDefaults()
+        .withSerializationDefaults()
+        .withTransactingDefaults()
+        .withCoinsAndBalancesDefaults()
+        .withTransactionHistoryDefaults()
+        .withKeysDefaults()
+        // Type cast required because: the chain accumulates `TConfig` and `TContext` as intersections of the
+        // individual `Default*` fragments, which are structurally weaker than the complete `DefaultV1Configuration`
+        // and `RunningV1Variant.Context` that `DefaultV1Builder` names — the defaults do produce both in full, but the
+        // chain's type cannot express that. The widening itself predates the migration seam; it has to route through
+        // `unknown` only since `BaseV1Configuration` gained the optional `dustParameters`, which is what puts the two
+        // sides past what TypeScript will accept as directly comparable.
+        .withCoinSelectionDefaults() as unknown as DefaultV1Builder
+    );
   }
 
-  withTransactionType<Transaction>(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, Transaction, TStartAux> {
-    return new V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, Transaction, TStartAux>({
+  withTransactionType<Transaction>(): V1Builder<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    Transaction,
+    TStartAux,
+    TPreviousState
+  > {
+    return new V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, Transaction, TStartAux, TPreviousState>({
       ...this.#buildState,
       transactingCapability: undefined,
     });
@@ -129,7 +196,8 @@ export class V1Builder<
     TSerialized,
     TSyncUpdate,
     FinalizedTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return this.withTransactionType<FinalizedTransaction>();
   }
@@ -140,7 +208,8 @@ export class V1Builder<
     TSerialized,
     WalletSyncUpdate,
     TTransaction,
-    DustSecretKey
+    DustSecretKey,
+    TPreviousState
   > {
     return this.withSync(makeDefaultSyncService, makeDefaultSyncCapability);
   }
@@ -159,14 +228,23 @@ export class V1Builder<
       configuration: TSyncConfig,
       getContext: () => TSyncContext,
     ) => SyncCapability<CoreWallet, TSyncUpdate, ChangesResult>,
-  ): V1Builder<TConfig & TSyncConfig, TContext & TSyncContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  ): V1Builder<
+    TConfig & TSyncConfig,
+    TContext & TSyncContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return new V1Builder<
       TConfig & TSyncConfig,
       TContext & TSyncContext,
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       syncService,
@@ -174,7 +252,15 @@ export class V1Builder<
     });
   }
 
-  withSerializationDefaults(): V1Builder<TConfig, TContext, string, TSyncUpdate, TTransaction, TStartAux> {
+  withSerializationDefaults(): V1Builder<
+    TConfig,
+    TContext,
+    string,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return this.withSerialization(makeDefaultV1SerializationCapability);
   }
 
@@ -193,7 +279,8 @@ export class V1Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V1Builder<
       TConfig & TSerializationConfig,
@@ -201,7 +288,8 @@ export class V1Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       serializationCapability,
@@ -209,14 +297,15 @@ export class V1Builder<
   }
 
   withTransactingDefaults(
-    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, FinalizedTransaction, TStartAux>,
+    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, FinalizedTransaction, TStartAux, TPreviousState>,
   ): V1Builder<
     TConfig & DefaultTransactingConfiguration,
     TContext & DefaultTransactingContext,
     TSerialized,
     TSyncUpdate,
     FinalizedTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return this.withTransacting(makeDefaultTransactingCapability);
   }
@@ -232,7 +321,8 @@ export class V1Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V1Builder<
       TConfig & TTransactingConfig,
@@ -240,7 +330,8 @@ export class V1Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       transactingCapability,
@@ -255,7 +346,8 @@ export class V1Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V1Builder<
       TConfig & TCoinSelectionConfig,
@@ -263,14 +355,23 @@ export class V1Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       coinSelection,
     });
   }
 
-  withCoinSelectionDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  withCoinSelectionDefaults(): V1Builder<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return this.withCoinSelection(() => chooseCoin);
   }
 
@@ -280,7 +381,8 @@ export class V1Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return this.withCoinsAndBalances(makeDefaultCoinsAndBalancesCapability);
   }
@@ -296,7 +398,8 @@ export class V1Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V1Builder<
       TConfig & TBalancesConfig,
@@ -304,7 +407,8 @@ export class V1Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       coinsAndBalancesCapability,
@@ -312,14 +416,15 @@ export class V1Builder<
   }
 
   withTransactionHistoryDefaults(
-    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, FinalizedTransaction, TStartAux>,
+    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, FinalizedTransaction, TStartAux, TPreviousState>,
   ): V1Builder<
     TConfig & DefaultTransactionHistoryConfiguration,
     TContext,
     TSerialized,
     TSyncUpdate,
     FinalizedTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return this.withTransactionHistory(makeDefaultTransactionHistoryService);
   }
@@ -338,7 +443,8 @@ export class V1Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V1Builder<
       TConfig & TTransactionHistoryConfig,
@@ -346,30 +452,114 @@ export class V1Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       transactionHistoryService,
     });
   }
 
-  withKeysDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  withKeysDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState> {
     return this.withKeys(makeDefaultKeysCapability);
   }
 
   withKeys<TKeysConfig, TKeysContext extends Partial<RunningV1Variant.AnyContext>>(
     keysCapability: (configuration: TKeysConfig, getContext: () => TKeysContext) => KeysCapability<CoreWallet>,
-  ): V1Builder<TConfig & TKeysConfig, TContext & TKeysContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  ): V1Builder<
+    TConfig & TKeysConfig,
+    TContext & TKeysContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return new V1Builder<
       TConfig & TKeysConfig,
       TContext & TKeysContext,
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       keysCapability,
+    });
+  }
+
+  /**
+   * Uses the default migration: an empty wallet built from nothing.
+   *
+   * @remarks
+   *   This is what an unconfigured builder already does, so calling it changes no behaviour — it states the choice rather
+   *   than inheriting it. Registering this variant as the target of a real fork means calling
+   *   {@link V1Builder.withMigration} with {@link makeCrossLedgerMigration} instead.
+   *
+   *   The parameters the empty dust state is valued against come from the builder configuration when it names them, and
+   *   from the ledger's initial parameters when it does not.
+   */
+  withMigrationDefaults(
+    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, null>,
+  ): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, null> {
+    return this.withMigration((configuration: BaseV1Configuration) =>
+      makeEmptyWalletMigration(emptyWalletMigrationConfiguration(configuration)),
+    );
+  }
+
+  /**
+   * Chooses how this variant produces its first state from the state that preceded it.
+   *
+   * @remarks
+   *   The strategy's input type becomes the variant's `TPreviousState`, which is what the runtime type-checks a
+   *   registration against: a variant declaring it migrates from a ledger-v8 dust wallet cannot be registered after one
+   *   that produces something else.
+   *
+   *   The context the factory reads is a type parameter of the method, exactly as it is for every other capability here,
+   *   rather than the builder's own `TContext`. Naming `TContext` in an argument position would make the builder
+   *   invariant in it, and a chain that has not yet configured every capability — which is how the simulator-backed
+   *   variants are assembled — could then no longer be handed to {@link V1Builder.build}.
+   * @example
+   *   ```typescript
+   *   const forkTarget = new V1Builder().withDefaults().withMigration(makeCrossLedgerMigration);
+   *   ```;
+   *
+   * @param migration Builds the migration from the configuration and the sibling capabilities.
+   */
+  withMigration<TMigrationConfig, TMigrationContext extends Partial<RunningV1Variant.AnyContext>, TPrevious>(
+    migration: (configuration: TMigrationConfig, getContext: () => TMigrationContext) => StateMigration<TPrevious>,
+  ): V1Builder<
+    TConfig & TMigrationConfig,
+    TContext & TMigrationContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPrevious
+  > {
+    const capabilities: V1Builder.CapabilityBuildState<
+      TConfig & TMigrationConfig,
+      TContext & TMigrationContext,
+      TSerialized,
+      TSyncUpdate,
+      TTransaction,
+      TStartAux
+    > = this.#buildState;
+
+    return new V1Builder<
+      TConfig & TMigrationConfig,
+      TContext & TMigrationContext,
+      TSerialized,
+      TSyncUpdate,
+      TTransaction,
+      TStartAux,
+      TPrevious
+    >({
+      // Only the capability half crosses: the strategy being replaced is typed against the *old* previous-state
+      // parameter, so it cannot ride along even though it is about to be overwritten.
+      ...capabilities,
+      migration,
     });
   }
 
@@ -380,11 +570,14 @@ export class V1Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >,
     configuration: TConfig,
-  ): V1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  ): V1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState> {
     const v1Context = this.#buildContextFromBuildState(configuration);
+    const migration = this.#resolveMigration(configuration, () => v1Context);
+
     return {
       __polyTag__: V1Tag,
       coinsAndBalances: v1Context.coinsAndBalancesCapability,
@@ -403,14 +596,41 @@ export class V1Builder<
           return new RunningV1Variant(scope, context, v1Context);
         });
       },
-      migrateState(prevState) {
-        // TODO: re-implement
-        return Effect.succeed(prevState);
-      },
+      // An unconfigured builder produces an empty wallet, which is what `startEmpty` asks of a first variant — the stub
+      // this replaces handed its own argument back, so it could only ever have returned `null`. Anything else —
+      // carrying dust within a ledger version, or projecting a wallet's identity across one — is the injected
+      // strategy's business, and its failures are reported on the runtime's state stream rather than thrown.
+      migrateState: (previousState: TPreviousState) =>
+        migration.migrate(previousState).pipe(
+          Effect.mapError(
+            (error) =>
+              new WalletRuntimeError({
+                message: 'Failed to migrate dust wallet state into this variant',
+                cause: error,
+              }),
+          ),
+        ),
+
       deserializeState: (serialized: TSerialized): Either.Either<CoreWallet, WalletError> => {
         return v1Context.serializationCapability.deserialize(null, serialized);
       },
     };
+  }
+
+  /**
+   * Resolves the configured migration, or the empty-wallet fallback when none was configured.
+   *
+   * @remarks
+   *   The fallback is written as a nullary function on purpose. It ignores whatever preceded it — it builds an empty
+   *   wallet from nothing — which makes it a valid migration from _any_ previous state, but a `StateMigration<null>`
+   *   value could only be widened to `StateMigration<TPreviousState>` through a cast. Declaring no parameter says the
+   *   same thing to the type system without one.
+   */
+  #resolveMigration(configuration: TConfig, getContext: () => TContext): StateMigration<TPreviousState> {
+    const configured = this.#buildState.migration;
+    return configured === undefined
+      ? { migrate: () => makeEmptyWalletMigration(emptyWalletMigrationConfiguration(configuration)).migrate(null) }
+      : configured(configuration, getContext);
   }
 
   #buildContextFromBuildState(
@@ -420,7 +640,8 @@ export class V1Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >,
     configuration: TConfig,
   ): RunningV1Variant.Context<TSerialized, TSyncUpdate, TTransaction, TStartAux> {
@@ -515,7 +736,17 @@ declare namespace V1Builder {
       HasKeys<TConfig, TContext> &
       HasTransactionHistory<TConfig, TContext>
   >;
-  type PartialBuildState<
+  /**
+   * The migration entry, kept out of {@link FullBuildState} on purpose: absent means "empty wallet", which is the
+   * behaviour every builder had before migrations were configurable, so a builder that never mentions migration must
+   * still be considered complete.
+   */
+  type HasMigration<TConfig, TContext, TPreviousState> = {
+    readonly migration: (configuration: TConfig, getContext: () => TContext) => StateMigration<TPreviousState>;
+  };
+
+  /** The capability half of the build state — everything that does not depend on the previous-state parameter. */
+  type CapabilityBuildState<
     TConfig = object,
     TContext = object,
     TSerialized = never,
@@ -527,6 +758,21 @@ declare namespace V1Builder {
       FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux>[K] | undefined;
   };
 
+  type PartialBuildState<
+    TConfig = object,
+    TContext = object,
+    TSerialized = never,
+    TSyncUpdate = never,
+    TTransaction = never,
+    TStartAux = object,
+    TPreviousState = null,
+  > = {
+    [K in keyof (FullBuildState<never, never, never, never, never, never> & HasMigration<never, never, never>)]?:
+      | (FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> &
+          HasMigration<TConfig, TContext, TPreviousState>)[K]
+      | undefined;
+  };
+
   /** Utility interface that manages the type variance of {@link V1Builder}. */
   interface Variance<R> {
     readonly [V1BuilderSymbol.typeId]: {
@@ -535,8 +781,16 @@ declare namespace V1Builder {
   }
 }
 
-const isBuildStateFull = <TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux>(
-  buildState: V1Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux>,
+const isBuildStateFull = <TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState>(
+  buildState: V1Builder.PartialBuildState<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  >,
 ): buildState is V1Builder.FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> => {
   const allBuildStateKeys = [
     'syncService',

--- a/packages/dust-wallet/src/v1/index.ts
+++ b/packages/dust-wallet/src/v1/index.ts
@@ -13,6 +13,7 @@
 export * from './CoreWallet.js';
 export * from '../DustWallet.js';
 export * as Keys from './Keys.js';
+export * as Migration from './Migration.js';
 export { V8 as Simulator } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 export * as SyncService from './Sync.js';
 export * as Transacting from './Transacting.js';

--- a/packages/dust-wallet/src/v1/test/dustEvents.ts
+++ b/packages/dust-wallet/src/v1/test/dustEvents.ts
@@ -23,7 +23,11 @@ import {
   signData,
   signatureVerifyingKey,
 } from '@midnight-ntwrk/ledger-v8';
-import { InMemoryTransactionHistoryStorage, type NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  InMemoryTransactionHistoryStorage,
+  type NetworkId,
+  ProtocolVersion,
+} from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustAddress } from '@midnightntwrk/wallet-sdk-address-format';
 import { V8 } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import { HDWallet, Roles } from '@midnightntwrk/wallet-sdk-hd';
@@ -38,12 +42,12 @@ import { V1Builder } from '../V1Builder.js';
 
 const NIGHT_TOKEN_TYPE = nativeToken().raw;
 const SEED = '0000000000000000000000000000000000000000000000000000000000000001';
-const NETWORK: NetworkId.NetworkId = 'undeployed' as NetworkId.NetworkId;
+const NETWORK: NetworkId.NetworkId = 'undeployed';
 
 /**
  * How many Night UTXOs are rewarded, and therefore how many dust events the fixture produces.
  *
- * One reward per block, then one *separate* registration transaction per Night UTXO, so every registration block
+ * One reward per block, then one _separate_ registration transaction per Night UTXO, so every registration block
  * carries exactly one `dustInitialUtxo` event. Registering several UTXOs in a single transaction does not work for this
  * purpose: the registration splits them across the guaranteed and fallible sections and only some of them produce an
  * event, so the event count stops tracking the input count.
@@ -117,7 +121,8 @@ export type DustChain = {
  *
  *   Each call builds a fresh chain. The simulator's blocks hold the only live `Event` instances, and replaying them
  *   consumes them, so a state cannot be shared between two tests that both apply it.
- * @param protocolVersion The version every block of this chain is stamped with. Defaults to the simulator's own default.
+ * @param protocolVersion The version every block of this chain is stamped with. Defaults to the simulator's own
+ *   default.
  */
 export const buildDustChain = (protocolVersion?: ProtocolVersion.ProtocolVersion): Promise<DustChain> =>
   Effect.gen(function* () {

--- a/packages/dust-wallet/src/v1/test/dustEvents.ts
+++ b/packages/dust-wallet/src/v1/test/dustEvents.ts
@@ -1,0 +1,199 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import {
+  type DustParameters,
+  DustSecretKey,
+  Event,
+  LedgerParameters,
+  type ProofErasedTransaction,
+  type SignatureVerifyingKey,
+  type UserAddress,
+  addressFromKey,
+  nativeToken,
+  signData,
+  signatureVerifyingKey,
+} from '@midnight-ntwrk/ledger-v8';
+import { InMemoryTransactionHistoryStorage, type NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { DustAddress } from '@midnightntwrk/wallet-sdk-address-format';
+import { V8 } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { HDWallet, Roles } from '@midnightntwrk/wallet-sdk-hd';
+import { DateOps } from '@midnightntwrk/wallet-sdk-utilities';
+import { Effect, Stream, SubscriptionRef } from 'effect';
+import { CoreWallet } from '../CoreWallet.js';
+import { makeSimulatorSyncCapability, makeSimulatorSyncService } from '../Sync.js';
+import { DustTransactionHistoryEntrySchema, makeSimulatorTransactionHistoryService } from '../TransactionHistory.js';
+import * as Transacting from '../Transacting.js';
+import { type UtxoWithMeta } from '../types/Dust.js';
+import { V1Builder } from '../V1Builder.js';
+
+const NIGHT_TOKEN_TYPE = nativeToken().raw;
+const SEED = '0000000000000000000000000000000000000000000000000000000000000001';
+const NETWORK: NetworkId.NetworkId = 'undeployed' as NetworkId.NetworkId;
+
+/**
+ * How many Night UTXOs are rewarded, and therefore how many dust events the fixture produces.
+ *
+ * One reward per block, then one *separate* registration transaction per Night UTXO, so every registration block
+ * carries exactly one `dustInitialUtxo` event. Registering several UTXOs in a single transaction does not work for this
+ * purpose: the registration splits them across the guaranteed and fallible sections and only some of them produce an
+ * event, so the event count stops tracking the input count.
+ */
+export const DUST_EVENT_COUNT = 4;
+
+/** The dust HD key for {@link SEED} — the same derivation the wallet itself uses. */
+const dustSeed = (): Uint8Array => {
+  const result = HDWallet.fromSeed(Buffer.from(SEED, 'hex'));
+  const { hdWallet } = result as { type: 'seedOk'; hdWallet: HDWallet };
+  const derived = hdWallet.selectAccount(0).selectRole(Roles.Dust).deriveKeyAt(0);
+  if (derived.type === 'keyOutOfBounds') {
+    throw new Error('Key derivation out of bounds');
+  }
+  return derived.key;
+};
+
+/**
+ * A minimal unshielded keystore over the dust seed.
+ *
+ * @remarks
+ *   Local rather than imported from the package's `test/` directory: that copy speaks ledger-v9's tagged signing keys,
+ *   while this tree needs ledger-v8's plain hex-string form of the same thing.
+ */
+const keystoreOf = (seed: Uint8Array) => {
+  const signingKey = Buffer.from(seed).toString('hex');
+  const publicKey = (): SignatureVerifyingKey => signatureVerifyingKey(signingKey);
+  return {
+    publicKey,
+    address: (): UserAddress => addressFromKey(publicKey()),
+    sign: (data: Uint8Array) => signData(signingKey, data),
+  };
+};
+
+const nightWithMeta = (state: V8.SimulatorState, address: UserAddress): UtxoWithMeta[] =>
+  [...state.ledger.utxo.filter(address)]
+    .filter((utxo) => utxo.type === NIGHT_TOKEN_TYPE)
+    .flatMap((utxo) => {
+      const meta = state.ledger.utxo.lookupMeta(utxo);
+      return meta === undefined ? [] : [{ ...utxo, ctime: meta.ctime, registeredForDustGeneration: false }];
+    });
+
+export const dustParameters = (): DustParameters => LedgerParameters.initialParameters().dust;
+
+export const fixtureSecretKey = (): DustSecretKey => DustSecretKey.fromSeed(Buffer.from(dustSeed()));
+
+export const freshWallet = (): CoreWallet => CoreWallet.initEmpty(dustParameters(), fixtureSecretKey(), NETWORK);
+
+/** A real dust chain plus the events it produced. */
+export type DustChain = {
+  /**
+   * Serialized bytes of the {@link DUST_EVENT_COUNT} real `dustInitialUtxo` events, in chain order.
+   *
+   * Bytes rather than `Event` instances on purpose: `replayEventsWithChanges` takes ownership of the events it is
+   * handed (wasm-bindgen moves them), so re-using an instance throws. Every use deserializes its own.
+   */
+  readonly eventBytes: readonly Uint8Array[];
+  /** The simulator state after the last registration. Its blocks still hold live, unconsumed `Event` instances. */
+  readonly state: V8.SimulatorState;
+  /** A time strictly after the last block, safe to value the resulting dust at. */
+  readonly syncTime: Date;
+};
+
+/**
+ * Drives a real dust chain: {@link DUST_EVENT_COUNT} Night rewards, then one registration transaction per Night UTXO.
+ *
+ * @remarks
+ *   Every registration block carries exactly one `dustInitialUtxo` event, so block numbers and event ids line up one to
+ *   one — which is what lets the same fixture drive both the batched indexer capability and the block-granular
+ *   simulator capability.
+ *
+ *   Each call builds a fresh chain. The simulator's blocks hold the only live `Event` instances, and replaying them
+ *   consumes them, so a state cannot be shared between two tests that both apply it.
+ * @param protocolVersion The version every block of this chain is stamped with. Defaults to the simulator's own default.
+ */
+export const buildDustChain = (protocolVersion?: ProtocolVersion.ProtocolVersion): Promise<DustChain> =>
+  Effect.gen(function* () {
+    const simulator = yield* V8.Simulator.init({
+      networkId: NETWORK,
+      ...(protocolVersion === undefined ? {} : { protocolVersion }),
+    });
+    const secretKey = fixtureSecretKey();
+    const keystore = keystoreOf(dustSeed());
+    const verifyingKey = keystore.publicKey();
+
+    const variant = new V1Builder()
+      .withTransactionType<ProofErasedTransaction>()
+      .withCoinSelectionDefaults()
+      .withTransacting(Transacting.makeSimulatorTransactingCapability)
+      .withSync(makeSimulatorSyncService, makeSimulatorSyncCapability)
+      .withCoinsAndBalancesDefaults()
+      .withKeysDefaults()
+      .withSerializationDefaults()
+      .withTransactionHistory(makeSimulatorTransactionHistoryService)
+      .build({
+        simulator,
+        networkId: NETWORK,
+        costParameters: { feeBlocksMargin: 5 },
+        txHistoryStorage: new InMemoryTransactionHistoryStorage(DustTransactionHistoryEntrySchema),
+        indexerClientConnection: { indexerHttpUrl: '' },
+      });
+
+    const initial = CoreWallet.initEmpty(dustParameters(), secretKey, NETWORK);
+    const stateRef = yield* SubscriptionRef.make(initial);
+    const running = yield* variant.start({
+      stateRef,
+      activationRange: ProtocolVersion.makeRange(
+        ProtocolVersion.MinSupportedVersion,
+        ProtocolVersion.MaxSupportedVersion,
+      ),
+    });
+    yield* running.startSyncInBackground(secretKey);
+
+    const syncedTo = (blockNumber: bigint) =>
+      Stream.runLast(stateRef.changes.pipe(Stream.find((wallet) => wallet.progress.appliedIndex >= blockNumber + 1n)));
+
+    yield* Effect.repeatN(simulator.rewardNight(verifyingKey, 150_000_000_000n), DUST_EVENT_COUNT - 1);
+    yield* syncedTo(BigInt(DUST_EVENT_COUNT));
+
+    const rewarded = yield* simulator.getLatestState();
+    const nightUtxos = nightWithMeta(rewarded, keystore.address());
+
+    yield* Effect.forEach(
+      nightUtxos,
+      (utxo, index) =>
+        Effect.gen(function* () {
+          const current = yield* simulator.getLatestState();
+          const now = DateOps.addSeconds(current.currentTime, 1);
+          const unsigned = yield* running.createDustGenerationTransaction(
+            now,
+            DateOps.addSeconds(now, 1),
+            [utxo],
+            verifyingKey,
+            new DustAddress(initial.publicKey.publicKey),
+          );
+          const signature = keystore.sign(unsigned.intents!.get(1)!.signatureData(1));
+          const signed = yield* running.addDustGenerationSignature(unsigned, signature);
+          // The simulator takes proof-erased transactions, so erasing here is the whole of "proving" on this path —
+          // the same shortcut `makeSimulatorProvingServiceEffect` takes, without depending on it.
+          yield* simulator.submitTransaction(signed.eraseProofs(), 'InBlock');
+          yield* syncedTo(BigInt(DUST_EVENT_COUNT + index + 1));
+        }),
+      { discard: true },
+    );
+
+    const state = yield* simulator.getLatestState();
+    const eventBytes = [...V8.getBlockEventsFrom(state, 0n)].map((event) => event.serialize());
+    return { eventBytes, state, syncTime: DateOps.addSeconds(state.currentTime, 2) };
+  }).pipe(Effect.scoped, Effect.runPromise);
+
+/** Deserializes a fresh, unconsumed instance of the fixture event at `index`. */
+export const eventAt = (eventBytes: readonly Uint8Array[], index: number): Event =>
+  Event.deserialize(eventBytes[index]);

--- a/packages/dust-wallet/src/v1/test/dustEvents.ts
+++ b/packages/dust-wallet/src/v1/test/dustEvents.ts
@@ -54,8 +54,16 @@ const NETWORK: NetworkId.NetworkId = 'undeployed';
  */
 export const DUST_EVENT_COUNT = 4;
 
-/** The dust HD key for {@link SEED} — the same derivation the wallet itself uses. */
-const dustSeed = (): Uint8Array => {
+/**
+ * The dust HD key for {@link SEED} — the same derivation the wallet itself uses.
+ *
+ * @remarks
+ *   Exported as well as used here because a wallet crossing a hard fork needs the seed rather than a key: the two
+ *   variants speak different ledger modules, so each derives its own `DustSecretKey` from this (see
+ *   `src/test/forkWallet.ts`). Only the dust this fixture's events are addressed to can decrypt them, so the fork proof
+ *   has to derive from exactly this seed.
+ */
+export const dustSeed = (): Uint8Array => {
   const result = HDWallet.fromSeed(Buffer.from(SEED, 'hex'));
   const { hdWallet } = result as { type: 'seedOk'; hdWallet: HDWallet };
   const derived = hdWallet.selectAccount(0).selectRole(Roles.Dust).deriveKeyAt(0);

--- a/packages/dust-wallet/src/v1/test/dustEvents.ts
+++ b/packages/dust-wallet/src/v1/test/dustEvents.ts
@@ -183,7 +183,7 @@ export const buildDustChain = (protocolVersion?: ProtocolVersion.ProtocolVersion
           const signed = yield* running.addDustGenerationSignature(unsigned, signature);
           // The simulator takes proof-erased transactions, so erasing here is the whole of "proving" on this path —
           // the same shortcut `makeSimulatorProvingServiceEffect` takes, without depending on it.
-          yield* simulator.submitTransaction(signed.eraseProofs(), 'InBlock');
+          yield* simulator.submitTransaction(signed.eraseProofs());
           yield* syncedTo(BigInt(DUST_EVENT_COUNT + index + 1));
         }),
       { discard: true },

--- a/packages/dust-wallet/src/v1/test/migration.test.ts
+++ b/packages/dust-wallet/src/v1/test/migration.test.ts
@@ -123,8 +123,12 @@ describe('the cross-ledger migration', () => {
     const wallet = await Effect.runPromise(migration().migrate(previous));
 
     expect(wallet.state.utxos).toEqual([]);
-    expect(wallet.state.commitmentTreeFirstFree).toBe(0n);
-    expect(wallet.state.generatingTreeFirstFree).toBe(0n);
+    // The v2 twin of this test reads `commitmentTreeFirstFree` / `generatingTreeFirstFree`, which ledger-v8's
+    // `DustLocalState` does not expose. Stated instead as: the migrated state's trees are indistinguishable from those
+    // of a state that never held anything.
+    const untouched = new ledger.DustLocalState(dustParameters());
+    expect(wallet.state.commitmentTreeRoot()).toBe(untouched.commitmentTreeRoot());
+    expect(wallet.state.generatingTreeRoot()).toBe(untouched.generatingTreeRoot());
     expect(wallet.pendingDust).toEqual([]);
   });
 

--- a/packages/dust-wallet/src/v1/test/migration.test.ts
+++ b/packages/dust-wallet/src/v1/test/migration.test.ts
@@ -1,0 +1,161 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * How this variant builds its first state from whatever preceded it.
+ *
+ * @remarks
+ *   The three strategies differ in exactly one thing — how much of the previous wallet is allowed to survive — so that is
+ *   what these pin down: everything (same ledger version), nothing (no previous wallet at all), and, across a ledger
+ *   version boundary, identity only.
+ */
+
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { CoreWallet, PublicKey } from '../CoreWallet.js';
+import {
+  type PreviousLedgerWallet,
+  makeCarryOverMigration,
+  makeCrossLedgerMigration,
+  makeEmptyWalletMigration,
+} from '../Migration.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+const seed = Buffer.alloc(32, 7);
+const secretKey = (): ledger.DustSecretKey => ledger.DustSecretKey.fromSeed(seed);
+const dustParameters = (): ledger.DustParameters => ledger.LedgerParameters.initialParameters().dust;
+
+/** The version that triggered the hand-over: the first one the previous variant saw outside its own range. */
+const forkVersion = ProtocolVersion.ProtocolVersion(7n);
+
+/**
+ * A wallet of the previous ledger version, as plain data.
+ *
+ * @remarks
+ *   Deliberately wider than {@link PreviousLedgerWallet}: it also carries the dust a real pre-fork wallet would be
+ *   holding, so that "that does not cross" is something this file can actually observe rather than merely fail to
+ *   mention. Its cursor is non-zero for the opposite reason — what does cross has to be seen crossing. Structural
+ *   because the real thing is built on the other ledger's WASM module, and a projection that reads no ledger object out
+ *   of it has no reason to load one.
+ */
+type PreviousWalletStandIn = PreviousLedgerWallet & {
+  readonly utxos: readonly Readonly<{ nonce: string; initialValue: bigint }>[];
+};
+
+const previousWallet = (): PreviousWalletStandIn => ({
+  publicKey: { publicKey: PublicKey.fromSecretKey(secretKey()).publicKey },
+  networkId,
+  protocolVersion: forkVersion,
+  progress: {
+    appliedIndex: 4321n,
+    highestRelevantWalletIndex: 4400n,
+    highestIndex: 4400n,
+    highestRelevantIndex: 4400n,
+    isConnected: true,
+  },
+  utxos: [
+    { nonce: 'bb'.repeat(32), initialValue: 100n },
+    { nonce: 'cc'.repeat(32), initialValue: 200n },
+  ],
+});
+
+describe('the empty-wallet migration', () => {
+  it('produces a wallet holding no dust on the configured network', async () => {
+    const wallet = await Effect.runPromise(
+      makeEmptyWalletMigration({ networkId, dustParameters: dustParameters() }).migrate(null),
+    );
+
+    expect(wallet.networkId).toBe(networkId);
+    expect(wallet.state.utxos).toEqual([]);
+    expect(wallet.pendingDust).toEqual([]);
+    expect(wallet.progress.appliedIndex).toBe(0n);
+    expect(wallet.protocolVersion).toBe(ProtocolVersion.MinSupportedVersion);
+  });
+});
+
+describe('the carry-over migration', () => {
+  it('hands the previous state through untouched', async () => {
+    const previous = CoreWallet.initEmpty(dustParameters(), secretKey(), networkId);
+
+    const wallet = await Effect.runPromise(makeCarryOverMigration().migrate(previous));
+
+    expect(wallet).toBe(previous);
+  });
+});
+
+describe('the cross-ledger migration', () => {
+  const migration = () => makeCrossLedgerMigration({ dustParameters: dustParameters() });
+
+  it('carries the dust public key, so the replayed timeline can be decrypted into the same dust', async () => {
+    const previous = previousWallet();
+
+    const wallet = await Effect.runPromise(migration().migrate(previous));
+
+    expect(wallet.publicKey.publicKey).toBe(PublicKey.fromSecretKey(secretKey()).publicKey);
+    expect(wallet.networkId).toBe(networkId);
+  });
+
+  it('records the version that triggered the hand-over, so the new variant starts inside its own range', async () => {
+    const wallet = await Effect.runPromise(migration().migrate(previousWallet()));
+
+    expect(wallet.protocolVersion).toBe(forkVersion);
+  });
+
+  it('starts from an empty local state rather than carrying the previous version dust', async () => {
+    // The indexer replays the timeline after the fork, so this dust is generated again by events of this ledger
+    // version. Carrying it as well would double-count it, and it is backed by a Merkle tree of the other ledger's
+    // making that this ledger cannot read.
+    const previous = previousWallet();
+    expect(previous.utxos.length).toBeGreaterThan(0);
+
+    const wallet = await Effect.runPromise(migration().migrate(previous));
+
+    expect(wallet.state.utxos).toEqual([]);
+    expect(wallet.state.commitmentTreeFirstFree).toBe(0n);
+    expect(wallet.state.generatingTreeFirstFree).toBe(0n);
+    expect(wallet.pendingDust).toEqual([]);
+  });
+
+  it('builds the fresh state on this ledger version parameters, not the previous version', async () => {
+    // Dust's local state is parameterised by the ledger's dust parameters, and those are a WASM object of whichever
+    // ledger module produced them. The previous variant's copy therefore cannot cross; the migration is handed this
+    // version's parameters instead. (No shielded analogue — `ZswapLocalState` takes no parameters.)
+    const wallet = await Effect.runPromise(migration().migrate(previousWallet()));
+
+    expect(wallet.state.params.nightDustRatio).toBe(dustParameters().nightDustRatio);
+    expect(wallet.state.params.generationDecayRate).toBe(dustParameters().generationDecayRate);
+    expect(wallet.state.params.dustGracePeriodSeconds).toBe(dustParameters().dustGracePeriodSeconds);
+  });
+
+  it('parks sync progress at the fork, because the replayed timeline continues the ids it left off at', async () => {
+    // The confirmed semantics: after the hard fork the indexer replays the events again, numbering them onwards from
+    // whatever id it had reached when the fork happened — never from zero. So the migrated wallet resumes from where
+    // its predecessor stopped. Rewinding to zero would point it at a stretch of the timeline the replay does not
+    // occupy, and it would sit there waiting for events that already went by under the previous ledger version.
+    const previous = previousWallet();
+    expect(previous.progress.appliedIndex).toBeGreaterThan(0n);
+
+    const wallet = await Effect.runPromise(migration().migrate(previous));
+
+    expect(wallet.progress.appliedIndex).toBe(previous.progress.appliedIndex);
+    expect(wallet.progress.highestIndex).toBe(previous.progress.highestIndex);
+    expect(wallet.progress.highestRelevantIndex).toBe(previous.progress.highestRelevantIndex);
+    expect(wallet.progress.highestRelevantWalletIndex).toBe(previous.progress.highestRelevantWalletIndex);
+    // The position crosses; being connected does not. This state has no running sync behind it yet — the restart that
+    // follows the migration is what reconnects it — and claiming otherwise would report a gap that nothing is closing.
+    expect(previous.progress.isConnected).toBe(true);
+    expect(wallet.progress.isConnected).toBe(false);
+  });
+});

--- a/packages/dust-wallet/src/v1/test/runningV1Variant.test.ts
+++ b/packages/dust-wallet/src/v1/test/runningV1Variant.test.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import {
+  DustLocalState,
   DustSecretKey,
   type DustStateChanges,
   type FinalizedTransaction,
@@ -18,6 +19,7 @@ import {
 } from '@midnight-ntwrk/ledger-v8';
 import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import {
+  Chunk,
   Deferred,
   Duration,
   Effect,
@@ -32,8 +34,9 @@ import {
 } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { chooseCoin, makeDefaultCoinsAndBalancesCapability } from '../CoinsAndBalances.js';
-import { CoreWallet } from '../CoreWallet.js';
+import { CoreWallet, PublicKey } from '../CoreWallet.js';
 import { makeDefaultKeysCapability } from '../Keys.js';
+import { StateChange, VersionChangeType } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { RunningV1Variant } from '../RunningV1Variant.js';
 import { makeDefaultV1SerializationCapability } from '../Serialization.js';
 import { type ChangesResult, type SyncCapability, type SyncService } from '../Sync.js';
@@ -293,5 +296,90 @@ describe('RunningV1Variant sync serialization', () => {
     }).pipe(Effect.runPromise);
 
     expect(result).toBe(2);
+  });
+});
+
+describe('RunningV1Variant.state protocol version signalling', () => {
+  /** The variant under test owns `[0, 7)`; 7 and above belong to whatever variant comes next. */
+  const activationRange = ProtocolVersion.makeRange(
+    ProtocolVersion.MinSupportedVersion,
+    ProtocolVersion.ProtocolVersion(7n),
+  );
+
+  const walletAtVersion = (protocolVersion: bigint): CoreWallet =>
+    CoreWallet.restore(
+      new DustLocalState(LedgerParameters.initialParameters().dust),
+      PublicKey.fromSecretKey(DustSecretKey.fromSeed(Buffer.alloc(32, 1))),
+      [],
+      { appliedIndex: 0n, highestRelevantWalletIndex: 0n, highestIndex: 0n, highestRelevantIndex: 0n },
+      protocolVersion,
+      networkId,
+    );
+
+  const versionChangesOf = (changes: Chunk.Chunk<StateChange.StateChange<CoreWallet>>): readonly bigint[] =>
+    Chunk.toArray(changes)
+      .filter(StateChange.isVersionChange)
+      .map(({ change }) => {
+        expect(VersionChangeType.isVersion(change)).toBe(true);
+        return VersionChangeType.isVersion(change) ? change.version : -1n;
+      });
+
+  /**
+   * Drains the variant's state stream for a fixed window and returns everything it emitted. A bounded window rather
+   * than `Stream.take(n)` on purpose: the point of these tests is _how many_ version changes appear, so a missing one
+   * has to surface as a failed assertion, not as a hang.
+   */
+  const emissionsWithin = (
+    initialState: CoreWallet,
+    act: (stateRef: SubscriptionRef.SubscriptionRef<CoreWallet>) => Effect.Effect<void> = () => Effect.void,
+  ): Promise<Chunk.Chunk<StateChange.StateChange<CoreWallet>>> =>
+    Effect.gen(function* () {
+      const stateRef = yield* SubscriptionRef.make(initialState);
+      const scope = yield* Scope.make();
+      const variant = new RunningV1Variant(
+        scope,
+        { stateRef, activationRange },
+        variantContextOf(
+          [],
+          trackingHistoryService({
+            inFlight: yield* Ref.make(0),
+            maxInFlight: yield* Ref.make(0),
+            recorded: yield* Ref.make(0),
+          }),
+        ),
+      );
+
+      const collector = yield* Effect.fork(
+        variant.state.pipe(Stream.interruptAfter(Duration.millis(300)), Stream.runCollect),
+      );
+      yield* Effect.sleep(Duration.millis(50));
+      yield* act(stateRef);
+      const collected = yield* Fiber.join(collector);
+      yield* Scope.close(scope, Exit.void);
+      return collected;
+    }).pipe(Effect.runPromise);
+
+  it('emits exactly one VersionChange when the state transitions to a new protocol version', async () => {
+    const collected = await emissionsWithin(walletAtVersion(0n), (stateRef) =>
+      SubscriptionRef.set(stateRef, walletAtVersion(5n)),
+    );
+
+    expect(versionChangesOf(collected)).toEqual([5n]);
+  });
+
+  it('emits an immediate healing VersionChange when the initial state is outside the activation range', async () => {
+    // A snapshot serialized after the version was annotated but before the runtime migrated restores here. Without a
+    // healing emission the wallet would sit on a version it does not own and never hand over.
+    const collected = await emissionsWithin(walletAtVersion(9n));
+
+    expect(versionChangesOf(collected)).toEqual([9n]);
+  });
+
+  it('emits no VersionChange when the initial state is inside the activation range', async () => {
+    const collected = await emissionsWithin(walletAtVersion(3n));
+
+    expect(versionChangesOf(collected)).toEqual([]);
+    // The stream still reports the state itself, so an empty result would be a false pass.
+    expect(Chunk.toArray(collected).filter(StateChange.isState).length).toBeGreaterThan(0);
   });
 });

--- a/packages/dust-wallet/src/v1/test/syncCapability.test.ts
+++ b/packages/dust-wallet/src/v1/test/syncCapability.test.ts
@@ -1,0 +1,297 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { type CoreWallet } from '../CoreWallet.js';
+import {
+  makeDefaultSyncCapability,
+  makeSimulatorSyncCapability,
+  type WalletSyncSubscription,
+  WalletSyncUpdate,
+} from '../Sync.js';
+import { DUST_EVENT_COUNT, type DustChain, buildDustChain, eventAt, freshWallet, fixtureSecretKey } from './dustEvents.js';
+
+vi.setConfig({ testTimeout: 60000 });
+
+/**
+ * The boundary under test. The variant owns `[0, 7)`; anything the source reports at 7 or beyond belongs to the next
+ * variant and must be left unapplied for it to fetch.
+ */
+const activeRange = ProtocolVersion.makeRange(ProtocolVersion.ProtocolVersion(0n), ProtocolVersion.ProtocolVersion(7n));
+
+let chain: DustChain;
+
+beforeAll(async () => {
+  chain = await buildDustChain();
+  expect(chain.eventBytes.length).toBe(DUST_EVENT_COUNT);
+});
+
+/**
+ * Builds a batch of sync updates, one per item, each carrying its own fresh event instance.
+ *
+ * A `protocolVersion` of `undefined` models an indexer that does not report the field at all — the shape dust's
+ * subscription has today.
+ */
+const batch = (items: readonly (readonly [id: number, protocolVersion: number | undefined])[]): WalletSyncUpdate =>
+  WalletSyncUpdate.create(
+    items.map(
+      ([id, protocolVersion]): WalletSyncSubscription => ({
+        id,
+        maxId: DUST_EVENT_COUNT,
+        raw: eventAt(chain.eventBytes, id - 1),
+        ...(protocolVersion === undefined ? {} : { protocolVersion }),
+      }),
+    ),
+    fixtureSecretKey(),
+    chain.syncTime,
+  );
+
+const utxoCount = (wallet: CoreWallet): number => wallet.state.utxos.length;
+
+const dustBalance = (wallet: CoreWallet): bigint => wallet.state.walletBalance(chain.syncTime);
+
+describe('makeDefaultSyncCapability.applyUpdate boundary handling', () => {
+  const capability = makeDefaultSyncCapability();
+
+  it('applies every update and annotates the state when the whole batch is inside the active range', () => {
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 3],
+        [2, 3],
+        [3, 3],
+        [4, 3],
+      ]),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(4n);
+    expect(state.progress.highestRelevantWalletIndex).toBe(BigInt(DUST_EVENT_COUNT));
+    expect(state.progress.isConnected).toBe(true);
+    expect(state.protocolVersion).toBe(3n);
+    expect(utxoCount(state)).toBe(DUST_EVENT_COUNT);
+    expect(dustBalance(state)).toBeGreaterThan(0n);
+    expect(result.changes.length).toBe(DUST_EVENT_COUNT);
+    expect(result.protocolVersion).toBe(3);
+  });
+
+  it('re-annotates the state on a version bump that stays inside the active range', () => {
+    const [afterFirst] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 3],
+        [2, 3],
+      ]),
+      activeRange,
+    );
+    expect(afterFirst.protocolVersion).toBe(3n);
+
+    const [state, result] = capability.applyUpdate(
+      afterFirst,
+      batch([
+        [3, 5],
+        [4, 5],
+      ]),
+      activeRange,
+    );
+
+    expect(state.protocolVersion).toBe(5n);
+    expect(state.progress.appliedIndex).toBe(4n);
+    expect(utxoCount(state)).toBe(DUST_EVENT_COUNT);
+    expect(result.changes.length).toBe(2);
+  });
+
+  it('applies only the prefix of a straddling batch and takes the version from the first suffix item', () => {
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 3],
+        [2, 3],
+        [3, 9],
+        [4, 11],
+      ]),
+      activeRange,
+    );
+
+    // Prefix only: the last applied id is 2, so the next variant resumes there and re-fetches ids 3-4.
+    expect(state.progress.appliedIndex).toBe(2n);
+    // The suffix's first version is what makes the variant hand over — not the batch's last version.
+    expect(state.protocolVersion).toBe(9n);
+    expect(utxoCount(state)).toBe(2);
+    // Changes come from the prefix alone.
+    expect(result.changes.length).toBe(2);
+    // The reported version tags the applied changes, so it is the prefix's version.
+    expect(result.protocolVersion).toBe(3);
+    // The tip is a property of the source, so it still comes from the batch tail.
+    expect(state.progress.highestRelevantWalletIndex).toBe(BigInt(DUST_EVENT_COUNT));
+  });
+
+  it('applies nothing when the whole batch is at or beyond the end of the active range', () => {
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 7],
+        [2, 7],
+        [3, 9],
+        [4, 9],
+      ]),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(0n);
+    expect(state.protocolVersion).toBe(7n);
+    expect(utxoCount(state)).toBe(0);
+    expect(result.changes).toEqual([]);
+    expect(state.progress.highestRelevantWalletIndex).toBe(BigInt(DUST_EVENT_COUNT));
+  });
+
+  it('never lowers the recorded protocol version when a later batch reports a stale lower one', () => {
+    const [afterFirst] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 5],
+        [2, 5],
+      ]),
+      activeRange,
+    );
+    expect(afterFirst.protocolVersion).toBe(5n);
+
+    const [state] = capability.applyUpdate(
+      afterFirst,
+      batch([
+        [3, 2],
+        [4, 2],
+      ]),
+      activeRange,
+    );
+
+    // The batch still applies; only the version annotation is held at its high-water mark.
+    expect(state.protocolVersion).toBe(5n);
+    expect(state.progress.appliedIndex).toBe(4n);
+    expect(utxoCount(state)).toBe(DUST_EVENT_COUNT);
+  });
+
+  it('leaves the state untouched for an empty batch', () => {
+    const initial = freshWallet();
+    const [state, result] = capability.applyUpdate(
+      initial,
+      WalletSyncUpdate.create([], fixtureSecretKey(), chain.syncTime),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(0n);
+    expect(state.protocolVersion).toBe(ProtocolVersion.MinSupportedVersion);
+    expect(utxoCount(state)).toBe(0);
+    expect(result.changes).toEqual([]);
+    expect(result.protocolVersion).toBe(Number(initial.protocolVersion));
+  });
+
+  // --- dust-specific: the subscription does not carry `protocolVersion` yet ---
+
+  it('applies a batch whose items carry no protocol version at all, leaving the recorded version untouched', () => {
+    const initial = freshWallet();
+    const [state, result] = capability.applyUpdate(
+      initial,
+      batch([
+        [1, undefined],
+        [2, undefined],
+        [3, undefined],
+        [4, undefined],
+      ]),
+      activeRange,
+    );
+
+    // An absent version means "the indexer did not say", which is treated as in-range: apply normally...
+    expect(state.progress.appliedIndex).toBe(4n);
+    expect(utxoCount(state)).toBe(DUST_EVENT_COUNT);
+    expect(result.changes.length).toBe(DUST_EVENT_COUNT);
+    // ...and leave the annotation exactly where it was, rather than inventing a version.
+    expect(state.protocolVersion).toBe(initial.protocolVersion);
+    expect(result.protocolVersion).toBe(Number(initial.protocolVersion));
+  });
+
+  it('handles a mixed batch, ignoring untagged items for the boundary and splitting on the tagged one', () => {
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, undefined],
+        [2, 3],
+        [3, 9],
+        [4, undefined],
+      ]),
+      activeRange,
+    );
+
+    // Untagged items never trigger a hand-over; the first tagged out-of-range item still does, and everything from it
+    // onwards is deferred — including the untagged item behind it, because a batch is one contiguous slice.
+    expect(state.progress.appliedIndex).toBe(2n);
+    expect(state.protocolVersion).toBe(9n);
+    expect(utxoCount(state)).toBe(2);
+    expect(result.changes.length).toBe(2);
+    expect(result.protocolVersion).toBe(3);
+  });
+
+  it('keeps a mixed batch whose only tagged item is in range fully applied', () => {
+    const [state] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, undefined],
+        [2, 4],
+        [3, undefined],
+        [4, undefined],
+      ]),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(4n);
+    expect(utxoCount(state)).toBe(DUST_EVENT_COUNT);
+    // The last version actually observed in the batch is what gets recorded.
+    expect(state.protocolVersion).toBe(4n);
+  });
+});
+
+describe('makeSimulatorSyncCapability.applyUpdate boundary handling', () => {
+  const capability = makeSimulatorSyncCapability();
+
+  it('applies in-range blocks and annotates the state with the block version', async () => {
+    const inRange = await buildDustChain(ProtocolVersion.ProtocolVersion(3n));
+
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      { update: inRange.state, secretKey: fixtureSecretKey() },
+      activeRange,
+    );
+
+    // Blocks 0..8: four rewards, four registrations. The next block to process is one past the last.
+    expect(state.progress.appliedIndex).toBe(BigInt(DUST_EVENT_COUNT) * 2n + 1n);
+    expect(state.protocolVersion).toBe(3n);
+    expect(state.state.utxos.length).toBe(DUST_EVENT_COUNT);
+    expect(result.changes.length).toBe(DUST_EVENT_COUNT);
+  });
+
+  it('applies no block at or beyond the end of the active range, but still annotates the version', async () => {
+    const outOfRange = await buildDustChain(ProtocolVersion.ProtocolVersion(9n));
+
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      { update: outOfRange.state, secretKey: fixtureSecretKey() },
+      activeRange,
+    );
+
+    // Every block carries a real dust event; none of them may be applied by this variant.
+    expect(state.progress.appliedIndex).toBe(0n);
+    expect(state.protocolVersion).toBe(9n);
+    expect(state.state.utxos.length).toBe(0);
+    expect(result.changes).toEqual([]);
+  });
+});

--- a/packages/dust-wallet/src/v1/test/syncCapability.test.ts
+++ b/packages/dust-wallet/src/v1/test/syncCapability.test.ts
@@ -19,7 +19,14 @@ import {
   type WalletSyncSubscription,
   WalletSyncUpdate,
 } from '../Sync.js';
-import { DUST_EVENT_COUNT, type DustChain, buildDustChain, eventAt, freshWallet, fixtureSecretKey } from './dustEvents.js';
+import {
+  DUST_EVENT_COUNT,
+  type DustChain,
+  buildDustChain,
+  eventAt,
+  freshWallet,
+  fixtureSecretKey,
+} from './dustEvents.js';
 
 vi.setConfig({ testTimeout: 60000 });
 
@@ -44,14 +51,12 @@ beforeAll(async () => {
  */
 const batch = (items: readonly (readonly [id: number, protocolVersion: number | undefined])[]): WalletSyncUpdate =>
   WalletSyncUpdate.create(
-    items.map(
-      ([id, protocolVersion]): WalletSyncSubscription => ({
-        id,
-        maxId: DUST_EVENT_COUNT,
-        raw: eventAt(chain.eventBytes, id - 1),
-        ...(protocolVersion === undefined ? {} : { protocolVersion }),
-      }),
-    ),
+    items.map(([id, protocolVersion]): WalletSyncSubscription => ({
+      id,
+      maxId: DUST_EVENT_COUNT,
+      raw: eventAt(chain.eventBytes, id - 1),
+      ...(protocolVersion === undefined ? {} : { protocolVersion }),
+    })),
     fixtureSecretKey(),
     chain.syncTime,
   );

--- a/packages/dust-wallet/src/v2/CoreWallet.ts
+++ b/packages/dust-wallet/src/v2/CoreWallet.ts
@@ -101,8 +101,8 @@ export const CoreWallet = {
    *
    * @remarks
    *   Only ever raises it. A stale lower report — a late batch from behind the tip, a source that rewound — would
-   *   otherwise look like a downward version change and send the runtime migrating backwards into a variant this
-   *   wallet has already left.
+   *   otherwise look like a downward version change and send the runtime migrating backwards into a variant this wallet
+   *   has already left.
    */
   withProtocolVersion(wallet: CoreWallet, version: ProtocolVersion.ProtocolVersion): CoreWallet {
     return version > wallet.protocolVersion ? { ...wallet, protocolVersion: version } : wallet;

--- a/packages/dust-wallet/src/v2/CoreWallet.ts
+++ b/packages/dust-wallet/src/v2/CoreWallet.ts
@@ -96,6 +96,46 @@ export const CoreWallet = {
     };
   },
 
+  /**
+   * Records an observed protocol version, monotonically.
+   *
+   * @remarks
+   *   Only ever raises it. A stale lower report — a late batch from behind the tip, a source that rewound — would
+   *   otherwise look like a downward version change and send the runtime migrating backwards into a variant this
+   *   wallet has already left.
+   */
+  withProtocolVersion(wallet: CoreWallet, version: ProtocolVersion.ProtocolVersion): CoreWallet {
+    return version > wallet.protocolVersion ? { ...wallet, protocolVersion: version } : wallet;
+  },
+
+  /**
+   * The first state of this ledger version, projected from the wallet of the version it replaced.
+   *
+   * @remarks
+   *   Identity and position only. The dust itself is deliberately absent: the indexer replays the timeline after the
+   *   fork, so the same dust is generated again by events of this ledger version and re-discovered by ordinary sync.
+   *
+   *   `dustParameters` has to be supplied rather than carried, and this is where dust departs from shielded:
+   *   `DustLocalState` is parameterised by the ledger's dust parameters, and those are a WASM object belonging to
+   *   whichever ledger module produced them. The previous variant's copy cannot be handed to this one.
+   */
+  fromPreviousVersion(previous: {
+    readonly publicKey: PublicKey;
+    readonly networkId: NetworkId;
+    readonly protocolVersion: bigint;
+    readonly progress: SyncProgress.SyncProgressData;
+    readonly dustParameters: DustParameters;
+  }): CoreWallet {
+    return {
+      state: new DustLocalState(previous.dustParameters),
+      publicKey: previous.publicKey,
+      networkId: previous.networkId,
+      pendingDust: [],
+      progress: SyncProgress.createSyncProgress({ ...previous.progress, isConnected: false }),
+      protocolVersion: ProtocolVersion.ProtocolVersion(previous.protocolVersion),
+    };
+  },
+
   applyEventsWithChanges(
     wallet: CoreWallet,
     secretKey: DustSecretKey,

--- a/packages/dust-wallet/src/v2/Migration.ts
+++ b/packages/dust-wallet/src/v2/Migration.ts
@@ -1,0 +1,150 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { type DustParameters, DustSecretKey } from '@midnightntwrk/ledger-v9';
+import { type SyncProgress, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect } from 'effect';
+import { CoreWallet, PublicKey } from './CoreWallet.js';
+import { type NetworkId } from './types/ledger.js';
+import { type WalletError } from './WalletError.js';
+
+/**
+ * How this variant produces its first state from whatever came before it.
+ *
+ * @remarks
+ *   The strategy is injected through the builder rather than hard-coded into the variant, because "whatever came before"
+ *   is not one thing: an empty wallet at first start, a wallet of this same ledger version, or a wallet of the ledger
+ *   version this one replaced. Those are different functions with different input types, and the runtime only ever
+ *   needs one of them per registration — so which one is a build-time decision, expressed as a dictionary in the
+ *   repository's usual dictionary-passing style.
+ * @typeParam TPreviousState The state this migration consumes.
+ */
+export type StateMigration<TPreviousState> = {
+  migrate: (previousState: TPreviousState) => Effect.Effect<CoreWallet, WalletError>;
+};
+
+export type EmptyWalletMigrationConfiguration = {
+  networkId: NetworkId;
+  /**
+   * The dust parameters the fresh state is built on.
+   *
+   * @remarks
+   *   Dust's local state is parameterised where shielded's is not: generation and decay rates live on the state itself,
+   *   so there is no such thing as a parameterless empty dust wallet.
+   */
+  dustParameters: DustParameters;
+};
+
+/**
+ * The migration used when there is no previous wallet at all.
+ *
+ * @remarks
+ *   It backs `WalletLike.startEmpty`, which builds a wallet before any key material exists. The resulting state holds no
+ *   dust and has a public key derived from a fixed placeholder seed; it is a scaffold to be replaced by a real start,
+ *   not a wallet anybody can pay fees with.
+ * @example
+ *   ```typescript
+ *   const builder = new V2Builder().withDefaults().withMigration(makeEmptyWalletMigration({ networkId, dustParameters }));
+ *   ```;
+ *
+ * @param configuration Supplies the network the scaffold state claims to be on, and the dust parameters it uses.
+ * @returns A migration from `null`.
+ */
+export const makeEmptyWalletMigration = (configuration: EmptyWalletMigrationConfiguration): StateMigration<null> => ({
+  migrate: () => {
+    const seed = WalletSeed.fromString('0000000000000000000000000000000000000000000000000000000000000001');
+    return Effect.succeed(
+      CoreWallet.initEmpty(configuration.dustParameters, DustSecretKey.fromSeed(seed), configuration.networkId),
+    );
+  },
+});
+
+/**
+ * The migration between two variants that share this ledger version.
+ *
+ * @remarks
+ *   Both sides speak the same state type, so the carry is the identity: the generation and commitment trees, the dust
+ *   UTXOs and sync progress all remain valid. This is the right strategy for a protocol bump that does not change
+ *   serialization.
+ * @returns A migration from a {@link CoreWallet} of this ledger version.
+ */
+export const makeCarryOverMigration = (): StateMigration<CoreWallet> => ({
+  migrate: (previousState) => Effect.succeed(previousState),
+});
+
+/**
+ * The shape a wallet of the _previous_ ledger version must expose to be projected across a hard fork.
+ *
+ * @remarks
+ *   Structural on purpose. The previous variant's `CoreWallet` is built on a different ledger module, and naming that
+ *   module here would drag a second multi-megabyte WASM binary into this variant for the sake of a type. Everything the
+ *   projection reads is plain data — the dust public key is a `bigint` and the network id a string — so a structural
+ *   description is both sufficient and the only version-agnostic option.
+ *
+ *   `progress` is where the migrated wallet resumes from: the replayed timeline continues the indexer's event ids rather
+ *   than restarting them, so the previous variant's cursor is the position the next one has to start at (see
+ *   {@link makeCrossLedgerMigration}).
+ */
+export type PreviousLedgerWallet = Readonly<{
+  publicKey: { readonly publicKey: bigint };
+  networkId: string;
+  protocolVersion: bigint;
+  progress: SyncProgress.SyncProgressData;
+}>;
+
+export type CrossLedgerMigrationConfiguration = {
+  /**
+   * This ledger version's dust parameters.
+   *
+   * @remarks
+   *   Supplied rather than carried, and this is where dust departs from shielded. `DustLocalState` is parameterised by
+   *   the ledger's dust parameters, and those are a WASM object belonging to whichever ledger module produced them —
+   *   the previous variant's copy cannot be handed to this one, and its values need not even still be current.
+   */
+  dustParameters: DustParameters;
+};
+
+/**
+ * The migration across a ledger-version boundary: a dustless state of this version, carrying identity and position.
+ *
+ * @remarks
+ *   The indexer replays the timeline after the hard fork, re-emitting the wallet's history as events of the new ledger
+ *   version. A migrated wallet therefore does not need — and must not attempt — to carry its dust: exactly the same dust
+ *   is generated again by ordinary sync, from the replayed registration events, and valued against this version's
+ *   parameters. Carrying it across as well would double-count what the replay is about to deliver, on top of requiring
+ *   generation and commitment trees that this ledger's WASM module cannot read.
+ *
+ *   So what crosses is the dust public key, the network, the protocol version that triggered the hand-over, and the
+ *   cursor. Sync progress is **parked at the fork** rather than rewound: the indexer numbers the replayed events onwards
+ *   from whatever id it had reached when the fork happened, never from zero, so the inherited cursor is exactly where
+ *   the replay begins. A wallet that rewound to zero would wait on a stretch of the timeline this ledger version's
+ *   events do not occupy.
+ *
+ *   If the ledger team ships a byte-level translation for wallet local state, it replaces this instance without touching
+ *   anything around it — that is the point of the {@link StateMigration} seam.
+ * @param configuration Supplies this ledger version's dust parameters for the fresh state.
+ * @returns A migration from a previous-ledger-version wallet.
+ */
+export const makeCrossLedgerMigration = (
+  configuration: CrossLedgerMigrationConfiguration,
+): StateMigration<PreviousLedgerWallet> => ({
+  migrate: (previousState) =>
+    Effect.succeed(
+      CoreWallet.fromPreviousVersion({
+        publicKey: { publicKey: previousState.publicKey.publicKey },
+        networkId: previousState.networkId,
+        protocolVersion: previousState.protocolVersion,
+        progress: previousState.progress,
+        dustParameters: configuration.dustParameters,
+      }),
+    ),
+});

--- a/packages/dust-wallet/src/v2/Migration.ts
+++ b/packages/dust-wallet/src/v2/Migration.ts
@@ -13,7 +13,7 @@
 import { type DustParameters, DustSecretKey } from '@midnightntwrk/ledger-v9';
 import { type SyncProgress, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Effect } from 'effect';
-import { CoreWallet, PublicKey } from './CoreWallet.js';
+import { CoreWallet } from './CoreWallet.js';
 import { type NetworkId } from './types/ledger.js';
 import { type WalletError } from './WalletError.js';
 
@@ -118,16 +118,16 @@ export type CrossLedgerMigrationConfiguration = {
  *
  * @remarks
  *   The indexer replays the timeline after the hard fork, re-emitting the wallet's history as events of the new ledger
- *   version. A migrated wallet therefore does not need — and must not attempt — to carry its dust: exactly the same dust
- *   is generated again by ordinary sync, from the replayed registration events, and valued against this version's
+ *   version. A migrated wallet therefore does not need — and must not attempt — to carry its dust: exactly the same
+ *   dust is generated again by ordinary sync, from the replayed registration events, and valued against this version's
  *   parameters. Carrying it across as well would double-count what the replay is about to deliver, on top of requiring
  *   generation and commitment trees that this ledger's WASM module cannot read.
  *
  *   So what crosses is the dust public key, the network, the protocol version that triggered the hand-over, and the
- *   cursor. Sync progress is **parked at the fork** rather than rewound: the indexer numbers the replayed events onwards
- *   from whatever id it had reached when the fork happened, never from zero, so the inherited cursor is exactly where
- *   the replay begins. A wallet that rewound to zero would wait on a stretch of the timeline this ledger version's
- *   events do not occupy.
+ *   cursor. Sync progress is **parked at the fork** rather than rewound: the indexer numbers the replayed events
+ *   onwards from whatever id it had reached when the fork happened, never from zero, so the inherited cursor is exactly
+ *   where the replay begins. A wallet that rewound to zero would wait on a stretch of the timeline this ledger
+ *   version's events do not occupy.
  *
  *   If the ledger team ships a byte-level translation for wallet local state, it replaces this instance without touching
  *   anything around it — that is the point of the {@link StateMigration} seam.

--- a/packages/dust-wallet/src/v2/RunningV2Variant.ts
+++ b/packages/dust-wallet/src/v2/RunningV2Variant.ts
@@ -73,11 +73,11 @@ const progress = (state: CoreWallet): StateChange.StateChange<CoreWallet>[] => {
  * The version signals this variant puts on its state stream.
  *
  * @remarks
- *   Two of them, for two different situations. A transition is the ordinary one: the state moved to a version the
- *   variant may or may not own, and the runtime decides. The healing emission covers restore: a snapshot taken between
- *   the moment sync annotated an out-of-range version and the moment the runtime acted on it comes back with a version
- *   this variant does not own and no transition to announce it, so it would sit there forever. Announcing it on the
- *   first observation is what forward-migrates such a snapshot.
+ *   Two of them, for two different situations. A transition is the ordinary one: the state moved to a version the variant
+ *   may or may not own, and the runtime decides. The healing emission covers restore: a snapshot taken between the
+ *   moment sync annotated an out-of-range version and the moment the runtime acted on it comes back with a version this
+ *   variant does not own and no transition to announce it, so it would sit there forever. Announcing it on the first
+ *   observation is what forward-migrates such a snapshot.
  */
 const protocolVersionChange = (
   previous: CoreWallet,
@@ -214,10 +214,10 @@ export class RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
               Effect.try({
                 try: () => {
                   const [newState, changesResult] = this.#v2Context.syncCapability.applyUpdate(
-                state,
-                update,
-                this.#context.activationRange,
-              );
+                    state,
+                    update,
+                    this.#context.activationRange,
+                  );
                   return [changesResult, newState] as const;
                 },
                 catch: (err) =>

--- a/packages/dust-wallet/src/v2/RunningV2Variant.ts
+++ b/packages/dust-wallet/src/v2/RunningV2Variant.ts
@@ -69,8 +69,26 @@ const progress = (state: CoreWallet): StateChange.StateChange<CoreWallet>[] => {
   return [StateChange.ProgressUpdate({ sourceGap, applyGap })];
 };
 
-const protocolVersionChange = (previous: CoreWallet, current: CoreWallet): StateChange.StateChange<CoreWallet>[] => {
-  return previous.protocolVersion != current.protocolVersion
+/**
+ * The version signals this variant puts on its state stream.
+ *
+ * @remarks
+ *   Two of them, for two different situations. A transition is the ordinary one: the state moved to a version the
+ *   variant may or may not own, and the runtime decides. The healing emission covers restore: a snapshot taken between
+ *   the moment sync annotated an out-of-range version and the moment the runtime acted on it comes back with a version
+ *   this variant does not own and no transition to announce it, so it would sit there forever. Announcing it on the
+ *   first observation is what forward-migrates such a snapshot.
+ */
+const protocolVersionChange = (
+  previous: CoreWallet,
+  current: CoreWallet,
+  isInitial: boolean,
+  activationRange: ProtocolVersion.ProtocolVersion.Range,
+): StateChange.StateChange<CoreWallet>[] => {
+  const transitioned = previous.protocolVersion != current.protocolVersion;
+  const strandedOutsideRange = isInitial && !ProtocolVersion.withinRange(current.protocolVersion, activationRange);
+
+  return transitioned || strandedOutsideRange
     ? [
         StateChange.VersionChange({
           change: VersionChangeType.Version({
@@ -128,18 +146,27 @@ export class RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
     this.state = Stream.fromEffect(context.stateRef.get).pipe(
       Stream.flatMap((initialState) =>
         context.stateRef.changes.pipe(
-          Stream.mapAccum(initialState, (previous: CoreWallet, current: CoreWallet) => {
-            return [current, [previous, current]] as const;
-          }),
+          // The accumulator carries the "have we seen anything yet" flag alongside the previous state: the first
+          // observation is the only one that can be a restored state nobody has inspected against this variant's
+          // range yet, and `SubscriptionRef.changes` replays the current value, so it is exactly this element.
+          Stream.mapAccum(
+            { previous: initialState, isInitial: true },
+            (seen, current: CoreWallet) =>
+              [{ previous: current, isInitial: false }, [seen.previous, current, seen.isInitial] as const] as const,
+          ),
         ),
       ),
       Stream.mapConcat(
-        ([previous, current]: readonly [CoreWallet, CoreWallet]): StateChange.StateChange<CoreWallet>[] => {
+        ([previous, current, isInitial]: readonly [
+          CoreWallet,
+          CoreWallet,
+          boolean,
+        ]): StateChange.StateChange<CoreWallet>[] => {
           // TODO: emit progress only upon actual change
           return [
             StateChange.State({ state: current }),
             ...progress(current),
-            ...protocolVersionChange(previous, current),
+            ...protocolVersionChange(previous, current, isInitial, context.activationRange),
           ];
         },
       ),
@@ -186,7 +213,11 @@ export class RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
             SubscriptionRef.modifyEffect(this.#context.stateRef, (state) =>
               Effect.try({
                 try: () => {
-                  const [newState, changesResult] = this.#v2Context.syncCapability.applyUpdate(state, update);
+                  const [newState, changesResult] = this.#v2Context.syncCapability.applyUpdate(
+                state,
+                update,
+                this.#context.activationRange,
+              );
                   return [changesResult, newState] as const;
                 },
                 catch: (err) =>

--- a/packages/dust-wallet/src/v2/Sync.ts
+++ b/packages/dust-wallet/src/v2/Sync.ts
@@ -26,6 +26,7 @@ import {
   Chunk,
   Schedule,
 } from 'effect';
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import {
   dustNullifier,
   successorDustUtxo,
@@ -104,8 +105,92 @@ export type ChangesResult = {
 };
 
 export interface SyncCapability<TState, TUpdate, TResult> {
-  applyUpdate: (state: TState, update: TUpdate) => [TState, TResult];
+  /**
+   * Folds a sync update into the wallet state.
+   *
+   * @param state The state to fold into.
+   * @param update The update to apply.
+   * @param activeRange The half-open protocol version range the running variant owns. Anything the source reports at or
+   *   beyond its end belongs to a later variant and must be left unapplied for that variant to fetch.
+   */
+  applyUpdate: (
+    state: TState,
+    update: TUpdate,
+    activeRange: ProtocolVersion.ProtocolVersion.Range,
+  ) => [TState, TResult];
 }
+
+/** The result of splitting a batch of version-tagged items at a variant's activation boundary. */
+export type BoundarySplit<T> = {
+  /** The leading items this variant owns, in source order. */
+  readonly applied: readonly T[];
+  /** The trailing items belonging to a later protocol version, left for the next variant to re-fetch. */
+  readonly deferred: readonly T[];
+  /**
+   * The protocol version to record on the state: the first deferred item's version when there is one — that is the
+   * signal that triggers migration — otherwise the last version any applied item reported. `None` when the batch was
+   * empty, and also when nothing in it reported a version at all.
+   */
+  readonly observedVersion: Option.Option<ProtocolVersion.ProtocolVersion>;
+};
+
+/**
+ * Splits a batch of version-tagged items at the end of a variant's activation range.
+ *
+ * @remarks
+ *   The split is positional, not a filter: everything from the first out-of-range item onwards is deferred, even if a
+ *   later item reports an in-range version again. A batch is a contiguous slice of one timeline, so applying past a
+ *   boundary and then resuming behind it would leave a hole no cursor can describe.
+ *
+ *   An item whose version is `undefined` is treated as in-range and contributes no annotation. Dust's subscription does
+ *   not report `protocolVersion` yet, so an absent value means "the indexer did not say" — which must keep today's
+ *   behaviour exactly, rather than being read as version zero and dragging the recorded version down.
+ *
+ *   This is the one place the boundary rule lives; the indexer capability (per event) and the simulator capability (per
+ *   block) both go through it, so they cannot drift apart.
+ * @param items The batch, in source order.
+ * @param versionOf Reads the protocol version an item was reported at, or `undefined` if it carries none.
+ * @param activeRange The variant's half-open activation range.
+ * @returns The applied/deferred split and the version to record.
+ */
+export const splitAtVersionBoundary = <T>(
+  items: readonly T[],
+  versionOf: (item: T) => number | undefined,
+  activeRange: ProtocolVersion.ProtocolVersion.Range,
+): BoundarySplit<T> => {
+  const [, end] = activeRange;
+  const boundary = items.findIndex((item) => {
+    const version = versionOf(item);
+    return version !== undefined && BigInt(version) >= end;
+  });
+  const [applied, deferred] =
+    boundary < 0 ? [items, [] as readonly T[]] : [items.slice(0, boundary), items.slice(boundary)];
+  // The first deferred item is the hand-over signal. Failing that, the last applied item that actually reported a
+  // version — searching backwards so a trailing untagged item does not erase an earlier tagged one.
+  const signalling =
+    deferred.at(0) ?? [...applied].reverse().find((item) => versionOf(item) !== undefined);
+  const signalledVersion = signalling === undefined ? undefined : versionOf(signalling);
+
+  return {
+    applied,
+    deferred,
+    observedVersion:
+      signalledVersion === undefined
+        ? Option.none()
+        : Option.some(ProtocolVersion.ProtocolVersion(BigInt(signalledVersion))),
+  };
+};
+
+/** Records a batch's observed protocol version on the state, monotonically. A batch that observed none is a no-op. */
+export const annotateVersion = (
+  state: CoreWallet,
+  observedVersion: Option.Option<ProtocolVersion.ProtocolVersion>,
+): CoreWallet =>
+  Option.match(observedVersion, {
+    onNone: () => state,
+    onSome: (version) => CoreWallet.withProtocolVersion(state, version),
+  });
+
 
 export type IndexerClientConnection = {
   indexerHttpUrl: string;
@@ -662,7 +747,11 @@ export const makeIndexerSyncService = (config: DefaultSyncConfiguration): Indexe
 
 export const makeDefaultSyncCapability = (): SyncCapability<CoreWallet, WalletSyncUpdate, ChangesResult> => {
   return {
-    applyUpdate(state: CoreWallet, wrappedUpdate: WalletSyncUpdate): [CoreWallet, ChangesResult] {
+    applyUpdate(
+      state: CoreWallet,
+      wrappedUpdate: WalletSyncUpdate,
+      activeRange: ProtocolVersion.ProtocolVersion.Range,
+    ): [CoreWallet, ChangesResult] {
       const { updates, secretKey } = wrappedUpdate;
 
       // Nothing to update yet
@@ -673,32 +762,71 @@ export const makeDefaultSyncCapability = (): SyncCapability<CoreWallet, WalletSy
       const appliedIndex = state.progress.appliedIndex;
       const freshUpdates = updates.filter((u) => BigInt(u.id) > appliedIndex);
 
+      // The tip is a property of the source, not of what this variant chose to apply, so it is read from the batch
+      // tail even when the tail belongs to the next protocol version.
       const highestRelevantWalletIndex = BigInt(updates.at(-1)!.maxId);
 
+      const { applied, observedVersion } = splitAtVersionBoundary(
+        freshUpdates,
+        (update) => update.protocolVersion,
+        activeRange,
+      );
+
       const [newState, changes]: [CoreWallet, DustStateChanges[]] =
-        freshUpdates.length === 0
+        applied.length === 0
           ? [state, []]
           : CoreWallet.applyEventsWithChanges(
               state,
               secretKey,
-              freshUpdates.map((u) => u.raw),
+              applied.map((u) => u.raw),
               wrappedUpdate.timestamp,
             );
 
-      const updatedState = CoreWallet.updateProgress(newState, {
-        appliedIndex: freshUpdates.length === 0 ? appliedIndex : BigInt(freshUpdates.at(-1)!.id),
+      // `appliedIndex` stops at the last event this variant actually replayed. The next variant resumes one below it
+      // on an inclusive cursor, so the deferred suffix is re-fetched rather than skipped.
+      const updatedState = CoreWallet.updateProgress(annotateVersion(newState, observedVersion), {
+        appliedIndex: applied.length === 0 ? appliedIndex : BigInt(applied.at(-1)!.id),
         highestRelevantWalletIndex,
         isConnected: true,
       });
 
-      return [updatedState, { changes, protocolVersion: Number(updatedState.protocolVersion) }];
+      return [
+        updatedState,
+        {
+          changes,
+          // Tags the changes that were actually produced, so tx-history records the version they were applied under
+          // rather than the one that is about to trigger the hand-over.
+          protocolVersion:
+            [...applied].reverse().find((u) => u.protocolVersion !== undefined)?.protocolVersion ??
+            Number(state.protocolVersion),
+        },
+      ];
     },
   };
 };
 
+/**
+ * The projections-based fast-sync capability.
+ *
+ * @remarks
+ *   **This path does not implement the fork boundary, and cannot yet.** It takes `activeRange` for signature parity with
+ *   the other capabilities and deliberately ignores it: a projections update is a folded snapshot of dust state — Merkle
+ *   tree updates, new and spent UTXOs, a block header — not a sequence of version-tagged timeline items, so there is
+ *   nothing in it to split and nothing that reports the protocol version a piece of it belongs to. `BlockData` carries
+ *   height, hash, timestamp and ledger parameters, but no version.
+ *
+ *   A wallet syncing through this path therefore never annotates a version and never hands over. Closing that needs a
+ *   version on the projections wire format, which is the same deferred indexer question as the one on
+ *   `SyncEventsUpdateSchema` — recorded here rather than papered over with a boundary check that would silently do
+ *   nothing.
+ */
 export const makeEventLessSyncCapability = (): SyncCapability<CoreWallet, DustProjectionsUpdate, ChangesResult> => {
   return {
-    applyUpdate(state: CoreWallet, update: DustProjectionsUpdate): [CoreWallet, ChangesResult] {
+    applyUpdate(
+      state: CoreWallet,
+      update: DustProjectionsUpdate,
+      _activeRange: ProtocolVersion.ProtocolVersion.Range,
+    ): [CoreWallet, ChangesResult] {
       if (isProgressUpdate(update)) {
         return [
           CoreWallet.updateProgress(state, {
@@ -921,27 +1049,50 @@ export const makeSimulatorSyncService = (
 
 export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, SimulatorSyncUpdate, ChangesResult> => {
   return {
-    applyUpdate: (state: CoreWallet, update: SimulatorSyncUpdate): [CoreWallet, ChangesResult] => {
+    applyUpdate: (
+      state: CoreWallet,
+      update: SimulatorSyncUpdate,
+      activeRange: ProtocolVersion.ProtocolVersion.Range,
+    ): [CoreWallet, ChangesResult] => {
       const lastBlock = getLastBlock(update.update);
       // If no block exists yet (blank simulator), skip update
       if (lastBlock === undefined) {
         return [state, { changes: [], protocolVersion: Number(state.protocolVersion) }];
       }
-      // Get all events from blocks starting at appliedIndex (the next block to process).
+
       // appliedIndex semantics: the first block number we haven't processed yet.
       // Initial: appliedIndex = 0 (haven't processed any blocks)
       // After processing block N: appliedIndex = N + 1 (next block to process)
-      const events = [...getBlockEventsFrom(update.update, state.progress.appliedIndex)];
-      const [newState, changes] = CoreWallet.applyEventsWithChanges(
-        state,
-        update.secretKey,
-        events,
-        lastBlock.timestamp,
+      //
+      // The boundary is applied at block granularity here — a block carries exactly one protocol version, stamped when
+      // it was produced — but it is the same rule and the same helper the indexer path uses. Blocks are walked
+      // individually rather than through `getBlockEventsFrom` so that the split has something to cut.
+      const pending = update.update.blocks.filter((block) => block.number >= state.progress.appliedIndex);
+      const { applied, observedVersion } = splitAtVersionBoundary(
+        pending,
+        (block) => Number(block.protocolVersion),
+        activeRange,
       );
-      const updatedState = CoreWallet.updateProgress(newState, {
-        appliedIndex: lastBlock.number + 1n,
+
+      const events = applied.flatMap((block) => block.transactions.flatMap((tx) => tx.result.events));
+      const lastAppliedBlock = applied.at(-1);
+
+      const [newState, changes] =
+        applied.length === 0
+          ? [state, []]
+          : CoreWallet.applyEventsWithChanges(state, update.secretKey, events, lastAppliedBlock!.timestamp);
+
+      const updatedState = CoreWallet.updateProgress(annotateVersion(newState, observedVersion), {
+        appliedIndex: lastAppliedBlock === undefined ? state.progress.appliedIndex : lastAppliedBlock.number + 1n,
       });
-      return [updatedState, { changes, protocolVersion: Number(updatedState.protocolVersion) }];
+      return [
+        updatedState,
+        {
+          changes,
+          protocolVersion:
+            lastAppliedBlock === undefined ? Number(state.protocolVersion) : Number(lastAppliedBlock.protocolVersion),
+        },
+      ];
     },
   };
 };

--- a/packages/dust-wallet/src/v2/Sync.ts
+++ b/packages/dust-wallet/src/v2/Sync.ts
@@ -53,12 +53,7 @@ import {
 import { EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
 import { type URLError, WsURL } from '@midnightntwrk/wallet-sdk-utilities/networking';
 import { OtherWalletError, SyncWalletError, type WalletError } from './WalletError.js';
-import {
-  type Simulator,
-  type SimulatorState,
-  getBlockEventsFrom,
-  getLastBlock,
-} from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { type Simulator, type SimulatorState, getLastBlock } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import { CoreWallet } from './CoreWallet.js';
 import { type NetworkId } from './types/ledger.js';
 import {
@@ -167,8 +162,7 @@ export const splitAtVersionBoundary = <T>(
     boundary < 0 ? [items, [] as readonly T[]] : [items.slice(0, boundary), items.slice(boundary)];
   // The first deferred item is the hand-over signal. Failing that, the last applied item that actually reported a
   // version — searching backwards so a trailing untagged item does not erase an earlier tagged one.
-  const signalling =
-    deferred.at(0) ?? [...applied].reverse().find((item) => versionOf(item) !== undefined);
+  const signalling = deferred.at(0) ?? [...applied].reverse().find((item) => versionOf(item) !== undefined);
   const signalledVersion = signalling === undefined ? undefined : versionOf(signalling);
 
   return {
@@ -190,7 +184,6 @@ export const annotateVersion = (
     onNone: () => state,
     onSome: (version) => CoreWallet.withProtocolVersion(state, version),
   });
-
 
 export type IndexerClientConnection = {
   indexerHttpUrl: string;
@@ -810,10 +803,10 @@ export const makeDefaultSyncCapability = (): SyncCapability<CoreWallet, WalletSy
  *
  * @remarks
  *   **This path does not implement the fork boundary, and cannot yet.** It takes `activeRange` for signature parity with
- *   the other capabilities and deliberately ignores it: a projections update is a folded snapshot of dust state — Merkle
- *   tree updates, new and spent UTXOs, a block header — not a sequence of version-tagged timeline items, so there is
- *   nothing in it to split and nothing that reports the protocol version a piece of it belongs to. `BlockData` carries
- *   height, hash, timestamp and ledger parameters, but no version.
+ *   the other capabilities and deliberately ignores it: a projections update is a folded snapshot of dust state —
+ *   Merkle tree updates, new and spent UTXOs, a block header — not a sequence of version-tagged timeline items, so
+ *   there is nothing in it to split and nothing that reports the protocol version a piece of it belongs to. `BlockData`
+ *   carries height, hash, timestamp and ledger parameters, but no version.
  *
  *   A wallet syncing through this path therefore never annotates a version and never hands over. Closing that needs a
  *   version on the projections wire format, which is the same deferred indexer question as the one on

--- a/packages/dust-wallet/src/v2/SyncSchema.ts
+++ b/packages/dust-wallet/src/v2/SyncSchema.ts
@@ -396,6 +396,17 @@ export const SyncEventsUpdateSchema = Schema.Struct({
   id: Schema.Number,
   raw: HexedEvent,
   maxId: Schema.Number,
+  /**
+   * The protocol version the indexer reported this event under, when it reports one at all.
+   *
+   * @remarks
+   *   Optional because dust's subscription does not select the field yet — the schema defines it on `DustLedgerEvent`,
+   *   but adding the selection-set line waits on confirmation from a deployed indexer. Until then every item arrives
+   *   without it, and an absent value means "the indexer did not say", which is treated as in-range: the event applies
+   *   normally and the wallet's recorded version is left alone. Reading it as zero instead would drag the recorded
+   *   version down and, on a wallet already past the boundary, look like a migration backwards.
+   */
+  protocolVersion: Schema.optional(Schema.Number),
 });
 
 export type WalletSyncSubscription = Schema.Schema.Type<typeof SyncEventsUpdateSchema>;

--- a/packages/dust-wallet/src/v2/V2Builder.ts
+++ b/packages/dust-wallet/src/v2/V2Builder.ts
@@ -12,13 +12,15 @@
 // limitations under the License.
 import { Effect, Scope, type Types, type Either } from 'effect';
 import { type Expect, type ItemType } from '@midnightntwrk/wallet-sdk-utilities/types';
-import { type DustSecretKey, type FinalizedTransaction } from '@midnightntwrk/ledger-v9';
 import {
-  type WalletRuntimeError,
-  type VariantBuilder,
-  type Variant,
-} from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+  type DustParameters,
+  type DustSecretKey,
+  type FinalizedTransaction,
+  LedgerParameters,
+} from '@midnightntwrk/ledger-v9';
+import { WalletRuntimeError, type VariantBuilder, type Variant } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type WalletError } from './WalletError.js';
+import { type EmptyWalletMigrationConfiguration, type StateMigration, makeEmptyWalletMigration } from './Migration.js';
 import {
   type SyncService,
   type SyncCapability,
@@ -56,9 +58,34 @@ import { type TotalCostParameters } from './types/transaction.js';
 export type BaseV2Configuration = {
   networkId: NetworkId;
   costParameters: TotalCostParameters;
+  /**
+   * The dust parameters a state built from nothing is valued against.
+   *
+   * @remarks
+   *   Consulted by the migration seam alone — nothing else in the variant reads it. It exists because dust's local state
+   *   is parameterised where shielded's is not: generation and decay rates live on the state, so an empty dust wallet
+   *   cannot be built without a set of them. Optional, and defaulting to `LedgerParameters.initialParameters().dust`,
+   *   because it is the empty-wallet fallback that needs it, and that fallback is what every builder written before
+   *   migrations were configurable silently relies on. A variant registered as the target of a real fork does not use
+   *   this field at all: {@link makeCrossLedgerMigration} carries its own, required, parameters.
+   */
+  dustParameters?: DustParameters;
 };
 
 export type DefaultV2Configuration = BaseV2Configuration & DefaultTransactionHistoryConfiguration;
+
+/**
+ * Completes a builder configuration into the one the empty-wallet migration asks for.
+ *
+ * @remarks
+ *   The dust parameters are optional on the builder and required on the migration, and this is the single place that gap
+ *   is closed, so the fallback the unconfigured `build` takes and the one {@link V2Builder.withMigrationDefaults} states
+ *   explicitly cannot drift apart.
+ */
+const emptyWalletMigrationConfiguration = (configuration: BaseV2Configuration): EmptyWalletMigrationConfiguration => ({
+  networkId: configuration.networkId,
+  dustParameters: configuration.dustParameters ?? LedgerParameters.initialParameters().dust,
+});
 
 const V2BuilderSymbol: {
   readonly typeId: unique symbol;
@@ -68,10 +95,10 @@ const V2BuilderSymbol: {
 
 export type DefaultV2Variant = V2Variant<string, WalletSyncUpdate, FinalizedTransaction, DustSecretKey>;
 
-export type V2Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData> = Variant.Variant<
+export type V2Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData, TPreviousState = null> = Variant.Variant<
   typeof V2Tag,
   CoreWallet,
-  CoreWallet, // null,
+  TPreviousState,
   RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData>
 > & {
   deserializeState: (serialized: TSerialized) => Either.Either<CoreWallet, WalletError>;
@@ -81,12 +108,14 @@ export type V2Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData> = Varian
   transactionHistory: TransactionHistoryService;
 };
 
-export type DefaultV2Builder = V2Builder<
+export type DefaultV2Builder<TPreviousState = null> = V2Builder<
   DefaultV2Configuration,
   RunningV2Variant.Context<string, WalletSyncUpdate, FinalizedTransaction, DustSecretKey>,
   string,
   WalletSyncUpdate,
-  FinalizedTransaction
+  FinalizedTransaction,
+  object,
+  TPreviousState
 >;
 
 export class V2Builder<
@@ -96,28 +125,66 @@ export class V2Builder<
   TSyncUpdate = never,
   TTransaction = never,
   TStartAux extends object = object,
-> implements VariantBuilder.VariantBuilder<V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>, TConfig> {
-  #buildState: V2Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux>;
+  TPreviousState = null,
+> implements VariantBuilder.VariantBuilder<
+  V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState>,
+  TConfig
+> {
+  #buildState: V2Builder.PartialBuildState<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  >;
 
   constructor(
-    buildState: V2Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> = {},
+    buildState: V2Builder.PartialBuildState<
+      TConfig,
+      TContext,
+      TSerialized,
+      TSyncUpdate,
+      TTransaction,
+      TStartAux,
+      TPreviousState
+    > = {},
   ) {
     this.#buildState = buildState;
   }
 
-  withDefaults(): DefaultV2Builder {
-    return this.withDefaultTransactionType()
-      .withSyncDefaults()
-      .withSerializationDefaults()
-      .withTransactingDefaults()
-      .withCoinsAndBalancesDefaults()
-      .withTransactionHistoryDefaults()
-      .withKeysDefaults()
-      .withCoinSelectionDefaults() as DefaultV2Builder;
+  withDefaults(
+    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, null>,
+  ): DefaultV2Builder {
+    return (
+      this.withDefaultTransactionType()
+        .withSyncDefaults()
+        .withSerializationDefaults()
+        .withTransactingDefaults()
+        .withCoinsAndBalancesDefaults()
+        .withTransactionHistoryDefaults()
+        .withKeysDefaults()
+        // Type cast required because: the chain accumulates `TConfig` and `TContext` as intersections of the
+        // individual `Default*` fragments, which are structurally weaker than the complete `DefaultV2Configuration`
+        // and `RunningV2Variant.Context` that `DefaultV2Builder` names — the defaults do produce both in full, but the
+        // chain's type cannot express that. The widening itself predates the migration seam; it has to route through
+        // `unknown` only since `BaseV2Configuration` gained the optional `dustParameters`, which is what puts the two
+        // sides past what TypeScript will accept as directly comparable.
+        .withCoinSelectionDefaults() as unknown as DefaultV2Builder
+    );
   }
 
-  withTransactionType<Transaction>(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, Transaction, TStartAux> {
-    return new V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, Transaction, TStartAux>({
+  withTransactionType<Transaction>(): V2Builder<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    Transaction,
+    TStartAux,
+    TPreviousState
+  > {
+    return new V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, Transaction, TStartAux, TPreviousState>({
       ...this.#buildState,
       transactingCapability: undefined,
     });
@@ -129,7 +196,8 @@ export class V2Builder<
     TSerialized,
     TSyncUpdate,
     FinalizedTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return this.withTransactionType<FinalizedTransaction>();
   }
@@ -140,7 +208,8 @@ export class V2Builder<
     TSerialized,
     WalletSyncUpdate,
     TTransaction,
-    DustSecretKey
+    DustSecretKey,
+    TPreviousState
   > {
     return this.withSync(makeDefaultSyncService, makeDefaultSyncCapability);
   }
@@ -159,14 +228,23 @@ export class V2Builder<
       configuration: TSyncConfig,
       getContext: () => TSyncContext,
     ) => SyncCapability<CoreWallet, TSyncUpdate, ChangesResult>,
-  ): V2Builder<TConfig & TSyncConfig, TContext & TSyncContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  ): V2Builder<
+    TConfig & TSyncConfig,
+    TContext & TSyncContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return new V2Builder<
       TConfig & TSyncConfig,
       TContext & TSyncContext,
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       syncService,
@@ -174,7 +252,15 @@ export class V2Builder<
     });
   }
 
-  withSerializationDefaults(): V2Builder<TConfig, TContext, string, TSyncUpdate, TTransaction, TStartAux> {
+  withSerializationDefaults(): V2Builder<
+    TConfig,
+    TContext,
+    string,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return this.withSerialization(makeDefaultV2SerializationCapability);
   }
 
@@ -193,7 +279,8 @@ export class V2Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V2Builder<
       TConfig & TSerializationConfig,
@@ -201,7 +288,8 @@ export class V2Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       serializationCapability,
@@ -209,14 +297,15 @@ export class V2Builder<
   }
 
   withTransactingDefaults(
-    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, FinalizedTransaction, TStartAux>,
+    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, FinalizedTransaction, TStartAux, TPreviousState>,
   ): V2Builder<
     TConfig & DefaultTransactingConfiguration,
     TContext & DefaultTransactingContext,
     TSerialized,
     TSyncUpdate,
     FinalizedTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return this.withTransacting(makeDefaultTransactingCapability);
   }
@@ -232,7 +321,8 @@ export class V2Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V2Builder<
       TConfig & TTransactingConfig,
@@ -240,7 +330,8 @@ export class V2Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       transactingCapability,
@@ -255,7 +346,8 @@ export class V2Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V2Builder<
       TConfig & TCoinSelectionConfig,
@@ -263,14 +355,23 @@ export class V2Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       coinSelection,
     });
   }
 
-  withCoinSelectionDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  withCoinSelectionDefaults(): V2Builder<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return this.withCoinSelection(() => chooseCoin);
   }
 
@@ -280,7 +381,8 @@ export class V2Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return this.withCoinsAndBalances(makeDefaultCoinsAndBalancesCapability);
   }
@@ -296,7 +398,8 @@ export class V2Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V2Builder<
       TConfig & TBalancesConfig,
@@ -304,7 +407,8 @@ export class V2Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       coinsAndBalancesCapability,
@@ -312,14 +416,15 @@ export class V2Builder<
   }
 
   withTransactionHistoryDefaults(
-    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, FinalizedTransaction, TStartAux>,
+    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, FinalizedTransaction, TStartAux, TPreviousState>,
   ): V2Builder<
     TConfig & DefaultTransactionHistoryConfiguration,
     TContext,
     TSerialized,
     TSyncUpdate,
     FinalizedTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return this.withTransactionHistory(makeDefaultTransactionHistoryService);
   }
@@ -338,7 +443,8 @@ export class V2Builder<
     TSerialized,
     TSyncUpdate,
     TTransaction,
-    TStartAux
+    TStartAux,
+    TPreviousState
   > {
     return new V2Builder<
       TConfig & TTransactionHistoryConfig,
@@ -346,30 +452,114 @@ export class V2Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       transactionHistoryService,
     });
   }
 
-  withKeysDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  withKeysDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState> {
     return this.withKeys(makeDefaultKeysCapability);
   }
 
   withKeys<TKeysConfig, TKeysContext extends Partial<RunningV2Variant.AnyContext>>(
     keysCapability: (configuration: TKeysConfig, getContext: () => TKeysContext) => KeysCapability<CoreWallet>,
-  ): V2Builder<TConfig & TKeysConfig, TContext & TKeysContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  ): V2Builder<
+    TConfig & TKeysConfig,
+    TContext & TKeysContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  > {
     return new V2Builder<
       TConfig & TKeysConfig,
       TContext & TKeysContext,
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >({
       ...this.#buildState,
       keysCapability,
+    });
+  }
+
+  /**
+   * Uses the default migration: an empty wallet built from nothing.
+   *
+   * @remarks
+   *   This is what an unconfigured builder already does, so calling it changes no behaviour — it states the choice rather
+   *   than inheriting it. Registering this variant as the target of a real fork means calling
+   *   {@link V2Builder.withMigration} with {@link makeCrossLedgerMigration} instead.
+   *
+   *   The parameters the empty dust state is valued against come from the builder configuration when it names them, and
+   *   from the ledger's initial parameters when it does not.
+   */
+  withMigrationDefaults(
+    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, null>,
+  ): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, null> {
+    return this.withMigration((configuration: BaseV2Configuration) =>
+      makeEmptyWalletMigration(emptyWalletMigrationConfiguration(configuration)),
+    );
+  }
+
+  /**
+   * Chooses how this variant produces its first state from the state that preceded it.
+   *
+   * @remarks
+   *   The strategy's input type becomes the variant's `TPreviousState`, which is what the runtime type-checks a
+   *   registration against: a variant declaring it migrates from a ledger-v8 dust wallet cannot be registered after one
+   *   that produces something else.
+   *
+   *   The context the factory reads is a type parameter of the method, exactly as it is for every other capability here,
+   *   rather than the builder's own `TContext`. Naming `TContext` in an argument position would make the builder
+   *   invariant in it, and a chain that has not yet configured every capability — which is how the simulator-backed
+   *   variants are assembled — could then no longer be handed to {@link V2Builder.build}.
+   * @example
+   *   ```typescript
+   *   const forkTarget = new V2Builder().withDefaults().withMigration(makeCrossLedgerMigration);
+   *   ```;
+   *
+   * @param migration Builds the migration from the configuration and the sibling capabilities.
+   */
+  withMigration<TMigrationConfig, TMigrationContext extends Partial<RunningV2Variant.AnyContext>, TPrevious>(
+    migration: (configuration: TMigrationConfig, getContext: () => TMigrationContext) => StateMigration<TPrevious>,
+  ): V2Builder<
+    TConfig & TMigrationConfig,
+    TContext & TMigrationContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPrevious
+  > {
+    const capabilities: V2Builder.CapabilityBuildState<
+      TConfig & TMigrationConfig,
+      TContext & TMigrationContext,
+      TSerialized,
+      TSyncUpdate,
+      TTransaction,
+      TStartAux
+    > = this.#buildState;
+
+    return new V2Builder<
+      TConfig & TMigrationConfig,
+      TContext & TMigrationContext,
+      TSerialized,
+      TSyncUpdate,
+      TTransaction,
+      TStartAux,
+      TPrevious
+    >({
+      // Only the capability half crosses: the strategy being replaced is typed against the *old* previous-state
+      // parameter, so it cannot ride along even though it is about to be overwritten.
+      ...capabilities,
+      migration,
     });
   }
 
@@ -380,11 +570,14 @@ export class V2Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >,
     configuration: TConfig,
-  ): V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux> {
+  ): V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState> {
     const v2Context = this.#buildContextFromBuildState(configuration);
+    const migration = this.#resolveMigration(configuration, () => v2Context);
+
     return {
       __polyTag__: V2Tag,
       coinsAndBalances: v2Context.coinsAndBalancesCapability,
@@ -403,14 +596,41 @@ export class V2Builder<
           return new RunningV2Variant(scope, context, v2Context);
         });
       },
-      migrateState(prevState) {
-        // TODO: re-implement
-        return Effect.succeed(prevState);
-      },
+      // An unconfigured builder produces an empty wallet, which is what `startEmpty` asks of a first variant — the stub
+      // this replaces handed its own argument back, so it could only ever have returned `null`. Anything else —
+      // carrying dust within a ledger version, or projecting a wallet's identity across one — is the injected
+      // strategy's business, and its failures are reported on the runtime's state stream rather than thrown.
+      migrateState: (previousState: TPreviousState) =>
+        migration.migrate(previousState).pipe(
+          Effect.mapError(
+            (error) =>
+              new WalletRuntimeError({
+                message: 'Failed to migrate dust wallet state into this variant',
+                cause: error,
+              }),
+          ),
+        ),
+
       deserializeState: (serialized: TSerialized): Either.Either<CoreWallet, WalletError> => {
         return v2Context.serializationCapability.deserialize(null, serialized);
       },
     };
+  }
+
+  /**
+   * Resolves the configured migration, or the empty-wallet fallback when none was configured.
+   *
+   * @remarks
+   *   The fallback is written as a nullary function on purpose. It ignores whatever preceded it — it builds an empty
+   *   wallet from nothing — which makes it a valid migration from _any_ previous state, but a `StateMigration<null>`
+   *   value could only be widened to `StateMigration<TPreviousState>` through a cast. Declaring no parameter says the
+   *   same thing to the type system without one.
+   */
+  #resolveMigration(configuration: TConfig, getContext: () => TContext): StateMigration<TPreviousState> {
+    const configured = this.#buildState.migration;
+    return configured === undefined
+      ? { migrate: () => makeEmptyWalletMigration(emptyWalletMigrationConfiguration(configuration)).migrate(null) }
+      : configured(configuration, getContext);
   }
 
   #buildContextFromBuildState(
@@ -420,7 +640,8 @@ export class V2Builder<
       TSerialized,
       TSyncUpdate,
       TTransaction,
-      TStartAux
+      TStartAux,
+      TPreviousState
     >,
     configuration: TConfig,
   ): RunningV2Variant.Context<TSerialized, TSyncUpdate, TTransaction, TStartAux> {
@@ -515,7 +736,17 @@ declare namespace V2Builder {
       HasKeys<TConfig, TContext> &
       HasTransactionHistory<TConfig, TContext>
   >;
-  type PartialBuildState<
+  /**
+   * The migration entry, kept out of {@link FullBuildState} on purpose: absent means "empty wallet", which is the
+   * behaviour every builder had before migrations were configurable, so a builder that never mentions migration must
+   * still be considered complete.
+   */
+  type HasMigration<TConfig, TContext, TPreviousState> = {
+    readonly migration: (configuration: TConfig, getContext: () => TContext) => StateMigration<TPreviousState>;
+  };
+
+  /** The capability half of the build state — everything that does not depend on the previous-state parameter. */
+  type CapabilityBuildState<
     TConfig = object,
     TContext = object,
     TSerialized = never,
@@ -527,6 +758,21 @@ declare namespace V2Builder {
       FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux>[K] | undefined;
   };
 
+  type PartialBuildState<
+    TConfig = object,
+    TContext = object,
+    TSerialized = never,
+    TSyncUpdate = never,
+    TTransaction = never,
+    TStartAux = object,
+    TPreviousState = null,
+  > = {
+    [K in keyof (FullBuildState<never, never, never, never, never, never> & HasMigration<never, never, never>)]?:
+      | (FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> &
+          HasMigration<TConfig, TContext, TPreviousState>)[K]
+      | undefined;
+  };
+
   /** Utility interface that manages the type variance of {@link V2Builder}. */
   interface Variance<R> {
     readonly [V2BuilderSymbol.typeId]: {
@@ -535,8 +781,16 @@ declare namespace V2Builder {
   }
 }
 
-const isBuildStateFull = <TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux>(
-  buildState: V2Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux>,
+const isBuildStateFull = <TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState>(
+  buildState: V2Builder.PartialBuildState<
+    TConfig,
+    TContext,
+    TSerialized,
+    TSyncUpdate,
+    TTransaction,
+    TStartAux,
+    TPreviousState
+  >,
 ): buildState is V2Builder.FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> => {
   const allBuildStateKeys = [
     'syncService',

--- a/packages/dust-wallet/src/v2/index.ts
+++ b/packages/dust-wallet/src/v2/index.ts
@@ -13,6 +13,7 @@
 export * from './CoreWallet.js';
 export * from '../DustWallet.js';
 export * as Keys from './Keys.js';
+export * as Migration from './Migration.js';
 export * as Simulator from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 export * as SyncService from './Sync.js';
 export * as Transacting from './Transacting.js';

--- a/packages/dust-wallet/src/v2/test/dustEvents.ts
+++ b/packages/dust-wallet/src/v2/test/dustEvents.ts
@@ -183,7 +183,7 @@ export const buildDustChain = (protocolVersion?: ProtocolVersion.ProtocolVersion
           const signed = yield* running.addDustGenerationSignature(unsigned, signature);
           // The simulator takes proof-erased transactions, so erasing here is the whole of "proving" on this path —
           // the same shortcut `makeSimulatorProvingServiceEffect` takes, without depending on it.
-          yield* simulator.submitTransaction(signed.eraseProofs(), 'InBlock');
+          yield* simulator.submitTransaction(signed.eraseProofs());
           yield* syncedTo(BigInt(DUST_EVENT_COUNT + index + 1));
         }),
       { discard: true },

--- a/packages/dust-wallet/src/v2/test/dustEvents.ts
+++ b/packages/dust-wallet/src/v2/test/dustEvents.ts
@@ -23,7 +23,11 @@ import {
   signData,
   signatureVerifyingKey,
 } from '@midnightntwrk/ledger-v9';
-import { InMemoryTransactionHistoryStorage, type NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  InMemoryTransactionHistoryStorage,
+  type NetworkId,
+  ProtocolVersion,
+} from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustAddress } from '@midnightntwrk/wallet-sdk-address-format';
 import { Simulator, type SimulatorState, getBlockEventsFrom } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import { HDWallet, Roles } from '@midnightntwrk/wallet-sdk-hd';
@@ -38,12 +42,12 @@ import { V2Builder } from '../V2Builder.js';
 
 const NIGHT_TOKEN_TYPE = nativeToken().raw;
 const SEED = '0000000000000000000000000000000000000000000000000000000000000001';
-const NETWORK: NetworkId.NetworkId = 'undeployed' as NetworkId.NetworkId;
+const NETWORK: NetworkId.NetworkId = 'undeployed';
 
 /**
  * How many Night UTXOs are rewarded, and therefore how many dust events the fixture produces.
  *
- * One reward per block, then one *separate* registration transaction per Night UTXO, so every registration block
+ * One reward per block, then one _separate_ registration transaction per Night UTXO, so every registration block
  * carries exactly one `dustInitialUtxo` event. Registering several UTXOs in a single transaction does not work for this
  * purpose: the registration splits them across the guaranteed and fallible sections and only some of them produce an
  * event, so the event count stops tracking the input count.
@@ -117,7 +121,8 @@ export type DustChain = {
  *
  *   Each call builds a fresh chain. The simulator's blocks hold the only live `Event` instances, and replaying them
  *   consumes them, so a state cannot be shared between two tests that both apply it.
- * @param protocolVersion The version every block of this chain is stamped with. Defaults to the simulator's own default.
+ * @param protocolVersion The version every block of this chain is stamped with. Defaults to the simulator's own
+ *   default.
  */
 export const buildDustChain = (protocolVersion?: ProtocolVersion.ProtocolVersion): Promise<DustChain> =>
   Effect.gen(function* () {

--- a/packages/dust-wallet/src/v2/test/dustEvents.ts
+++ b/packages/dust-wallet/src/v2/test/dustEvents.ts
@@ -1,0 +1,199 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import {
+  type DustParameters,
+  DustSecretKey,
+  Event,
+  LedgerParameters,
+  type ProofErasedTransaction,
+  type SignatureVerifyingKey,
+  type UserAddress,
+  addressFromKey,
+  nativeToken,
+  signData,
+  signatureVerifyingKey,
+} from '@midnightntwrk/ledger-v9';
+import { InMemoryTransactionHistoryStorage, type NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { DustAddress } from '@midnightntwrk/wallet-sdk-address-format';
+import { Simulator, type SimulatorState, getBlockEventsFrom } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { HDWallet, Roles } from '@midnightntwrk/wallet-sdk-hd';
+import { DateOps } from '@midnightntwrk/wallet-sdk-utilities';
+import { Effect, Stream, SubscriptionRef } from 'effect';
+import { CoreWallet } from '../CoreWallet.js';
+import { makeSimulatorSyncCapability, makeSimulatorSyncService } from '../Sync.js';
+import { DustTransactionHistoryEntrySchema, makeSimulatorTransactionHistoryService } from '../TransactionHistory.js';
+import * as Transacting from '../Transacting.js';
+import { type UtxoWithMeta } from '../types/Dust.js';
+import { V2Builder } from '../V2Builder.js';
+
+const NIGHT_TOKEN_TYPE = nativeToken().raw;
+const SEED = '0000000000000000000000000000000000000000000000000000000000000001';
+const NETWORK: NetworkId.NetworkId = 'undeployed' as NetworkId.NetworkId;
+
+/**
+ * How many Night UTXOs are rewarded, and therefore how many dust events the fixture produces.
+ *
+ * One reward per block, then one *separate* registration transaction per Night UTXO, so every registration block
+ * carries exactly one `dustInitialUtxo` event. Registering several UTXOs in a single transaction does not work for this
+ * purpose: the registration splits them across the guaranteed and fallible sections and only some of them produce an
+ * event, so the event count stops tracking the input count.
+ */
+export const DUST_EVENT_COUNT = 4;
+
+/** The dust HD key for {@link SEED} — the same derivation the wallet itself uses. */
+const dustSeed = (): Uint8Array => {
+  const result = HDWallet.fromSeed(Buffer.from(SEED, 'hex'));
+  const { hdWallet } = result as { type: 'seedOk'; hdWallet: HDWallet };
+  const derived = hdWallet.selectAccount(0).selectRole(Roles.Dust).deriveKeyAt(0);
+  if (derived.type === 'keyOutOfBounds') {
+    throw new Error('Key derivation out of bounds');
+  }
+  return derived.key;
+};
+
+/**
+ * A minimal unshielded keystore over the dust seed.
+ *
+ * @remarks
+ *   Local rather than imported from the package's `test/` directory: that copy is shared with the top-level wallet test
+ *   and the v1 twin of this fixture needs the ledger-v8 shape of the same thing, so each tree keeps its own.
+ */
+const keystoreOf = (seed: Uint8Array) => {
+  const signingKey = { tag: 'schnorr' as const, value: Buffer.from(seed).toString('hex') };
+  const publicKey = (): SignatureVerifyingKey => signatureVerifyingKey(signingKey);
+  return {
+    publicKey,
+    address: (): UserAddress => addressFromKey(publicKey()),
+    sign: (data: Uint8Array) => signData(signingKey, data),
+  };
+};
+
+const nightWithMeta = (state: SimulatorState, address: UserAddress): UtxoWithMeta[] =>
+  [...state.ledger.utxo.filter(address)]
+    .filter((utxo) => utxo.type === NIGHT_TOKEN_TYPE)
+    .flatMap((utxo) => {
+      const meta = state.ledger.utxo.lookupMeta(utxo);
+      return meta === undefined ? [] : [{ ...utxo, ctime: meta.ctime, registeredForDustGeneration: false }];
+    });
+
+export const dustParameters = (): DustParameters => LedgerParameters.initialParameters().dust;
+
+export const fixtureSecretKey = (): DustSecretKey => DustSecretKey.fromSeed(Buffer.from(dustSeed()));
+
+export const freshWallet = (): CoreWallet => CoreWallet.initEmpty(dustParameters(), fixtureSecretKey(), NETWORK);
+
+/** A real dust chain plus the events it produced. */
+export type DustChain = {
+  /**
+   * Serialized bytes of the {@link DUST_EVENT_COUNT} real `dustInitialUtxo` events, in chain order.
+   *
+   * Bytes rather than `Event` instances on purpose: `replayEventsWithChanges` takes ownership of the events it is
+   * handed (wasm-bindgen moves them), so re-using an instance throws. Every use deserializes its own.
+   */
+  readonly eventBytes: readonly Uint8Array[];
+  /** The simulator state after the last registration. Its blocks still hold live, unconsumed `Event` instances. */
+  readonly state: SimulatorState;
+  /** A time strictly after the last block, safe to value the resulting dust at. */
+  readonly syncTime: Date;
+};
+
+/**
+ * Drives a real dust chain: {@link DUST_EVENT_COUNT} Night rewards, then one registration transaction per Night UTXO.
+ *
+ * @remarks
+ *   Every registration block carries exactly one `dustInitialUtxo` event, so block numbers and event ids line up one to
+ *   one — which is what lets the same fixture drive both the batched indexer capability and the block-granular
+ *   simulator capability.
+ *
+ *   Each call builds a fresh chain. The simulator's blocks hold the only live `Event` instances, and replaying them
+ *   consumes them, so a state cannot be shared between two tests that both apply it.
+ * @param protocolVersion The version every block of this chain is stamped with. Defaults to the simulator's own default.
+ */
+export const buildDustChain = (protocolVersion?: ProtocolVersion.ProtocolVersion): Promise<DustChain> =>
+  Effect.gen(function* () {
+    const simulator = yield* Simulator.init({
+      networkId: NETWORK,
+      ...(protocolVersion === undefined ? {} : { protocolVersion }),
+    });
+    const secretKey = fixtureSecretKey();
+    const keystore = keystoreOf(dustSeed());
+    const verifyingKey = keystore.publicKey();
+
+    const variant = new V2Builder()
+      .withTransactionType<ProofErasedTransaction>()
+      .withCoinSelectionDefaults()
+      .withTransacting(Transacting.makeSimulatorTransactingCapability)
+      .withSync(makeSimulatorSyncService, makeSimulatorSyncCapability)
+      .withCoinsAndBalancesDefaults()
+      .withKeysDefaults()
+      .withSerializationDefaults()
+      .withTransactionHistory(makeSimulatorTransactionHistoryService)
+      .build({
+        simulator,
+        networkId: NETWORK,
+        costParameters: { feeBlocksMargin: 5 },
+        txHistoryStorage: new InMemoryTransactionHistoryStorage(DustTransactionHistoryEntrySchema),
+        indexerClientConnection: { indexerHttpUrl: '' },
+      });
+
+    const initial = CoreWallet.initEmpty(dustParameters(), secretKey, NETWORK);
+    const stateRef = yield* SubscriptionRef.make(initial);
+    const running = yield* variant.start({
+      stateRef,
+      activationRange: ProtocolVersion.makeRange(
+        ProtocolVersion.MinSupportedVersion,
+        ProtocolVersion.MaxSupportedVersion,
+      ),
+    });
+    yield* running.startSyncInBackground(secretKey);
+
+    const syncedTo = (blockNumber: bigint) =>
+      Stream.runLast(stateRef.changes.pipe(Stream.find((wallet) => wallet.progress.appliedIndex >= blockNumber + 1n)));
+
+    yield* Effect.repeatN(simulator.rewardNight(verifyingKey, 150_000_000_000n), DUST_EVENT_COUNT - 1);
+    yield* syncedTo(BigInt(DUST_EVENT_COUNT));
+
+    const rewarded = yield* simulator.getLatestState();
+    const nightUtxos = nightWithMeta(rewarded, keystore.address());
+
+    yield* Effect.forEach(
+      nightUtxos,
+      (utxo, index) =>
+        Effect.gen(function* () {
+          const current = yield* simulator.getLatestState();
+          const now = DateOps.addSeconds(current.currentTime, 1);
+          const unsigned = yield* running.createDustGenerationTransaction(
+            now,
+            DateOps.addSeconds(now, 1),
+            [utxo],
+            verifyingKey,
+            new DustAddress(initial.publicKey.publicKey),
+          );
+          const signature = keystore.sign(unsigned.intents!.get(1)!.signatureData(1));
+          const signed = yield* running.addDustGenerationSignature(unsigned, signature);
+          // The simulator takes proof-erased transactions, so erasing here is the whole of "proving" on this path —
+          // the same shortcut `makeSimulatorProvingServiceEffect` takes, without depending on it.
+          yield* simulator.submitTransaction(signed.eraseProofs(), 'InBlock');
+          yield* syncedTo(BigInt(DUST_EVENT_COUNT + index + 1));
+        }),
+      { discard: true },
+    );
+
+    const state = yield* simulator.getLatestState();
+    const eventBytes = [...getBlockEventsFrom(state, 0n)].map((event) => event.serialize());
+    return { eventBytes, state, syncTime: DateOps.addSeconds(state.currentTime, 2) };
+  }).pipe(Effect.scoped, Effect.runPromise);
+
+/** Deserializes a fresh, unconsumed instance of the fixture event at `index`. */
+export const eventAt = (eventBytes: readonly Uint8Array[], index: number): Event =>
+  Event.deserialize(eventBytes[index]);

--- a/packages/dust-wallet/src/v2/test/migration.test.ts
+++ b/packages/dust-wallet/src/v2/test/migration.test.ts
@@ -1,0 +1,161 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * How this variant builds its first state from whatever preceded it.
+ *
+ * @remarks
+ *   The three strategies differ in exactly one thing — how much of the previous wallet is allowed to survive — so that is
+ *   what these pin down: everything (same ledger version), nothing (no previous wallet at all), and, across a ledger
+ *   version boundary, identity only.
+ */
+
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { CoreWallet, PublicKey } from '../CoreWallet.js';
+import {
+  type PreviousLedgerWallet,
+  makeCarryOverMigration,
+  makeCrossLedgerMigration,
+  makeEmptyWalletMigration,
+} from '../Migration.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+const seed = Buffer.alloc(32, 7);
+const secretKey = (): ledger.DustSecretKey => ledger.DustSecretKey.fromSeed(seed);
+const dustParameters = (): ledger.DustParameters => ledger.LedgerParameters.initialParameters().dust;
+
+/** The version that triggered the hand-over: the first one the previous variant saw outside its own range. */
+const forkVersion = ProtocolVersion.ProtocolVersion(7n);
+
+/**
+ * A wallet of the previous ledger version, as plain data.
+ *
+ * @remarks
+ *   Deliberately wider than {@link PreviousLedgerWallet}: it also carries the dust a real pre-fork wallet would be
+ *   holding, so that "that does not cross" is something this file can actually observe rather than merely fail to
+ *   mention. Its cursor is non-zero for the opposite reason — what does cross has to be seen crossing. Structural
+ *   because the real thing is built on the other ledger's WASM module, and a projection that reads no ledger object out
+ *   of it has no reason to load one.
+ */
+type PreviousWalletStandIn = PreviousLedgerWallet & {
+  readonly utxos: readonly Readonly<{ nonce: string; initialValue: bigint }>[];
+};
+
+const previousWallet = (): PreviousWalletStandIn => ({
+  publicKey: { publicKey: PublicKey.fromSecretKey(secretKey()).publicKey },
+  networkId,
+  protocolVersion: forkVersion,
+  progress: {
+    appliedIndex: 4321n,
+    highestRelevantWalletIndex: 4400n,
+    highestIndex: 4400n,
+    highestRelevantIndex: 4400n,
+    isConnected: true,
+  },
+  utxos: [
+    { nonce: 'bb'.repeat(32), initialValue: 100n },
+    { nonce: 'cc'.repeat(32), initialValue: 200n },
+  ],
+});
+
+describe('the empty-wallet migration', () => {
+  it('produces a wallet holding no dust on the configured network', async () => {
+    const wallet = await Effect.runPromise(
+      makeEmptyWalletMigration({ networkId, dustParameters: dustParameters() }).migrate(null),
+    );
+
+    expect(wallet.networkId).toBe(networkId);
+    expect(wallet.state.utxos).toEqual([]);
+    expect(wallet.pendingDust).toEqual([]);
+    expect(wallet.progress.appliedIndex).toBe(0n);
+    expect(wallet.protocolVersion).toBe(ProtocolVersion.MinSupportedVersion);
+  });
+});
+
+describe('the carry-over migration', () => {
+  it('hands the previous state through untouched', async () => {
+    const previous = CoreWallet.initEmpty(dustParameters(), secretKey(), networkId);
+
+    const wallet = await Effect.runPromise(makeCarryOverMigration().migrate(previous));
+
+    expect(wallet).toBe(previous);
+  });
+});
+
+describe('the cross-ledger migration', () => {
+  const migration = () => makeCrossLedgerMigration({ dustParameters: dustParameters() });
+
+  it('carries the dust public key, so the replayed timeline can be decrypted into the same dust', async () => {
+    const previous = previousWallet();
+
+    const wallet = await Effect.runPromise(migration().migrate(previous));
+
+    expect(wallet.publicKey.publicKey).toBe(PublicKey.fromSecretKey(secretKey()).publicKey);
+    expect(wallet.networkId).toBe(networkId);
+  });
+
+  it('records the version that triggered the hand-over, so the new variant starts inside its own range', async () => {
+    const wallet = await Effect.runPromise(migration().migrate(previousWallet()));
+
+    expect(wallet.protocolVersion).toBe(forkVersion);
+  });
+
+  it('starts from an empty local state rather than carrying the previous version dust', async () => {
+    // The indexer replays the timeline after the fork, so this dust is generated again by events of this ledger
+    // version. Carrying it as well would double-count it, and it is backed by a Merkle tree of the other ledger's
+    // making that this ledger cannot read.
+    const previous = previousWallet();
+    expect(previous.utxos.length).toBeGreaterThan(0);
+
+    const wallet = await Effect.runPromise(migration().migrate(previous));
+
+    expect(wallet.state.utxos).toEqual([]);
+    expect(wallet.state.commitmentTreeFirstFree).toBe(0n);
+    expect(wallet.state.generatingTreeFirstFree).toBe(0n);
+    expect(wallet.pendingDust).toEqual([]);
+  });
+
+  it('builds the fresh state on this ledger version parameters, not the previous version', async () => {
+    // Dust's local state is parameterised by the ledger's dust parameters, and those are a WASM object of whichever
+    // ledger module produced them. The previous variant's copy therefore cannot cross; the migration is handed this
+    // version's parameters instead. (No shielded analogue — `ZswapLocalState` takes no parameters.)
+    const wallet = await Effect.runPromise(migration().migrate(previousWallet()));
+
+    expect(wallet.state.params.nightDustRatio).toBe(dustParameters().nightDustRatio);
+    expect(wallet.state.params.generationDecayRate).toBe(dustParameters().generationDecayRate);
+    expect(wallet.state.params.dustGracePeriodSeconds).toBe(dustParameters().dustGracePeriodSeconds);
+  });
+
+  it('parks sync progress at the fork, because the replayed timeline continues the ids it left off at', async () => {
+    // The confirmed semantics: after the hard fork the indexer replays the events again, numbering them onwards from
+    // whatever id it had reached when the fork happened — never from zero. So the migrated wallet resumes from where
+    // its predecessor stopped. Rewinding to zero would point it at a stretch of the timeline the replay does not
+    // occupy, and it would sit there waiting for events that already went by under the previous ledger version.
+    const previous = previousWallet();
+    expect(previous.progress.appliedIndex).toBeGreaterThan(0n);
+
+    const wallet = await Effect.runPromise(migration().migrate(previous));
+
+    expect(wallet.progress.appliedIndex).toBe(previous.progress.appliedIndex);
+    expect(wallet.progress.highestIndex).toBe(previous.progress.highestIndex);
+    expect(wallet.progress.highestRelevantIndex).toBe(previous.progress.highestRelevantIndex);
+    expect(wallet.progress.highestRelevantWalletIndex).toBe(previous.progress.highestRelevantWalletIndex);
+    // The position crosses; being connected does not. This state has no running sync behind it yet — the restart that
+    // follows the migration is what reconnects it — and claiming otherwise would report a gap that nothing is closing.
+    expect(previous.progress.isConnected).toBe(true);
+    expect(wallet.progress.isConnected).toBe(false);
+  });
+});

--- a/packages/dust-wallet/src/v2/test/runningV2Variant.test.ts
+++ b/packages/dust-wallet/src/v2/test/runningV2Variant.test.ts
@@ -11,17 +11,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import {
+  DustLocalState,
   DustSecretKey,
   type DustStateChanges,
   type FinalizedTransaction,
   LedgerParameters,
 } from '@midnightntwrk/ledger-v9';
 import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Duration, Effect, Exit, Ref, Scope, Stream, SubscriptionRef, TestClock, TestContext } from 'effect';
+import { Chunk, Duration, Effect, Exit, Fiber, Ref, Scope, Stream, SubscriptionRef, TestClock, TestContext } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { chooseCoin, makeDefaultCoinsAndBalancesCapability } from '../CoinsAndBalances.js';
-import { CoreWallet } from '../CoreWallet.js';
+import { CoreWallet, PublicKey } from '../CoreWallet.js';
 import { makeDefaultKeysCapability } from '../Keys.js';
+import { StateChange, VersionChangeType } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { RunningV2Variant } from '../RunningV2Variant.js';
 import { makeDefaultV2SerializationCapability } from '../Serialization.js';
 import { type ChangesResult, type SyncCapability, type SyncService } from '../Sync.js';
@@ -162,5 +164,90 @@ describe('RunningV2Variant.startSync tx-history fan-out', () => {
     expect(result.maxInFlight).toBe(8);
     // The cap only queues work, it never drops it.
     expect(result.recorded).toBe(12);
+  });
+});
+
+describe('RunningV2Variant.state protocol version signalling', () => {
+  /** The variant under test owns `[0, 7)`; 7 and above belong to whatever variant comes next. */
+  const activationRange = ProtocolVersion.makeRange(
+    ProtocolVersion.MinSupportedVersion,
+    ProtocolVersion.ProtocolVersion(7n),
+  );
+
+  const walletAtVersion = (protocolVersion: bigint): CoreWallet =>
+    CoreWallet.restore(
+      new DustLocalState(LedgerParameters.initialParameters().dust),
+      PublicKey.fromSecretKey(DustSecretKey.fromSeed(Buffer.alloc(32, 1))),
+      [],
+      { appliedIndex: 0n, highestRelevantWalletIndex: 0n, highestIndex: 0n, highestRelevantIndex: 0n },
+      protocolVersion,
+      networkId,
+    );
+
+  const versionChangesOf = (changes: Chunk.Chunk<StateChange.StateChange<CoreWallet>>): readonly bigint[] =>
+    Chunk.toArray(changes)
+      .filter(StateChange.isVersionChange)
+      .map(({ change }) => {
+        expect(VersionChangeType.isVersion(change)).toBe(true);
+        return VersionChangeType.isVersion(change) ? change.version : -1n;
+      });
+
+  /**
+   * Drains the variant's state stream for a fixed window and returns everything it emitted. A bounded window rather
+   * than `Stream.take(n)` on purpose: the point of these tests is _how many_ version changes appear, so a missing one
+   * has to surface as a failed assertion, not as a hang.
+   */
+  const emissionsWithin = (
+    initialState: CoreWallet,
+    act: (stateRef: SubscriptionRef.SubscriptionRef<CoreWallet>) => Effect.Effect<void> = () => Effect.void,
+  ): Promise<Chunk.Chunk<StateChange.StateChange<CoreWallet>>> =>
+    Effect.gen(function* () {
+      const stateRef = yield* SubscriptionRef.make(initialState);
+      const scope = yield* Scope.make();
+      const variant = new RunningV2Variant(
+        scope,
+        { stateRef, activationRange },
+        variantContextOf(
+          [],
+          trackingHistoryService({
+            inFlight: yield* Ref.make(0),
+            maxInFlight: yield* Ref.make(0),
+            recorded: yield* Ref.make(0),
+          }),
+        ),
+      );
+
+      const collector = yield* Effect.fork(
+        variant.state.pipe(Stream.interruptAfter(Duration.millis(300)), Stream.runCollect),
+      );
+      yield* Effect.sleep(Duration.millis(50));
+      yield* act(stateRef);
+      const collected = yield* Fiber.join(collector);
+      yield* Scope.close(scope, Exit.void);
+      return collected;
+    }).pipe(Effect.runPromise);
+
+  it('emits exactly one VersionChange when the state transitions to a new protocol version', async () => {
+    const collected = await emissionsWithin(walletAtVersion(0n), (stateRef) =>
+      SubscriptionRef.set(stateRef, walletAtVersion(5n)),
+    );
+
+    expect(versionChangesOf(collected)).toEqual([5n]);
+  });
+
+  it('emits an immediate healing VersionChange when the initial state is outside the activation range', async () => {
+    // A snapshot serialized after the version was annotated but before the runtime migrated restores here. Without a
+    // healing emission the wallet would sit on a version it does not own and never hand over.
+    const collected = await emissionsWithin(walletAtVersion(9n));
+
+    expect(versionChangesOf(collected)).toEqual([9n]);
+  });
+
+  it('emits no VersionChange when the initial state is inside the activation range', async () => {
+    const collected = await emissionsWithin(walletAtVersion(3n));
+
+    expect(versionChangesOf(collected)).toEqual([]);
+    // The stream still reports the state itself, so an empty result would be a false pass.
+    expect(Chunk.toArray(collected).filter(StateChange.isState).length).toBeGreaterThan(0);
   });
 });

--- a/packages/dust-wallet/src/v2/test/runningV2Variant.test.ts
+++ b/packages/dust-wallet/src/v2/test/runningV2Variant.test.ts
@@ -18,7 +18,19 @@ import {
   LedgerParameters,
 } from '@midnightntwrk/ledger-v9';
 import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Chunk, Duration, Effect, Exit, Fiber, Ref, Scope, Stream, SubscriptionRef, TestClock, TestContext } from 'effect';
+import {
+  Chunk,
+  Duration,
+  Effect,
+  Exit,
+  Fiber,
+  Ref,
+  Scope,
+  Stream,
+  SubscriptionRef,
+  TestClock,
+  TestContext,
+} from 'effect';
 import { describe, expect, it } from 'vitest';
 import { chooseCoin, makeDefaultCoinsAndBalancesCapability } from '../CoinsAndBalances.js';
 import { CoreWallet, PublicKey } from '../CoreWallet.js';

--- a/packages/dust-wallet/src/v2/test/sync.test.ts
+++ b/packages/dust-wallet/src/v2/test/sync.test.ts
@@ -48,9 +48,9 @@ import {
 const networkId = NetworkId.NetworkId.Undeployed;
 
 /**
- * The projections capability takes an activation range like every other sync capability, but has nothing to apply it
- * to — see the note on `makeEventLessSyncCapability`. A full span is passed here so these tests keep asserting what
- * they always asserted.
+ * The projections capability takes an activation range like every other sync capability, but has nothing to apply it to
+ * — see the note on `makeEventLessSyncCapability`. A full span is passed here so these tests keep asserting what they
+ * always asserted.
  */
 const fullSpan = ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, ProtocolVersion.MaxSupportedVersion);
 const dustParameters = LedgerParameters.initialParameters().dust;
@@ -151,7 +151,11 @@ describe('V2 projections sync capability', () => {
     const inputSyncTime = state.state.syncTime;
     const timestamp = new Date('2026-07-14T10:00:00.000Z');
 
-    const [updatedState, result] = makeEventLessSyncCapability().applyUpdate(state, projectionUpdate(timestamp), fullSpan);
+    const [updatedState, result] = makeEventLessSyncCapability().applyUpdate(
+      state,
+      projectionUpdate(timestamp),
+      fullSpan,
+    );
 
     expect(updatedState.state).not.toBe(state.state);
     expect(updatedState.state.syncTime).toEqual(timestamp);
@@ -168,7 +172,10 @@ describe('V2 projections sync capability', () => {
     // version on the projections format; until then this test is what keeps the gap visible.
     const secretKey = DustSecretKey.fromSeed(Buffer.from(seedHex, 'hex'));
     const state = CoreWallet.initEmpty(dustParameters, secretKey, networkId);
-    const narrowRange = ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, ProtocolVersion.ProtocolVersion(1n));
+    const narrowRange = ProtocolVersion.makeRange(
+      ProtocolVersion.MinSupportedVersion,
+      ProtocolVersion.ProtocolVersion(1n),
+    );
 
     const [updatedState, result] = makeEventLessSyncCapability().applyUpdate(
       state,
@@ -191,7 +198,11 @@ describe('V2 projections sync capability', () => {
     const timestamp = new Date('2026-07-14T10:00:00.000Z');
 
     expect(() =>
-      makeEventLessSyncCapability().applyUpdate(state, projectionUpdate(timestamp, 'unexpected-commitment-root'), fullSpan),
+      makeEventLessSyncCapability().applyUpdate(
+        state,
+        projectionUpdate(timestamp, 'unexpected-commitment-root'),
+        fullSpan,
+      ),
     ).toThrow('Root hashes don`t match');
 
     expect(state.state.syncTime).toEqual(inputSyncTime);

--- a/packages/dust-wallet/src/v2/test/sync.test.ts
+++ b/packages/dust-wallet/src/v2/test/sync.test.ts
@@ -17,7 +17,7 @@ import {
   type Event as LedgerEvent,
   LedgerParameters,
 } from '@midnightntwrk/ledger-v9';
-import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { BlockHash, DustLedgerEvents, DustNullifierTransactions } from '@midnightntwrk/wallet-sdk-indexer-client';
 import type {
   BlockHashQuery,
@@ -46,6 +46,13 @@ import {
 } from '../SyncSchema.js';
 
 const networkId = NetworkId.NetworkId.Undeployed;
+
+/**
+ * The projections capability takes an activation range like every other sync capability, but has nothing to apply it
+ * to — see the note on `makeEventLessSyncCapability`. A full span is passed here so these tests keep asserting what
+ * they always asserted.
+ */
+const fullSpan = ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, ProtocolVersion.MaxSupportedVersion);
 const dustParameters = LedgerParameters.initialParameters().dust;
 const seedHex = '0000000000000000000000000000000000000000000000000000000000000001';
 
@@ -144,7 +151,7 @@ describe('V2 projections sync capability', () => {
     const inputSyncTime = state.state.syncTime;
     const timestamp = new Date('2026-07-14T10:00:00.000Z');
 
-    const [updatedState, result] = makeEventLessSyncCapability().applyUpdate(state, projectionUpdate(timestamp));
+    const [updatedState, result] = makeEventLessSyncCapability().applyUpdate(state, projectionUpdate(timestamp), fullSpan);
 
     expect(updatedState.state).not.toBe(state.state);
     expect(updatedState.state.syncTime).toEqual(timestamp);
@@ -152,6 +159,27 @@ describe('V2 projections sync capability', () => {
     expect(result.changes).toEqual([]);
     expect(state.state.syncTime).toEqual(inputSyncTime);
     expect(state.state.serialize()).toEqual(serializedInput);
+  });
+
+  it('does not annotate a protocol version, because a projections update carries none', () => {
+    // Documents a real gap rather than hiding it. The projections wire format has no per-item protocol version — a
+    // projections update is a folded snapshot, not a run of version-tagged timeline items — so this capability takes an
+    // activation range it cannot act on. A wallet syncing this way never hands over at a fork. Closing that needs a
+    // version on the projections format; until then this test is what keeps the gap visible.
+    const secretKey = DustSecretKey.fromSeed(Buffer.from(seedHex, 'hex'));
+    const state = CoreWallet.initEmpty(dustParameters, secretKey, networkId);
+    const narrowRange = ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, ProtocolVersion.ProtocolVersion(1n));
+
+    const [updatedState, result] = makeEventLessSyncCapability().applyUpdate(
+      state,
+      projectionUpdate(new Date('2026-07-14T10:00:00.000Z')),
+      narrowRange,
+    );
+
+    // Applied in full despite the range being as narrow as it can be, and the version left exactly where it was.
+    expect(updatedState.progress.highestIndex).toBe(1n);
+    expect(updatedState.protocolVersion).toBe(state.protocolVersion);
+    expect(result.protocolVersion).toBe(Number(state.protocolVersion));
   });
 
   it('does not mutate or advance the input state when root validation fails', () => {
@@ -163,7 +191,7 @@ describe('V2 projections sync capability', () => {
     const timestamp = new Date('2026-07-14T10:00:00.000Z');
 
     expect(() =>
-      makeEventLessSyncCapability().applyUpdate(state, projectionUpdate(timestamp, 'unexpected-commitment-root')),
+      makeEventLessSyncCapability().applyUpdate(state, projectionUpdate(timestamp, 'unexpected-commitment-root'), fullSpan),
     ).toThrow('Root hashes don`t match');
 
     expect(state.state.syncTime).toEqual(inputSyncTime);

--- a/packages/dust-wallet/src/v2/test/syncCapability.test.ts
+++ b/packages/dust-wallet/src/v2/test/syncCapability.test.ts
@@ -1,0 +1,293 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { type CoreWallet } from '../CoreWallet.js';
+import { makeDefaultSyncCapability, makeSimulatorSyncCapability } from '../Sync.js';
+import { type WalletSyncSubscription, WalletSyncUpdate } from '../SyncSchema.js';
+import { DUST_EVENT_COUNT, type DustChain, buildDustChain, eventAt, freshWallet, fixtureSecretKey } from './dustEvents.js';
+
+vi.setConfig({ testTimeout: 60000 });
+
+/**
+ * The boundary under test. The variant owns `[0, 7)`; anything the source reports at 7 or beyond belongs to the next
+ * variant and must be left unapplied for it to fetch.
+ */
+const activeRange = ProtocolVersion.makeRange(ProtocolVersion.ProtocolVersion(0n), ProtocolVersion.ProtocolVersion(7n));
+
+let chain: DustChain;
+
+beforeAll(async () => {
+  chain = await buildDustChain();
+  expect(chain.eventBytes.length).toBe(DUST_EVENT_COUNT);
+});
+
+/**
+ * Builds a batch of sync updates, one per item, each carrying its own fresh event instance.
+ *
+ * A `protocolVersion` of `undefined` models an indexer that does not report the field at all — the shape dust's
+ * subscription has today.
+ */
+const batch = (items: readonly (readonly [id: number, protocolVersion: number | undefined])[]): WalletSyncUpdate =>
+  WalletSyncUpdate.create(
+    items.map(
+      ([id, protocolVersion]): WalletSyncSubscription => ({
+        id,
+        maxId: DUST_EVENT_COUNT,
+        raw: eventAt(chain.eventBytes, id - 1),
+        ...(protocolVersion === undefined ? {} : { protocolVersion }),
+      }),
+    ),
+    fixtureSecretKey(),
+    chain.syncTime,
+  );
+
+const utxoCount = (wallet: CoreWallet): number => wallet.state.utxos.length;
+
+const dustBalance = (wallet: CoreWallet): bigint => wallet.state.walletBalance(chain.syncTime);
+
+describe('makeDefaultSyncCapability.applyUpdate boundary handling', () => {
+  const capability = makeDefaultSyncCapability();
+
+  it('applies every update and annotates the state when the whole batch is inside the active range', () => {
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 3],
+        [2, 3],
+        [3, 3],
+        [4, 3],
+      ]),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(4n);
+    expect(state.progress.highestRelevantWalletIndex).toBe(BigInt(DUST_EVENT_COUNT));
+    expect(state.progress.isConnected).toBe(true);
+    expect(state.protocolVersion).toBe(3n);
+    expect(utxoCount(state)).toBe(DUST_EVENT_COUNT);
+    expect(dustBalance(state)).toBeGreaterThan(0n);
+    expect(result.changes.length).toBe(DUST_EVENT_COUNT);
+    expect(result.protocolVersion).toBe(3);
+  });
+
+  it('re-annotates the state on a version bump that stays inside the active range', () => {
+    const [afterFirst] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 3],
+        [2, 3],
+      ]),
+      activeRange,
+    );
+    expect(afterFirst.protocolVersion).toBe(3n);
+
+    const [state, result] = capability.applyUpdate(
+      afterFirst,
+      batch([
+        [3, 5],
+        [4, 5],
+      ]),
+      activeRange,
+    );
+
+    expect(state.protocolVersion).toBe(5n);
+    expect(state.progress.appliedIndex).toBe(4n);
+    expect(utxoCount(state)).toBe(DUST_EVENT_COUNT);
+    expect(result.changes.length).toBe(2);
+  });
+
+  it('applies only the prefix of a straddling batch and takes the version from the first suffix item', () => {
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 3],
+        [2, 3],
+        [3, 9],
+        [4, 11],
+      ]),
+      activeRange,
+    );
+
+    // Prefix only: the last applied id is 2, so the next variant resumes there and re-fetches ids 3-4.
+    expect(state.progress.appliedIndex).toBe(2n);
+    // The suffix's first version is what makes the variant hand over — not the batch's last version.
+    expect(state.protocolVersion).toBe(9n);
+    expect(utxoCount(state)).toBe(2);
+    // Changes come from the prefix alone.
+    expect(result.changes.length).toBe(2);
+    // The reported version tags the applied changes, so it is the prefix's version.
+    expect(result.protocolVersion).toBe(3);
+    // The tip is a property of the source, so it still comes from the batch tail.
+    expect(state.progress.highestRelevantWalletIndex).toBe(BigInt(DUST_EVENT_COUNT));
+  });
+
+  it('applies nothing when the whole batch is at or beyond the end of the active range', () => {
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 7],
+        [2, 7],
+        [3, 9],
+        [4, 9],
+      ]),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(0n);
+    expect(state.protocolVersion).toBe(7n);
+    expect(utxoCount(state)).toBe(0);
+    expect(result.changes).toEqual([]);
+    expect(state.progress.highestRelevantWalletIndex).toBe(BigInt(DUST_EVENT_COUNT));
+  });
+
+  it('never lowers the recorded protocol version when a later batch reports a stale lower one', () => {
+    const [afterFirst] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 5],
+        [2, 5],
+      ]),
+      activeRange,
+    );
+    expect(afterFirst.protocolVersion).toBe(5n);
+
+    const [state] = capability.applyUpdate(
+      afterFirst,
+      batch([
+        [3, 2],
+        [4, 2],
+      ]),
+      activeRange,
+    );
+
+    // The batch still applies; only the version annotation is held at its high-water mark.
+    expect(state.protocolVersion).toBe(5n);
+    expect(state.progress.appliedIndex).toBe(4n);
+    expect(utxoCount(state)).toBe(DUST_EVENT_COUNT);
+  });
+
+  it('leaves the state untouched for an empty batch', () => {
+    const initial = freshWallet();
+    const [state, result] = capability.applyUpdate(
+      initial,
+      WalletSyncUpdate.create([], fixtureSecretKey(), chain.syncTime),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(0n);
+    expect(state.protocolVersion).toBe(ProtocolVersion.MinSupportedVersion);
+    expect(utxoCount(state)).toBe(0);
+    expect(result.changes).toEqual([]);
+    expect(result.protocolVersion).toBe(Number(initial.protocolVersion));
+  });
+
+  // --- dust-specific: the subscription does not carry `protocolVersion` yet ---
+
+  it('applies a batch whose items carry no protocol version at all, leaving the recorded version untouched', () => {
+    const initial = freshWallet();
+    const [state, result] = capability.applyUpdate(
+      initial,
+      batch([
+        [1, undefined],
+        [2, undefined],
+        [3, undefined],
+        [4, undefined],
+      ]),
+      activeRange,
+    );
+
+    // An absent version means "the indexer did not say", which is treated as in-range: apply normally...
+    expect(state.progress.appliedIndex).toBe(4n);
+    expect(utxoCount(state)).toBe(DUST_EVENT_COUNT);
+    expect(result.changes.length).toBe(DUST_EVENT_COUNT);
+    // ...and leave the annotation exactly where it was, rather than inventing a version.
+    expect(state.protocolVersion).toBe(initial.protocolVersion);
+    expect(result.protocolVersion).toBe(Number(initial.protocolVersion));
+  });
+
+  it('handles a mixed batch, ignoring untagged items for the boundary and splitting on the tagged one', () => {
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, undefined],
+        [2, 3],
+        [3, 9],
+        [4, undefined],
+      ]),
+      activeRange,
+    );
+
+    // Untagged items never trigger a hand-over; the first tagged out-of-range item still does, and everything from it
+    // onwards is deferred — including the untagged item behind it, because a batch is one contiguous slice.
+    expect(state.progress.appliedIndex).toBe(2n);
+    expect(state.protocolVersion).toBe(9n);
+    expect(utxoCount(state)).toBe(2);
+    expect(result.changes.length).toBe(2);
+    expect(result.protocolVersion).toBe(3);
+  });
+
+  it('keeps a mixed batch whose only tagged item is in range fully applied', () => {
+    const [state] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, undefined],
+        [2, 4],
+        [3, undefined],
+        [4, undefined],
+      ]),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(4n);
+    expect(utxoCount(state)).toBe(DUST_EVENT_COUNT);
+    // The last version actually observed in the batch is what gets recorded.
+    expect(state.protocolVersion).toBe(4n);
+  });
+});
+
+describe('makeSimulatorSyncCapability.applyUpdate boundary handling', () => {
+  const capability = makeSimulatorSyncCapability();
+
+  it('applies in-range blocks and annotates the state with the block version', async () => {
+    const inRange = await buildDustChain(ProtocolVersion.ProtocolVersion(3n));
+
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      { update: inRange.state, secretKey: fixtureSecretKey() },
+      activeRange,
+    );
+
+    // Blocks 0..8: four rewards, four registrations. The next block to process is one past the last.
+    expect(state.progress.appliedIndex).toBe(BigInt(DUST_EVENT_COUNT) * 2n + 1n);
+    expect(state.protocolVersion).toBe(3n);
+    expect(state.state.utxos.length).toBe(DUST_EVENT_COUNT);
+    expect(result.changes.length).toBe(DUST_EVENT_COUNT);
+  });
+
+  it('applies no block at or beyond the end of the active range, but still annotates the version', async () => {
+    const outOfRange = await buildDustChain(ProtocolVersion.ProtocolVersion(9n));
+
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      { update: outOfRange.state, secretKey: fixtureSecretKey() },
+      activeRange,
+    );
+
+    // Every block carries a real dust event; none of them may be applied by this variant.
+    expect(state.progress.appliedIndex).toBe(0n);
+    expect(state.protocolVersion).toBe(9n);
+    expect(state.state.utxos.length).toBe(0);
+    expect(result.changes).toEqual([]);
+  });
+});

--- a/packages/dust-wallet/src/v2/test/syncCapability.test.ts
+++ b/packages/dust-wallet/src/v2/test/syncCapability.test.ts
@@ -15,7 +15,14 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { type CoreWallet } from '../CoreWallet.js';
 import { makeDefaultSyncCapability, makeSimulatorSyncCapability } from '../Sync.js';
 import { type WalletSyncSubscription, WalletSyncUpdate } from '../SyncSchema.js';
-import { DUST_EVENT_COUNT, type DustChain, buildDustChain, eventAt, freshWallet, fixtureSecretKey } from './dustEvents.js';
+import {
+  DUST_EVENT_COUNT,
+  type DustChain,
+  buildDustChain,
+  eventAt,
+  freshWallet,
+  fixtureSecretKey,
+} from './dustEvents.js';
 
 vi.setConfig({ testTimeout: 60000 });
 
@@ -40,14 +47,12 @@ beforeAll(async () => {
  */
 const batch = (items: readonly (readonly [id: number, protocolVersion: number | undefined])[]): WalletSyncUpdate =>
   WalletSyncUpdate.create(
-    items.map(
-      ([id, protocolVersion]): WalletSyncSubscription => ({
-        id,
-        maxId: DUST_EVENT_COUNT,
-        raw: eventAt(chain.eventBytes, id - 1),
-        ...(protocolVersion === undefined ? {} : { protocolVersion }),
-      }),
-    ),
+    items.map(([id, protocolVersion]): WalletSyncSubscription => ({
+      id,
+      maxId: DUST_EVENT_COUNT,
+      raw: eventAt(chain.eventBytes, id - 1),
+      ...(protocolVersion === undefined ? {} : { protocolVersion }),
+    })),
     fixtureSecretKey(),
     chain.syncTime,
   );


### PR DESCRIPTION
Phase 6, dust increment (2 of 2): the fork wiring + migration + proof pattern (#655 + #656) applied to the dust wallet. Stacked on #668. TDD: the red proof commit precedes every implementation commit; **20 red → 143 passing** (121 → 143 tests).

## What this delivers

- **Boundary wiring (D2/D3), both variants**: pure split/annotate helpers in dust's `Sync.ts`; monotone version recording on dust's core state; `activationRange` stored and threaded; healing emission. **Dust-specific D3 rule**: dust's sync schema gains an optional `protocolVersion` — an item WITHOUT a version applies normally and leaves the state version untouched (the deployed indexer doesn't serve the field yet; the selection-set + codegen stays deferred per the plan of record). Capability matrix covers untagged items and mixed batches.
- **Migration seam + cross-version instance**: fresh dust state, keys/network carried as plain data, **cursor parked at the fork** (the confirmed ids-continue semantics). Replaces the old `TODO` `migrateState` that returned `prevState`. Dust-specific: `DustParameters` are version-specific WASM objects that cannot cross — both migrations take them as builder configuration (optional, defaulting to initial parameters; no call site breaks). `withMigration` takes context per-method rather than as the builder's `TContext` (shielded's form makes the builder invariant in `TContext` and breaks dust's partially-configured chains — documented in place).
- **Restart wiring (D1)**: `DustWallet` retains the start aux in a private `Option`, registers the activation watcher once, re-dispatches `startSyncInBackground(retainedAux)` on the new variant; `stop()` clears. `DustSecretKey.fromSeed` parity across v8/v9 verified (seed retention works for dust too).
- **The crossing proof** (`test/…` unit tier): a real dust chain (4 Night rewards, then one registration per Night UTXO — one `dustInitialUtxo` event per block, which is what lets one fixture drive both the batched and block-granular capabilities) → fork → `VersionChange` → migration captured with parked cursor → fresh post-fork state → **dust re-discovered from the replayed timeline and compared UTXO-for-UTXO** (not just by count) → both negatives (within-range bump; fresh post-fork wallet). Mutation-verified: park→reset fails 2 tests (`expected 0n to be 4n`); corrupting a replayed event's payload fails 3.

## Honest limits (in docstrings and the changeset, not hidden)

- **No closing spend**: dust is spent as the fee half of a transaction a *chain* must validate; an indexer replay is an event log, not a ledger. Commitment-root equality stands in its place.
- **No WASM-translation fidelity link — deliberately unit-tier only**: ledger-v8 and v9 encode a `dustInitialUtxo` identically apart from the header tag, so the replay uses the *same bytes* where shielded re-mints *equivalent* coins. The proof opens by asserting that byte-equivalence, so a future ledger encoding change retires the model loudly. `turbo.json`/CI integration gates are correctly untouched.
- **Finding — the projections fast-sync path cannot do boundary handling**: a projections update is a folded snapshot with no per-item version, and `BlockData` carries none. It accepts `activeRange` for signature parity and ignores it — a wallet syncing exclusively via projections will not hand over at a fork. Pinned by a dedicated test and called out in the changeset; resolving it needs indexer-side versioning on projections (same ask family as the deferred selection-set work).

## Verification

Branch tip: `yarn dist --force` 17/17 · `typecheck --force` 37/37 · `lint` 58/58 · `test:unit --force` 53/53 · dust suite 143 passed · cross-package typecheck · Effect diagnostics clean · `format:check` · changeset status clean. All commits GPG-signed.