### PR TITLE
feat(unshielded): per-message fork boundary, structural migration, and the crossing proof

### DIFF
--- a/.changeset/shielded-v1-v2-restructure.md
+++ b/.changeset/shielded-v1-v2-restructure.md
@@ -13,11 +13,12 @@ Restructure the shielded wallet for the coming hard fork: the variant directorie
 `RunningV1Variant`→`RunningV2Variant`, and so on). Imports of the old names from `./v1` will no longer resolve — switch
 the subpath to `./v2`.
 
-`./v1` now holds the restored pre-fork ledger-v8 variant, byte-for-byte the `3.x` line's shielded internals with its
-honest `V1` names, kept for wallets that must sync pre-fork history across the fork. This makes
-`@midnight-ntwrk/ledger-v8` a runtime dependency of the package: consumers of the `./v1` subpath load a second ledger
-WASM module, which matters for browser bundle size. The `Simulator` namespace exported from `./v1` is the ledger-v8
-simulator twin only, where it previously re-exported the whole simulation entry point.
+`./v1` now holds the pre-fork ledger-v8 variant with its honest `V1` names, kept for wallets that must sync pre-fork
+history across the fork: the `3.x` line's shielded internals restored, and then given this line's fork wiring, so both
+variants carry the same boundary splitting, migration seam and healing emission (see the boundary-wiring change). This
+makes `@midnight-ntwrk/ledger-v8` a runtime dependency of the package: consumers of the `./v1` subpath load a second
+ledger WASM module, which matters for browser bundle size. The `Simulator` namespace exported from `./v1` is the
+ledger-v8 simulator twin only, where it previously re-exported the whole simulation entry point.
 
 `@midnightntwrk/wallet-sdk` mirrors this: `shielded/v1` now re-exports the ledger-v8 variant, and a new `shielded/v2`
 subpath re-exports the ledger-v9 one.

--- a/.changeset/unshielded-fork-boundary-wiring.md
+++ b/.changeset/unshielded-fork-boundary-wiring.md
@@ -1,0 +1,49 @@
+---
+'@midnightntwrk/wallet-sdk-unshielded-wallet': minor
+---
+
+Make the unshielded wallet able to follow the chain across a hard fork: sync now recognises the protocol version the
+indexer reports, hands over at the variant boundary, and carries the wallet's UTXOs into the next ledger version's
+variant.
+
+**Behavioural change: wallet state now tracks the reported protocol version.** Until now nothing wrote the indexer's
+`protocolVersion` into the wallet state, so it stayed pinned at its initial value and a protocol version change could
+never be signalled. It is now recorded on every applied transaction. The value only ever increases — a source that
+briefly reports an older version (a reconnect replaying from an earlier cursor, say) cannot drag the wallet back below
+a boundary it has already crossed. Progress messages never touch it: the wire schema carries no version on them.
+
+**Breaking for custom `withSync` authors: `SyncCapability.applyUpdate` takes a third argument.** It is now
+`applyUpdate(state, update, activeRange)`, where `activeRange` is the half-open protocol version range the running
+variant owns. Implementations that ignore the parameter keep their present behaviour; the exported
+`isBeyondActiveRange` and `annotateVersion` helpers implement the rule for anyone who wants it.
+
+Unshielded's boundary rule is per message, not per batch, because its sync delivers one transaction at a time. A
+transaction reported at or beyond the end of the range is left **entirely** unapplied — no UTXO change, no `appliedId`
+movement, no transaction-history write — and only its version is recorded. Because the cursor does not move, the next
+variant re-fetches that same transaction and applies it exactly once.
+
+**New: the migration seam.** `Migration.ts` exports `StateMigration` with three instances —
+`makeEmptyWalletMigration` (no previous wallet), `makeCarryOverMigration` (same ledger version), and
+`makeCrossLedgerMigration` (across a fork). The builder gains `withMigration` and `withMigrationDefaults` plus a
+defaulted `TPreviousState` type parameter, and `migrateState` — which until now ignored its argument and rebuilt a
+placeholder wallet from a fixed seed, so a ledger-v8 wallet would have been silently replaced by an empty one — runs
+the configured strategy. The strategy is optional, defaulting to the empty-wallet migration, so no existing
+`build({ ... })` call site changes.
+
+The cross-ledger strategy is a **structural carry**, and this is where the unshielded wallet differs from the shielded
+and dust ones. Those start the new variant on a fresh, empty state and let the indexer's post-fork replay hand their
+coins back, because their coins are shielded and re-deriving them needs secret keys a migration by design never
+receives. Unshielded UTXOs are public ledger data held as plain records, so every one of them is simply rebuilt on the
+other side — available and pending, field for field — with no replay to wait for and no window in which the wallet
+reports a balance it does not have. The verifying key is widened from ledger-v8's bare hex string to ledger-v9's
+`{tag, value}` record, defaulting to `schnorr` because that ledger version had exactly one signature scheme. The sync
+cursor is carried unchanged: parked at the boundary, neither rewound nor advanced.
+
+**Sync now restarts itself after a migration.** `UnshieldedWallet.start` registers a runtime activation watcher that
+re-dispatches `startSyncInBackground` onto the newly activated variant; the class registered no watcher at all before.
+Unlike the shielded and dust wallets it retains no key, because unshielded sync is watch-only and signing is supplied
+per call by the caller — the restart needs no argument at all. `stop` marks the wallet stopped so a late activation
+cannot resurrect it.
+
+A state restored from a snapshot taken between the version being recorded and the runtime acting on it now emits an
+immediate healing version change instead of stalling on a version its variant does not own.

--- a/packages/unshielded-wallet/src/UnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/UnshieldedWallet.ts
@@ -21,7 +21,7 @@ import {
   type UnboundTransaction,
 } from './v2/index.js';
 import type * as ledger from '@midnightntwrk/ledger-v9';
-import { Effect, Either, type Scope } from 'effect';
+import { Effect, Either, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
 import { type SerializationCapability } from './v2/Serialization.js';
 import { type TransactionHistoryService } from './v2/TransactionHistory.js';
@@ -34,6 +34,7 @@ import {
   type UnprovenTransactionBalanceResult,
 } from './v2/Transacting.js';
 import { type WalletSyncUpdate } from './v2/SyncSchema.js';
+import { type RunningV2Variant } from './v2/RunningV2Variant.js';
 import { type SignSegment } from './v2/Signing.js';
 import { type UtxoWithMeta } from './v2/UnshieldedState.js';
 import { type Variant, type VariantBuilder, type WalletLike } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
@@ -245,8 +246,52 @@ export function CustomUnshieldedWallet<
       );
     }
 
+    /**
+     * Whether the activation watcher has been registered.
+     *
+     * @remarks
+     *   Registration is per wallet, not per `start`: watchers accumulate, so registering on every call would restart sync
+     *   once per historical `start` on the next activation. Flipped with `getAndSet` so concurrent `start` calls cannot
+     *   both observe it unset.
+     */
+    readonly #watcherRegistered = Ref.unsafeMake(false);
+
+    /**
+     * Whether the wallet is currently started.
+     *
+     * @remarks
+     *   The unshielded counterpart of the retained start-aux the shielded and dust wallets hold. This wallet is
+     *   watch-only — sync needs nothing secret, and signing is supplied per call by the caller — so there is no key to
+     *   keep and the restart needs no argument. All the watcher has to know is whether a stopped wallet should be left
+     *   stopped, which is what this records; `stop` clears it so a stopped wallet cannot be resurrected by a late
+     *   activation.
+     */
+    readonly #started = Ref.unsafeMake(false);
+
     start(): Promise<void> {
-      return this.runtime.dispatch({ [V2Tag]: (v2) => v2.startSyncInBackground() }).pipe(Effect.runPromise);
+      return Effect.gen(this, function* () {
+        yield* Ref.set(this.#started, true);
+
+        // Registered before the first dispatch, and only once: `onVariantActivation` resolves only after its
+        // subscription is live, so an activation racing this call is queued rather than missed.
+        const alreadyRegistered = yield* Ref.getAndSet(this.#watcherRegistered, true);
+        if (!alreadyRegistered) {
+          yield* this.runtime.onVariantActivation({
+            [V2Tag]: (v2: RunningV2Variant<TSerialized, TSyncUpdate>) =>
+              Ref.get(this.#started).pipe(
+                // Stopped, or never started: there is nothing to resume.
+                Effect.flatMap((started) => (started ? v2.startSyncInBackground() : Effect.void)),
+              ),
+          });
+        }
+
+        yield* this.runtime.dispatch({ [V2Tag]: (v2) => v2.startSyncInBackground() });
+      }).pipe(Effect.runPromise);
+    }
+
+    override async stop(): Promise<void> {
+      Ref.set(this.#started, false).pipe(Effect.runSync);
+      await super.stop();
     }
 
     balanceFinalizedTransaction(tx: ledger.FinalizedTransaction): Promise<FinalizedTransactionBalanceResult> {

--- a/packages/unshielded-wallet/src/test/forkSimulation.test.ts
+++ b/packages/unshielded-wallet/src/test/forkSimulation.test.ts
@@ -1,0 +1,206 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The unshielded hard-fork crossing, end to end.
+//
+// The load-bearing claim is narrower and sharper than the shielded and dust proofs make, because unshielded's design
+// is: THE BOUNDARY TRANSACTION IS APPLIED EXACTLY ONCE, BY THE NEW VARIANT. The old variant sees it, records its
+// version and refuses to apply any part of it; the cursor consequently does not move; the migration parks that cursor;
+// and the new variant, subscribing from it, is served that same transaction and applies it. Every step of that chain is
+// asserted separately, because each one alone is satisfiable by a wrong implementation.
+//
+// The second claim is the structural carry: unlike shielded and dust, which start the new variant empty and wait for
+// the indexer's replay to hand their coins back, unshielded carries every UTXO across. So the wallet never passes
+// through a state in which it has forgotten what it owns.
+//
+// Tier: unit. There is no WASM translation anywhere in this path and none is warranted — unshielded state is public
+// data and the wire format is JSON, so there is no ledger encoding for a translation to be faithful to. The two
+// variants are nonetheless the genuine ledger-v8 and ledger-v9 trees, each with its own ledger module, and the
+// identities are derived through each version's real keystore.
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect, identity, Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { CoreWallet as PreForkWallet } from '../v1/CoreWallet.js';
+import { UnshieldedState as PreForkState } from '../v1/UnshieldedState.js';
+import { V1Tag } from '../v1/index.js';
+import { V2Tag } from '../v2/index.js';
+import { forkSeed, postForkIdentity, preForkIdentity, timelineTransaction } from './forkTimeline.js';
+import { makeForkWallet, utxosOf, type CarriedUtxo } from './forkWallet.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+/** The pre-fork variant owns everything below this; the post-fork variant takes over at it. */
+const forkVersion = ProtocolVersion.ProtocolVersion(7n);
+const preForkVersion = 1;
+
+const preFork = preForkIdentity(networkId);
+const postFork = postForkIdentity(networkId);
+
+/**
+ * Three pre-fork transactions, the boundary transaction, and two beyond it.
+ *
+ * @remarks
+ *   Ids run continuously across the boundary, which is the confirmed indexer semantics: the post-fork timeline continues
+ *   the numbering rather than restarting it.
+ */
+const timeline = [
+  timelineTransaction({ id: 1, protocolVersion: preForkVersion, owner: preFork.addressHex, value: 100n }),
+  timelineTransaction({ id: 2, protocolVersion: preForkVersion, owner: preFork.addressHex, value: 200n }),
+  timelineTransaction({ id: 3, protocolVersion: preForkVersion, owner: preFork.addressHex, value: 300n }),
+  // The boundary transaction: reported at the fork version, so the pre-fork variant must not apply it.
+  timelineTransaction({ id: 4, protocolVersion: Number(forkVersion), owner: preFork.addressHex, value: 444n }),
+  timelineTransaction({ id: 5, protocolVersion: Number(forkVersion), owner: preFork.addressHex, value: 500n }),
+  timelineTransaction({ id: 6, protocolVersion: Number(forkVersion), owner: preFork.addressHex, value: 600n }),
+];
+
+const emptyPreForkWallet = () =>
+  PreForkWallet.restore(
+    PreForkState.empty(),
+    preFork,
+    { appliedId: 0n, highestTransactionId: 0n },
+    ProtocolVersion.MinSupportedVersion,
+    networkId,
+  );
+
+const valuesOf = (utxos: readonly CarriedUtxo[]): readonly bigint[] => utxos.map((u) => u.value);
+
+describe('unshielded hard-fork crossing', () => {
+  it('carries every UTXO across and applies the boundary transaction exactly once, in the new variant', async () => {
+    const wallet = makeForkWallet({ timeline, forkVersion, initialState: emptyPreForkWallet() });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        // Subscribed BEFORE starting: `stateChanges` does not replay, so a settled state reached while nobody was
+        // listening would be missed and the wait would hang rather than fail.
+        const settled = yield* Effect.fork(wallet.awaitState((state) => state.state.progress.appliedId === 6n));
+        yield* wallet.start;
+        const migration = yield* wallet.awaitMigration;
+        const final = yield* settled.await.pipe(Effect.flatMap(identity));
+        const tag = yield* wallet.activeTag;
+        yield* wallet.stop;
+        return { migration, final: final.state, tag };
+      }),
+    );
+
+    // --- the old variant stopped exactly at the boundary ---
+    // It applied 1..3 and refused the whole of 4, so its cursor sits at 3 and it holds three UTXOs.
+    expect(result.migration.from.appliedId).toBe(3n);
+    expect(valuesOf(result.migration.from.utxos)).toEqual([100n, 200n, 300n]);
+    // It DID record the boundary version — that is what triggered the hand-over.
+    expect(result.migration.from.protocolVersion).toBe(7n);
+    // And it did NOT take the boundary transaction's UTXO.
+    expect(valuesOf(result.migration.from.utxos)).not.toContain(444n);
+
+    // --- the migration is a structural carry, not a fresh state ---
+    // This is the assertion that distinguishes unshielded from shielded and dust: everything crosses.
+    expect(result.migration.to.utxos).toEqual(result.migration.from.utxos);
+    // Identity and network cross too, with the key widened to the tagged form.
+    expect(result.migration.to.address).toBe(preFork.address);
+    expect(result.migration.to.networkId).toBe(networkId);
+    expect(result.migration.to.protocolVersion).toBe(7n);
+    // The cursor is PARKED. Asserted on the state the migration produced, before any sync has touched it, which is the
+    // only place parking is distinguishable from rewinding: a cursor reset to 0 would re-read 1..3 and still end up
+    // looking correct, and a cursor advanced past the boundary would silently lose transaction 4.
+    expect(result.migration.to.appliedId).toBe(result.migration.from.appliedId);
+    expect(result.migration.to.appliedId).toBe(3n);
+
+    // --- the new variant is running and consumed the rest of the timeline ---
+    expect(result.tag).toBe(V2Tag);
+    expect(result.final.progress.appliedId).toBe(6n);
+
+    // --- the boundary transaction was applied EXACTLY once ---
+    const finalUtxos = utxosOf(result.final);
+    expect(valuesOf(finalUtxos).filter((v) => v === 444n)).toEqual([444n]);
+    // ...and the wallet holds the pre-fork three plus the three from the boundary onwards. Six, not nine: nothing was
+    // applied twice, and nothing was dropped.
+    expect(valuesOf(finalUtxos)).toEqual([100n, 200n, 300n, 444n, 500n, 600n]);
+  });
+
+  it('carries the pre-fork UTXOs field for field, not merely by count', async () => {
+    const wallet = makeForkWallet({ timeline, forkVersion, initialState: emptyPreForkWallet() });
+
+    const { before, after } = await Effect.runPromise(
+      Effect.gen(function* () {
+        const settled = yield* Effect.fork(wallet.awaitState((state) => state.state.progress.appliedId === 6n));
+        yield* wallet.start;
+        const migration = yield* wallet.awaitMigration;
+        const final = yield* settled.await.pipe(Effect.flatMap(identity));
+        yield* wallet.stop;
+        return { before: migration.from.utxos, after: utxosOf(final.state) };
+      }),
+    );
+
+    // UTXO for UTXO: value, owner, token type, intent hash, output number and creation time all survive the crossing.
+    const carried = after.filter((u) => before.some((b) => b.value === u.value));
+    expect(carried).toEqual(before);
+  });
+
+  it('derives the same address from the same secret on both sides of the boundary', () => {
+    // The lemma the structural carry rests on: the two ledger versions disagree about the SHAPE of a verifying key,
+    // but not about the address it derives to. If they ever diverge here, carrying the address across is a fiction and
+    // this test retires the model loudly.
+    expect(postFork.addressHex).toBe(preFork.addressHex);
+    expect(postFork.address).toBe(preFork.address);
+    // The keys themselves are shaped differently, which is exactly what the migration widens.
+    expect(typeof preFork.publicKey).toBe('string');
+    expect(postFork.publicKey).toEqual({ tag: 'schnorr', value: preFork.publicKey });
+    expect(forkSeed()).toHaveLength(32);
+  });
+
+  it('does not migrate on a version bump that stays inside the running variant range', async () => {
+    const withinRange = [
+      timelineTransaction({ id: 1, protocolVersion: 1, owner: preFork.addressHex, value: 100n }),
+      // 5 is still below the boundary of 7, so this must be applied, not deferred.
+      timelineTransaction({ id: 2, protocolVersion: 5, owner: preFork.addressHex, value: 200n }),
+    ];
+    const wallet = makeForkWallet({ timeline: withinRange, forkVersion, initialState: emptyPreForkWallet() });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const settledFiber = yield* Effect.fork(wallet.awaitState((state) => state.state.progress.appliedId === 2n));
+        yield* wallet.start;
+        const settled = yield* settledFiber.await.pipe(Effect.flatMap(identity));
+        const tag = yield* wallet.activeTag;
+        const migration = yield* wallet.migration;
+        yield* wallet.stop;
+        return { settled: settled.state, tag, migration };
+      }),
+    );
+
+    expect(result.tag).toBe(V1Tag);
+    expect(Option.isNone(result.migration)).toBe(true);
+    // Applied, not deferred: the cursor moved and the UTXO is held.
+    expect(result.settled.progress.appliedId).toBe(2n);
+    expect(valuesOf(utxosOf(result.settled))).toEqual([100n, 200n]);
+    expect(result.settled.protocolVersion).toBe(5n);
+  });
+
+  it('reaches the same end state from a wallet whose first sync already contains the fork', async () => {
+    // Scenario 2: a fresh wallet syncing a timeline that already straddles the boundary. It still syncs the pre-fork
+    // prefix with the old variant, hands over, and consumes the rest — double work by design, correct by construction.
+    const wallet = makeForkWallet({ timeline, forkVersion, initialState: emptyPreForkWallet() });
+
+    const final = await Effect.runPromise(
+      Effect.gen(function* () {
+        const settledFiber = yield* Effect.fork(wallet.awaitState((state) => state.state.progress.appliedId === 6n));
+        yield* wallet.start;
+        yield* wallet.awaitMigration;
+        const settled = yield* settledFiber.await.pipe(Effect.flatMap(identity));
+        yield* wallet.stop;
+        return settled.state;
+      }),
+    );
+
+    expect(valuesOf(utxosOf(final))).toEqual([100n, 200n, 300n, 444n, 500n, 600n]);
+    expect(final.progress.appliedId).toBe(6n);
+  });
+});

--- a/packages/unshielded-wallet/src/test/forkTimeline.ts
+++ b/packages/unshielded-wallet/src/test/forkTimeline.ts
@@ -1,0 +1,105 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The timeline the fork proof reads.
+//
+// A note on fidelity, because it is the honest difference between this proof and the shielded and dust ones. Those two
+// must re-frame or re-mint real ledger `Event` bytes across the boundary, because their state is shielded and only the
+// ledger can say whether the tree they rebuild is the tree the fork produced. Unshielded has no such indirection: what
+// the indexer serves is public UTXO data as JSON, and what the wallet stores is that same data. So the timeline here IS
+// the wire format — one shape, read by both variants, exactly as the indexer would serve it before and after the fork.
+// Nothing is being modelled away; there is no ledger encoding in this path to be unfaithful to.
+//
+// What the timeline does model is the CURSOR, and that is the load-bearing part: items are served to whichever variant
+// asks, filtered by the cursor that variant presents. The boundary item is therefore genuinely re-fetched by the second
+// variant rather than handed to it.
+import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { createKeystore as createPostForkKeystore, PublicKey as PostForkPublicKey } from '../KeyStore.js';
+import { createKeystore as createPreForkKeystore, PublicKey as PreForkPublicKey } from '../v1/KeyStore.js';
+
+/** One indexer message, with the protocol version the indexer reported it under. */
+export type TimelineItem = {
+  readonly id: number;
+  readonly protocolVersion: number;
+  /** Structurally a `WalletSyncUpdate` of either ledger version — the two are the same decoded JSON shape. */
+  readonly update: unknown;
+};
+
+/** A fixed 32-byte secret, so both variants derive the same identity from it. */
+export const forkSeed = (): Uint8Array => Uint8Array.from({ length: 32 }, (_, i) => (i * 13 + 5) % 256);
+
+/** The pre-fork (ledger-v8) identity: a bare hex verifying key. */
+export const preForkIdentity = (networkId: NetworkId.NetworkId = NetworkId.NetworkId.Undeployed): PreForkPublicKey =>
+  PreForkPublicKey.fromKeyStore(createPreForkKeystore(forkSeed(), networkId));
+
+/** The post-fork (ledger-v9) identity derived from the same secret: a `{tag, value}` verifying key. */
+export const postForkIdentity = (networkId: NetworkId.NetworkId = NetworkId.NetworkId.Undeployed): PostForkPublicKey =>
+  PostForkPublicKey.fromKeyStore(createPostForkKeystore({ kind: 'schnorr', secret: forkSeed() }, networkId));
+
+/** A UTXO as it appears on the wire, in the shape both variants decode it to. */
+export type TimelineUtxo = {
+  readonly utxo: {
+    readonly value: bigint;
+    readonly owner: string;
+    readonly type: string;
+    readonly intentHash: string;
+    readonly outputNo: number;
+  };
+  readonly meta: { readonly ctime: Date; readonly registeredForDustGeneration: boolean };
+};
+
+/** A UTXO addressed to `owner`, deterministic in every field so the two sides can be compared exactly. */
+export const timelineUtxo = (owner: string, value: bigint, outputNo: number): TimelineUtxo => ({
+  utxo: {
+    value,
+    owner,
+    type: '0100000000000000000000000000000000000000000000000000000000000000',
+    intentHash: `intent-${outputNo}`.padEnd(64, '0'),
+    outputNo,
+  },
+  meta: {
+    ctime: new Date(1_700_000_000_000 + outputNo * 1000),
+    registeredForDustGeneration: false,
+  },
+});
+
+/** One transaction on the timeline, creating a single UTXO of `value`. */
+export const timelineTransaction = (params: {
+  readonly id: number;
+  readonly protocolVersion: number;
+  readonly owner: string;
+  readonly value: bigint;
+}): TimelineItem => ({
+  id: params.id,
+  protocolVersion: params.protocolVersion,
+  update: {
+    type: 'UnshieldedTransaction',
+    transaction: {
+      id: params.id,
+      hash: `hash-${params.id}`,
+      type: 'RegularTransaction',
+      protocolVersion: params.protocolVersion,
+      identifiers: [],
+      block: {
+        hash: `block-${params.id}`,
+        height: params.id,
+        timestamp: new Date(1_700_000_000_000 + params.id * 6000),
+      },
+      fees: { paidFees: 0n, estimatedFees: 0n },
+      transactionResult: { status: 'SUCCESS', segments: [{ id: 1, success: true }] },
+    },
+    createdUtxos: [timelineUtxo(params.owner, params.value, params.id)],
+    spentUtxos: [],
+    status: 'SUCCESS',
+  },
+});

