### PR TITLE
chore: improve the PR and issue conventions

### DIFF
--- a/.changeset/pr-issue-linking-rules.md
+++ b/.changeset/pr-issue-linking-rules.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: improve the PR and issue conventions

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+# Related Issue
+
+_A plain reference (`#123`), or `none — <reason>` when there is no issue. Do **not** use a closing keyword
+(`Closes`/`Fixes`/`Resolves`): issues here are closed manually after QA, so an auto-close on merge would close them
+before QA has seen the change._
+
 # Description
 
 _A clear and concise description of what this pull request does or fixes._

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -20,7 +20,7 @@
 
 <!--
 - Link any relevant Confluence or additional Jira tickets if need be
-- If your PR closes some of the existing issues, please add links to them here.
-  Mentioned issues will be automatically closed.
-  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
+- Reference related issues with a plain reference ("#123") — do NOT use a closing keyword
+  ("Closes"/"Fixes"/"Resolves"). Issues in this repo are closed manually after QA, so an
+  auto-close on merge would close them before QA has seen the change.
 -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,16 @@ examples:** `packages/docs-snippets` — always check there first when implement
   footer.
 - **Never commit, push, or create/edit PRs, issues, or comments unattended** — show the user the diff and the exact
   message/content first, and wait for explicit approval.
-- Issues and PRs use the `.github/` templates, every section filled. Link issues with plain references (`#123`) —
-  **never** closing keywords (`Closes`/`Fixes`/`Resolves`); issues are closed manually after QA.
+- Issues and PRs use the `.github/` templates, every section filled. For PRs that means
+  `.github/PULL_REQUEST_TEMPLATE.md` — the root file GitHub applies automatically — not
+  `.github/PULL_REQUEST_TEMPLATE/pull_request_template.md`, which is reachable only via `?template=`.
+- Link issues with plain references (`#123`) — **never** closing keywords (`Closes`/`Fixes`/`Resolves`); issues are
+  closed manually after QA, so an auto-close on merge would close them before QA has seen the change. State the issue in
+  the PR body's **Related Issue** section (`none — <reason>` when there isn't one). A plain reference cross-links the
+  issue's timeline but does **not** fill GitHub's "Development" panel: that link is the same feature as auto-close and
+  cannot be created from the CLI, so ask the author to add it from the PR sidebar if it is wanted.
+- After opening a PR or an issue, say what is left for the user to do by hand: add it to the **Development** panel, and
+  apply any labels the repo expects — `component:*`, `status:*`, `fixversion:*`, `epic:*`. Nothing infers those.
 
 ## Build Commands
 


### PR DESCRIPTION
# Related Issue

none — no ticket; convention change agreed directly.

# Description

Two problems with the same symptom: a PR that never records the issue it belongs to.

`.github/PULL_REQUEST_TEMPLATE.md` — the template GitHub applies automatically — has no section for the related issue. There is nowhere to put it, so it gets dropped, and the connection between a PR and its issue survives only in the memory of whoever opened it.

`.github/PULL_REQUEST_TEMPLATE/pull_request_template.md` is a second, different template whose Links section says the opposite of repo policy: *"If your PR closes some of the existing issues, please add links to them here. Mentioned issues will be automatically closed. Usage: 'Closes #<issue number>'"*. Issues here are closed manually after QA, so an auto-close on merge would close them before QA has seen the change. That template is dormant — templates in a `PULL_REQUEST_TEMPLATE/` directory are only used when selected with `?template=` — but the instruction is wrong wherever it is read, and two divergent templates leave it unclear which one governs.

# Proposed Solution

Give the reference a home: a `# Related Issue` section, first, in the template GitHub actually applies. `none — <reason>` is a valid answer, so there is no incentive to leave it blank.

Correct the dormant template's Links section to match policy — plain reference, no closing keyword, with the reason stated so nobody "fixes" it back. Corrected rather than deleted: it carries a useful submission checklist, and whether two templates should exist at all is a question for the team, not a side effect of this change.

Record all of it in `CLAUDE.md`: which template is authoritative, the linking rule with its reason, and the manual follow-ups to state when a PR or issue is opened (the Development-panel link, and any labels the repo expects — nothing infers those).

Why not simply link issues properly and skip the convention: every route to GitHub's "Development" panel writes the same `closingIssuesReferences` edge, so the formal link *is* the auto-close. Verified rather than assumed — a PR opened from a branch attached with the `createLinkedBranch` GraphQL mutation carried the closing reference with no reference and no keyword anywhere in its body, and merging it closed the issue. Probe run in a throwaway repo, since deleted. That detail lives here rather than in `CLAUDE.md`, which is read every session and is better kept lean.

# Important Changes Introduced

**Opening a PR by hand:** the default template gains a first section asking for the related issue. Nothing enforces it — this is a convention, not a check.

**Using the `?template=` variant:** its Links section no longer tells you to write `Closes #<issue number>`. If you had been following it, that guidance was wrong for this repo — the auto-close it produces closes issues before QA has seen the change.

**Working with Claude in this repo:** `CLAUDE.md` now asks it to state the manual follow-ups whenever it opens a PR or an issue — adding the item to the Development panel, and applying any labels the repo expects (`component:*`, `status:*`, `fixversion:*`, `epic:*`), since nothing infers those. Expect that as a closing note on anything it opens. It also records which of the two PR templates is authoritative, so it stops guessing.

**Not touched:** no workflows, no CI, no package code. An empty changeset is included, since docs and tooling changes still need one.

# Testing

No code changes, so the test suites are unaffected. `prettier` reports all three markdown files conformant at the repo's 120 columns.