--- a/packages/unshielded-wallet/src/test/forkWallet.ts
+++ b/packages/unshielded-wallet/src/test/forkWallet.ts
@@ -1,0 +1,264 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// A test-only unshielded wallet registered over BOTH variants, so a crossing can actually be driven.
+//
+// The shipped `UnshieldedWallet` registers exactly one variant and is typed as a one-element HList throughout, so it
+// cannot express a fork-crossing wallet. Rather than widen the public surface ahead of the API redesign, this builds the
+// two-variant wallet the way `packages/e2e-tests` builds its custom wallets: `WalletBuilder.init()` with both variant
+// builders registered directly. Nothing here is exported from the package.
+//
+// This factory is markedly simpler than the shielded and dust equivalents, and the reason is the point of the whole
+// unshielded increment: there is no key to retain. Unshielded sync is watch-only — the address is public and signing is
+// supplied per call by the caller — so `startSyncInBackground` takes no argument, the activation watcher re-dispatches
+// with nothing, and none of the start-aux workarounds those factories document apply here.
+import { NetworkId, ProtocolVersion, type ProtocolState } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
+import { Deferred, Effect, FiberId, HashMap, Option, Stream, pipe } from 'effect';
+import { V1Builder, V1Tag, type CoreWallet as PreForkWallet } from '../v1/index.js';
+import * as PreForkSync from '../v1/Sync.js';
+import * as PreForkMigration from '../v1/Migration.js';
+import { V2Builder, V2Tag, type CoreWallet as PostForkWallet } from '../v2/index.js';
+import * as PostForkSync from '../v2/Sync.js';
+import * as PostForkMigration from '../v2/Migration.js';
+import { type TransactionHistoryService as PreForkHistory } from '../v1/TransactionHistory.js';
+import { type TransactionHistoryService as PostForkHistory } from '../v2/TransactionHistory.js';
+import { type WalletSyncUpdate as PreForkUpdate } from '../v1/SyncSchema.js';
+import { type WalletSyncUpdate as PostForkUpdate } from '../v2/SyncSchema.js';
+import { type TimelineItem } from './forkTimeline.js';
+
+/**
+ * A migration captured as plain data.
+ *
+ * @remarks
+ *   Captured rather than inspected live so assertions can be made after the crossing, when the pre-fork variant's scope
+ *   has closed.
+ */
+export type CapturedMigration = {
+  readonly from: MigrationSide;
+  readonly to: MigrationSide;
+};
+
+/** The version-agnostic view of a wallet either side of the boundary. */
+export type MigrationSide = {
+  readonly utxos: readonly CarriedUtxo[];
+  readonly appliedId: bigint;
+  readonly protocolVersion: bigint;
+  readonly networkId: string;
+  readonly address: string;
+};
+
+/** A UTXO as plain data, comparable across the two ledger versions. */
+export type CarriedUtxo = {
+  readonly value: bigint;
+  readonly owner: string;
+  readonly type: string;
+  readonly intentHash: string;
+  readonly outputNo: number;
+  readonly ctime: number;
+};
+
+const sideOf = (wallet: PreForkWallet | PostForkWallet): MigrationSide => ({
+  utxos: utxosOf(wallet),
+  appliedId: wallet.progress.appliedId,
+  protocolVersion: wallet.protocolVersion,
+  networkId: wallet.networkId,
+  address: wallet.publicKey.address,
+});
+
+/** A held UTXO reduced to plain data, comparable across the two ledger versions. */
+const plainUtxo = (held: {
+  readonly utxo: {
+    readonly value: bigint;
+    readonly owner: string;
+    readonly type: string;
+    readonly intentHash: string;
+    readonly outputNo: number;
+  };
+  readonly meta: { readonly ctime: Date };
+}): CarriedUtxo => ({
+  value: held.utxo.value,
+  owner: held.utxo.owner,
+  type: held.utxo.type,
+  intentHash: held.utxo.intentHash,
+  outputNo: held.utxo.outputNo,
+  ctime: held.meta.ctime.getTime(),
+});
+
+const sortedCarried = (utxos: readonly CarriedUtxo[]): readonly CarriedUtxo[] =>
+  [...utxos].sort((a, b) => (a.value === b.value ? a.outputNo - b.outputNo : Number(a.value - b.value)));
+
+/** Every available UTXO, as plain data, in a stable order so two sides can be compared directly. */
+export const utxosOf = (wallet: PreForkWallet | PostForkWallet): readonly CarriedUtxo[] =>
+  sortedCarried(Array.from(HashMap.values(wallet.state.availableUtxos), plainUtxo));
+
+/** Wraps the real cross-ledger migration so the test can see exactly what crossed. */
+const capturingCrossLedgerMigration = (
+  captured: Deferred.Deferred<CapturedMigration>,
+): PostForkMigration.StateMigration<PostForkMigration.PreviousLedgerWallet> => {
+  const inner = PostForkMigration.makeCrossLedgerMigration();
+  return {
+    migrate: (previousState) =>
+      pipe(
+        inner.migrate(previousState),
+        Effect.tap((migrated) =>
+          Deferred.succeed(captured, {
+            from: {
+              utxos: sortedCarried(Array.from(HashMap.values(previousState.state.availableUtxos), plainUtxo)),
+              appliedId: previousState.progress.appliedId,
+              protocolVersion: previousState.protocolVersion,
+              networkId: previousState.networkId,
+              address: previousState.publicKey.address,
+            },
+            to: sideOf(migrated),
+          }),
+        ),
+      ),
+  };
+};
+
+const noOpPreForkHistory: PreForkHistory = { put: () => Effect.void };
+const noOpPostForkHistory: PostForkHistory = { put: () => Effect.void };
+
+/**
+ * A sync service over an in-memory timeline, honouring the wallet's cursor.
+ *
+ * @remarks
+ *   This is the whole fidelity of the model, and it is deliberately the one thing not stubbed away: the source is asked
+ *   for everything _after_ the cursor the wallet presents, exactly as the indexer subscription is
+ *   (`subscription(transactionId: appliedId)`). A post-fork variant that resumes from a parked cursor therefore really
+ *   does re-fetch the boundary transaction, and one that resumed from a bumped cursor really would miss it.
+ */
+const timelineSyncService = <TUpdate>(
+  timeline: readonly TimelineItem[],
+  toUpdate: (item: TimelineItem) => TUpdate,
+) => ({
+  updates: (state: PreForkWallet | PostForkWallet) =>
+    Stream.fromIterable(timeline.filter((item) => BigInt(item.id) > state.progress.appliedId).map(toUpdate)),
+});
+
+export type ForkWalletConfig = {
+  /** The single timeline both variants read, each decoding it as its own ledger version's update. */
+  readonly timeline: readonly TimelineItem[];
+  /** The protocol version at which the second variant takes over. */
+  readonly forkVersion: ProtocolVersion.ProtocolVersion;
+  /** The wallet's starting state, built on the pre-fork ledger version. */
+  readonly initialState: PreForkWallet;
+  readonly networkId?: NetworkId.NetworkId;
+};
+
+export type ForkWallet = {
+  readonly start: Effect.Effect<void, WalletRuntimeError>;
+  readonly awaitMigration: Effect.Effect<CapturedMigration>;
+  readonly migration: Effect.Effect<Option.Option<CapturedMigration>>;
+  readonly activeTag: Effect.Effect<string | symbol>;
+  readonly currentState: Effect.Effect<ProtocolState.ProtocolState<PreForkWallet | PostForkWallet>, WalletRuntimeError>;
+  readonly awaitState: (
+    predicate: (state: ProtocolState.ProtocolState<PreForkWallet | PostForkWallet>) => boolean,
+  ) => Effect.Effect<ProtocolState.ProtocolState<PreForkWallet | PostForkWallet>, WalletRuntimeError>;
+  readonly stop: Effect.Effect<void>;
+};
+
+/**
+ * Builds and starts an unshielded wallet registered over both variants.
+ *
+ * @param config The timeline, the boundary version and the starting state.
+ * @returns The running wallet and its observation channels.
+ */
+export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
+  const networkId = config.networkId ?? NetworkId.NetworkId.Undeployed;
+  const captured = Deferred.unsafeMake<CapturedMigration>(FiberId.none);
+
+  const preForkBuilder = new V1Builder()
+    .withSync(
+      () => timelineSyncService<PreForkUpdate>(config.timeline, (item) => item.update as PreForkUpdate),
+      // The REAL capability, boundary rule and all — only the service that would open a WebSocket is substituted.
+      (_c: object, getContext: () => { transactionHistoryService: PreForkHistory }) =>
+        PreForkSync.makeDefaultSyncCapability({ indexerClientConnection: { indexerHttpUrl: 'http://unused' } }, () =>
+          getContext(),
+        ),
+    )
+    .withSerializationDefaults()
+    .withTransactingDefaults()
+    .withSigningDefaults()
+    .withCoinsAndBalancesDefaults()
+    .withTransactionHistory(() => noOpPreForkHistory)
+    .withKeysDefaults()
+    .withCoinSelectionDefaults()
+    .withMigration(() => PreForkMigration.makeEmptyWalletMigration({ networkId }));
+
+  const postForkBuilder = new V2Builder()
+    .withSync(
+      () => timelineSyncService<PostForkUpdate>(config.timeline, (item) => item.update as PostForkUpdate),
+      (_c: object, getContext: () => { transactionHistoryService: PostForkHistory }) =>
+        PostForkSync.makeDefaultSyncCapability({ indexerClientConnection: { indexerHttpUrl: 'http://unused' } }, () =>
+          getContext(),
+        ),
+    )
+    .withSerializationDefaults()
+    .withTransactingDefaults()
+    .withSigningDefaults()
+    .withCoinsAndBalancesDefaults()
+    .withTransactionHistory(() => noOpPostForkHistory)
+    .withKeysDefaults()
+    .withCoinSelectionDefaults()
+    .withMigration(() => capturingCrossLedgerMigration(captured));
+
+  const WalletClass = WalletBuilder.init()
+    .withVariant(ProtocolVersion.MinSupportedVersion, preForkBuilder)
+    .withVariant(config.forkVersion, postForkBuilder)
+    .build({ networkId });
+
+  const wallet = WalletClass.startFirst(WalletClass, config.initialState);
+  const runtime = wallet.runtime;
+
+  return {
+    start: Effect.gen(function* () {
+      // Registered before the first dispatch and only once, exactly as `UnshieldedWallet.start` does it — and with no
+      // argument, which is the point: nothing secret has to survive the crossing.
+      yield* runtime.onVariantActivation({
+        [V1Tag]: (v1) => v1.startSyncInBackground(),
+        [V2Tag]: (v2) => v2.startSyncInBackground(),
+      });
+      yield* runtime.dispatch({
+        [V1Tag]: (v1) => v1.startSyncInBackground(),
+        [V2Tag]: (v2) => v2.startSyncInBackground(),
+      });
+    }),
+
+    awaitMigration: Deferred.await(captured),
+
+    migration: Deferred.poll(captured).pipe(
+      Effect.flatMap(Option.match({ onNone: () => Effect.succeedNone, onSome: Effect.asSome })),
+    ),
+
+    activeTag: pipe(
+      runtime.currentVariant,
+      Effect.map((current) => current.runningVariant.__polyTag__),
+    ),
+
+    currentState: pipe(runtime.stateChanges, Stream.take(1), Stream.runHead, Effect.map(Option.getOrThrow)),
+
+    awaitState: (predicate) =>
+      pipe(
+        runtime.stateChanges,
+        Stream.filter(predicate),
+        Stream.take(1),
+        Stream.runHead,
+        Effect.map(Option.getOrThrow),
+      ),
+
+    stop: Effect.promise(() => wallet.stop()),
+  };
+};

--- a/packages/unshielded-wallet/src/v1/CoreWallet.ts
+++ b/packages/unshielded-wallet/src/v1/CoreWallet.ts
@@ -65,6 +65,21 @@ export const CoreWallet = {
     return { ...wallet, progress };
   },
 
+  /**
+   * Records an observed protocol version, monotonically.
+   *
+   * @remarks
+   *   Only ever raises it. A stale lower report — a reconnect replaying from an earlier cursor, say — would otherwise
+   *   look like a downward version change and send the runtime migrating backwards into a variant this wallet has
+   *   already left.
+   * @param wallet The wallet to annotate.
+   * @param version The protocol version the source reported.
+   * @returns The wallet carrying the higher of the two versions.
+   */
+  withProtocolVersion(wallet: CoreWallet, version: ProtocolVersion.ProtocolVersion): CoreWallet {
+    return version > wallet.protocolVersion ? { ...wallet, protocolVersion: version } : wallet;
+  },
+
   applyUpdate(coreWallet: CoreWallet, update: UnshieldedUpdate): Either.Either<CoreWallet, WalletError> {
     return UnshieldedState.applyUpdate(coreWallet.state, update).pipe(
       Either.map((state) => ({ ...coreWallet, state })),

--- a/packages/unshielded-wallet/src/v1/Migration.ts
+++ b/packages/unshielded-wallet/src/v1/Migration.ts
@@ -1,0 +1,183 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { type NetworkId, ProtocolVersion, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect } from 'effect';
+import { CoreWallet } from './CoreWallet.js';
+import { type SyncProgressData } from './SyncProgress.js';
+import { createKeystore, PublicKey } from './KeyStore.js';
+import { UnshieldedState, UtxoWithMeta } from './UnshieldedState.js';
+import { type WalletError } from './WalletError.js';
+
+/**
+ * How this variant produces its first state from whatever came before it.
+ *
+ * @remarks
+ *   The strategy is injected through the builder rather than hard-coded into the variant, because "whatever came before"
+ *   is not one thing: an empty wallet at first start, a wallet of this same ledger version, or a wallet of the ledger
+ *   version this one replaced. Those are different functions with different input types, and the runtime only ever
+ *   needs one of them per registration — so which one is a build-time decision, expressed as a dictionary in the
+ *   repository's usual dictionary-passing style.
+ * @typeParam TPreviousState The state this migration consumes.
+ */
+export type StateMigration<TPreviousState> = {
+  migrate: (previousState: TPreviousState) => Effect.Effect<CoreWallet, WalletError>;
+};
+
+export type EmptyWalletMigrationConfiguration = {
+  networkId: NetworkId.NetworkId;
+};
+
+/**
+ * The migration used when there is no previous wallet at all.
+ *
+ * @remarks
+ *   It backs `WalletLike.startEmpty`, which builds a wallet before any key material exists. The resulting state has no
+ *   UTXOs and a public key derived from a fixed placeholder seed; it is a scaffold to be replaced by a real start, not
+ *   a wallet anybody can transact with. Preserved verbatim from the pre-fork implementation so that `startEmpty`
+ *   behaves exactly as it did.
+ * @example
+ *   ```typescript
+ *   const builder = new V2Builder().withDefaults().withMigration(makeEmptyWalletMigration({ networkId }));
+ *   ```;
+ *
+ * @param configuration Supplies the network the scaffold state claims to be on.
+ * @returns A migration from `null`.
+ */
+export const makeEmptyWalletMigration = (configuration: EmptyWalletMigrationConfiguration): StateMigration<null> => ({
+  migrate: () => {
+    const seed = WalletSeed.fromString('0000000000000000000000000000000000000000000000000000000000000001');
+    return Effect.succeed(
+      CoreWallet.init(PublicKey.fromKeyStore(createKeystore(seed, configuration.networkId)), configuration.networkId),
+    );
+  },
+});
+
+/**
+ * The migration between two variants that share this ledger version.
+ *
+ * @remarks
+ *   Both sides speak the same state type, so the carry is the identity. This is the right strategy for a protocol bump
+ *   that does not change serialization.
+ * @returns A migration from a {@link CoreWallet} of this ledger version.
+ */
+export const makeCarryOverMigration = (): StateMigration<CoreWallet> => ({
+  migrate: (previousState) => Effect.succeed(previousState),
+});
+
+/**
+ * The shape a wallet of the _previous_ ledger version must expose to be carried across a hard fork.
+ *
+ * @remarks
+ *   Structural on purpose. The previous variant's `CoreWallet` is built on a different ledger module, and naming that
+ *   module here would drag a second multi-megabyte WASM binary into this variant for the sake of a type. That is
+ *   affordable precisely because unshielded state is public: UTXOs are plain records of value, owner, token type,
+ *   intent hash and output number, with no ledger object anywhere in them.
+ *
+ *   The verifying key is the one place the two ledger versions genuinely disagree, and it is described here as the
+ *   previous version has it — a bare hex string.
+ */
+export type PreviousLedgerWallet = Readonly<{
+  state: {
+    readonly availableUtxos: Iterable<UtxoLike>;
+    readonly pendingUtxos: Iterable<UtxoLike>;
+  };
+  publicKey: {
+    readonly publicKey: string;
+    readonly addressHex: string;
+    readonly address: string;
+  };
+  networkId: string;
+  protocolVersion: bigint;
+  progress: SyncProgressData;
+}>;
+
+/** A UTXO of the previous ledger version, as plain data. */
+export type UtxoLike = {
+  readonly utxo: {
+    readonly value: bigint;
+    readonly owner: string;
+    readonly type: string;
+    readonly intentHash: string;
+    readonly outputNo: number;
+  };
+  readonly meta: {
+    readonly ctime: Date;
+    readonly registeredForDustGeneration: boolean;
+  };
+};
+
+/**
+ * The migration across a ledger-version boundary: a structural carry of everything the wallet holds.
+ *
+ * @remarks
+ *   Kept symmetric with the ledger-v9 tree so the seam has the same shape on both sides, though nothing precedes
+ *   ledger-v8 in this SDK: here the carry is purely structural, with no key widening to perform, because this ledger
+ *   version's verifying keys are already bare hex strings.
+ *
+ *   This is where unshielded parts company with shielded and dust. Those two start the new variant on a **fresh, empty**
+ *   state and let the indexer's post-fork replay hand their coins back, because their coins are shielded: re-deriving
+ *   them means decrypting events with secret keys that migration, by design, never receives. Unshielded has no such
+ *   problem. Its UTXOs are public ledger data that the wallet holds as plain records, so they can simply be rebuilt on
+ *   the other side — no replay to wait for, no keys required, and no window in which the wallet reports a zero balance
+ *   it does not have.
+ *
+ *   So everything crosses: available and pending UTXOs field for field, the address, the network, and the protocol
+ *   version that triggered the hand-over. The one transformation is the verifying key, which gains the scheme tag that
+ *   ledger-v9 requires and ledger-v8 had no room for — the same widening the deserializer already performs on legacy
+ *   snapshots, which is where the `schnorr` default comes from: ledger-v8 had exactly one signature scheme, so a key
+ *   that reaches here can only have been a schnorr key.
+ *
+ *   Sync progress is carried **unchanged** — parked, not rewound and not advanced. The boundary transaction was observed
+ *   and annotated but deliberately never applied, so the cursor still points just before it; the new variant re-fetches
+ *   it from there and applies it exactly once. Rewinding to zero would re-apply history the wallet already holds;
+ *   advancing past it would lose the boundary transaction outright.
+ * @returns A migration from a previous-ledger-version wallet.
+ */
+export const makeCrossLedgerMigration = (): StateMigration<PreviousLedgerWallet> => ({
+  migrate: (previousState) =>
+    Effect.succeed(
+      CoreWallet.restore(
+        UnshieldedState.restore(
+          Array.from(previousState.state.availableUtxos, carryUtxo),
+          Array.from(previousState.state.pendingUtxos, carryUtxo),
+        ),
+        {
+          publicKey: previousState.publicKey.publicKey,
+          addressHex: previousState.publicKey.addressHex,
+          address: previousState.publicKey.address,
+        },
+        {
+          appliedId: previousState.progress.appliedId,
+          highestTransactionId: previousState.progress.highestTransactionId,
+        },
+        ProtocolVersion.ProtocolVersion(previousState.protocolVersion),
+        previousState.networkId,
+      ),
+    ),
+});
+
+/** Rebuilds a previous-version UTXO as one of this version's, field for field. */
+const carryUtxo = (carried: UtxoLike): UtxoWithMeta =>
+  new UtxoWithMeta({
+    utxo: {
+      value: carried.utxo.value,
+      owner: carried.utxo.owner,
+      type: carried.utxo.type,
+      intentHash: carried.utxo.intentHash,
+      outputNo: carried.utxo.outputNo,
+    },
+    meta: {
+      ctime: carried.meta.ctime,
+      registeredForDustGeneration: carried.meta.registeredForDustGeneration,
+    },
+  });

--- a/packages/unshielded-wallet/src/v1/Migration.ts
+++ b/packages/unshielded-wallet/src/v1/Migration.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { type NetworkId, ProtocolVersion, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Effect } from 'effect';
+import { Effect, HashMap } from 'effect';
 import { CoreWallet } from './CoreWallet.js';
 import { type SyncProgressData } from './SyncProgress.js';
 import { createKeystore, PublicKey } from './KeyStore.js';
@@ -88,8 +88,12 @@ export const makeCarryOverMigration = (): StateMigration<CoreWallet> => ({
  */
 export type PreviousLedgerWallet = Readonly<{
   state: {
-    readonly availableUtxos: Iterable<UtxoLike>;
-    readonly pendingUtxos: Iterable<UtxoLike>;
+    // Effect `HashMap`s, as the previous variant really holds them — not arrays. The distinction matters and is easy
+    // to get wrong: iterating a `HashMap` yields `[key, value]` entries, so a type that merely said `Iterable<UtxoLike>`
+    // would be satisfied by the real state and then silently carry across a list of malformed pairs. `HashMap` is an
+    // Effect type, not a ledger one, so naming it here keeps this description version-agnostic.
+    readonly availableUtxos: HashMap.HashMap<string, UtxoLike>;
+    readonly pendingUtxos: HashMap.HashMap<string, UtxoLike>;
   };
   publicKey: {
     readonly publicKey: string;
@@ -148,8 +152,8 @@ export const makeCrossLedgerMigration = (): StateMigration<PreviousLedgerWallet>
     Effect.succeed(
       CoreWallet.restore(
         UnshieldedState.restore(
-          Array.from(previousState.state.availableUtxos, carryUtxo),
-          Array.from(previousState.state.pendingUtxos, carryUtxo),
+          Array.from(HashMap.values(previousState.state.availableUtxos), carryUtxo),
+          Array.from(HashMap.values(previousState.state.pendingUtxos), carryUtxo),
         ),
         {
           publicKey: previousState.publicKey.publicKey,

--- a/packages/unshielded-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/unshielded-wallet/src/v1/RunningV1Variant.ts
@@ -50,8 +50,26 @@ const progress = (state: CoreWallet): StateChange.StateChange<CoreWallet>[] => {
   return [StateChange.ProgressUpdate({ sourceGap, applyGap })];
 };
 
-const protocolVersionChange = (previous: CoreWallet, current: CoreWallet): StateChange.StateChange<CoreWallet>[] => {
-  return previous.protocolVersion != current.protocolVersion
+/**
+ * The version signals this variant puts on its state stream.
+ *
+ * @remarks
+ *   Two of them, for two different situations. A transition is the ordinary one: the state moved to a version the variant
+ *   may or may not own, and the runtime decides. The healing emission covers restore: a snapshot taken between the
+ *   moment sync annotated an out-of-range version and the moment the runtime acted on it comes back with a version this
+ *   variant does not own and no transition to announce it, so it would sit there forever. Announcing it on the first
+ *   observation is what forward-migrates such a snapshot.
+ */
+const protocolVersionChange = (
+  previous: CoreWallet,
+  current: CoreWallet,
+  isInitial: boolean,
+  activationRange: ProtocolVersion.ProtocolVersion.Range,
+): StateChange.StateChange<CoreWallet>[] => {
+  const transitioned = previous.protocolVersion != current.protocolVersion;
+  const strandedOutsideRange = isInitial && !ProtocolVersion.withinRange(current.protocolVersion, activationRange);
+
+  return transitioned || strandedOutsideRange
     ? [
         StateChange.VersionChange({
           change: VersionChangeType.Version({
@@ -101,18 +119,27 @@ export class RunningV1Variant<TSerialized, TSyncUpdate> implements Variant.Runni
     this.state = Stream.fromEffect(context.stateRef.get).pipe(
       Stream.flatMap((initialState) =>
         context.stateRef.changes.pipe(
-          Stream.mapAccum(initialState, (previous: CoreWallet, current: CoreWallet) => {
-            return [current, [previous, current]] as const;
-          }),
+          // The accumulator carries a "have we seen anything yet" flag alongside the previous state: the first
+          // observation is the only one that can be a restored state nobody has checked against this variant's range
+          // yet, and `SubscriptionRef.changes` replays the current value, so it is exactly this element.
+          Stream.mapAccum(
+            { previous: initialState, isInitial: true },
+            (seen, current: CoreWallet) =>
+              [{ previous: current, isInitial: false }, [seen.previous, current, seen.isInitial] as const] as const,
+          ),
         ),
       ),
       Stream.mapConcat(
-        ([previous, current]: readonly [CoreWallet, CoreWallet]): StateChange.StateChange<CoreWallet>[] => {
+        ([previous, current, isInitial]: readonly [
+          CoreWallet,
+          CoreWallet,
+          boolean,
+        ]): StateChange.StateChange<CoreWallet>[] => {
           // TODO: emit progress only upon actual change
           return [
             StateChange.State({ state: current }),
             ...progress(current),
-            ...protocolVersionChange(previous, current),
+            ...protocolVersionChange(previous, current, isInitial, context.activationRange),
           ];
         },
       ),
@@ -134,7 +161,10 @@ export class RunningV1Variant<TSerialized, TSyncUpdate> implements Variant.Runni
       Stream.flatMap((state) => this.#v1Context.syncService.updates(state)),
       Stream.mapEffect((update) => {
         return SubscriptionRef.updateEffect(this.#context.stateRef, (state) =>
-          pipe(this.#v1Context.syncCapability.applyUpdate(state, update), EitherOps.toEffect),
+          pipe(
+            this.#v1Context.syncCapability.applyUpdate(state, update, this.#context.activationRange),
+            EitherOps.toEffect,
+          ),
         );
       }),
       Stream.tapError((error) => Console.error(error)),

--- a/packages/unshielded-wallet/src/v1/Sync.ts
+++ b/packages/unshielded-wallet/src/v1/Sync.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Effect, type Scope, Stream, Schema, pipe, Either, HashMap } from 'effect';
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { CoreWallet } from './CoreWallet.js';
 import { UtxoWithMeta } from './UnshieldedState.js';
 // The simulation package re-exports the ledger-v9 twin unqualified and offers both lines as `V8`/`V9` namespaces. This
@@ -31,8 +32,47 @@ export interface SyncService<TState, TUpdate> {
 }
 
 export interface SyncCapability<TState, TUpdate> {
-  applyUpdate: (state: TState, update: TUpdate) => Either.Either<TState, WalletError>;
+  /**
+   * Folds a single sync message into the wallet state.
+   *
+   * @param state The state to fold into.
+   * @param update The message to apply.
+   * @param activeRange The half-open protocol version range the running variant owns. A message the source reports at
+   *   or beyond its end belongs to a later variant and must be left entirely unapplied, for that variant to fetch.
+   */
+  applyUpdate: (
+    state: TState,
+    update: TUpdate,
+    activeRange: ProtocolVersion.ProtocolVersion.Range,
+  ) => Either.Either<TState, WalletError>;
 }
+
+/**
+ * Whether a reported protocol version belongs to a variant later than the one owning `activeRange`.
+ *
+ * @remarks
+ *   Unshielded sync is message-at-a-time, so this is the whole of the boundary rule — there is no batch to split into an
+ *   applied prefix and a deferred suffix, only a yes/no per message. Exported so the indexer and simulator sync
+ *   capabilities cannot drift apart on the question.
+ * @param version The protocol version the source reported for this message.
+ * @param activeRange The running variant's half-open activation range.
+ * @returns `true` when the message must be left unapplied.
+ */
+export const isBeyondActiveRange = (version: number, activeRange: ProtocolVersion.ProtocolVersion.Range): boolean =>
+  BigInt(version) >= activeRange[1];
+
+/**
+ * Records an observed protocol version on the state, monotonically.
+ *
+ * @remarks
+ *   This is the only thing written when a message is deferred at the boundary, and it is what the runtime watches to
+ *   decide that the variant must hand over.
+ * @param state The state to annotate.
+ * @param version The protocol version the source reported.
+ * @returns The state carrying the higher of the two versions.
+ */
+export const annotateVersion = (state: CoreWallet, version: number): CoreWallet =>
+  CoreWallet.withProtocolVersion(state, ProtocolVersion.ProtocolVersion(BigInt(version)));
 
 export type IndexerClientConnection = {
   indexerHttpUrl: string;
@@ -104,14 +144,27 @@ export const makeDefaultSyncCapability = (
   getContext: () => DefaultSyncContext,
 ): SyncCapability<CoreWallet, WalletSyncUpdate> => {
   return {
-    applyUpdate: (state: CoreWallet, update: WalletSyncUpdate): Either.Either<CoreWallet, WalletError> => {
+    applyUpdate: (
+      state: CoreWallet,
+      update: WalletSyncUpdate,
+      activeRange: ProtocolVersion.ProtocolVersion.Range,
+    ): Either.Either<CoreWallet, WalletError> => {
       if (update.type === 'UnshieldedTransactionsProgress') {
+        // A progress message reports the tip of the source, not a transaction, and the wire schema carries no protocol
+        // version on it. It therefore never annotates: reading one as version zero would drag a wallet that has
+        // already crossed a boundary back below it.
         return Either.right(
           CoreWallet.updateProgress(state, {
             highestTransactionId: BigInt(update.highestTransactionId),
             isConnected: true,
           }),
         );
+      } else if (isBeyondActiveRange(update.transaction.protocolVersion, activeRange)) {
+        // The hand-over point. This transaction belongs to the next variant, so NOTHING about it is applied: no UTXO
+        // change, no cursor movement, no transaction-history write. Only the version is recorded, which is what makes
+        // the runtime migrate. Because the cursor did not move, the next variant re-fetches this very transaction from
+        // it and applies it exactly once.
+        return Either.right(annotateVersion(state, update.transaction.protocolVersion));
       } else {
         const updatePayload = {
           createdUtxos: update.createdUtxos,
@@ -133,7 +186,7 @@ export const makeDefaultSyncCapability = (
             const { transactionHistoryService } = getContext();
             Effect.runFork(transactionHistoryService.put(update));
 
-            return stateAfterUpdatingProgress;
+            return annotateVersion(stateAfterUpdatingProgress, update.transaction.protocolVersion);
           }),
         );
       }
@@ -182,7 +235,17 @@ export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, Simula
   const utxoKey = (utxo: { intentHash: string; outputNo: number }) => `${utxo.intentHash}#${utxo.outputNo}`;
 
   return {
-    applyUpdate: (state: CoreWallet, update: SimulatorSyncUpdate): Either.Either<CoreWallet, WalletError> => {
+    applyUpdate: (
+      state: CoreWallet,
+      update: SimulatorSyncUpdate,
+      activeRange: ProtocolVersion.ProtocolVersion.Range,
+    ): Either.Either<CoreWallet, WalletError> => {
+      // The same rule at the simulator's granularity: a chain state tagged at or beyond the boundary belongs to the
+      // next variant, so nothing of it is applied and only the version is recorded.
+      if (isBeyondActiveRange(Number(update.update.protocolVersion), activeRange)) {
+        return Either.right(annotateVersion(state, Number(update.update.protocolVersion)));
+      }
+
       const { ledger: ledgerState, currentTime } = update.update;
       const walletAddress = state.publicKey.addressHex;
       const nativeTokenType = ledger.nativeToken().raw;
@@ -223,13 +286,16 @@ export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, Simula
       const updateProgress = (wallet: CoreWallet) =>
         CoreWallet.updateProgress(wallet, { appliedId: blockNumber, isConnected: true });
 
+      const annotate = (wallet: CoreWallet) => annotateVersion(wallet, Number(update.update.protocolVersion));
+
       if (createdUtxos.length === 0 && spentUtxos.length === 0) {
-        return Either.right(updateProgress(state));
+        return Either.right(annotate(updateProgress(state)));
       }
 
       return pipe(
         CoreWallet.applyUpdate(state, { createdUtxos, spentUtxos, status: 'SUCCESS' as const }),
         Either.map(updateProgress),
+        Either.map(annotate),
       );
     },
   };

--- a/packages/unshielded-wallet/src/v1/V1Builder.ts
+++ b/packages/unshielded-wallet/src/v1/V1Builder.ts
@@ -12,12 +12,8 @@
 // limitations under the License.
 import type * as ledger from '@midnight-ntwrk/ledger-v8';
 import { Effect, type Either, Scope, type Types } from 'effect';
-import { WalletSeed, type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
-import {
-  type Variant,
-  type VariantBuilder,
-  type WalletRuntimeError,
-} from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type Variant, type VariantBuilder, WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { RunningV1Variant, V1Tag } from './RunningV1Variant.js';
 import { makeDefaultV1SerializationCapability, type SerializationCapability } from './Serialization.js';
 import {
@@ -36,18 +32,18 @@ import {
   type TransactingCapability,
 } from './Transacting.js';
 import { type WalletError } from './WalletError.js';
+import { makeEmptyWalletMigration, type StateMigration } from './Migration.js';
 import { makeDefaultSigningService, type SigningService } from './Signing.js';
 import { type CoinsAndBalancesCapability, makeDefaultCoinsAndBalancesCapability } from './CoinsAndBalances.js';
 import { type KeysCapability, makeDefaultKeysCapability } from './Keys.js';
 import { type CoinSelection, chooseCoin } from '@midnightntwrk/wallet-sdk-capabilities';
-import { CoreWallet } from './CoreWallet.js';
+import { type CoreWallet } from './CoreWallet.js';
 import {
   type DefaultTransactionHistoryConfiguration,
   type TransactionHistoryService,
   makeDefaultTransactionHistoryService,
 } from './TransactionHistory.js';
 import { type Expect, type Equal, type ItemType } from '@midnightntwrk/wallet-sdk-utilities/types';
-import { createKeystore, PublicKey } from './KeyStore.js';
 
 export type BaseV1Configuration = {
   networkId: NetworkId.NetworkId;
@@ -64,10 +60,10 @@ const V1BuilderSymbol: {
   typeId: Symbol('@midnight-ntwrk/unshielded-wallet#V1Builder') as (typeof V1BuilderSymbol)['typeId'],
 } as const;
 
-export type V1Variant<TSerialized, TSyncUpdate> = Variant.Variant<
+export type V1Variant<TSerialized, TSyncUpdate, TPreviousState = null> = Variant.Variant<
   typeof V1Tag,
   CoreWallet,
-  null,
+  TPreviousState,
   RunningV1Variant<TSerialized, TSyncUpdate>
 > & {
   deserializeState: (serialized: TSerialized) => Either.Either<CoreWallet, WalletError>;
@@ -78,24 +74,25 @@ export type V1Variant<TSerialized, TSyncUpdate> = Variant.Variant<
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyV1Variant = V1Variant<any, any>;
-export type DefaultV1Variant = V1Variant<string, WalletSyncUpdate>;
+export type AnyV1Variant = V1Variant<any, any, any>;
+export type DefaultV1Variant = V1Variant<string, WalletSyncUpdate, null>;
 
 export type TransactionOf<T extends AnyV1Variant> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  T extends V1Variant<any, any>
+  T extends V1Variant<any, any, any>
     ? ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>
     : never;
 
 export type SerializedStateOf<T extends AnyV1Variant> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  T extends V1Variant<infer TSerialized, any> ? TSerialized : never;
+  T extends V1Variant<infer TSerialized, any, any> ? TSerialized : never;
 
 export type DefaultV1Builder = V1Builder<
   DefaultV1Configuration,
   RunningV1Variant.Context<string, WalletSyncUpdate>,
   string,
-  WalletSyncUpdate
+  WalletSyncUpdate,
+  null
 >;
 
 export class V1Builder<
@@ -103,10 +100,13 @@ export class V1Builder<
   TContext extends Partial<RunningV1Variant.AnyContext> = object,
   TSerialized = never,
   TSyncUpdate = never,
-> implements VariantBuilder.VariantBuilder<V1Variant<TSerialized, TSyncUpdate>, TConfig> {
-  readonly #buildState: V1Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate>;
+  TPreviousState = null,
+> implements VariantBuilder.VariantBuilder<V1Variant<TSerialized, TSyncUpdate, TPreviousState>, TConfig> {
+  readonly #buildState: V1Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState>;
 
-  constructor(buildState: V1Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate> = {}) {
+  constructor(
+    buildState: V1Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState> = {},
+  ) {
     this.#buildState = buildState;
   }
 
@@ -125,7 +125,8 @@ export class V1Builder<
     TConfig & DefaultSyncConfiguration,
     TContext & DefaultSyncContext,
     TSerialized,
-    WalletSyncUpdate
+    WalletSyncUpdate,
+    TPreviousState
   > {
     return this.withSync(makeDefaultSyncService, makeDefaultSyncCapability);
   }
@@ -136,15 +137,15 @@ export class V1Builder<
       configuration: TSyncConfig,
       getContext: () => TSyncContext,
     ) => SyncCapability<CoreWallet, TSyncUpdate>,
-  ): V1Builder<TConfig & TSyncConfig, TContext & TSyncContext, TSerialized, TSyncUpdate> {
-    return new V1Builder<TConfig & TSyncConfig, TContext & TSyncContext, TSerialized, TSyncUpdate>({
+  ): V1Builder<TConfig & TSyncConfig, TContext & TSyncContext, TSerialized, TSyncUpdate, TPreviousState> {
+    return new V1Builder<TConfig & TSyncConfig, TContext & TSyncContext, TSerialized, TSyncUpdate, TPreviousState>({
       ...this.#buildState,
       syncService,
       syncCapability,
     });
   }
 
-  withSerializationDefaults(): V1Builder<TConfig, TContext, string, TSyncUpdate> {
+  withSerializationDefaults(): V1Builder<TConfig, TContext, string, TSyncUpdate, TPreviousState> {
     return this.withSerialization(makeDefaultV1SerializationCapability);
   }
 
@@ -157,20 +158,33 @@ export class V1Builder<
       configuration: TSerializationConfig,
       getContext: () => TSerializationContext,
     ) => SerializationCapability<CoreWallet, TSerialized>,
-  ): V1Builder<TConfig & TSerializationConfig, TContext & TSerializationContext, TSerialized, TSyncUpdate> {
-    return new V1Builder<TConfig & TSerializationConfig, TContext & TSerializationContext, TSerialized, TSyncUpdate>({
+  ): V1Builder<
+    TConfig & TSerializationConfig,
+    TContext & TSerializationContext,
+    TSerialized,
+    TSyncUpdate,
+    TPreviousState
+  > {
+    return new V1Builder<
+      TConfig & TSerializationConfig,
+      TContext & TSerializationContext,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >({
       ...this.#buildState,
       serializationCapability,
     });
   }
 
   withTransactingDefaults(
-    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate>,
+    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState>,
   ): V1Builder<
     TConfig & DefaultTransactingConfiguration,
     TContext & DefaultTransactingContext,
     TSerialized,
-    TSyncUpdate
+    TSyncUpdate,
+    TPreviousState
   > {
     return this.withTransacting(makeDefaultTransactingCapability);
   }
@@ -180,24 +194,76 @@ export class V1Builder<
       config: TTransactingConfig,
       getContext: () => TTransactingContext,
     ) => TransactingCapability<CoreWallet>,
-  ): V1Builder<TConfig & TTransactingConfig, TContext & TTransactingContext, TSerialized, TSyncUpdate> {
-    return new V1Builder<TConfig & TTransactingConfig, TContext & TTransactingContext, TSerialized, TSyncUpdate>({
+  ): V1Builder<TConfig & TTransactingConfig, TContext & TTransactingContext, TSerialized, TSyncUpdate, TPreviousState> {
+    return new V1Builder<
+      TConfig & TTransactingConfig,
+      TContext & TTransactingContext,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >({
       ...this.#buildState,
       transactingCapability,
     });
   }
 
-  withSigningDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate> {
+  withSigningDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState> {
     return this.withSigning(makeDefaultSigningService);
   }
 
   withSigning<TSigningConfig, TSigningContext extends Partial<RunningV1Variant.AnyContext>>(
     signingService: (configuration: TSigningConfig, getContext: () => TSigningContext) => SigningService,
-  ): V1Builder<TConfig & TSigningConfig, TContext & TSigningContext, TSerialized, TSyncUpdate> {
-    return new V1Builder<TConfig & TSigningConfig, TContext & TSigningContext, TSerialized, TSyncUpdate>({
+  ): V1Builder<TConfig & TSigningConfig, TContext & TSigningContext, TSerialized, TSyncUpdate, TPreviousState> {
+    return new V1Builder<
+      TConfig & TSigningConfig,
+      TContext & TSigningContext,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >({
       ...this.#buildState,
       signingService,
     });
+  }
+
+  /**
+   * Configures this variant to start from an empty wallet when there is nothing before it.
+   *
+   * @remarks
+   *   The default for a first-registered variant, and what `startEmpty` relies on.
+   * @returns A builder whose previous state is `null`.
+   */
+  withMigrationDefaults(
+    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, null>,
+  ): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, null> {
+    return this.withMigration((configuration: BaseV1Configuration) =>
+      makeEmptyWalletMigration({ networkId: configuration.networkId }),
+    );
+  }
+
+  /**
+   * Configures how this variant produces its first state from whatever variant preceded it.
+   *
+   * @remarks
+   *   The context is a method-level type parameter rather than the builder's own `TContext`, matching `withSync` and
+   *   `withKeys` in this file. Binding it to the builder's `TContext` would make the builder invariant in it and break
+   *   the partially-configured chains the tests build.
+   * @param migration Produces the strategy from the configuration and the variant context.
+   * @returns A builder whose previous state is whatever the strategy consumes.
+   */
+  withMigration<TMigrationConfig, TMigrationContext extends Partial<RunningV1Variant.AnyContext>, TPrevious>(
+    migration: (configuration: TMigrationConfig, getContext: () => TMigrationContext) => StateMigration<TPrevious>,
+  ): V1Builder<TConfig & TMigrationConfig, TContext & TMigrationContext, TSerialized, TSyncUpdate, TPrevious> {
+    // Only the capability half of the build state crosses: the strategy being replaced is typed against the OLD
+    // previous-state parameter, so it cannot ride along even though it is about to be overwritten.
+    const { migration: _replaced, ...capabilities } = this.#buildState;
+
+    return new V1Builder<TConfig & TMigrationConfig, TContext & TMigrationContext, TSerialized, TSyncUpdate, TPrevious>(
+      {
+        ...capabilities,
+        migration,
+      },
+    );
   }
 
   withCoinSelection<TCoinSelectionConfig, TCoinSelectionContext extends Partial<RunningV1Variant.AnyContext>>(
@@ -205,18 +271,30 @@ export class V1Builder<
       config: TCoinSelectionConfig,
       getContext: () => TCoinSelectionContext,
     ) => CoinSelection<ledger.Utxo>,
-  ): V1Builder<TConfig & TCoinSelectionConfig, TContext & TCoinSelectionContext, TSerialized, TSyncUpdate> {
-    return new V1Builder<TConfig & TCoinSelectionConfig, TContext & TCoinSelectionContext, TSerialized, TSyncUpdate>({
+  ): V1Builder<
+    TConfig & TCoinSelectionConfig,
+    TContext & TCoinSelectionContext,
+    TSerialized,
+    TSyncUpdate,
+    TPreviousState
+  > {
+    return new V1Builder<
+      TConfig & TCoinSelectionConfig,
+      TContext & TCoinSelectionContext,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >({
       ...this.#buildState,
       coinSelection,
     });
   }
 
-  withCoinSelectionDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate> {
+  withCoinSelectionDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState> {
     return this.withCoinSelection(() => chooseCoin);
   }
 
-  withCoinsAndBalancesDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate> {
+  withCoinsAndBalancesDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState> {
     return this.withCoinsAndBalances(makeDefaultCoinsAndBalancesCapability);
   }
 
@@ -225,16 +303,22 @@ export class V1Builder<
       configuration: TBalancesConfig,
       getContext: () => TBalancesContext,
     ) => CoinsAndBalancesCapability<CoreWallet>,
-  ): V1Builder<TConfig & TBalancesConfig, TContext & TBalancesContext, TSerialized, TSyncUpdate> {
-    return new V1Builder<TConfig & TBalancesConfig, TContext & TBalancesContext, TSerialized, TSyncUpdate>({
+  ): V1Builder<TConfig & TBalancesConfig, TContext & TBalancesContext, TSerialized, TSyncUpdate, TPreviousState> {
+    return new V1Builder<
+      TConfig & TBalancesConfig,
+      TContext & TBalancesContext,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >({
       ...this.#buildState,
       coinsAndBalancesCapability,
     });
   }
 
   withTransactionHistoryDefaults(
-    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate>,
-  ): V1Builder<TConfig & DefaultTransactionHistoryConfiguration, TContext, TSerialized, TSyncUpdate> {
+    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState>,
+  ): V1Builder<TConfig & DefaultTransactionHistoryConfiguration, TContext, TSerialized, TSyncUpdate, TPreviousState> {
     return this.withTransactionHistory(makeDefaultTransactionHistoryService);
   }
 
@@ -246,37 +330,50 @@ export class V1Builder<
       configuration: TTransactionHistoryConfig,
       getContext: () => TTransactionHistoryContext,
     ) => TransactionHistoryService,
-  ): V1Builder<TConfig & TTransactionHistoryConfig, TContext & TTransactionHistoryContext, TSerialized, TSyncUpdate> {
+  ): V1Builder<
+    TConfig & TTransactionHistoryConfig,
+    TContext & TTransactionHistoryContext,
+    TSerialized,
+    TSyncUpdate,
+    TPreviousState
+  > {
     return new V1Builder<
       TConfig & TTransactionHistoryConfig,
       TContext & TTransactionHistoryContext,
       TSerialized,
-      TSyncUpdate
+      TSyncUpdate,
+      TPreviousState
     >({
       ...this.#buildState,
       transactionHistoryService,
     });
   }
 
-  withKeysDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate> {
+  withKeysDefaults(): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState> {
     return this.withKeys(makeDefaultKeysCapability);
   }
 
   withKeys<TKeysConfig, TKeysContext extends Partial<RunningV1Variant.AnyContext>>(
     keysCapability: (configuration: TKeysConfig, getContext: () => TKeysContext) => KeysCapability<CoreWallet>,
-  ): V1Builder<TConfig & TKeysConfig, TContext & TKeysContext, TSerialized, TSyncUpdate> {
-    return new V1Builder<TConfig & TKeysConfig, TContext & TKeysContext, TSerialized, TSyncUpdate>({
+  ): V1Builder<TConfig & TKeysConfig, TContext & TKeysContext, TSerialized, TSyncUpdate, TPreviousState> {
+    return new V1Builder<TConfig & TKeysConfig, TContext & TKeysContext, TSerialized, TSyncUpdate, TPreviousState>({
       ...this.#buildState,
       keysCapability,
     });
   }
 
   build(
-    this: V1Builder<TConfig, RunningV1Variant.Context<TSerialized, TSyncUpdate>, TSerialized, TSyncUpdate>,
+    this: V1Builder<
+      TConfig,
+      RunningV1Variant.Context<TSerialized, TSyncUpdate>,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >,
     configuration: TConfig,
-  ): V1Variant<TSerialized, TSyncUpdate> {
+  ): V1Variant<TSerialized, TSyncUpdate, TPreviousState> {
     const v1Context = this.#buildContextFromBuildState(configuration);
-    const { networkId } = configuration;
+    const migration = this.#resolveMigration(configuration, () => v1Context);
 
     return {
       __polyTag__: V1Tag,
@@ -292,10 +389,18 @@ export class V1Builder<
           return new RunningV1Variant(scope, context, v1Context);
         });
       },
-      migrateState(_previousState) {
-        const seed = WalletSeed.fromString('0000000000000000000000000000000000000000000000000000000000000001');
-
-        return Effect.succeed(CoreWallet.init(PublicKey.fromKeyStore(createKeystore(seed, networkId)), networkId));
+      // Until this was wired, `migrateState` ignored its argument and rebuilt a placeholder wallet, so a wallet of the
+      // previous ledger version would have been silently replaced by an empty one rather than carried across.
+      migrateState(previousState: TPreviousState) {
+        return migration.migrate(previousState).pipe(
+          Effect.mapError(
+            (error) =>
+              new WalletRuntimeError({
+                message: 'Failed to migrate unshielded wallet state into this variant',
+                cause: error,
+              }),
+          ),
+        );
       },
 
       deserializeState: (serialized: TSerialized): Either.Either<CoreWallet, WalletError> => {
@@ -304,12 +409,43 @@ export class V1Builder<
     };
   }
 
+  /**
+   * The migration strategy to build with.
+   *
+   * @remarks
+   *   An unconfigured builder produces an empty wallet, which is what `startEmpty` asks of a first variant. The nullary
+   *   wrapper is what lets the `null`-consuming default stand in for a `TPreviousState`-consuming strategy without a
+   *   cast: the argument is simply not passed on.
+   */
+  #resolveMigration(
+    this: V1Builder<
+      TConfig,
+      RunningV1Variant.Context<TSerialized, TSyncUpdate>,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >,
+    configuration: TConfig,
+    getContext: () => RunningV1Variant.Context<TSerialized, TSyncUpdate>,
+  ): StateMigration<TPreviousState> {
+    const configured = this.#buildState.migration;
+    return configured === undefined
+      ? { migrate: () => makeEmptyWalletMigration({ networkId: configuration.networkId }).migrate(null) }
+      : configured(configuration, getContext);
+  }
+
   #buildContextFromBuildState(
-    this: V1Builder<TConfig, RunningV1Variant.Context<TSerialized, TSyncUpdate>, TSerialized, TSyncUpdate>,
+    this: V1Builder<
+      TConfig,
+      RunningV1Variant.Context<TSerialized, TSyncUpdate>,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >,
     configuration: TConfig,
   ): RunningV1Variant.Context<TSerialized, TSyncUpdate> {
     if (!isBuildStateFull(this.#buildState)) {
-      throw new Error('Not all components are configured in V1 Builder');
+      throw new Error('Not all components are configured in V2 Builder');
     }
 
     const {
@@ -403,9 +539,21 @@ declare namespace V1Builder {
       HasKeys<TConfig, TContext> &
       HasTransactionHistory<TConfig, TContext>
   >;
-  type PartialBuildState<TConfig = object, TContext = object, TSerialized = never, TSyncUpdate = never> = {
+  type PartialBuildState<
+    TConfig = object,
+    TContext = object,
+    TSerialized = never,
+    TSyncUpdate = never,
+    TPreviousState = null,
+  > = {
     [K in keyof FullBuildState<never, never, never, never>]?:
       FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate>[K] | undefined;
+  } & {
+    /**
+     * Deliberately outside {@link FullBuildState}: a builder with no migration configured is complete, and falls back to
+     * the empty-wallet strategy. Requiring it would break every existing `build({ ... })` call site.
+     */
+    readonly migration?: (configuration: TConfig, getContext: () => TContext) => StateMigration<TPreviousState>;
   };
 
   /** Utility interface that manages the type variance of {@link V1Builder}. */
@@ -416,9 +564,10 @@ declare namespace V1Builder {
   }
 }
 
-const isBuildStateFull = <TConfig, TContext, TSerialized, TSyncUpdate>(
-  buildState: V1Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate>,
-): buildState is V1Builder.FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate> => {
+const isBuildStateFull = <TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState>(
+  buildState: V1Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState>,
+): buildState is V1Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState> &
+  V1Builder.FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate> => {
   const allBuildStateKeys = [
     'syncService',
     'syncCapability',

--- a/packages/unshielded-wallet/src/v1/index.ts
+++ b/packages/unshielded-wallet/src/v1/index.ts
@@ -17,6 +17,7 @@ export * as Transacting from './Transacting.js';
 export * as Signing from './Signing.js';
 export * as TransactionHistory from './TransactionHistory.js';
 export * as Serialization from './Serialization.js';
+export * as Migration from './Migration.js';
 export * as CoinsAndBalances from './CoinsAndBalances.js';
 export * as Keys from './Keys.js';
 export * from './RunningV1Variant.js';

--- a/packages/unshielded-wallet/src/v1/test/migration.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/migration.test.ts
@@ -1,0 +1,154 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The migration seam, ledger-v8 side. Kept symmetric with the ledger-v9 tree so the seam has the same shape in both,
+// though nothing precedes ledger-v8 in this SDK: this variant's cross-ledger migration is a pure structural carry with
+// no key transformation to perform, since v8 verifying keys are already bare hex strings on both sides.
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect, HashMap } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { CoreWallet } from '../CoreWallet.js';
+import {
+  makeCarryOverMigration,
+  makeCrossLedgerMigration,
+  makeEmptyWalletMigration,
+  type PreviousLedgerWallet,
+} from '../Migration.js';
+import { UnshieldedState } from '../UnshieldedState.js';
+import { fixtureOwner, fixtureUtxo } from './syncFixtures.js';
+
+const owner = fixtureOwner();
+
+/** A previous-ledger wallet, described structurally. Its verifying key is a bare hex string, as this ledger's are. */
+const previousWallet = (params: {
+  readonly available: readonly ReturnType<typeof fixtureUtxo>[];
+  readonly pending?: readonly ReturnType<typeof fixtureUtxo>[];
+  readonly appliedId: bigint;
+  readonly protocolVersion: bigint;
+}): PreviousLedgerWallet => ({
+  state: {
+    availableUtxos: params.available,
+    pendingUtxos: params.pending ?? [],
+  },
+  publicKey: {
+    publicKey: owner.publicKey,
+    addressHex: owner.addressHex,
+    address: owner.address,
+  },
+  networkId: NetworkId.NetworkId.Undeployed,
+  protocolVersion: params.protocolVersion,
+  progress: { appliedId: params.appliedId, highestTransactionId: params.appliedId, isConnected: true },
+});
+
+describe('unshielded state migration', () => {
+  describe('empty-wallet migration', () => {
+    it('produces a coinless wallet on the configured network', async () => {
+      const migration = makeEmptyWalletMigration({ networkId: NetworkId.NetworkId.Undeployed });
+      const wallet = await Effect.runPromise(migration.migrate(null));
+
+      expect(HashMap.size(wallet.state.availableUtxos)).toBe(0);
+      expect(HashMap.size(wallet.state.pendingUtxos)).toBe(0);
+      expect(wallet.networkId).toBe(NetworkId.NetworkId.Undeployed);
+    });
+  });
+
+  describe('carry-over migration', () => {
+    it('hands the previous state straight back when both sides share a ledger version', async () => {
+      const previous = CoreWallet.restore(
+        UnshieldedState.restore([fixtureUtxo(owner, 100n, 0)], []),
+        owner,
+        { appliedId: 4n, highestTransactionId: 4n },
+        ProtocolVersion.ProtocolVersion(3n),
+        NetworkId.NetworkId.Undeployed,
+      );
+
+      const wallet = await Effect.runPromise(makeCarryOverMigration().migrate(previous));
+
+      expect(wallet).toBe(previous);
+    });
+  });
+
+  describe('cross-ledger migration', () => {
+    it('carries every UTXO across, value for value', async () => {
+      const utxos = [fixtureUtxo(owner, 100n, 0), fixtureUtxo(owner, 250n, 1), fixtureUtxo(owner, 7n, 2)];
+      const previous = previousWallet({ available: utxos, appliedId: 4n, protocolVersion: 7n });
+
+      const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+      expect(HashMap.size(wallet.state.availableUtxos)).toBe(3);
+      expect(
+        [...HashMap.values(wallet.state.availableUtxos)].map((u) => u.utxo.value).sort((a, b) => Number(a - b)),
+      ).toEqual([7n, 100n, 250n]);
+    });
+
+    it('carries pending UTXOs as pending', async () => {
+      const previous = previousWallet({
+        available: [fixtureUtxo(owner, 100n, 0)],
+        pending: [fixtureUtxo(owner, 55n, 9)],
+        appliedId: 4n,
+        protocolVersion: 7n,
+      });
+
+      const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+      expect(HashMap.size(wallet.state.availableUtxos)).toBe(1);
+      expect(HashMap.size(wallet.state.pendingUtxos)).toBe(1);
+      expect([...HashMap.values(wallet.state.pendingUtxos)][0].utxo.value).toBe(55n);
+    });
+
+    it('preserves each UTXO field, not merely the count', async () => {
+      const utxo = fixtureUtxo(owner, 100n, 3);
+      const previous = previousWallet({ available: [utxo], appliedId: 4n, protocolVersion: 7n });
+
+      const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+      const carried = [...HashMap.values(wallet.state.availableUtxos)][0];
+
+      expect(carried.utxo.value).toBe(utxo.utxo.value);
+      expect(carried.utxo.owner).toBe(utxo.utxo.owner);
+      expect(carried.utxo.type).toBe(utxo.utxo.type);
+      expect(carried.utxo.intentHash).toBe(utxo.utxo.intentHash);
+      expect(carried.utxo.outputNo).toBe(utxo.utxo.outputNo);
+      expect(carried.meta.ctime.getTime()).toBe(utxo.meta.ctime.getTime());
+      expect(carried.meta.registeredForDustGeneration).toBe(utxo.meta.registeredForDustGeneration);
+    });
+
+    it('carries the verifying key across unchanged', async () => {
+      const previous = previousWallet({ available: [], appliedId: 4n, protocolVersion: 7n });
+
+      const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+      expect(wallet.publicKey.publicKey).toBe(owner.publicKey);
+      expect(wallet.publicKey.addressHex).toBe(owner.addressHex);
+      expect(wallet.publicKey.address).toBe(owner.address);
+    });
+
+    it('leaves the sync cursor exactly where the previous variant left it', async () => {
+      const previous = previousWallet({ available: [], appliedId: 4n, protocolVersion: 7n });
+
+      const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+      // Parked, not rewound and not advanced: the boundary transaction was observed but never applied, so the new
+      // variant has to re-fetch it from this very cursor.
+      expect(wallet.progress.appliedId).toBe(4n);
+    });
+
+    it('carries the network and the version that triggered the hand-over', async () => {
+      const previous = previousWallet({ available: [], appliedId: 4n, protocolVersion: 7n });
+
+      const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+      expect(wallet.networkId).toBe(NetworkId.NetworkId.Undeployed);
+      expect(wallet.protocolVersion).toBe(7n);
+    });
+  });
+});

--- a/packages/unshielded-wallet/src/v1/test/migration.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/migration.test.ts
@@ -36,10 +36,10 @@ const previousWallet = (params: {
   readonly appliedId: bigint;
   readonly protocolVersion: bigint;
 }): PreviousLedgerWallet => ({
-  state: {
-    availableUtxos: params.available,
-    pendingUtxos: params.pending ?? [],
-  },
+  // Built through the real `UnshieldedState`, not from plain arrays: the previous variant hands over a state whose
+  // UTXOs live in Effect `HashMap`s, and a fixture that passed arrays would let a migration that iterated entries
+  // instead of values pass here and fail only against a real wallet.
+  state: UnshieldedState.restore(params.available, params.pending ?? []),
   publicKey: {
     publicKey: owner.publicKey,
     addressHex: owner.addressHex,

--- a/packages/unshielded-wallet/src/v1/test/runningV1Variant.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/runningV1Variant.test.ts
@@ -1,0 +1,109 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The version signals the running variant puts on its state stream: an ordinary transition, and the healing emission
+// that rescues a snapshot restored at a version this variant does not own.
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { StateChange, type Variant, VersionChangeType } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { Duration, Effect, Scope, Stream, SubscriptionRef } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { CoreWallet } from '../CoreWallet.js';
+import { RunningV1Variant } from '../RunningV1Variant.js';
+import { UnshieldedState } from '../UnshieldedState.js';
+import { fixtureOwner } from './syncFixtures.js';
+
+const owner = fixtureOwner();
+
+/** The variant owns versions 0..6. */
+const activationRange = ProtocolVersion.makeRange(
+  ProtocolVersion.MinSupportedVersion,
+  ProtocolVersion.ProtocolVersion(7n),
+);
+
+const walletAt = (protocolVersion: bigint): CoreWallet =>
+  CoreWallet.restore(
+    UnshieldedState.empty(),
+    owner,
+    { appliedId: 0n, highestTransactionId: 0n },
+    ProtocolVersion.ProtocolVersion(protocolVersion),
+    NetworkId.NetworkId.Undeployed,
+  );
+
+/**
+ * Drains the variant's state stream for a bounded window and returns the versions it announced.
+ *
+ * @remarks
+ *   Bounded by time rather than by `Stream.take(n)` on purpose: a missing emission has to surface as a failed
+ *   assertion on an empty list, not as a hung test.
+ */
+const announcedVersions = (
+  initial: CoreWallet,
+  drive: (ref: SubscriptionRef.SubscriptionRef<CoreWallet>) => Effect.Effect<void>,
+): Promise<readonly bigint[]> =>
+  Effect.gen(function* () {
+    const scope = yield* Scope.make();
+    const stateRef = yield* SubscriptionRef.make(initial);
+    const context: Variant.VariantContext<CoreWallet> = { stateRef, activationRange };
+    const variant = new RunningV1Variant(scope, context, {} as never);
+
+    const collected = yield* Effect.fork(
+      variant.state.pipe(
+        Stream.interruptAfter(Duration.millis(300)),
+        Stream.filter(StateChange.isVersionChange),
+        Stream.map((change) =>
+          VersionChangeType.isVersion(change.change) ? change.change.version : ProtocolVersion.ProtocolVersion(-1n),
+        ),
+        Stream.runCollect,
+      ),
+    );
+
+    // Let the collector's subscription attach before driving the change: `SubscriptionRef.changes` replays only the
+    // value current at subscription time, so a change published first would be indistinguishable from no change.
+    yield* Effect.sleep(Duration.millis(50));
+    yield* drive(stateRef);
+    const chunk = yield* collected.await;
+    return chunk._tag === 'Success' ? Array.from(chunk.value).map((v) => v as bigint) : [];
+  }).pipe(Effect.scoped, Effect.runPromise);
+
+describe('unshielded running variant version signals', () => {
+  it('announces a version transition observed on the state', async () => {
+    const versions = await announcedVersions(walletAt(0n), (ref) =>
+      SubscriptionRef.set(ref, walletAt(5n)),
+    );
+
+    expect(versions).toEqual([5n]);
+  });
+
+  it('heals a state restored outside the activation range by announcing it immediately', async () => {
+    const versions = await announcedVersions(walletAt(9n), () => Effect.void);
+
+    expect(versions).toEqual([9n]);
+  });
+
+  it('announces nothing for a state restored inside the activation range', async () => {
+    const emissions = await Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const stateRef = yield* SubscriptionRef.make(walletAt(3n));
+      const context: Variant.VariantContext<CoreWallet> = { stateRef, activationRange };
+      const variant = new RunningV1Variant(scope, context, {} as never);
+
+      const chunk = yield* variant.state.pipe(Stream.interruptAfter(Duration.millis(300)), Stream.runCollect);
+      return Array.from(chunk);
+    }).pipe(Effect.scoped, Effect.runPromise);
+
+    // No version announcement...
+    expect(emissions.filter(StateChange.isVersionChange)).toEqual([]);
+    // ...but the stream was genuinely live, so the empty result above is not a false pass.
+    expect(emissions.filter(StateChange.isState).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/unshielded-wallet/src/v1/test/runningV1Variant.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/runningV1Variant.test.ts
@@ -43,8 +43,8 @@ const walletAt = (protocolVersion: bigint): CoreWallet =>
  * Drains the variant's state stream for a bounded window and returns the versions it announced.
  *
  * @remarks
- *   Bounded by time rather than by `Stream.take(n)` on purpose: a missing emission has to surface as a failed
- *   assertion on an empty list, not as a hung test.
+ *   Bounded by time rather than by `Stream.take(n)` on purpose: a missing emission has to surface as a failed assertion
+ *   on an empty list, not as a hung test.
  */
 const announcedVersions = (
   initial: CoreWallet,
@@ -72,14 +72,12 @@ const announcedVersions = (
     yield* Effect.sleep(Duration.millis(50));
     yield* drive(stateRef);
     const chunk = yield* collected.await;
-    return chunk._tag === 'Success' ? Array.from(chunk.value).map((v) => v as bigint) : [];
+    return chunk._tag === 'Success' ? Array.from(chunk.value) : [];
   }).pipe(Effect.scoped, Effect.runPromise);
 
 describe('unshielded running variant version signals', () => {
   it('announces a version transition observed on the state', async () => {
-    const versions = await announcedVersions(walletAt(0n), (ref) =>
-      SubscriptionRef.set(ref, walletAt(5n)),
-    );
+    const versions = await announcedVersions(walletAt(0n), (ref) => SubscriptionRef.set(ref, walletAt(5n)));
 
     expect(versions).toEqual([5n]);
   });

--- a/packages/unshielded-wallet/src/v1/test/syncCapability.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/syncCapability.test.ts
@@ -33,9 +33,12 @@ const owner = fixtureOwner();
 describe('unshielded sync capability at a variant boundary', () => {
   const setup = () => {
     const history = recordingHistory();
-    const capability = makeDefaultSyncCapability({ indexerClientConnection: { indexerHttpUrl: 'http://unused' } }, () => ({
-      transactionHistoryService: history.service,
-    }));
+    const capability = makeDefaultSyncCapability(
+      { indexerClientConnection: { indexerHttpUrl: 'http://unused' } },
+      () => ({
+        transactionHistoryService: history.service,
+      }),
+    );
     return { capability, history };
   };
 
@@ -53,7 +56,11 @@ describe('unshielded sync capability at a variant boundary', () => {
     const created = fixtureUtxo(owner, 100n, 0);
 
     const result = capability
-      .applyUpdate(emptyWallet(), fixtureTransaction({ id: 1, protocolVersion: 3, createdUtxos: [created] }), activeRange)
+      .applyUpdate(
+        emptyWallet(),
+        fixtureTransaction({ id: 1, protocolVersion: 3, createdUtxos: [created] }),
+        activeRange,
+      )
       .pipe(EitherOps.getOrThrowLeft);
 
     expect(HashMap.size(result.state.availableUtxos)).toBe(1);

--- a/packages/unshielded-wallet/src/v1/test/syncCapability.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/syncCapability.test.ts
@@ -1,0 +1,226 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The per-message boundary rule. Unshielded sync is message-at-a-time, not batched: there is no prefix to apply and no
+// suffix to defer, only the question "does this one transaction belong to this variant?". A transaction reported at or
+// beyond the end of the variant's activation range is not applied AT ALL — no UTXO change, no `appliedId` bump, no
+// transaction-history write — and only its version is recorded, which is what triggers the hand-over. Because the
+// cursor did not move, the next variant re-fetches that same transaction and applies it exactly once.
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
+import { HashMap } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { CoreWallet } from '../CoreWallet.js';
+import { makeDefaultSyncCapability } from '../Sync.js';
+import { UnshieldedState } from '../UnshieldedState.js';
+import { fixtureOwner, fixtureProgress, fixtureTransaction, fixtureUtxo, recordingHistory } from './syncFixtures.js';
+
+/** The running variant owns versions 0..6; 7 and above belong to whatever replaces it. */
+const activeRange = ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, ProtocolVersion.ProtocolVersion(7n));
+
+const owner = fixtureOwner();
+
+describe('unshielded sync capability at a variant boundary', () => {
+  const setup = () => {
+    const history = recordingHistory();
+    const capability = makeDefaultSyncCapability({ indexerClientConnection: { indexerHttpUrl: 'http://unused' } }, () => ({
+      transactionHistoryService: history.service,
+    }));
+    return { capability, history };
+  };
+
+  const emptyWallet = (protocolVersion: bigint = 0n, appliedId: bigint = 0n): CoreWallet =>
+    CoreWallet.restore(
+      UnshieldedState.empty(),
+      owner,
+      { appliedId, highestTransactionId: appliedId },
+      ProtocolVersion.ProtocolVersion(protocolVersion),
+      NetworkId.NetworkId.Undeployed,
+    );
+
+  it('applies a transaction reported below the boundary and records its version', () => {
+    const { capability, history } = setup();
+    const created = fixtureUtxo(owner, 100n, 0);
+
+    const result = capability
+      .applyUpdate(emptyWallet(), fixtureTransaction({ id: 1, protocolVersion: 3, createdUtxos: [created] }), activeRange)
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(HashMap.size(result.state.availableUtxos)).toBe(1);
+    expect(result.progress.appliedId).toBe(1n);
+    expect(result.protocolVersion).toBe(3n);
+    expect(history.puts()).toHaveLength(1);
+  });
+
+  it('re-annotates on a version bump that stays inside the range', () => {
+    const { capability, history } = setup();
+    const created = fixtureUtxo(owner, 50n, 1);
+
+    const result = capability
+      .applyUpdate(
+        emptyWallet(3n, 1n),
+        fixtureTransaction({ id: 2, protocolVersion: 5, createdUtxos: [created] }),
+        activeRange,
+      )
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(HashMap.size(result.state.availableUtxos)).toBe(1);
+    expect(result.progress.appliedId).toBe(2n);
+    expect(result.protocolVersion).toBe(5n);
+    expect(history.puts()).toHaveLength(1);
+  });
+
+  it('does not apply a transaction reported AT the boundary — only its version is recorded', () => {
+    const { capability, history } = setup();
+    const alreadyHeld = fixtureUtxo(owner, 100n, 0);
+    const before = CoreWallet.applyUpdate(emptyWallet(3n, 1n), {
+      createdUtxos: [alreadyHeld],
+      spentUtxos: [],
+      status: 'SUCCESS',
+    }).pipe(EitherOps.getOrThrowLeft);
+
+    const boundaryTx = fixtureTransaction({
+      id: 2,
+      protocolVersion: 7,
+      createdUtxos: [fixtureUtxo(owner, 999n, 5)],
+    });
+
+    const result = capability.applyUpdate(before, boundaryTx, activeRange).pipe(EitherOps.getOrThrowLeft);
+
+    // No UTXO change: the wallet still holds exactly what it held, and nothing of the boundary transaction.
+    expect(HashMap.size(result.state.availableUtxos)).toBe(1);
+    expect([...HashMap.values(result.state.availableUtxos)].map((u) => u.utxo.value)).toEqual([100n]);
+    // No cursor movement: this is what makes the next variant re-fetch the same transaction.
+    expect(result.progress.appliedId).toBe(1n);
+    // No transaction-history write.
+    expect(history.puts()).toHaveLength(0);
+    // The version IS recorded — it is the migration signal.
+    expect(result.protocolVersion).toBe(7n);
+  });
+
+  it('does not apply a transaction reported BEYOND the boundary', () => {
+    const { capability, history } = setup();
+
+    const result = capability
+      .applyUpdate(
+        emptyWallet(3n, 1n),
+        fixtureTransaction({ id: 2, protocolVersion: 9, createdUtxos: [fixtureUtxo(owner, 5n, 2)] }),
+        activeRange,
+      )
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(HashMap.size(result.state.availableUtxos)).toBe(0);
+    expect(result.progress.appliedId).toBe(1n);
+    expect(history.puts()).toHaveLength(0);
+    expect(result.protocolVersion).toBe(9n);
+  });
+
+  it('does not apply a SPEND reported at the boundary — the spent UTXO stays available', () => {
+    const { capability, history } = setup();
+    const held = fixtureUtxo(owner, 100n, 0);
+    const before = CoreWallet.applyUpdate(emptyWallet(3n, 1n), {
+      createdUtxos: [held],
+      spentUtxos: [],
+      status: 'SUCCESS',
+    }).pipe(EitherOps.getOrThrowLeft);
+
+    const result = capability
+      .applyUpdate(before, fixtureTransaction({ id: 2, protocolVersion: 7, spentUtxos: [held] }), activeRange)
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(HashMap.size(result.state.availableUtxos)).toBe(1);
+    expect(result.progress.appliedId).toBe(1n);
+    expect(history.puts()).toHaveLength(0);
+  });
+
+  it('does not apply a FAILED transaction reported at the boundary either', () => {
+    const { capability, history } = setup();
+
+    const result = capability
+      .applyUpdate(
+        emptyWallet(3n, 1n),
+        fixtureTransaction({
+          id: 2,
+          protocolVersion: 7,
+          createdUtxos: [fixtureUtxo(owner, 5n, 2)],
+          status: 'FAILURE',
+        }),
+        activeRange,
+      )
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(result.progress.appliedId).toBe(1n);
+    expect(history.puts()).toHaveLength(0);
+    expect(result.protocolVersion).toBe(7n);
+  });
+
+  it('applies a failed transaction reported below the boundary and records its version', () => {
+    const { capability } = setup();
+
+    const result = capability
+      .applyUpdate(
+        emptyWallet(0n, 0n),
+        fixtureTransaction({
+          id: 1,
+          protocolVersion: 4,
+          createdUtxos: [fixtureUtxo(owner, 5n, 2)],
+          status: 'FAILURE',
+        }),
+        activeRange,
+      )
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(result.progress.appliedId).toBe(1n);
+    expect(result.protocolVersion).toBe(4n);
+  });
+
+  it('never lowers the recorded version', () => {
+    const { capability } = setup();
+
+    const result = capability
+      .applyUpdate(
+        emptyWallet(5n, 1n),
+        fixtureTransaction({ id: 2, protocolVersion: 2, createdUtxos: [fixtureUtxo(owner, 7n, 3)] }),
+        activeRange,
+      )
+      .pipe(EitherOps.getOrThrowLeft);
+
+    // Applied — 2 is inside the range — but the recorded version does not go backwards.
+    expect(result.progress.appliedId).toBe(2n);
+    expect(HashMap.size(result.state.availableUtxos)).toBe(1);
+    expect(result.protocolVersion).toBe(5n);
+  });
+
+  it('progress messages never touch the recorded version', () => {
+    const { capability } = setup();
+
+    const result = capability
+      .applyUpdate(emptyWallet(3n, 1n), fixtureProgress(42), activeRange)
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(result.progress.highestTransactionId).toBe(42n);
+    expect(result.progress.isConnected).toBe(true);
+    expect(result.progress.appliedId).toBe(1n);
+    expect(result.protocolVersion).toBe(3n);
+  });
+
+  it('a progress message on a wallet at the range floor still records nothing', () => {
+    const { capability } = setup();
+
+    const result = capability
+      .applyUpdate(emptyWallet(0n, 0n), fixtureProgress(7), activeRange)
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(result.protocolVersion).toBe(0n);
+  });
+});

--- a/packages/unshielded-wallet/src/v1/test/syncFixtures.ts
+++ b/packages/unshielded-wallet/src/v1/test/syncFixtures.ts
@@ -1,0 +1,109 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The ledger-v8 twin of the v9 fixtures. It differs only where the ledger versions genuinely differ: the keystore
+// takes a bare secret rather than a `{kind, secret}` record, and the verifying key it yields is a hex string.
+//
+// Deterministic fixtures for the sync-boundary tests. Unshielded sync updates are plain decoded JSON — the indexer
+// reports UTXOs as public data — so a fixture can build them directly and still be the real shape, unlike shielded and
+// dust whose fixtures must mint real events through a simulator. What is NOT synthetic here is the identity: the owner
+// address is derived through the real keystore from a fixed seed, so the UTXOs are addressed to an address the ledger
+// would actually produce.
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect, Ref } from 'effect';
+import { createKeystore, type PublicKey, PublicKey as PublicKeyOps } from '../KeyStore.js';
+import { type UnshieldedUpdate, type UtxoWithMeta, type WalletSyncUpdate } from '../SyncSchema.js';
+import { type TransactionHistoryService } from '../TransactionHistory.js';
+
+/** A fixed 32-byte secret, so every fixture run addresses UTXOs to the same real address. */
+export const fixtureSeed = (): Uint8Array => Uint8Array.from({ length: 32 }, (_, i) => (i * 7 + 11) % 256);
+
+/** The fixture owner, derived through the real keystore. */
+export const fixtureOwner = (): PublicKey =>
+  PublicKeyOps.fromKeyStore(
+    createKeystore(fixtureSeed(), NetworkId.NetworkId.Undeployed),
+  );
+
+/** A UTXO addressed to `owner`, deterministic in `outputNo`. */
+export const fixtureUtxo = (owner: PublicKey, value: bigint, outputNo: number): UtxoWithMeta => ({
+  utxo: {
+    value,
+    owner: owner.addressHex,
+    type: ledger.nativeToken().raw,
+    intentHash: ledger.sampleIntentHash(),
+    outputNo,
+  },
+  meta: {
+    ctime: new Date(1_700_000_000_000 + outputNo * 1000),
+    registeredForDustGeneration: false,
+  },
+});
+
+/**
+ * A transaction update as the indexer reports it: one event, one id, one protocol version. This is the unit the
+ * unshielded boundary rule operates on — there is no batch to split.
+ */
+export const fixtureTransaction = (params: {
+  readonly id: number;
+  readonly protocolVersion: number;
+  readonly createdUtxos?: readonly UtxoWithMeta[];
+  readonly spentUtxos?: readonly UtxoWithMeta[];
+  readonly status?: 'SUCCESS' | 'FAILURE';
+}): UnshieldedUpdate => {
+  const status = params.status ?? 'SUCCESS';
+  return {
+    type: 'UnshieldedTransaction',
+    transaction: {
+      id: params.id,
+      hash: `hash-${params.id}`,
+      type: 'RegularTransaction',
+      protocolVersion: params.protocolVersion,
+      identifiers: [],
+      block: {
+        hash: `block-${params.id}`,
+        height: params.id,
+        timestamp: new Date(1_700_000_000_000 + params.id * 6000),
+      },
+      fees: { paidFees: 0n, estimatedFees: 0n },
+      transactionResult: { status, segments: [{ id: 1, success: status === 'SUCCESS' }] },
+    },
+    createdUtxos: params.createdUtxos ?? [],
+    spentUtxos: params.spentUtxos ?? [],
+    status,
+  } as UnshieldedUpdate;
+};
+
+/** A progress message. It carries no protocol version at all — the wire schema has no field for one. */
+export const fixtureProgress = (highestTransactionId: number): WalletSyncUpdate => ({
+  type: 'UnshieldedTransactionsProgress',
+  highestTransactionId,
+});
+
+/**
+ * A transaction-history service that records what it was asked to write instead of writing it.
+ *
+ * @remarks
+ *   A stub, not a mock: the assertions read the recorded list, they do not interrogate a spy. This is what makes "the
+ *   boundary transaction produced no tx-history put" directly observable.
+ */
+export const recordingHistory = (): {
+  readonly service: TransactionHistoryService;
+  readonly puts: () => readonly UnshieldedUpdate[];
+} => {
+  const recorded = Ref.unsafeMake<readonly UnshieldedUpdate[]>([]);
+  return {
+    service: { put: (update: UnshieldedUpdate) => Ref.update(recorded, (all) => [...all, update]) },
+    puts: () => Effect.runSync(Ref.get(recorded)),
+  };
+};

--- a/packages/unshielded-wallet/src/v1/test/syncFixtures.ts
+++ b/packages/unshielded-wallet/src/v1/test/syncFixtures.ts
@@ -31,9 +31,7 @@ export const fixtureSeed = (): Uint8Array => Uint8Array.from({ length: 32 }, (_,
 
 /** The fixture owner, derived through the real keystore. */
 export const fixtureOwner = (): PublicKey =>
-  PublicKeyOps.fromKeyStore(
-    createKeystore(fixtureSeed(), NetworkId.NetworkId.Undeployed),
-  );
+  PublicKeyOps.fromKeyStore(createKeystore(fixtureSeed(), NetworkId.NetworkId.Undeployed));
 
 /** A UTXO addressed to `owner`, deterministic in `outputNo`. */
 export const fixtureUtxo = (owner: PublicKey, value: bigint, outputNo: number): UtxoWithMeta => ({
@@ -81,7 +79,7 @@ export const fixtureTransaction = (params: {
     createdUtxos: params.createdUtxos ?? [],
     spentUtxos: params.spentUtxos ?? [],
     status,
-  } as UnshieldedUpdate;
+  };
 };
 
 /** A progress message. It carries no protocol version at all — the wire schema has no field for one. */

--- a/packages/unshielded-wallet/src/v2/CoreWallet.ts
+++ b/packages/unshielded-wallet/src/v2/CoreWallet.ts
@@ -65,6 +65,21 @@ export const CoreWallet = {
     return { ...wallet, progress };
   },
 
+  /**
+   * Records an observed protocol version, monotonically.
+   *
+   * @remarks
+   *   Only ever raises it. A stale lower report — a reconnect replaying from an earlier cursor, say — would otherwise
+   *   look like a downward version change and send the runtime migrating backwards into a variant this wallet has
+   *   already left.
+   * @param wallet The wallet to annotate.
+   * @param version The protocol version the source reported.
+   * @returns The wallet carrying the higher of the two versions.
+   */
+  withProtocolVersion(wallet: CoreWallet, version: ProtocolVersion.ProtocolVersion): CoreWallet {
+    return version > wallet.protocolVersion ? { ...wallet, protocolVersion: version } : wallet;
+  },
+
   applyUpdate(coreWallet: CoreWallet, update: UnshieldedUpdate): Either.Either<CoreWallet, WalletError> {
     return UnshieldedState.applyUpdate(coreWallet.state, update).pipe(
       Either.map((state) => ({ ...coreWallet, state })),

--- a/packages/unshielded-wallet/src/v2/Migration.ts
+++ b/packages/unshielded-wallet/src/v2/Migration.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { type NetworkId, ProtocolVersion, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Effect } from 'effect';
+import { Effect, HashMap } from 'effect';
 import { CoreWallet } from './CoreWallet.js';
 import { type SyncProgressData } from './SyncProgress.js';
 import { createKeystore, PublicKey } from '../KeyStore.js';
@@ -91,8 +91,12 @@ export const makeCarryOverMigration = (): StateMigration<CoreWallet> => ({
  */
 export type PreviousLedgerWallet = Readonly<{
   state: {
-    readonly availableUtxos: Iterable<UtxoLike>;
-    readonly pendingUtxos: Iterable<UtxoLike>;
+    // Effect `HashMap`s, as the previous variant really holds them — not arrays. The distinction matters and is easy
+    // to get wrong: iterating a `HashMap` yields `[key, value]` entries, so a type that merely said `Iterable<UtxoLike>`
+    // would be satisfied by the real state and then silently carry across a list of malformed pairs. `HashMap` is an
+    // Effect type, not a ledger one, so naming it here keeps this description version-agnostic.
+    readonly availableUtxos: HashMap.HashMap<string, UtxoLike>;
+    readonly pendingUtxos: HashMap.HashMap<string, UtxoLike>;
   };
   publicKey: {
     readonly publicKey: string;
@@ -147,8 +151,8 @@ export const makeCrossLedgerMigration = (): StateMigration<PreviousLedgerWallet>
     Effect.succeed(
       CoreWallet.restore(
         UnshieldedState.restore(
-          Array.from(previousState.state.availableUtxos, carryUtxo),
-          Array.from(previousState.state.pendingUtxos, carryUtxo),
+          Array.from(HashMap.values(previousState.state.availableUtxos), carryUtxo),
+          Array.from(HashMap.values(previousState.state.pendingUtxos), carryUtxo),
         ),
         {
           // ledger-v8 had a single signature scheme, so an untagged key crossing this boundary is a schnorr key.

--- a/packages/unshielded-wallet/src/v2/Migration.ts
+++ b/packages/unshielded-wallet/src/v2/Migration.ts
@@ -1,0 +1,183 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { type NetworkId, ProtocolVersion, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect } from 'effect';
+import { CoreWallet } from './CoreWallet.js';
+import { type SyncProgressData } from './SyncProgress.js';
+import { createKeystore, PublicKey } from '../KeyStore.js';
+import { UnshieldedState, UtxoWithMeta } from './UnshieldedState.js';
+import { type WalletError } from './WalletError.js';
+
+/**
+ * How this variant produces its first state from whatever came before it.
+ *
+ * @remarks
+ *   The strategy is injected through the builder rather than hard-coded into the variant, because "whatever came before"
+ *   is not one thing: an empty wallet at first start, a wallet of this same ledger version, or a wallet of the ledger
+ *   version this one replaced. Those are different functions with different input types, and the runtime only ever
+ *   needs one of them per registration — so which one is a build-time decision, expressed as a dictionary in the
+ *   repository's usual dictionary-passing style.
+ * @typeParam TPreviousState The state this migration consumes.
+ */
+export type StateMigration<TPreviousState> = {
+  migrate: (previousState: TPreviousState) => Effect.Effect<CoreWallet, WalletError>;
+};
+
+export type EmptyWalletMigrationConfiguration = {
+  networkId: NetworkId.NetworkId;
+};
+
+/**
+ * The migration used when there is no previous wallet at all.
+ *
+ * @remarks
+ *   It backs `WalletLike.startEmpty`, which builds a wallet before any key material exists. The resulting state has no
+ *   UTXOs and a public key derived from a fixed placeholder seed; it is a scaffold to be replaced by a real start, not
+ *   a wallet anybody can transact with. Preserved verbatim from the pre-fork implementation so that `startEmpty`
+ *   behaves exactly as it did.
+ * @example
+ *   ```typescript
+ *   const builder = new V2Builder().withDefaults().withMigration(makeEmptyWalletMigration({ networkId }));
+ *   ```;
+ *
+ * @param configuration Supplies the network the scaffold state claims to be on.
+ * @returns A migration from `null`.
+ */
+export const makeEmptyWalletMigration = (configuration: EmptyWalletMigrationConfiguration): StateMigration<null> => ({
+  migrate: () => {
+    const seed = WalletSeed.fromString('0000000000000000000000000000000000000000000000000000000000000001');
+    return Effect.succeed(
+      CoreWallet.init(
+        PublicKey.fromKeyStore(createKeystore({ kind: 'schnorr', secret: seed }, configuration.networkId)),
+        configuration.networkId,
+      ),
+    );
+  },
+});
+
+/**
+ * The migration between two variants that share this ledger version.
+ *
+ * @remarks
+ *   Both sides speak the same state type, so the carry is the identity. This is the right strategy for a protocol bump
+ *   that does not change serialization.
+ * @returns A migration from a {@link CoreWallet} of this ledger version.
+ */
+export const makeCarryOverMigration = (): StateMigration<CoreWallet> => ({
+  migrate: (previousState) => Effect.succeed(previousState),
+});
+
+/**
+ * The shape a wallet of the _previous_ ledger version must expose to be carried across a hard fork.
+ *
+ * @remarks
+ *   Structural on purpose. The previous variant's `CoreWallet` is built on a different ledger module, and naming that
+ *   module here would drag a second multi-megabyte WASM binary into this variant for the sake of a type. That is
+ *   affordable precisely because unshielded state is public: UTXOs are plain records of value, owner, token type,
+ *   intent hash and output number, with no ledger object anywhere in them.
+ *
+ *   The verifying key is the one place the two ledger versions genuinely disagree, and it is described here as the
+ *   previous version has it — a bare hex string.
+ */
+export type PreviousLedgerWallet = Readonly<{
+  state: {
+    readonly availableUtxos: Iterable<UtxoLike>;
+    readonly pendingUtxos: Iterable<UtxoLike>;
+  };
+  publicKey: {
+    readonly publicKey: string;
+    readonly addressHex: string;
+    readonly address: string;
+  };
+  networkId: string;
+  protocolVersion: bigint;
+  progress: SyncProgressData;
+}>;
+
+/** A UTXO of the previous ledger version, as plain data. */
+export type UtxoLike = {
+  readonly utxo: {
+    readonly value: bigint;
+    readonly owner: string;
+    readonly type: string;
+    readonly intentHash: string;
+    readonly outputNo: number;
+  };
+  readonly meta: {
+    readonly ctime: Date;
+    readonly registeredForDustGeneration: boolean;
+  };
+};
+
+/**
+ * The migration across a ledger-version boundary: a structural carry of everything the wallet holds.
+ *
+ * @remarks
+ *   This is where unshielded parts company with shielded and dust. Those two start the new variant on a **fresh, empty**
+ *   state and let the indexer's post-fork replay hand their coins back, because their coins are shielded: re-deriving
+ *   them means decrypting events with secret keys that migration, by design, never receives. Unshielded has no such
+ *   problem. Its UTXOs are public ledger data that the wallet holds as plain records, so they can simply be rebuilt on
+ *   the other side — no replay to wait for, no keys required, and no window in which the wallet reports a zero balance
+ *   it does not have.
+ *
+ *   So everything crosses: available and pending UTXOs field for field, the address, the network, and the protocol
+ *   version that triggered the hand-over. The one transformation is the verifying key, which gains the scheme tag that
+ *   ledger-v9 requires and ledger-v8 had no room for — the same widening the deserializer already performs on legacy
+ *   snapshots, which is where the `schnorr` default comes from: ledger-v8 had exactly one signature scheme, so a key
+ *   that reaches here can only have been a schnorr key.
+ *
+ *   Sync progress is carried **unchanged** — parked, not rewound and not advanced. The boundary transaction was observed
+ *   and annotated but deliberately never applied, so the cursor still points just before it; the new variant re-fetches
+ *   it from there and applies it exactly once. Rewinding to zero would re-apply history the wallet already holds;
+ *   advancing past it would lose the boundary transaction outright.
+ * @returns A migration from a previous-ledger-version wallet.
+ */
+export const makeCrossLedgerMigration = (): StateMigration<PreviousLedgerWallet> => ({
+  migrate: (previousState) =>
+    Effect.succeed(
+      CoreWallet.restore(
+        UnshieldedState.restore(
+          Array.from(previousState.state.availableUtxos, carryUtxo),
+          Array.from(previousState.state.pendingUtxos, carryUtxo),
+        ),
+        {
+          // ledger-v8 had a single signature scheme, so an untagged key crossing this boundary is a schnorr key.
+          publicKey: { tag: 'schnorr', value: previousState.publicKey.publicKey },
+          addressHex: previousState.publicKey.addressHex,
+          address: previousState.publicKey.address,
+        },
+        {
+          appliedId: previousState.progress.appliedId,
+          highestTransactionId: previousState.progress.highestTransactionId,
+        },
+        ProtocolVersion.ProtocolVersion(previousState.protocolVersion),
+        previousState.networkId,
+      ),
+    ),
+});
+
+/** Rebuilds a previous-version UTXO as one of this version's, field for field. */
+const carryUtxo = (carried: UtxoLike): UtxoWithMeta =>
+  new UtxoWithMeta({
+    utxo: {
+      value: carried.utxo.value,
+      owner: carried.utxo.owner,
+      type: carried.utxo.type,
+      intentHash: carried.utxo.intentHash,
+      outputNo: carried.utxo.outputNo,
+    },
+    meta: {
+      ctime: carried.meta.ctime,
+      registeredForDustGeneration: carried.meta.registeredForDustGeneration,
+    },
+  });

--- a/packages/unshielded-wallet/src/v2/RunningV2Variant.ts
+++ b/packages/unshielded-wallet/src/v2/RunningV2Variant.ts
@@ -50,8 +50,26 @@ const progress = (state: CoreWallet): StateChange.StateChange<CoreWallet>[] => {
   return [StateChange.ProgressUpdate({ sourceGap, applyGap })];
 };
 
-const protocolVersionChange = (previous: CoreWallet, current: CoreWallet): StateChange.StateChange<CoreWallet>[] => {
-  return previous.protocolVersion != current.protocolVersion
+/**
+ * The version signals this variant puts on its state stream.
+ *
+ * @remarks
+ *   Two of them, for two different situations. A transition is the ordinary one: the state moved to a version the variant
+ *   may or may not own, and the runtime decides. The healing emission covers restore: a snapshot taken between the
+ *   moment sync annotated an out-of-range version and the moment the runtime acted on it comes back with a version this
+ *   variant does not own and no transition to announce it, so it would sit there forever. Announcing it on the first
+ *   observation is what forward-migrates such a snapshot.
+ */
+const protocolVersionChange = (
+  previous: CoreWallet,
+  current: CoreWallet,
+  isInitial: boolean,
+  activationRange: ProtocolVersion.ProtocolVersion.Range,
+): StateChange.StateChange<CoreWallet>[] => {
+  const transitioned = previous.protocolVersion != current.protocolVersion;
+  const strandedOutsideRange = isInitial && !ProtocolVersion.withinRange(current.protocolVersion, activationRange);
+
+  return transitioned || strandedOutsideRange
     ? [
         StateChange.VersionChange({
           change: VersionChangeType.Version({
@@ -101,18 +119,27 @@ export class RunningV2Variant<TSerialized, TSyncUpdate> implements Variant.Runni
     this.state = Stream.fromEffect(context.stateRef.get).pipe(
       Stream.flatMap((initialState) =>
         context.stateRef.changes.pipe(
-          Stream.mapAccum(initialState, (previous: CoreWallet, current: CoreWallet) => {
-            return [current, [previous, current]] as const;
-          }),
+          // The accumulator carries a "have we seen anything yet" flag alongside the previous state: the first
+          // observation is the only one that can be a restored state nobody has checked against this variant's range
+          // yet, and `SubscriptionRef.changes` replays the current value, so it is exactly this element.
+          Stream.mapAccum(
+            { previous: initialState, isInitial: true },
+            (seen, current: CoreWallet) =>
+              [{ previous: current, isInitial: false }, [seen.previous, current, seen.isInitial] as const] as const,
+          ),
         ),
       ),
       Stream.mapConcat(
-        ([previous, current]: readonly [CoreWallet, CoreWallet]): StateChange.StateChange<CoreWallet>[] => {
+        ([previous, current, isInitial]: readonly [
+          CoreWallet,
+          CoreWallet,
+          boolean,
+        ]): StateChange.StateChange<CoreWallet>[] => {
           // TODO: emit progress only upon actual change
           return [
             StateChange.State({ state: current }),
             ...progress(current),
-            ...protocolVersionChange(previous, current),
+            ...protocolVersionChange(previous, current, isInitial, context.activationRange),
           ];
         },
       ),
@@ -134,7 +161,10 @@ export class RunningV2Variant<TSerialized, TSyncUpdate> implements Variant.Runni
       Stream.flatMap((state) => this.#v2Context.syncService.updates(state)),
       Stream.mapEffect((update) => {
         return SubscriptionRef.updateEffect(this.#context.stateRef, (state) =>
-          pipe(this.#v2Context.syncCapability.applyUpdate(state, update), EitherOps.toEffect),
+          pipe(
+            this.#v2Context.syncCapability.applyUpdate(state, update, this.#context.activationRange),
+            EitherOps.toEffect,
+          ),
         );
       }),
       Stream.tapError((error) => Console.error(error)),

--- a/packages/unshielded-wallet/src/v2/Sync.ts
+++ b/packages/unshielded-wallet/src/v2/Sync.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Effect, type Scope, Stream, Schema, pipe, Either, HashMap } from 'effect';
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { CoreWallet } from './CoreWallet.js';
 import { UtxoWithMeta } from './UnshieldedState.js';
 import {
@@ -32,8 +33,47 @@ export interface SyncService<TState, TUpdate> {
 }
 
 export interface SyncCapability<TState, TUpdate> {
-  applyUpdate: (state: TState, update: TUpdate) => Either.Either<TState, WalletError>;
+  /**
+   * Folds a single sync message into the wallet state.
+   *
+   * @param state The state to fold into.
+   * @param update The message to apply.
+   * @param activeRange The half-open protocol version range the running variant owns. A message the source reports at
+   *   or beyond its end belongs to a later variant and must be left entirely unapplied, for that variant to fetch.
+   */
+  applyUpdate: (
+    state: TState,
+    update: TUpdate,
+    activeRange: ProtocolVersion.ProtocolVersion.Range,
+  ) => Either.Either<TState, WalletError>;
 }
+
+/**
+ * Whether a reported protocol version belongs to a variant later than the one owning `activeRange`.
+ *
+ * @remarks
+ *   Unshielded sync is message-at-a-time, so this is the whole of the boundary rule — there is no batch to split into an
+ *   applied prefix and a deferred suffix, only a yes/no per message. Exported so the indexer and simulator sync
+ *   capabilities cannot drift apart on the question.
+ * @param version The protocol version the source reported for this message.
+ * @param activeRange The running variant's half-open activation range.
+ * @returns `true` when the message must be left unapplied.
+ */
+export const isBeyondActiveRange = (version: number, activeRange: ProtocolVersion.ProtocolVersion.Range): boolean =>
+  BigInt(version) >= activeRange[1];
+
+/**
+ * Records an observed protocol version on the state, monotonically.
+ *
+ * @remarks
+ *   This is the only thing written when a message is deferred at the boundary, and it is what the runtime watches to
+ *   decide that the variant must hand over.
+ * @param state The state to annotate.
+ * @param version The protocol version the source reported.
+ * @returns The state carrying the higher of the two versions.
+ */
+export const annotateVersion = (state: CoreWallet, version: number): CoreWallet =>
+  CoreWallet.withProtocolVersion(state, ProtocolVersion.ProtocolVersion(BigInt(version)));
 
 export type IndexerClientConnection = {
   indexerHttpUrl: string;
@@ -105,14 +145,27 @@ export const makeDefaultSyncCapability = (
   getContext: () => DefaultSyncContext,
 ): SyncCapability<CoreWallet, WalletSyncUpdate> => {
   return {
-    applyUpdate: (state: CoreWallet, update: WalletSyncUpdate): Either.Either<CoreWallet, WalletError> => {
+    applyUpdate: (
+      state: CoreWallet,
+      update: WalletSyncUpdate,
+      activeRange: ProtocolVersion.ProtocolVersion.Range,
+    ): Either.Either<CoreWallet, WalletError> => {
       if (update.type === 'UnshieldedTransactionsProgress') {
+        // A progress message reports the tip of the source, not a transaction, and the wire schema carries no protocol
+        // version on it. It therefore never annotates: reading one as version zero would drag a wallet that has
+        // already crossed a boundary back below it.
         return Either.right(
           CoreWallet.updateProgress(state, {
             highestTransactionId: BigInt(update.highestTransactionId),
             isConnected: true,
           }),
         );
+      } else if (isBeyondActiveRange(update.transaction.protocolVersion, activeRange)) {
+        // The hand-over point. This transaction belongs to the next variant, so NOTHING about it is applied: no UTXO
+        // change, no cursor movement, no transaction-history write. Only the version is recorded, which is what makes
+        // the runtime migrate. Because the cursor did not move, the next variant re-fetches this very transaction from
+        // it and applies it exactly once.
+        return Either.right(annotateVersion(state, update.transaction.protocolVersion));
       } else {
         const updatePayload = {
           createdUtxos: update.createdUtxos,
@@ -134,7 +187,7 @@ export const makeDefaultSyncCapability = (
             const { transactionHistoryService } = getContext();
             Effect.runFork(transactionHistoryService.put(update));
 
-            return stateAfterUpdatingProgress;
+            return annotateVersion(stateAfterUpdatingProgress, update.transaction.protocolVersion);
           }),
         );
       }
@@ -183,7 +236,17 @@ export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, Simula
   const utxoKey = (utxo: { intentHash: string; outputNo: number }) => `${utxo.intentHash}#${utxo.outputNo}`;
 
   return {
-    applyUpdate: (state: CoreWallet, update: SimulatorSyncUpdate): Either.Either<CoreWallet, WalletError> => {
+    applyUpdate: (
+      state: CoreWallet,
+      update: SimulatorSyncUpdate,
+      activeRange: ProtocolVersion.ProtocolVersion.Range,
+    ): Either.Either<CoreWallet, WalletError> => {
+      // The same rule at the simulator's granularity: a chain state tagged at or beyond the boundary belongs to the
+      // next variant, so nothing of it is applied and only the version is recorded.
+      if (isBeyondActiveRange(Number(update.update.protocolVersion), activeRange)) {
+        return Either.right(annotateVersion(state, Number(update.update.protocolVersion)));
+      }
+
       const { ledger: ledgerState, currentTime } = update.update;
       const walletAddress = state.publicKey.addressHex;
       const nativeTokenType = ledger.nativeToken().raw;
@@ -224,13 +287,16 @@ export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, Simula
       const updateProgress = (wallet: CoreWallet) =>
         CoreWallet.updateProgress(wallet, { appliedId: blockNumber, isConnected: true });
 
+      const annotate = (wallet: CoreWallet) => annotateVersion(wallet, Number(update.update.protocolVersion));
+
       if (createdUtxos.length === 0 && spentUtxos.length === 0) {
-        return Either.right(updateProgress(state));
+        return Either.right(annotate(updateProgress(state)));
       }
 
       return pipe(
         CoreWallet.applyUpdate(state, { createdUtxos, spentUtxos, status: 'SUCCESS' as const }),
         Either.map(updateProgress),
+        Either.map(annotate),
       );
     },
   };

--- a/packages/unshielded-wallet/src/v2/V2Builder.ts
+++ b/packages/unshielded-wallet/src/v2/V2Builder.ts
@@ -12,12 +12,8 @@
 // limitations under the License.
 import type * as ledger from '@midnightntwrk/ledger-v9';
 import { Effect, type Either, Scope, type Types } from 'effect';
-import { WalletSeed, type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
-import {
-  type Variant,
-  type VariantBuilder,
-  type WalletRuntimeError,
-} from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type Variant, type VariantBuilder, WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { RunningV2Variant, V2Tag } from './RunningV2Variant.js';
 import { makeDefaultV2SerializationCapability, type SerializationCapability } from './Serialization.js';
 import {
@@ -36,18 +32,18 @@ import {
   type TransactingCapability,
 } from './Transacting.js';
 import { type WalletError } from './WalletError.js';
+import { makeEmptyWalletMigration, type StateMigration } from './Migration.js';
 import { makeDefaultSigningService, type SigningService } from './Signing.js';
 import { type CoinsAndBalancesCapability, makeDefaultCoinsAndBalancesCapability } from './CoinsAndBalances.js';
 import { type KeysCapability, makeDefaultKeysCapability } from './Keys.js';
 import { type CoinSelection, chooseCoin } from '@midnightntwrk/wallet-sdk-capabilities';
-import { CoreWallet } from './CoreWallet.js';
+import { type CoreWallet } from './CoreWallet.js';
 import {
   type DefaultTransactionHistoryConfiguration,
   type TransactionHistoryService,
   makeDefaultTransactionHistoryService,
 } from './TransactionHistory.js';
 import { type Expect, type Equal, type ItemType } from '@midnightntwrk/wallet-sdk-utilities/types';
-import { createKeystore, PublicKey } from '../KeyStore.js';
 
 export type BaseV2Configuration = {
   networkId: NetworkId.NetworkId;
@@ -64,10 +60,10 @@ const V2BuilderSymbol: {
   typeId: Symbol('@midnight-ntwrk/unshielded-wallet#V2Builder') as (typeof V2BuilderSymbol)['typeId'],
 } as const;
 
-export type V2Variant<TSerialized, TSyncUpdate> = Variant.Variant<
+export type V2Variant<TSerialized, TSyncUpdate, TPreviousState = null> = Variant.Variant<
   typeof V2Tag,
   CoreWallet,
-  null,
+  TPreviousState,
   RunningV2Variant<TSerialized, TSyncUpdate>
 > & {
   deserializeState: (serialized: TSerialized) => Either.Either<CoreWallet, WalletError>;
@@ -78,24 +74,25 @@ export type V2Variant<TSerialized, TSyncUpdate> = Variant.Variant<
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyV2Variant = V2Variant<any, any>;
-export type DefaultV2Variant = V2Variant<string, WalletSyncUpdate>;
+export type AnyV2Variant = V2Variant<any, any, any>;
+export type DefaultV2Variant = V2Variant<string, WalletSyncUpdate, null>;
 
 export type TransactionOf<T extends AnyV2Variant> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  T extends V2Variant<any, any>
+  T extends V2Variant<any, any, any>
     ? ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>
     : never;
 
 export type SerializedStateOf<T extends AnyV2Variant> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  T extends V2Variant<infer TSerialized, any> ? TSerialized : never;
+  T extends V2Variant<infer TSerialized, any, any> ? TSerialized : never;
 
 export type DefaultV2Builder = V2Builder<
   DefaultV2Configuration,
   RunningV2Variant.Context<string, WalletSyncUpdate>,
   string,
-  WalletSyncUpdate
+  WalletSyncUpdate,
+  null
 >;
 
 export class V2Builder<
@@ -103,10 +100,13 @@ export class V2Builder<
   TContext extends Partial<RunningV2Variant.AnyContext> = object,
   TSerialized = never,
   TSyncUpdate = never,
-> implements VariantBuilder.VariantBuilder<V2Variant<TSerialized, TSyncUpdate>, TConfig> {
-  readonly #buildState: V2Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate>;
+  TPreviousState = null,
+> implements VariantBuilder.VariantBuilder<V2Variant<TSerialized, TSyncUpdate, TPreviousState>, TConfig> {
+  readonly #buildState: V2Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState>;
 
-  constructor(buildState: V2Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate> = {}) {
+  constructor(
+    buildState: V2Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState> = {},
+  ) {
     this.#buildState = buildState;
   }
 
@@ -125,7 +125,8 @@ export class V2Builder<
     TConfig & DefaultSyncConfiguration,
     TContext & DefaultSyncContext,
     TSerialized,
-    WalletSyncUpdate
+    WalletSyncUpdate,
+    TPreviousState
   > {
     return this.withSync(makeDefaultSyncService, makeDefaultSyncCapability);
   }
@@ -136,15 +137,15 @@ export class V2Builder<
       configuration: TSyncConfig,
       getContext: () => TSyncContext,
     ) => SyncCapability<CoreWallet, TSyncUpdate>,
-  ): V2Builder<TConfig & TSyncConfig, TContext & TSyncContext, TSerialized, TSyncUpdate> {
-    return new V2Builder<TConfig & TSyncConfig, TContext & TSyncContext, TSerialized, TSyncUpdate>({
+  ): V2Builder<TConfig & TSyncConfig, TContext & TSyncContext, TSerialized, TSyncUpdate, TPreviousState> {
+    return new V2Builder<TConfig & TSyncConfig, TContext & TSyncContext, TSerialized, TSyncUpdate, TPreviousState>({
       ...this.#buildState,
       syncService,
       syncCapability,
     });
   }
 
-  withSerializationDefaults(): V2Builder<TConfig, TContext, string, TSyncUpdate> {
+  withSerializationDefaults(): V2Builder<TConfig, TContext, string, TSyncUpdate, TPreviousState> {
     return this.withSerialization(makeDefaultV2SerializationCapability);
   }
 
@@ -157,20 +158,33 @@ export class V2Builder<
       configuration: TSerializationConfig,
       getContext: () => TSerializationContext,
     ) => SerializationCapability<CoreWallet, TSerialized>,
-  ): V2Builder<TConfig & TSerializationConfig, TContext & TSerializationContext, TSerialized, TSyncUpdate> {
-    return new V2Builder<TConfig & TSerializationConfig, TContext & TSerializationContext, TSerialized, TSyncUpdate>({
+  ): V2Builder<
+    TConfig & TSerializationConfig,
+    TContext & TSerializationContext,
+    TSerialized,
+    TSyncUpdate,
+    TPreviousState
+  > {
+    return new V2Builder<
+      TConfig & TSerializationConfig,
+      TContext & TSerializationContext,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >({
       ...this.#buildState,
       serializationCapability,
     });
   }
 
   withTransactingDefaults(
-    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate>,
+    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState>,
   ): V2Builder<
     TConfig & DefaultTransactingConfiguration,
     TContext & DefaultTransactingContext,
     TSerialized,
-    TSyncUpdate
+    TSyncUpdate,
+    TPreviousState
   > {
     return this.withTransacting(makeDefaultTransactingCapability);
   }
@@ -180,24 +194,76 @@ export class V2Builder<
       config: TTransactingConfig,
       getContext: () => TTransactingContext,
     ) => TransactingCapability<CoreWallet>,
-  ): V2Builder<TConfig & TTransactingConfig, TContext & TTransactingContext, TSerialized, TSyncUpdate> {
-    return new V2Builder<TConfig & TTransactingConfig, TContext & TTransactingContext, TSerialized, TSyncUpdate>({
+  ): V2Builder<TConfig & TTransactingConfig, TContext & TTransactingContext, TSerialized, TSyncUpdate, TPreviousState> {
+    return new V2Builder<
+      TConfig & TTransactingConfig,
+      TContext & TTransactingContext,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >({
       ...this.#buildState,
       transactingCapability,
     });
   }
 
-  withSigningDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate> {
+  withSigningDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState> {
     return this.withSigning(makeDefaultSigningService);
   }
 
   withSigning<TSigningConfig, TSigningContext extends Partial<RunningV2Variant.AnyContext>>(
     signingService: (configuration: TSigningConfig, getContext: () => TSigningContext) => SigningService,
-  ): V2Builder<TConfig & TSigningConfig, TContext & TSigningContext, TSerialized, TSyncUpdate> {
-    return new V2Builder<TConfig & TSigningConfig, TContext & TSigningContext, TSerialized, TSyncUpdate>({
+  ): V2Builder<TConfig & TSigningConfig, TContext & TSigningContext, TSerialized, TSyncUpdate, TPreviousState> {
+    return new V2Builder<
+      TConfig & TSigningConfig,
+      TContext & TSigningContext,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >({
       ...this.#buildState,
       signingService,
     });
+  }
+
+  /**
+   * Configures this variant to start from an empty wallet when there is nothing before it.
+   *
+   * @remarks
+   *   The default for a first-registered variant, and what `startEmpty` relies on.
+   * @returns A builder whose previous state is `null`.
+   */
+  withMigrationDefaults(
+    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, null>,
+  ): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, null> {
+    return this.withMigration((configuration: BaseV2Configuration) =>
+      makeEmptyWalletMigration({ networkId: configuration.networkId }),
+    );
+  }
+
+  /**
+   * Configures how this variant produces its first state from whatever variant preceded it.
+   *
+   * @remarks
+   *   The context is a method-level type parameter rather than the builder's own `TContext`, matching `withSync` and
+   *   `withKeys` in this file. Binding it to the builder's `TContext` would make the builder invariant in it and break
+   *   the partially-configured chains the tests build.
+   * @param migration Produces the strategy from the configuration and the variant context.
+   * @returns A builder whose previous state is whatever the strategy consumes.
+   */
+  withMigration<TMigrationConfig, TMigrationContext extends Partial<RunningV2Variant.AnyContext>, TPrevious>(
+    migration: (configuration: TMigrationConfig, getContext: () => TMigrationContext) => StateMigration<TPrevious>,
+  ): V2Builder<TConfig & TMigrationConfig, TContext & TMigrationContext, TSerialized, TSyncUpdate, TPrevious> {
+    // Only the capability half of the build state crosses: the strategy being replaced is typed against the OLD
+    // previous-state parameter, so it cannot ride along even though it is about to be overwritten.
+    const { migration: _replaced, ...capabilities } = this.#buildState;
+
+    return new V2Builder<TConfig & TMigrationConfig, TContext & TMigrationContext, TSerialized, TSyncUpdate, TPrevious>(
+      {
+        ...capabilities,
+        migration,
+      },
+    );
   }
 
   withCoinSelection<TCoinSelectionConfig, TCoinSelectionContext extends Partial<RunningV2Variant.AnyContext>>(
@@ -205,18 +271,30 @@ export class V2Builder<
       config: TCoinSelectionConfig,
       getContext: () => TCoinSelectionContext,
     ) => CoinSelection<ledger.Utxo>,
-  ): V2Builder<TConfig & TCoinSelectionConfig, TContext & TCoinSelectionContext, TSerialized, TSyncUpdate> {
-    return new V2Builder<TConfig & TCoinSelectionConfig, TContext & TCoinSelectionContext, TSerialized, TSyncUpdate>({
+  ): V2Builder<
+    TConfig & TCoinSelectionConfig,
+    TContext & TCoinSelectionContext,
+    TSerialized,
+    TSyncUpdate,
+    TPreviousState
+  > {
+    return new V2Builder<
+      TConfig & TCoinSelectionConfig,
+      TContext & TCoinSelectionContext,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >({
       ...this.#buildState,
       coinSelection,
     });
   }
 
-  withCoinSelectionDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate> {
+  withCoinSelectionDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState> {
     return this.withCoinSelection(() => chooseCoin);
   }
 
-  withCoinsAndBalancesDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate> {
+  withCoinsAndBalancesDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState> {
     return this.withCoinsAndBalances(makeDefaultCoinsAndBalancesCapability);
   }
 
@@ -225,16 +303,22 @@ export class V2Builder<
       configuration: TBalancesConfig,
       getContext: () => TBalancesContext,
     ) => CoinsAndBalancesCapability<CoreWallet>,
-  ): V2Builder<TConfig & TBalancesConfig, TContext & TBalancesContext, TSerialized, TSyncUpdate> {
-    return new V2Builder<TConfig & TBalancesConfig, TContext & TBalancesContext, TSerialized, TSyncUpdate>({
+  ): V2Builder<TConfig & TBalancesConfig, TContext & TBalancesContext, TSerialized, TSyncUpdate, TPreviousState> {
+    return new V2Builder<
+      TConfig & TBalancesConfig,
+      TContext & TBalancesContext,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >({
       ...this.#buildState,
       coinsAndBalancesCapability,
     });
   }
 
   withTransactionHistoryDefaults(
-    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate>,
-  ): V2Builder<TConfig & DefaultTransactionHistoryConfiguration, TContext, TSerialized, TSyncUpdate> {
+    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState>,
+  ): V2Builder<TConfig & DefaultTransactionHistoryConfiguration, TContext, TSerialized, TSyncUpdate, TPreviousState> {
     return this.withTransactionHistory(makeDefaultTransactionHistoryService);
   }
 
@@ -246,37 +330,50 @@ export class V2Builder<
       configuration: TTransactionHistoryConfig,
       getContext: () => TTransactionHistoryContext,
     ) => TransactionHistoryService,
-  ): V2Builder<TConfig & TTransactionHistoryConfig, TContext & TTransactionHistoryContext, TSerialized, TSyncUpdate> {
+  ): V2Builder<
+    TConfig & TTransactionHistoryConfig,
+    TContext & TTransactionHistoryContext,
+    TSerialized,
+    TSyncUpdate,
+    TPreviousState
+  > {
     return new V2Builder<
       TConfig & TTransactionHistoryConfig,
       TContext & TTransactionHistoryContext,
       TSerialized,
-      TSyncUpdate
+      TSyncUpdate,
+      TPreviousState
     >({
       ...this.#buildState,
       transactionHistoryService,
     });
   }
 
-  withKeysDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate> {
+  withKeysDefaults(): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState> {
     return this.withKeys(makeDefaultKeysCapability);
   }
 
   withKeys<TKeysConfig, TKeysContext extends Partial<RunningV2Variant.AnyContext>>(
     keysCapability: (configuration: TKeysConfig, getContext: () => TKeysContext) => KeysCapability<CoreWallet>,
-  ): V2Builder<TConfig & TKeysConfig, TContext & TKeysContext, TSerialized, TSyncUpdate> {
-    return new V2Builder<TConfig & TKeysConfig, TContext & TKeysContext, TSerialized, TSyncUpdate>({
+  ): V2Builder<TConfig & TKeysConfig, TContext & TKeysContext, TSerialized, TSyncUpdate, TPreviousState> {
+    return new V2Builder<TConfig & TKeysConfig, TContext & TKeysContext, TSerialized, TSyncUpdate, TPreviousState>({
       ...this.#buildState,
       keysCapability,
     });
   }
 
   build(
-    this: V2Builder<TConfig, RunningV2Variant.Context<TSerialized, TSyncUpdate>, TSerialized, TSyncUpdate>,
+    this: V2Builder<
+      TConfig,
+      RunningV2Variant.Context<TSerialized, TSyncUpdate>,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >,
     configuration: TConfig,
-  ): V2Variant<TSerialized, TSyncUpdate> {
+  ): V2Variant<TSerialized, TSyncUpdate, TPreviousState> {
     const v2Context = this.#buildContextFromBuildState(configuration);
-    const { networkId } = configuration;
+    const migration = this.#resolveMigration(configuration, () => v2Context);
 
     return {
       __polyTag__: V2Tag,
@@ -292,13 +389,16 @@ export class V2Builder<
           return new RunningV2Variant(scope, context, v2Context);
         });
       },
-      migrateState(_previousState) {
-        const seed = WalletSeed.fromString('0000000000000000000000000000000000000000000000000000000000000001');
-
-        return Effect.succeed(
-          CoreWallet.init(
-            PublicKey.fromKeyStore(createKeystore({ kind: 'schnorr', secret: seed }, networkId)),
-            networkId,
+      // Until this was wired, `migrateState` ignored its argument and rebuilt a placeholder wallet, so a wallet of the
+      // previous ledger version would have been silently replaced by an empty one rather than carried across.
+      migrateState(previousState: TPreviousState) {
+        return migration.migrate(previousState).pipe(
+          Effect.mapError(
+            (error) =>
+              new WalletRuntimeError({
+                message: 'Failed to migrate unshielded wallet state into this variant',
+                cause: error,
+              }),
           ),
         );
       },
@@ -309,8 +409,39 @@ export class V2Builder<
     };
   }
 
+  /**
+   * The migration strategy to build with.
+   *
+   * @remarks
+   *   An unconfigured builder produces an empty wallet, which is what `startEmpty` asks of a first variant. The nullary
+   *   wrapper is what lets the `null`-consuming default stand in for a `TPreviousState`-consuming strategy without a
+   *   cast: the argument is simply not passed on.
+   */
+  #resolveMigration(
+    this: V2Builder<
+      TConfig,
+      RunningV2Variant.Context<TSerialized, TSyncUpdate>,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >,
+    configuration: TConfig,
+    getContext: () => RunningV2Variant.Context<TSerialized, TSyncUpdate>,
+  ): StateMigration<TPreviousState> {
+    const configured = this.#buildState.migration;
+    return configured === undefined
+      ? { migrate: () => makeEmptyWalletMigration({ networkId: configuration.networkId }).migrate(null) }
+      : configured(configuration, getContext);
+  }
+
   #buildContextFromBuildState(
-    this: V2Builder<TConfig, RunningV2Variant.Context<TSerialized, TSyncUpdate>, TSerialized, TSyncUpdate>,
+    this: V2Builder<
+      TConfig,
+      RunningV2Variant.Context<TSerialized, TSyncUpdate>,
+      TSerialized,
+      TSyncUpdate,
+      TPreviousState
+    >,
     configuration: TConfig,
   ): RunningV2Variant.Context<TSerialized, TSyncUpdate> {
     if (!isBuildStateFull(this.#buildState)) {
@@ -408,9 +539,21 @@ declare namespace V2Builder {
       HasKeys<TConfig, TContext> &
       HasTransactionHistory<TConfig, TContext>
   >;
-  type PartialBuildState<TConfig = object, TContext = object, TSerialized = never, TSyncUpdate = never> = {
+  type PartialBuildState<
+    TConfig = object,
+    TContext = object,
+    TSerialized = never,
+    TSyncUpdate = never,
+    TPreviousState = null,
+  > = {
     [K in keyof FullBuildState<never, never, never, never>]?:
       FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate>[K] | undefined;
+  } & {
+    /**
+     * Deliberately outside {@link FullBuildState}: a builder with no migration configured is complete, and falls back to
+     * the empty-wallet strategy. Requiring it would break every existing `build({ ... })` call site.
+     */
+    readonly migration?: (configuration: TConfig, getContext: () => TContext) => StateMigration<TPreviousState>;
   };
 
   /** Utility interface that manages the type variance of {@link V2Builder}. */
@@ -421,9 +564,10 @@ declare namespace V2Builder {
   }
 }
 
-const isBuildStateFull = <TConfig, TContext, TSerialized, TSyncUpdate>(
-  buildState: V2Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate>,
-): buildState is V2Builder.FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate> => {
+const isBuildStateFull = <TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState>(
+  buildState: V2Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState>,
+): buildState is V2Builder.PartialBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TPreviousState> &
+  V2Builder.FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate> => {
   const allBuildStateKeys = [
     'syncService',
     'syncCapability',

--- a/packages/unshielded-wallet/src/v2/index.ts
+++ b/packages/unshielded-wallet/src/v2/index.ts
@@ -17,6 +17,7 @@ export * as Transacting from './Transacting.js';
 export * as Signing from './Signing.js';
 export * as TransactionHistory from './TransactionHistory.js';
 export * as Serialization from './Serialization.js';
+export * as Migration from './Migration.js';
 export * as CoinsAndBalances from './CoinsAndBalances.js';
 export * as Keys from './Keys.js';
 export * from './RunningV2Variant.js';

--- a/packages/unshielded-wallet/src/v2/test/migration.test.ts
+++ b/packages/unshielded-wallet/src/v2/test/migration.test.ts
@@ -1,0 +1,158 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The migration seam. Unshielded's cross-ledger migration is a STRUCTURAL CARRY, not the fresh-state-and-replay that
+// shielded and dust use: unshielded state is public UTXO data, so there is nothing to decrypt, nothing to re-anchor,
+// and no reason to drop it and wait for a replay. Every UTXO crosses; the only real transformation is the key, which
+// goes from ledger-v8's bare hex string to ledger-v9's `{tag, value}` record.
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect, HashMap } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { CoreWallet } from '../CoreWallet.js';
+import {
+  makeCarryOverMigration,
+  makeCrossLedgerMigration,
+  makeEmptyWalletMigration,
+  type PreviousLedgerWallet,
+} from '../Migration.js';
+import { UnshieldedState } from '../UnshieldedState.js';
+import { fixtureOwner, fixtureUtxo } from './syncFixtures.js';
+
+const owner = fixtureOwner();
+
+/**
+ * A previous-ledger (v8) wallet, described structurally. Its verifying key is a bare hex string — that is exactly what
+ * ledger-v8 hands out, and the difference this migration has to reconcile.
+ */
+const previousWallet = (params: {
+  readonly available: readonly ReturnType<typeof fixtureUtxo>[];
+  readonly pending?: readonly ReturnType<typeof fixtureUtxo>[];
+  readonly appliedId: bigint;
+  readonly protocolVersion: bigint;
+}): PreviousLedgerWallet => ({
+  state: {
+    availableUtxos: params.available,
+    pendingUtxos: params.pending ?? [],
+  },
+  publicKey: {
+    publicKey: owner.publicKey.value,
+    addressHex: owner.addressHex,
+    address: owner.address,
+  },
+  networkId: NetworkId.NetworkId.Undeployed,
+  protocolVersion: params.protocolVersion,
+  progress: { appliedId: params.appliedId, highestTransactionId: params.appliedId, isConnected: true },
+});
+
+describe('unshielded state migration', () => {
+  describe('empty-wallet migration', () => {
+    it('produces a coinless wallet on the configured network', async () => {
+      const migration = makeEmptyWalletMigration({ networkId: NetworkId.NetworkId.Undeployed });
+      const wallet = await Effect.runPromise(migration.migrate(null));
+
+      expect(HashMap.size(wallet.state.availableUtxos)).toBe(0);
+      expect(HashMap.size(wallet.state.pendingUtxos)).toBe(0);
+      expect(wallet.networkId).toBe(NetworkId.NetworkId.Undeployed);
+    });
+  });
+
+  describe('carry-over migration', () => {
+    it('hands the previous state straight back when both sides share a ledger version', async () => {
+      const previous = CoreWallet.restore(
+        UnshieldedState.restore([fixtureUtxo(owner, 100n, 0)], []),
+        owner,
+        { appliedId: 4n, highestTransactionId: 4n },
+        ProtocolVersion.ProtocolVersion(3n),
+        NetworkId.NetworkId.Undeployed,
+      );
+
+      const wallet = await Effect.runPromise(makeCarryOverMigration().migrate(previous));
+
+      expect(wallet).toBe(previous);
+    });
+  });
+
+  describe('cross-ledger migration', () => {
+    it('carries every UTXO across, value for value', async () => {
+      const utxos = [fixtureUtxo(owner, 100n, 0), fixtureUtxo(owner, 250n, 1), fixtureUtxo(owner, 7n, 2)];
+      const previous = previousWallet({ available: utxos, appliedId: 4n, protocolVersion: 7n });
+
+      const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+      expect(HashMap.size(wallet.state.availableUtxos)).toBe(3);
+      expect(
+        [...HashMap.values(wallet.state.availableUtxos)].map((u) => u.utxo.value).sort((a, b) => Number(a - b)),
+      ).toEqual([7n, 100n, 250n]);
+    });
+
+    it('carries pending UTXOs as pending', async () => {
+      const previous = previousWallet({
+        available: [fixtureUtxo(owner, 100n, 0)],
+        pending: [fixtureUtxo(owner, 55n, 9)],
+        appliedId: 4n,
+        protocolVersion: 7n,
+      });
+
+      const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+      expect(HashMap.size(wallet.state.availableUtxos)).toBe(1);
+      expect(HashMap.size(wallet.state.pendingUtxos)).toBe(1);
+      expect([...HashMap.values(wallet.state.pendingUtxos)][0].utxo.value).toBe(55n);
+    });
+
+    it('preserves each UTXO field, not merely the count', async () => {
+      const utxo = fixtureUtxo(owner, 100n, 3);
+      const previous = previousWallet({ available: [utxo], appliedId: 4n, protocolVersion: 7n });
+
+      const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+      const carried = [...HashMap.values(wallet.state.availableUtxos)][0];
+
+      expect(carried.utxo.value).toBe(utxo.utxo.value);
+      expect(carried.utxo.owner).toBe(utxo.utxo.owner);
+      expect(carried.utxo.type).toBe(utxo.utxo.type);
+      expect(carried.utxo.intentHash).toBe(utxo.utxo.intentHash);
+      expect(carried.utxo.outputNo).toBe(utxo.utxo.outputNo);
+      expect(carried.meta.ctime.getTime()).toBe(utxo.meta.ctime.getTime());
+      expect(carried.meta.registeredForDustGeneration).toBe(utxo.meta.registeredForDustGeneration);
+    });
+
+    it('tags the previous ledger version bare-string verifying key as schnorr', async () => {
+      const previous = previousWallet({ available: [], appliedId: 4n, protocolVersion: 7n });
+
+      const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+      expect(wallet.publicKey.publicKey).toEqual({ tag: 'schnorr', value: owner.publicKey.value });
+      expect(wallet.publicKey.addressHex).toBe(owner.addressHex);
+      expect(wallet.publicKey.address).toBe(owner.address);
+    });
+
+    it('leaves the sync cursor exactly where the previous variant left it', async () => {
+      const previous = previousWallet({ available: [], appliedId: 4n, protocolVersion: 7n });
+
+      const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+      // Parked, not rewound and not advanced: the boundary transaction was observed but never applied, so the new
+      // variant has to re-fetch it from this very cursor.
+      expect(wallet.progress.appliedId).toBe(4n);
+    });
+
+    it('carries the network and the version that triggered the hand-over', async () => {
+      const previous = previousWallet({ available: [], appliedId: 4n, protocolVersion: 7n });
+
+      const wallet = await Effect.runPromise(makeCrossLedgerMigration().migrate(previous));
+
+      expect(wallet.networkId).toBe(NetworkId.NetworkId.Undeployed);
+      expect(wallet.protocolVersion).toBe(7n);
+    });
+  });
+});

--- a/packages/unshielded-wallet/src/v2/test/migration.test.ts
+++ b/packages/unshielded-wallet/src/v2/test/migration.test.ts
@@ -40,10 +40,10 @@ const previousWallet = (params: {
   readonly appliedId: bigint;
   readonly protocolVersion: bigint;
 }): PreviousLedgerWallet => ({
-  state: {
-    availableUtxos: params.available,
-    pendingUtxos: params.pending ?? [],
-  },
+  // Built through the real `UnshieldedState`, not from plain arrays: the previous variant hands over a state whose
+  // UTXOs live in Effect `HashMap`s, and a fixture that passed arrays would let a migration that iterated entries
+  // instead of values pass here and fail only against a real wallet.
+  state: UnshieldedState.restore(params.available, params.pending ?? []),
   publicKey: {
     publicKey: owner.publicKey.value,
     addressHex: owner.addressHex,

--- a/packages/unshielded-wallet/src/v2/test/runningV2Variant.test.ts
+++ b/packages/unshielded-wallet/src/v2/test/runningV2Variant.test.ts
@@ -1,0 +1,109 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The version signals the running variant puts on its state stream: an ordinary transition, and the healing emission
+// that rescues a snapshot restored at a version this variant does not own.
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { StateChange, type Variant, VersionChangeType } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { Duration, Effect, Scope, Stream, SubscriptionRef } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { CoreWallet } from '../CoreWallet.js';
+import { RunningV2Variant } from '../RunningV2Variant.js';
+import { UnshieldedState } from '../UnshieldedState.js';
+import { fixtureOwner } from './syncFixtures.js';
+
+const owner = fixtureOwner();
+
+/** The variant owns versions 0..6. */
+const activationRange = ProtocolVersion.makeRange(
+  ProtocolVersion.MinSupportedVersion,
+  ProtocolVersion.ProtocolVersion(7n),
+);
+
+const walletAt = (protocolVersion: bigint): CoreWallet =>
+  CoreWallet.restore(
+    UnshieldedState.empty(),
+    owner,
+    { appliedId: 0n, highestTransactionId: 0n },
+    ProtocolVersion.ProtocolVersion(protocolVersion),
+    NetworkId.NetworkId.Undeployed,
+  );
+
+/**
+ * Drains the variant's state stream for a bounded window and returns the versions it announced.
+ *
+ * @remarks
+ *   Bounded by time rather than by `Stream.take(n)` on purpose: a missing emission has to surface as a failed
+ *   assertion on an empty list, not as a hung test.
+ */
+const announcedVersions = (
+  initial: CoreWallet,
+  drive: (ref: SubscriptionRef.SubscriptionRef<CoreWallet>) => Effect.Effect<void>,
+): Promise<readonly bigint[]> =>
+  Effect.gen(function* () {
+    const scope = yield* Scope.make();
+    const stateRef = yield* SubscriptionRef.make(initial);
+    const context: Variant.VariantContext<CoreWallet> = { stateRef, activationRange };
+    const variant = new RunningV2Variant(scope, context, {} as never);
+
+    const collected = yield* Effect.fork(
+      variant.state.pipe(
+        Stream.interruptAfter(Duration.millis(300)),
+        Stream.filter(StateChange.isVersionChange),
+        Stream.map((change) =>
+          VersionChangeType.isVersion(change.change) ? change.change.version : ProtocolVersion.ProtocolVersion(-1n),
+        ),
+        Stream.runCollect,
+      ),
+    );
+
+    // Let the collector's subscription attach before driving the change: `SubscriptionRef.changes` replays only the
+    // value current at subscription time, so a change published first would be indistinguishable from no change.
+    yield* Effect.sleep(Duration.millis(50));
+    yield* drive(stateRef);
+    const chunk = yield* collected.await;
+    return chunk._tag === 'Success' ? Array.from(chunk.value).map((v) => v as bigint) : [];
+  }).pipe(Effect.scoped, Effect.runPromise);
+
+describe('unshielded running variant version signals', () => {
+  it('announces a version transition observed on the state', async () => {
+    const versions = await announcedVersions(walletAt(0n), (ref) =>
+      SubscriptionRef.set(ref, walletAt(5n)),
+    );
+
+    expect(versions).toEqual([5n]);
+  });
+
+  it('heals a state restored outside the activation range by announcing it immediately', async () => {
+    const versions = await announcedVersions(walletAt(9n), () => Effect.void);
+
+    expect(versions).toEqual([9n]);
+  });
+
+  it('announces nothing for a state restored inside the activation range', async () => {
+    const emissions = await Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const stateRef = yield* SubscriptionRef.make(walletAt(3n));
+      const context: Variant.VariantContext<CoreWallet> = { stateRef, activationRange };
+      const variant = new RunningV2Variant(scope, context, {} as never);
+
+      const chunk = yield* variant.state.pipe(Stream.interruptAfter(Duration.millis(300)), Stream.runCollect);
+      return Array.from(chunk);
+    }).pipe(Effect.scoped, Effect.runPromise);
+
+    // No version announcement...
+    expect(emissions.filter(StateChange.isVersionChange)).toEqual([]);
+    // ...but the stream was genuinely live, so the empty result above is not a false pass.
+    expect(emissions.filter(StateChange.isState).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/unshielded-wallet/src/v2/test/runningV2Variant.test.ts
+++ b/packages/unshielded-wallet/src/v2/test/runningV2Variant.test.ts
@@ -43,8 +43,8 @@ const walletAt = (protocolVersion: bigint): CoreWallet =>
  * Drains the variant's state stream for a bounded window and returns the versions it announced.
  *
  * @remarks
- *   Bounded by time rather than by `Stream.take(n)` on purpose: a missing emission has to surface as a failed
- *   assertion on an empty list, not as a hung test.
+ *   Bounded by time rather than by `Stream.take(n)` on purpose: a missing emission has to surface as a failed assertion
+ *   on an empty list, not as a hung test.
  */
 const announcedVersions = (
   initial: CoreWallet,
@@ -72,14 +72,12 @@ const announcedVersions = (
     yield* Effect.sleep(Duration.millis(50));
     yield* drive(stateRef);
     const chunk = yield* collected.await;
-    return chunk._tag === 'Success' ? Array.from(chunk.value).map((v) => v as bigint) : [];
+    return chunk._tag === 'Success' ? Array.from(chunk.value) : [];
   }).pipe(Effect.scoped, Effect.runPromise);
 
 describe('unshielded running variant version signals', () => {
   it('announces a version transition observed on the state', async () => {
-    const versions = await announcedVersions(walletAt(0n), (ref) =>
-      SubscriptionRef.set(ref, walletAt(5n)),
-    );
+    const versions = await announcedVersions(walletAt(0n), (ref) => SubscriptionRef.set(ref, walletAt(5n)));
 
     expect(versions).toEqual([5n]);
   });

--- a/packages/unshielded-wallet/src/v2/test/syncCapability.test.ts
+++ b/packages/unshielded-wallet/src/v2/test/syncCapability.test.ts
@@ -33,9 +33,12 @@ const owner = fixtureOwner();
 describe('unshielded sync capability at a variant boundary', () => {
   const setup = () => {
     const history = recordingHistory();
-    const capability = makeDefaultSyncCapability({ indexerClientConnection: { indexerHttpUrl: 'http://unused' } }, () => ({
-      transactionHistoryService: history.service,
-    }));
+    const capability = makeDefaultSyncCapability(
+      { indexerClientConnection: { indexerHttpUrl: 'http://unused' } },
+      () => ({
+        transactionHistoryService: history.service,
+      }),
+    );
     return { capability, history };
   };
 
@@ -53,7 +56,11 @@ describe('unshielded sync capability at a variant boundary', () => {
     const created = fixtureUtxo(owner, 100n, 0);
 
     const result = capability
-      .applyUpdate(emptyWallet(), fixtureTransaction({ id: 1, protocolVersion: 3, createdUtxos: [created] }), activeRange)
+      .applyUpdate(
+        emptyWallet(),
+        fixtureTransaction({ id: 1, protocolVersion: 3, createdUtxos: [created] }),
+        activeRange,
+      )
       .pipe(EitherOps.getOrThrowLeft);
 
     expect(HashMap.size(result.state.availableUtxos)).toBe(1);

--- a/packages/unshielded-wallet/src/v2/test/syncCapability.test.ts
+++ b/packages/unshielded-wallet/src/v2/test/syncCapability.test.ts
@@ -1,0 +1,226 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The per-message boundary rule. Unshielded sync is message-at-a-time, not batched: there is no prefix to apply and no
+// suffix to defer, only the question "does this one transaction belong to this variant?". A transaction reported at or
+// beyond the end of the variant's activation range is not applied AT ALL — no UTXO change, no `appliedId` bump, no
+// transaction-history write — and only its version is recorded, which is what triggers the hand-over. Because the
+// cursor did not move, the next variant re-fetches that same transaction and applies it exactly once.
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
+import { HashMap } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { CoreWallet } from '../CoreWallet.js';
+import { makeDefaultSyncCapability } from '../Sync.js';
+import { UnshieldedState } from '../UnshieldedState.js';
+import { fixtureOwner, fixtureProgress, fixtureTransaction, fixtureUtxo, recordingHistory } from './syncFixtures.js';
+
+/** The running variant owns versions 0..6; 7 and above belong to whatever replaces it. */
+const activeRange = ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, ProtocolVersion.ProtocolVersion(7n));
+
+const owner = fixtureOwner();
+
+describe('unshielded sync capability at a variant boundary', () => {
+  const setup = () => {
+    const history = recordingHistory();
+    const capability = makeDefaultSyncCapability({ indexerClientConnection: { indexerHttpUrl: 'http://unused' } }, () => ({
+      transactionHistoryService: history.service,
+    }));
+    return { capability, history };
+  };
+
+  const emptyWallet = (protocolVersion: bigint = 0n, appliedId: bigint = 0n): CoreWallet =>
+    CoreWallet.restore(
+      UnshieldedState.empty(),
+      owner,
+      { appliedId, highestTransactionId: appliedId },
+      ProtocolVersion.ProtocolVersion(protocolVersion),
+      NetworkId.NetworkId.Undeployed,
+    );
+
+  it('applies a transaction reported below the boundary and records its version', () => {
+    const { capability, history } = setup();
+    const created = fixtureUtxo(owner, 100n, 0);
+
+    const result = capability
+      .applyUpdate(emptyWallet(), fixtureTransaction({ id: 1, protocolVersion: 3, createdUtxos: [created] }), activeRange)
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(HashMap.size(result.state.availableUtxos)).toBe(1);
+    expect(result.progress.appliedId).toBe(1n);
+    expect(result.protocolVersion).toBe(3n);
+    expect(history.puts()).toHaveLength(1);
+  });
+
+  it('re-annotates on a version bump that stays inside the range', () => {
+    const { capability, history } = setup();
+    const created = fixtureUtxo(owner, 50n, 1);
+
+    const result = capability
+      .applyUpdate(
+        emptyWallet(3n, 1n),
+        fixtureTransaction({ id: 2, protocolVersion: 5, createdUtxos: [created] }),
+        activeRange,
+      )
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(HashMap.size(result.state.availableUtxos)).toBe(1);
+    expect(result.progress.appliedId).toBe(2n);
+    expect(result.protocolVersion).toBe(5n);
+    expect(history.puts()).toHaveLength(1);
+  });
+
+  it('does not apply a transaction reported AT the boundary — only its version is recorded', () => {
+    const { capability, history } = setup();
+    const alreadyHeld = fixtureUtxo(owner, 100n, 0);
+    const before = CoreWallet.applyUpdate(emptyWallet(3n, 1n), {
+      createdUtxos: [alreadyHeld],
+      spentUtxos: [],
+      status: 'SUCCESS',
+    }).pipe(EitherOps.getOrThrowLeft);
+
+    const boundaryTx = fixtureTransaction({
+      id: 2,
+      protocolVersion: 7,
+      createdUtxos: [fixtureUtxo(owner, 999n, 5)],
+    });
+
+    const result = capability.applyUpdate(before, boundaryTx, activeRange).pipe(EitherOps.getOrThrowLeft);
+
+    // No UTXO change: the wallet still holds exactly what it held, and nothing of the boundary transaction.
+    expect(HashMap.size(result.state.availableUtxos)).toBe(1);
+    expect([...HashMap.values(result.state.availableUtxos)].map((u) => u.utxo.value)).toEqual([100n]);
+    // No cursor movement: this is what makes the next variant re-fetch the same transaction.
+    expect(result.progress.appliedId).toBe(1n);
+    // No transaction-history write.
+    expect(history.puts()).toHaveLength(0);
+    // The version IS recorded — it is the migration signal.
+    expect(result.protocolVersion).toBe(7n);
+  });
+
+  it('does not apply a transaction reported BEYOND the boundary', () => {
+    const { capability, history } = setup();
+
+    const result = capability
+      .applyUpdate(
+        emptyWallet(3n, 1n),
+        fixtureTransaction({ id: 2, protocolVersion: 9, createdUtxos: [fixtureUtxo(owner, 5n, 2)] }),
+        activeRange,
+      )
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(HashMap.size(result.state.availableUtxos)).toBe(0);
+    expect(result.progress.appliedId).toBe(1n);
+    expect(history.puts()).toHaveLength(0);
+    expect(result.protocolVersion).toBe(9n);
+  });
+
+  it('does not apply a SPEND reported at the boundary — the spent UTXO stays available', () => {
+    const { capability, history } = setup();
+    const held = fixtureUtxo(owner, 100n, 0);
+    const before = CoreWallet.applyUpdate(emptyWallet(3n, 1n), {
+      createdUtxos: [held],
+      spentUtxos: [],
+      status: 'SUCCESS',
+    }).pipe(EitherOps.getOrThrowLeft);
+
+    const result = capability
+      .applyUpdate(before, fixtureTransaction({ id: 2, protocolVersion: 7, spentUtxos: [held] }), activeRange)
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(HashMap.size(result.state.availableUtxos)).toBe(1);
+    expect(result.progress.appliedId).toBe(1n);
+    expect(history.puts()).toHaveLength(0);
+  });
+
+  it('does not apply a FAILED transaction reported at the boundary either', () => {
+    const { capability, history } = setup();
+
+    const result = capability
+      .applyUpdate(
+        emptyWallet(3n, 1n),
+        fixtureTransaction({
+          id: 2,
+          protocolVersion: 7,
+          createdUtxos: [fixtureUtxo(owner, 5n, 2)],
+          status: 'FAILURE',
+        }),
+        activeRange,
+      )
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(result.progress.appliedId).toBe(1n);
+    expect(history.puts()).toHaveLength(0);
+    expect(result.protocolVersion).toBe(7n);
+  });
+
+  it('applies a failed transaction reported below the boundary and records its version', () => {
+    const { capability } = setup();
+
+    const result = capability
+      .applyUpdate(
+        emptyWallet(0n, 0n),
+        fixtureTransaction({
+          id: 1,
+          protocolVersion: 4,
+          createdUtxos: [fixtureUtxo(owner, 5n, 2)],
+          status: 'FAILURE',
+        }),
+        activeRange,
+      )
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(result.progress.appliedId).toBe(1n);
+    expect(result.protocolVersion).toBe(4n);
+  });
+
+  it('never lowers the recorded version', () => {
+    const { capability } = setup();
+
+    const result = capability
+      .applyUpdate(
+        emptyWallet(5n, 1n),
+        fixtureTransaction({ id: 2, protocolVersion: 2, createdUtxos: [fixtureUtxo(owner, 7n, 3)] }),
+        activeRange,
+      )
+      .pipe(EitherOps.getOrThrowLeft);
+
+    // Applied — 2 is inside the range — but the recorded version does not go backwards.
+    expect(result.progress.appliedId).toBe(2n);
+    expect(HashMap.size(result.state.availableUtxos)).toBe(1);
+    expect(result.protocolVersion).toBe(5n);
+  });
+
+  it('progress messages never touch the recorded version', () => {
+    const { capability } = setup();
+
+    const result = capability
+      .applyUpdate(emptyWallet(3n, 1n), fixtureProgress(42), activeRange)
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(result.progress.highestTransactionId).toBe(42n);
+    expect(result.progress.isConnected).toBe(true);
+    expect(result.progress.appliedId).toBe(1n);
+    expect(result.protocolVersion).toBe(3n);
+  });
+
+  it('a progress message on a wallet at the range floor still records nothing', () => {
+    const { capability } = setup();
+
+    const result = capability
+      .applyUpdate(emptyWallet(0n, 0n), fixtureProgress(7), activeRange)
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(result.protocolVersion).toBe(0n);
+  });
+});

--- a/packages/unshielded-wallet/src/v2/test/syncFixtures.ts
+++ b/packages/unshielded-wallet/src/v2/test/syncFixtures.ts
@@ -1,0 +1,106 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Deterministic fixtures for the sync-boundary tests. Unshielded sync updates are plain decoded JSON — the indexer
+// reports UTXOs as public data — so a fixture can build them directly and still be the real shape, unlike shielded and
+// dust whose fixtures must mint real events through a simulator. What is NOT synthetic here is the identity: the owner
+// address is derived through the real keystore from a fixed seed, so the UTXOs are addressed to an address the ledger
+// would actually produce.
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect, Ref } from 'effect';
+import { createKeystore, type PublicKey, PublicKey as PublicKeyOps } from '../../KeyStore.js';
+import { type UnshieldedUpdate, type UtxoWithMeta, type WalletSyncUpdate } from '../SyncSchema.js';
+import { type TransactionHistoryService } from '../TransactionHistory.js';
+
+/** A fixed 32-byte secret, so every fixture run addresses UTXOs to the same real address. */
+export const fixtureSeed = (): Uint8Array => Uint8Array.from({ length: 32 }, (_, i) => (i * 7 + 11) % 256);
+
+/** The fixture owner, derived through the real keystore. */
+export const fixtureOwner = (): PublicKey =>
+  PublicKeyOps.fromKeyStore(
+    createKeystore({ kind: 'schnorr', secret: fixtureSeed() }, NetworkId.NetworkId.Undeployed),
+  );
+
+/** A UTXO addressed to `owner`, deterministic in `outputNo`. */
+export const fixtureUtxo = (owner: PublicKey, value: bigint, outputNo: number): UtxoWithMeta => ({
+  utxo: {
+    value,
+    owner: owner.addressHex,
+    type: ledger.nativeToken().raw,
+    intentHash: ledger.sampleIntentHash(),
+    outputNo,
+  },
+  meta: {
+    ctime: new Date(1_700_000_000_000 + outputNo * 1000),
+    registeredForDustGeneration: false,
+  },
+});
+
+/**
+ * A transaction update as the indexer reports it: one event, one id, one protocol version. This is the unit the
+ * unshielded boundary rule operates on — there is no batch to split.
+ */
+export const fixtureTransaction = (params: {
+  readonly id: number;
+  readonly protocolVersion: number;
+  readonly createdUtxos?: readonly UtxoWithMeta[];
+  readonly spentUtxos?: readonly UtxoWithMeta[];
+  readonly status?: 'SUCCESS' | 'FAILURE';
+}): UnshieldedUpdate => {
+  const status = params.status ?? 'SUCCESS';
+  return {
+    type: 'UnshieldedTransaction',
+    transaction: {
+      id: params.id,
+      hash: `hash-${params.id}`,
+      type: 'RegularTransaction',
+      protocolVersion: params.protocolVersion,
+      identifiers: [],
+      block: {
+        hash: `block-${params.id}`,
+        height: params.id,
+        timestamp: new Date(1_700_000_000_000 + params.id * 6000),
+      },
+      fees: { paidFees: 0n, estimatedFees: 0n },
+      transactionResult: { status, segments: [{ id: 1, success: status === 'SUCCESS' }] },
+    },
+    createdUtxos: params.createdUtxos ?? [],
+    spentUtxos: params.spentUtxos ?? [],
+    status,
+  } as UnshieldedUpdate;
+};
+
+/** A progress message. It carries no protocol version at all — the wire schema has no field for one. */
+export const fixtureProgress = (highestTransactionId: number): WalletSyncUpdate => ({
+  type: 'UnshieldedTransactionsProgress',
+  highestTransactionId,
+});
+
+/**
+ * A transaction-history service that records what it was asked to write instead of writing it.
+ *
+ * @remarks
+ *   A stub, not a mock: the assertions read the recorded list, they do not interrogate a spy. This is what makes "the
+ *   boundary transaction produced no tx-history put" directly observable.
+ */
+export const recordingHistory = (): {
+  readonly service: TransactionHistoryService;
+  readonly puts: () => readonly UnshieldedUpdate[];
+} => {
+  const recorded = Ref.unsafeMake<readonly UnshieldedUpdate[]>([]);
+  return {
+    service: { put: (update: UnshieldedUpdate) => Ref.update(recorded, (all) => [...all, update]) },
+    puts: () => Effect.runSync(Ref.get(recorded)),
+  };
+};

--- a/packages/unshielded-wallet/src/v2/test/syncFixtures.ts
+++ b/packages/unshielded-wallet/src/v2/test/syncFixtures.ts
@@ -28,9 +28,7 @@ export const fixtureSeed = (): Uint8Array => Uint8Array.from({ length: 32 }, (_,
 
 /** The fixture owner, derived through the real keystore. */
 export const fixtureOwner = (): PublicKey =>
-  PublicKeyOps.fromKeyStore(
-    createKeystore({ kind: 'schnorr', secret: fixtureSeed() }, NetworkId.NetworkId.Undeployed),
-  );
+  PublicKeyOps.fromKeyStore(createKeystore({ kind: 'schnorr', secret: fixtureSeed() }, NetworkId.NetworkId.Undeployed));
 
 /** A UTXO addressed to `owner`, deterministic in `outputNo`. */
 export const fixtureUtxo = (owner: PublicKey, value: bigint, outputNo: number): UtxoWithMeta => ({
@@ -78,7 +76,7 @@ export const fixtureTransaction = (params: {
     createdUtxos: params.createdUtxos ?? [],
     spentUtxos: params.spentUtxos ?? [],
     status,
-  } as UnshieldedUpdate;
+  };
 };
 
 /** A progress message. It carries no protocol version at all — the wire schema has no field for one. */


### PR DESCRIPTION
Phase 6, unshielded increment (2 of 2) — and the last per-wallet increment of the hard-fork line. Stacked on #671. TDD: 16 red tests (+2 unloadable files) before implementation; 185/185 passing at the tip.

## What this delivers

- **Per-message boundary semantics (D2, unshielded rules)** — unlike shielded/dust's batched split, unshielded sync is per-message: a transaction at/after the boundary is **not applied at all** (no UTXO change, no `appliedId` bump, no tx-history put) — only the version annotation is written, and the next variant re-fetches it from the unchanged cursor. Progress messages never touch the version. Note: unshielded's `protocolVersion` is **required** on the transaction schema (unlike dust's optional), so there is no "absent means in-range" case.
- **Structural cross-version migration** — unshielded state is public UTXO data, so `migrateState` carries it field-for-field into the new variant (no fresh-state, no replay wait), with the cursor parked. The builder gains the migration seam (`withMigration` in dust's method-level-context form).
- **Keyless restart (D1)** — unshielded is watch-only; the activation watcher (previously absent entirely) re-dispatches `startSyncInBackground()` with no retained aux.
- **The crossing proof**: the load-bearing chain of assertions is that the boundary transaction is applied **exactly once, by the new variant** — each link asserted separately — plus field-for-field UTXO carry, the parked cursor asserted on the captured migration before sync touches it, both negatives, and a lemma that both ledger versions derive the same address from the same secret. Mutation-verified four ways: drop the carry (3 tests fail), advance the cursor by one (the boundary tx is lost), apply the boundary tx in the old variant (cursor moves), apply it there with the cursor parked (it arrives twice).

## A real bug the proof caught (and the unit tests could not)

`PreviousLedgerWallet.state` typed its UTXOs as `Iterable<UtxoLike>` — but the real state holds Effect `HashMap`s, whose iteration yields `[key, value]` **entries**, so the migration was carrying malformed pairs. Nothing caught it: the runtime casts into `migrateState` (TypeScript never checked) and the migration unit tests built fixtures from plain arrays that satisfy the type honestly. The fork proof failed end-to-end, the type now names `HashMap` (still version-agnostic — it's an Effect type), fixtures build through the real `UnshieldedState`, and the stronger type immediately caught the same mistake in the test factory. This is the unshielded instance of the silent-structural-compatibility hazard the dust increment flagged.

## No analogue, stated plainly

There is no re-framing/re-minting of ledger bytes and no integration companion: unshielded state is public and the wire format is JSON, so there is no ledger encoding for a translation to be faithful to. `turbo.json` and the CI integration workflow are untouched. Both variants are nonetheless genuinely ledger-v8 and ledger-v9 with their own modules.

## Verification

Branch tip (rebased onto #669's CI-timeout fix before push; dust 21/21 + unshielded 19/19 + typecheck 37/37 re-verified after the rebase): `yarn dist --force` 17/17 · `typecheck --force` 37/37 · `lint` 58/58 · `test:unit --force` 53/53 · 185/185 package tests · cross-package typecheck 19/19 · Effect diagnostics clean apart from the known-accepted `deterministicKeys` · `format:check` · changeset status clean. All commits GPG-signed.