### PR TITLE
feat(abstractions,runtime): version-dispatch primitives for the dual-ledger API

### DIFF
--- a/.changeset/package-owned-wallet-configuration.md
+++ b/.changeset/package-owned-wallet-configuration.md
@@ -1,0 +1,32 @@
+---
+'@midnightntwrk/wallet-sdk-shielded': major
+'@midnightntwrk/wallet-sdk-dust-wallet': major
+'@midnightntwrk/wallet-sdk-unshielded-wallet': major
+---
+
+**`DefaultShieldedConfiguration`, `DefaultDustConfiguration` and `DefaultUnshieldedConfiguration` are no longer aliases
+of their head variant's builder configuration.** Each package now declares its own configuration type. The declared
+shape is unchanged, so applications that pass a configuration object literal — which is all of them — need to change
+nothing.
+
+What breaks is the alias identity. Code that relied on these being the *same type* as `DefaultV2Configuration` no
+longer holds; in particular a package-owned configuration will not silently acquire a field that the v2 variant's
+builder configuration gains. If you were passing a package configuration straight into a variant builder, or vice
+versa, that still compiles today only because the shapes coincide, and the packages now assert that coincidence rather
+than assume it: each package has a type test requiring its configuration to stay interchangeable with what **both** its
+variants are built from, so a divergence surfaces as a compile error in the SDK instead of as a wallet that cannot be
+built for one of its variants. `DefaultV1Configuration` and `DefaultV2Configuration` are unchanged and still exported
+from the `./v1` and `./v2` subpaths.
+
+`ShieldedWallet(configuration)` and `UnshieldedWallet(configuration)` now take the package-owned type
+(`DustWallet(configuration)` already did). The `Custom*Wallet(configuration, builder)` entry points are unchanged:
+those take a variant builder, so a variant's configuration is the right contract there.
+
+The reason for the split: a wallet that spans a protocol boundary is built from more than one variant, so no single
+variant's configuration can be the wallet's public contract. The package states what it asks an application for and
+maps it onto whichever variants it registers — which is what lets those variants be configured independently of one
+another.
+
+Note for dust specifically: `dustParameters` is typed with ledger-v9's `DustParameters`, while the pre-fork variant's
+configuration types it with ledger-v8's. One configuration can serve both only because those two classes are
+structurally identical; that is now asserted rather than assumed.

--- a/.changeset/protocol-state-variant-tag.md
+++ b/.changeset/protocol-state-variant-tag.md
@@ -1,0 +1,33 @@
+---
+'@midnightntwrk/wallet-sdk-abstractions': minor
+'@midnightntwrk/wallet-sdk-runtime': minor
+---
+
+**Every state the runtime publishes now carries `variantTag`, the tag of the variant that produced it.** Read this note
+if you construct a `ProtocolState` anywhere — including in tests.
+
+`ProtocolState<TState>` becomes `ProtocolState<TState, TVariantTag extends string | symbol = string | symbol>` and
+gains a **required** `variantTag` field. The type parameter is defaulted, so every existing _annotation_ still compiles;
+what does not compile is a `ProtocolState` **value** built without a `variantTag`. In this repository that was only the
+runtime itself plus test fixtures asserting on emitted states, and the same is expected of consumers: the wallets read
+these values, they do not construct them. `ProtocolState.getEquivalence` now compares `variantTag` strictly as well, so
+two states that differ only in which variant produced them are no longer equal.
+
+Why the runtime hands it over rather than leaving it to be inferred: after a migration, the version alone identifies the
+producing variant only if the reader re-derives every variant's activation range and casts its way to the matching
+capabilities, on every emission. The runtime knows the answer at the moment it publishes, so it says so. Selecting the
+capabilities that understand a state is now a lookup by tag.
+
+The tag is taken from the variant whose stream the emission came from, including across a migration, so an emission can
+never be attributed to a variant that did not produce it.
+
+Also in the runtime:
+
+- `Runtime.RuntimeState<Variants>` names the published state shape once —
+  `ProtocolState<StateOf<Each<Variants>>, VariantTag<Each<Variants>>>` — and `Runtime.stateChanges`,
+  `WalletLike.rawState` and the built wallet class's `rawState` all use it, so they cannot drift apart. For a wallet
+  built over known variants, `variantTag` is typed as the union of exactly those variants' tags, not as
+  `string | symbol`.
+- `Variant.getVersionedVariantTag` is now generic over the versioned variant rather than over the variant inside it, so
+  a union of versioned variants yields the union of their tags instead of collapsing to the first member's. Existing
+  single-variant call sites are unaffected.

--- a/.changeset/protocol-version-registry.md
+++ b/.changeset/protocol-version-registry.md
@@ -1,0 +1,26 @@
+---
+'@midnightntwrk/wallet-sdk-abstractions': minor
+---
+
+Add `ProtocolVersion.Registry<T>`: values keyed by protocol version ranges, with a total selection.
+
+The SDK asks the same question in several places — which codec decodes a block, which prover proves a recipe, which
+transaction trait understands a pending transaction, which variant a snapshot restores into. All of them are "pick the
+implementation that speaks this protocol version", and each answering it for itself is how two of them come to disagree
+about where a boundary lies. This is that question, once.
+
+- `ProtocolVersion.Registry<T>` / `ProtocolVersion.RegistryEntry<T>` — an ordered, non-overlapping map from half-open
+  version ranges to values. `ProtocolVersion.emptyRegistry` is the empty one.
+- `ProtocolVersion.makeRegistry(entries)` takes entries that carry their own ranges;
+  `ProtocolVersion.makeRegistryFromActivations(activations)` takes the "since this version" shape registration already
+  has everywhere in the SDK and derives the ranges from it — entry _i_ serves
+  `[sinceVersion(i), sinceVersion(i + 1))`, the last one runs to `MaxSupportedVersion`. Both return an `Either`, failing
+  with `ProtocolVersion.RegistryError` when the versions are not strictly ascending, when ranges overlap, or when the
+  last activation leaves no room for a range above it.
+- `ProtocolVersion.select(registry, version)` and `ProtocolVersion.selectEntry(registry, version)` return an `Option`.
+  Selection is total: a version no entry covers is a `none`, never a throw, so callers decide what a miss means in their
+  own domain — an unsupported snapshot version is not the same failure as an unsupported proving version.
+
+Ranges keep the existing half-open semantics of `withinRange`: the start is included, the end is not.
+
+Purely additive; nothing that compiled before changes.

--- a/.changeset/variant-for-and-self-configured-variants.md
+++ b/.changeset/variant-for-and-self-configured-variants.md
@@ -1,0 +1,30 @@
+---
+'@midnightntwrk/wallet-sdk-runtime': minor
+---
+
+Two additions the wallet layer needs before it can register more than one variant.
+
+**Resolving a variant from a protocol version.** `BaseWalletClass.variantFor(version)` returns the registered versioned
+variant whose activation range contains `version`, as an `Option`; `Variant.selectByRange(variants, version)` is the
+same resolution over a plain array. Ranges come from `ProtocolVersion.makeRegistryFromActivations`, which is also what
+the runtime derives `VariantContext.activationRange` from, so the boundary a caller resolves against and the boundary
+the runtime migrates at are computed the same way. A version below the first registration selects nothing rather than
+throwing: a snapshot written by an unsupported protocol version is an answer a caller has to handle, not a defect. The
+resolved variant's tag addresses the never-yet-called `start(WalletClass, tag, state)`.
+
+**Variants that carry their own configuration.** `withVariant` gains a third argument:
+
+```ts
+withVariant(sinceVersion, variantBuilder, configuration);
+```
+
+A variant registered this way is built from that configuration and **leaves the build-time intersection entirely** —
+`build` then asks only for what the remaining variants still need, and asks for nothing at all when every variant is
+self-configured. `VariantBuilder.SelfConfiguredVariantBuilder<TBuilder>` and `VariantBuilder.PendingConfigurationOf<T>`
+express this in the types, and `VariantBuilder.AnyVersionedVariantBuilder` is now the union of the two registration
+shapes.
+
+This exists because a wallet spanning a protocol boundary has two variants that mean different, mutually unassignable
+things by the same configuration key — a `simulator` or a `dustParameters` belonging to one ledger or the other.
+Intersecting those produces a configuration no single variant can consume, which is why the fork test harnesses in the
+wallet packages route around the builder's configuration altogether today. The two-argument `withVariant` is unchanged.

--- a/packages/abstractions/src/ProtocolState.ts
+++ b/packages/abstractions/src/ProtocolState.ts
@@ -14,25 +14,37 @@ import { Equivalence } from 'effect';
 import type * as ProtocolVersion from './ProtocolVersion.js';
 
 /**
- * A type that associates some state with a given version of the Midnight protocol.
+ * A type that associates some state with a given version of the Midnight protocol, and with the variant that produced
+ * it.
  *
+ * @remarks
+ *   `variantTag` is the tag of the wallet variant the emission came from. The runtime knows it at the moment it publishes
+ *   a state, so it hands it over rather than leaving readers to infer the producing implementation from `version` —
+ *   which would mean re-deriving activation ranges, and casting, on every emission. It travels with the state so that
+ *   selecting the capabilities that understand a state is a lookup by tag.
  * @typeParam TState The type of state.
+ * @typeParam TVariantTag The tag, or union of tags, of the variants that can produce this state.
  */
-export type ProtocolState<TState> = Readonly<{ version: ProtocolVersion.ProtocolVersion; state: TState }>;
+export type ProtocolState<TState, TVariantTag extends string | symbol = string | symbol> = Readonly<{
+  version: ProtocolVersion.ProtocolVersion;
+  variantTag: TVariantTag;
+  state: TState;
+}>;
 
 export const state = <TState>(ps: ProtocolState<TState>): TState => ps.state;
 
 /**
  * Derives an {@link Equivalence.Equivalence} for {@link ProtocolState} values from an equivalence of the underlying
- * state. Versions are compared strictly.
+ * state. Versions and producing variant tags are compared strictly.
  *
  * @param stateEquivalence The equivalence used to compare the `state` field.
  * @returns An equivalence over `ProtocolState<TState>`.
  */
-export const getEquivalence = <TState>(
+export const getEquivalence = <TState, TVariantTag extends string | symbol = string | symbol>(
   stateEquivalence: Equivalence.Equivalence<TState>,
-): Equivalence.Equivalence<ProtocolState<TState>> =>
+): Equivalence.Equivalence<ProtocolState<TState, TVariantTag>> =>
   Equivalence.struct({
     version: Equivalence.strict(),
+    variantTag: Equivalence.strict<TVariantTag>(),
     state: stateEquivalence,
   });

--- a/packages/abstractions/src/ProtocolVersion.ts
+++ b/packages/abstractions/src/ProtocolVersion.ts
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as Brand from 'effect/Brand';
+import * as Data from 'effect/Data';
+import * as Either from 'effect/Either';
+import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 
 /** A branded `bigint` that represents a protocol version. */
@@ -66,3 +69,130 @@ export const MinSupportedVersion = ProtocolVersion(0n);
 
 /** Represents the maximum supported protocol version. */
 export const MaxSupportedVersion = ProtocolVersion(BigInt(Number.MAX_SAFE_INTEGER));
+
+/**
+ * A value together with the protocol version range it serves.
+ *
+ * @typeParam T The type of the registered value.
+ */
+export type RegistryEntry<T> = Readonly<{ range: ProtocolVersion.Range; value: T }>;
+
+/**
+ * An ordered collection of values, each keyed by the protocol version range it serves.
+ *
+ * @remarks
+ *   This is the shared shape behind every "which implementation speaks this protocol version?" question the SDK asks —
+ *   which codec decodes a block, which prover proves a recipe, which transaction trait understands a pending
+ *   transaction, which variant a snapshot should be restored into. Keeping one primitive means those answers cannot
+ *   disagree about what a version range is or where its boundaries lie.
+ *
+ *   Entries are ascending and non-overlapping by construction, and ranges are half-open (`withinRange`), so exactly one
+ *   entry can match a version. Gaps are allowed: a version no entry covers selects nothing, which callers turn into
+ *   whichever typed error means "unsupported" in their domain.
+ * @typeParam T The type of the registered values.
+ */
+export type Registry<T> = Readonly<{ entries: readonly RegistryEntry<T>[] }>;
+
+/**
+ * Raised when entries cannot form a {@link Registry} because their ranges are not ascending, overlap, or cannot be
+ * closed at all.
+ *
+ * @remarks
+ *   Construction is the only place this can happen: once built, a registry is total — selection returns an
+ *   {@link Option.Option} rather than failing.
+ */
+export class RegistryError extends Data.TaggedError(
+  '@midnightntwrk/wallet-sdk-abstractions/ProtocolVersion/RegistryError',
+)<{
+  readonly message: string;
+  /** The protocol versions whose ordering or overlap made the registry invalid. */
+  readonly versions: readonly ProtocolVersion[];
+}> {}
+
+/** A registry with no entries: {@link select} on it never finds anything. */
+export const emptyRegistry: Registry<never> = { entries: [] };
+
+/**
+ * Creates a registry from entries that already carry their own ranges.
+ *
+ * @param entries The entries, in ascending order of range start; ranges must not overlap, though gaps are allowed.
+ * @returns The registry, or a {@link RegistryError} naming the two range boundaries that could not be ordered.
+ */
+export const makeRegistry = <T>(entries: readonly RegistryEntry<T>[]): Either.Either<Registry<T>, RegistryError> => {
+  const brokenAt = entries.findIndex((entry, index) => index > 0 && entry.range[0] < entries[index - 1].range[1]);
+
+  return brokenAt < 0
+    ? Either.right({ entries })
+    : Either.left(
+        new RegistryError({
+          message: 'Protocol version registry entries must be ascending and must not overlap.',
+          versions: [entries[brokenAt - 1].range[1], entries[brokenAt].range[0]],
+        }),
+      );
+};
+
+/**
+ * Creates a registry from values keyed by the protocol version each becomes active at, deriving the ranges from the
+ * registration order: entry _i_ serves `[sinceVersion(i), sinceVersion(i + 1))`, and the last entry serves
+ * `[sinceVersion(last), MaxSupportedVersion)`.
+ *
+ * @remarks
+ *   This is the shape registration has everywhere in the SDK — a variant, codec or prover says which version it starts
+ *   answering for, never which version it stops at — so the boundary between two of them is derived in exactly one
+ *   place and cannot drift.
+ * @param activations The values and the versions they activate at, in strictly ascending order.
+ * @returns The registry, or a {@link RegistryError} naming the versions that broke the ordering.
+ */
+export const makeRegistryFromActivations = <T>(
+  activations: readonly Readonly<{ sinceVersion: ProtocolVersion; value: T }>[],
+): Either.Either<Registry<T>, RegistryError> => {
+  const brokenAt = activations.findIndex(
+    (activation, index) => index > 0 && activation.sinceVersion <= activations[index - 1].sinceVersion,
+  );
+
+  if (brokenAt >= 0) {
+    return Either.left(
+      new RegistryError({
+        message: 'Protocol version activations must be strictly ascending.',
+        versions: [activations[brokenAt - 1].sinceVersion, activations[brokenAt].sinceVersion],
+      }),
+    );
+  }
+
+  const last = activations.at(-1);
+  if (last !== undefined && last.sinceVersion >= MaxSupportedVersion) {
+    return Either.left(
+      new RegistryError({
+        message: 'A protocol version activation must leave room for a range above it.',
+        versions: [last.sinceVersion],
+      }),
+    );
+  }
+
+  return Either.right({
+    entries: activations.map(({ sinceVersion, value }, index) => ({
+      range: makeRange(sinceVersion, activations[index + 1]?.sinceVersion ?? MaxSupportedVersion),
+      value,
+    })),
+  });
+};
+
+/**
+ * Finds the entry whose range contains a given protocol version.
+ *
+ * @param registry The {@link Registry} to search.
+ * @param version The version to find an entry for.
+ * @returns The matching entry, or `Option.none()` when no entry covers `version`.
+ */
+export const selectEntry = <T>(registry: Registry<T>, version: ProtocolVersion): Option.Option<RegistryEntry<T>> =>
+  Option.fromNullable(registry.entries.find((entry) => withinRange(version, entry.range)));
+
+/**
+ * Finds the value whose range contains a given protocol version.
+ *
+ * @param registry The {@link Registry} to search.
+ * @param version The version to find a value for.
+ * @returns The matching value, or `Option.none()` when no entry covers `version`.
+ */
+export const select = <T>(registry: Registry<T>, version: ProtocolVersion): Option.Option<T> =>
+  selectEntry(registry, version).pipe(Option.map((entry) => entry.value));

--- a/packages/abstractions/src/test/protocolState.test.ts
+++ b/packages/abstractions/src/test/protocolState.test.ts
@@ -1,0 +1,49 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { Equivalence } from 'effect';
+import { describe, expect, it } from 'vitest';
+import * as ProtocolState from '../ProtocolState.js';
+import * as ProtocolVersion from '../ProtocolVersion.js';
+
+const preFork: ProtocolState.ProtocolState<number, 'pre' | 'post'> = {
+  version: ProtocolVersion.ProtocolVersion(8n),
+  variantTag: 'pre',
+  state: 42,
+};
+
+const equals = ProtocolState.getEquivalence(Equivalence.number);
+
+describe('ProtocolState', () => {
+  it('projects the state out', () => {
+    expect(ProtocolState.state(preFork)).toBe(42);
+  });
+
+  describe('getEquivalence', () => {
+    it('holds for identical version, producing variant and state', () => {
+      expect(equals(preFork, { ...preFork })).toBe(true);
+    });
+
+    it('distinguishes states produced by different variants', () => {
+      expect(equals(preFork, { ...preFork, variantTag: 'post' })).toBe(false);
+    });
+
+    it('distinguishes different protocol versions', () => {
+      expect(equals(preFork, { ...preFork, version: ProtocolVersion.ProtocolVersion(9n) })).toBe(false);
+    });
+
+    it('defers to the supplied state equivalence', () => {
+      expect(equals(preFork, { ...preFork, state: 43 })).toBe(false);
+      expect(ProtocolState.getEquivalence<number>(() => true)(preFork, { ...preFork, state: 43 })).toBe(true);
+    });
+  });
+});

--- a/packages/abstractions/src/test/protocolVersionRegistry.test.ts
+++ b/packages/abstractions/src/test/protocolVersionRegistry.test.ts
@@ -1,0 +1,205 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { Either, Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import * as ProtocolVersion from '../ProtocolVersion.js';
+
+const version = (value: bigint): ProtocolVersion.ProtocolVersion => ProtocolVersion.ProtocolVersion(value);
+
+const range = (start: bigint, end: bigint): ProtocolVersion.ProtocolVersion.Range =>
+  ProtocolVersion.makeRange(version(start), version(end));
+
+/** The registry the routing use cases have: one value per protocol era, the last era open-ended. */
+const eras = (): ProtocolVersion.Registry<string> =>
+  ProtocolVersion.makeRegistryFromActivations([
+    { sinceVersion: ProtocolVersion.MinSupportedVersion, value: 'v8' },
+    { sinceVersion: version(100n), value: 'v9' },
+  ]).pipe(Either.getOrThrow);
+
+describe('ProtocolVersion.Registry', () => {
+  describe('makeRegistry', () => {
+    it('accepts ascending, non-overlapping ranges and keeps them in registration order', () => {
+      const registry = ProtocolVersion.makeRegistry([
+        { range: range(0n, 100n), value: 'first' },
+        { range: range(100n, 200n), value: 'second' },
+      ]);
+
+      expect(registry).toStrictEqual(
+        Either.right({
+          entries: [
+            { range: range(0n, 100n), value: 'first' },
+            { range: range(100n, 200n), value: 'second' },
+          ],
+        }),
+      );
+    });
+
+    it('accepts gaps between ranges', () => {
+      const registry = ProtocolVersion.makeRegistry([
+        { range: range(0n, 10n), value: 'first' },
+        { range: range(50n, 60n), value: 'second' },
+      ]);
+
+      expect(Either.isRight(registry)).toBe(true);
+    });
+
+    it('accepts no entries at all', () => {
+      expect(ProtocolVersion.makeRegistry<string>([])).toStrictEqual(Either.right(ProtocolVersion.emptyRegistry));
+    });
+
+    it('rejects overlapping ranges, naming the boundary versions that overlap', () => {
+      const registry = ProtocolVersion.makeRegistry([
+        { range: range(0n, 100n), value: 'first' },
+        { range: range(99n, 200n), value: 'second' },
+      ]);
+
+      const error = registry.pipe(Either.flip, Either.getOrThrow);
+
+      expect(error._tag).toBe('@midnightntwrk/wallet-sdk-abstractions/ProtocolVersion/RegistryError');
+      expect(error.versions).toStrictEqual([version(100n), version(99n)]);
+    });
+
+    it('rejects ranges given out of ascending order', () => {
+      const registry = ProtocolVersion.makeRegistry([
+        { range: range(100n, 200n), value: 'second' },
+        { range: range(0n, 100n), value: 'first' },
+      ]);
+
+      const error = registry.pipe(Either.flip, Either.getOrThrow);
+
+      expect(error.versions).toStrictEqual([version(200n), version(0n)]);
+    });
+  });
+
+  describe('makeRegistryFromActivations', () => {
+    it('derives half-open ranges, running the last activation up to the maximum supported version', () => {
+      const registry = ProtocolVersion.makeRegistryFromActivations([
+        { sinceVersion: ProtocolVersion.MinSupportedVersion, value: 'v8' },
+        { sinceVersion: version(100n), value: 'v9' },
+      ]);
+
+      expect(registry).toStrictEqual(
+        Either.right({
+          entries: [
+            { range: ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, version(100n)), value: 'v8' },
+            { range: ProtocolVersion.makeRange(version(100n), ProtocolVersion.MaxSupportedVersion), value: 'v9' },
+          ],
+        }),
+      );
+    });
+
+    it('gives a single activation the whole range above it', () => {
+      const registry = ProtocolVersion.makeRegistryFromActivations([{ sinceVersion: version(7n), value: 'only' }]);
+
+      expect(registry).toStrictEqual(
+        Either.right({
+          entries: [
+            { range: ProtocolVersion.makeRange(version(7n), ProtocolVersion.MaxSupportedVersion), value: 'only' },
+          ],
+        }),
+      );
+    });
+
+    it('accepts no activations at all', () => {
+      expect(ProtocolVersion.makeRegistryFromActivations<string>([])).toStrictEqual(
+        Either.right(ProtocolVersion.emptyRegistry),
+      );
+    });
+
+    it('rejects two activations at the same version', () => {
+      const registry = ProtocolVersion.makeRegistryFromActivations([
+        { sinceVersion: version(100n), value: 'first' },
+        { sinceVersion: version(100n), value: 'second' },
+      ]);
+
+      const error = registry.pipe(Either.flip, Either.getOrThrow);
+
+      expect(error._tag).toBe('@midnightntwrk/wallet-sdk-abstractions/ProtocolVersion/RegistryError');
+      expect(error.versions).toStrictEqual([version(100n), version(100n)]);
+    });
+
+    it('rejects activations given out of ascending order', () => {
+      const registry = ProtocolVersion.makeRegistryFromActivations([
+        { sinceVersion: version(100n), value: 'second' },
+        { sinceVersion: version(50n), value: 'first' },
+      ]);
+
+      const error = registry.pipe(Either.flip, Either.getOrThrow);
+
+      expect(error.versions).toStrictEqual([version(100n), version(50n)]);
+    });
+
+    it('rejects an activation at the maximum supported version, which no range can follow', () => {
+      const registry = ProtocolVersion.makeRegistryFromActivations([
+        { sinceVersion: ProtocolVersion.MaxSupportedVersion, value: 'unreachable' },
+      ]);
+
+      const error = registry.pipe(Either.flip, Either.getOrThrow);
+
+      expect(error.versions).toStrictEqual([ProtocolVersion.MaxSupportedVersion]);
+    });
+  });
+
+  describe('select', () => {
+    it('returns the value whose range contains the version', () => {
+      expect(ProtocolVersion.select(eras(), version(0n))).toStrictEqual(Option.some('v8'));
+      expect(ProtocolVersion.select(eras(), version(99n))).toStrictEqual(Option.some('v8'));
+      expect(ProtocolVersion.select(eras(), version(100n))).toStrictEqual(Option.some('v9'));
+      expect(ProtocolVersion.select(eras(), version(1_000n))).toStrictEqual(Option.some('v9'));
+    });
+
+    it('includes the start of a range and excludes its end', () => {
+      const registry = ProtocolVersion.makeRegistry([{ range: range(10n, 20n), value: 'middle' }]).pipe(
+        Either.getOrThrow,
+      );
+
+      expect(ProtocolVersion.select(registry, version(9n))).toStrictEqual(Option.none());
+      expect(ProtocolVersion.select(registry, version(10n))).toStrictEqual(Option.some('middle'));
+      expect(ProtocolVersion.select(registry, version(19n))).toStrictEqual(Option.some('middle'));
+      expect(ProtocolVersion.select(registry, version(20n))).toStrictEqual(Option.none());
+    });
+
+    it('returns none inside a gap between ranges', () => {
+      const registry = ProtocolVersion.makeRegistry([
+        { range: range(0n, 10n), value: 'first' },
+        { range: range(50n, 60n), value: 'second' },
+      ]).pipe(Either.getOrThrow);
+
+      expect(ProtocolVersion.select(registry, version(25n))).toStrictEqual(Option.none());
+    });
+
+    it('returns none for an empty registry', () => {
+      expect(ProtocolVersion.select(ProtocolVersion.emptyRegistry, version(0n))).toStrictEqual(Option.none());
+    });
+
+    it('never throws for a version no entry covers', () => {
+      expect(() => ProtocolVersion.select(eras(), ProtocolVersion.MaxSupportedVersion)).not.toThrow();
+      expect(ProtocolVersion.select(eras(), ProtocolVersion.MaxSupportedVersion)).toStrictEqual(Option.none());
+    });
+  });
+
+  describe('selectEntry', () => {
+    it('returns the whole entry, so callers can read the range they matched', () => {
+      expect(ProtocolVersion.selectEntry(eras(), version(120n))).toStrictEqual(
+        Option.some({
+          range: ProtocolVersion.makeRange(version(100n), ProtocolVersion.MaxSupportedVersion),
+          value: 'v9',
+        }),
+      );
+    });
+
+    it('returns none when no entry covers the version', () => {
+      expect(ProtocolVersion.selectEntry(ProtocolVersion.emptyRegistry, version(0n))).toStrictEqual(Option.none());
+    });
+  });
+});

--- a/packages/dust-wallet/src/DustWallet.ts
+++ b/packages/dust-wallet/src/DustWallet.ts
@@ -24,7 +24,7 @@ import { type DustAddress } from '@midnightntwrk/wallet-sdk-address-format';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
 import { type Variant, type VariantBuilder, type WalletLike } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type Clock } from '@midnightntwrk/wallet-sdk-utilities';
-import { Effect, Either, Option, Ref, type Scope } from 'effect';
+import { type Duration, Effect, Either, Option, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
 import { type Balance, type CoinsAndBalancesCapability, type UtxoWithFullDustDetails } from './v2/CoinsAndBalances.js';
 import { CoreWallet } from './v2/CoreWallet.js';
@@ -34,7 +34,9 @@ import { type SerializationCapability } from './v2/Serialization.js';
 import { type NightUtxoSplitForDustRegistration } from './v2/Transacting.js';
 import { type DustFullInfo, type UtxoWithMeta } from './v2/types/Dust.js';
 import { type AnyTransaction } from './v2/types/ledger.js';
-import { type BaseV2Configuration, type DefaultV2Configuration, type V2Variant, V2Builder } from './v2/V2Builder.js';
+import { type BaseV2Configuration, type V2Variant, V2Builder } from './v2/V2Builder.js';
+import { type DustHistoryStorage } from './v2/TransactionHistory.js';
+import { type NetworkId, type TotalCostParameters } from './v2/types/index.js';
 import { type WalletSyncUpdate, type BlockData } from './v2/SyncSchema.js';
 
 export type { BlockData } from './v2/SyncSchema.js';
@@ -217,7 +219,26 @@ export type CustomizedDustWallet<
 > = DustWalletAPI<TStartAux, TSerialized> &
   WalletLike.WalletLike<[Variant.VersionedVariant<V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>>]>;
 
-export type DefaultDustConfiguration = DefaultV2Configuration;
+/**
+ * The configuration a default {@link DustWallet} is built from.
+ *
+ * @remarks
+ *   Declared by this package rather than aliased to a variant's configuration. A wallet that spans a protocol boundary is
+ *   built from more than one variant, so no single variant's configuration can be the wallet's public contract: the
+ *   package states what it asks an application for, and maps it onto whichever variants it registers.
+ *
+ *   `dustParameters` is the one field here that names a ledger type. It is version-agnostic only because the two ledgers'
+ *   `DustParameters` are structurally identical; `configuration.test.ts` asserts that, so a divergence surfaces as a
+ *   compile error here instead of as a wallet that cannot be built for one of its variants.
+ */
+export type DefaultDustConfiguration = {
+  networkId: NetworkId;
+  costParameters: TotalCostParameters;
+  dustParameters?: DustParameters;
+  txHistoryStorage: DustHistoryStorage;
+  indexerClientConnection: { indexerHttpUrl: string };
+  transactionDetailsRetryWindow?: Duration.DurationInput;
+};
 
 export interface CustomizedDustWalletClass<
   TStartAux = DustSecretKey,

--- a/packages/dust-wallet/src/test/configuration.test.ts
+++ b/packages/dust-wallet/src/test/configuration.test.ts
@@ -1,0 +1,49 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { type DustParameters } from '@midnightntwrk/ledger-v9';
+import { type CanAssign, type Equal, type Expect } from '@midnightntwrk/wallet-sdk-utilities/types';
+import { type Duration } from 'effect';
+import { describe, it } from 'vitest';
+import { type DefaultDustConfiguration } from '../DustWallet.js';
+import { type DefaultV1Configuration } from '../v1/V1Builder.js';
+import { type TransactionHistory as V2TransactionHistory } from '../v2/index.js';
+import { type NetworkId, type TotalCostParameters } from '../v2/types/index.js';
+import { type DefaultV2Configuration } from '../v2/V2Builder.js';
+
+describe('DefaultDustConfiguration', () => {
+  it('is a configuration the package declares itself, not the head variant s', () => {
+    type _1 = Expect<
+      Equal<
+        DefaultDustConfiguration,
+        {
+          networkId: NetworkId;
+          costParameters: TotalCostParameters;
+          dustParameters?: DustParameters;
+          txHistoryStorage: V2TransactionHistory.DustHistoryStorage;
+          indexerClientConnection: { indexerHttpUrl: string };
+          transactionDetailsRetryWindow?: Duration.DurationInput;
+        }
+      >
+    >;
+  });
+
+  it('stays interchangeable with what either variant is built from', () => {
+    type _1 = Expect<CanAssign<DefaultDustConfiguration, DefaultV2Configuration>>;
+    type _2 = Expect<CanAssign<DefaultV2Configuration, DefaultDustConfiguration>>;
+    // The pre-fork variant types `dustParameters` with ledger-v8's class rather than ledger-v9's. The two are
+    // structurally identical, which is the only reason one configuration can serve both — asserted here so a
+    // divergence shows up as a compile error rather than as a wallet that cannot be built for one of its variants.
+    type _3 = Expect<CanAssign<DefaultDustConfiguration, DefaultV1Configuration>>;
+    type _4 = Expect<CanAssign<DefaultV1Configuration, DefaultDustConfiguration>>;
+  });
+});

--- a/packages/runtime/src/Runtime.ts
+++ b/packages/runtime/src/Runtime.ts
@@ -15,12 +15,15 @@ import { type ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-a
 import { StateChange, type Variant, VersionChangeType, WalletRuntimeError } from './abstractions/index.js';
 import { EitherOps, HList, Poly } from '@midnightntwrk/wallet-sdk-utilities';
 
+/** The state a {@link Runtime} publishes: the variant's state, the protocol version, and the variant that produced it. */
+export type RuntimeState<Variants extends Variant.AnyVersionedVariantArray> = ProtocolState.ProtocolState<
+  Variant.StateOf<HList.Each<Variants>>,
+  Variant.VariantTag<HList.Each<Variants>>
+>;
+
 /** The {@link Runtime} service type. */
 export interface Runtime<Variants extends Variant.AnyVersionedVariantArray> {
-  readonly stateChanges: Stream.Stream<
-    ProtocolState.ProtocolState<Variant.StateOf<HList.Each<Variants>>>,
-    WalletRuntimeError
-  >;
+  readonly stateChanges: Stream.Stream<RuntimeState<Variants>, WalletRuntimeError>;
 
   readonly progress: Effect.Effect<Progress>;
 
@@ -103,9 +106,13 @@ export const init = <Variants extends Variant.AnyVersionedVariantArray, InitTag 
     Effect.bind('currentStateRef', ({ initiatedFirstVariant }) =>
       initiatedFirstVariant.currentStateRef.get.pipe(
         Effect.flatMap((state: Variant.StateOf<HList.Each<Variants>>) =>
-          SubscriptionRef.make<
-            Either.Either<ProtocolState.ProtocolState<Variant.StateOf<HList.Each<Variants>>>, WalletRuntimeError>
-          >(Either.right({ version: initiatedFirstVariant.initProtocolVersion, state })),
+          SubscriptionRef.make<Either.Either<RuntimeState<Variants>, WalletRuntimeError>>(
+            Either.right({
+              version: initiatedFirstVariant.initProtocolVersion,
+              variantTag: variantTagOf(initiatedFirstVariant),
+              state,
+            }),
+          ),
         ),
       ),
     ),
@@ -189,6 +196,18 @@ export const init = <Variants extends Variant.AnyVersionedVariantArray, InitTag 
     }),
   );
 };
+
+/**
+ * The tag of the variant a running variant record belongs to, narrowed to the tags this runtime can produce.
+ *
+ * @remarks
+ *   Type cast required because: inside a function generic over `Variants`, `EachRunningVariant` still describes its tag
+ *   through the `AnyVariant` constraint, so the property reads as `string | symbol`. The value is the same one
+ *   `initHeadVariant` copies off the variant it started, which is by construction one of `Variants`.
+ */
+const variantTagOf = <Variants extends Variant.AnyVersionedVariantArray>(
+  running: EachRunningVariant<Variants>,
+): Variant.VariantTag<HList.Each<Variants>> => running.__polyTag__ as Variant.VariantTag<HList.Each<Variants>>;
 
 export const dispatch = <Variants extends Variant.AnyVersionedVariantArray, TResult, E = never>(
   runtime: Runtime<Variants>,
@@ -298,9 +317,7 @@ const initHeadVariant = <Variants extends Variant.AnyVersionedVariantArray>(
 
 const runVariantStream = <Variants extends Variant.AnyVersionedVariantArray>(
   initiatedVariant: EachRunningVariant<Variants>,
-  stateRef: SubscriptionRef.SubscriptionRef<
-    Either.Either<ProtocolState.ProtocolState<Variant.StateOf<HList.Each<Variants>>>, WalletRuntimeError>
-  >,
+  stateRef: SubscriptionRef.SubscriptionRef<Either.Either<RuntimeState<Variants>, WalletRuntimeError>>,
   progressRef: SynchronizedRef.SynchronizedRef<Progress>,
   currentVariantRef: SynchronizedRef.SynchronizedRef<EachRunningVariant<Variants>>,
   activations: PubSub.PubSub<EachRunningVariant<Variants>>,
@@ -326,7 +343,14 @@ const runVariantStream = <Variants extends Variant.AnyVersionedVariantArray>(
         State: ({ state }) => {
           return SubscriptionRef.set(
             stateRef,
-            Either.right({ version: accumulator.protocolVersion, state } as const),
+            // The tag is taken from the variant whose stream this is, so an emission can never be
+            // attributed to a variant that did not produce it — including across a migration, where
+            // this function is re-entered with the newly activated variant.
+            Either.right({
+              version: accumulator.protocolVersion,
+              variantTag: variantTagOf(initiatedVariant),
+              state,
+            } as const),
           ).pipe(Effect.as({ ...accumulator, lastState: state }));
         },
         ProgressUpdate: (progress) => {

--- a/packages/runtime/src/WalletBuilder.ts
+++ b/packages/runtime/src/WalletBuilder.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 import { Effect, Exit, type Option, Scope, type Types } from 'effect';
 import * as rx from 'rxjs';
-import { type ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Variant, type VariantBuilder, type WalletLike, WalletRuntimeError } from './abstractions/index.js';
 import { type StateOf } from './abstractions/Variant.js';
 import { ObservableOps, HList, type Poly } from '@midnightntwrk/wallet-sdk-utilities';
@@ -84,7 +84,6 @@ export class WalletBuilder<TBuilders extends VariantBuilder.AnyVersionedVariantB
     ) as Variants;
 
     type WalletRuntime = Runtime.Runtime<Variants>;
-    type WalletState = Variant.StateOf<HList.Each<Variants>>;
 
     return class BaseWallet implements WalletLike.WalletLike<Variants> {
       static readonly configuration: WalletBuilder.FullConfiguration<TBuilders> = (maybeConfiguration ??
@@ -142,7 +141,7 @@ export class WalletBuilder<TBuilders extends VariantBuilder.AnyVersionedVariantB
 
       readonly runtime: WalletRuntime;
       readonly runtimeScope: Scope.CloseableScope;
-      readonly rawState: rx.Observable<ProtocolState.ProtocolState<WalletState>>;
+      readonly rawState: rx.Observable<Runtime.RuntimeState<Variants>>;
 
       get syncComplete(): boolean {
         const { sourceGap, applyGap } = Effect.runSync(this.runtime.progress);

--- a/packages/runtime/src/WalletBuilder.ts
+++ b/packages/runtime/src/WalletBuilder.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { Effect, Exit, Scope, type Types } from 'effect';
+import { Effect, Exit, type Option, Scope, type Types } from 'effect';
 import * as rx from 'rxjs';
 import { type ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Variant, type VariantBuilder, type WalletLike, WalletRuntimeError } from './abstractions/index.js';
@@ -96,6 +96,10 @@ export class WalletBuilder<TBuilders extends VariantBuilder.AnyVersionedVariantB
 
       static allVariantsRecord(): Variant.VariantRecord<Variants> {
         return Variant.makeVersionedRecord(BaseWallet.allVariants());
+      }
+
+      static variantFor(version: ProtocolVersion.ProtocolVersion): Option.Option<HList.Each<Variants>> {
+        return Variant.selectByRange(BaseWallet.allVariants(), version);
       }
 
       static startEmpty<T extends WalletLike.AnyWalletClass<Variants>>(WalletClass: T): WalletLike.WalletOf<T> {

--- a/packages/runtime/src/WalletBuilder.ts
+++ b/packages/runtime/src/WalletBuilder.ts
@@ -38,7 +38,7 @@ export class WalletBuilder<TBuilders extends VariantBuilder.AnyVersionedVariantB
   readonly #buildState: WalletBuilder.BuildState<TBuilders>;
 
   /**
-   * Ensures that the built wallet uses a given variant.
+   * Ensures that the built wallet uses a given variant, configured together with every other variant at build time.
    *
    * @param sinceVersion The Midnight protocol version that the variant should operate from.
    * @param variantBuilder A {@link VariantBuilder} that builds the variant.
@@ -47,7 +47,30 @@ export class WalletBuilder<TBuilders extends VariantBuilder.AnyVersionedVariantB
   withVariant<TBuilder extends VariantBuilder.AnyVariantBuilder>(
     sinceVersion: ProtocolVersion.ProtocolVersion,
     variantBuilder: TBuilder,
-  ): WalletBuilder<HList.Append<TBuilders, VariantBuilder.VersionedVariantBuilder<TBuilder>>> {
+  ): WalletBuilder<HList.Append<TBuilders, VariantBuilder.VersionedVariantBuilder<TBuilder>>>;
+  /**
+   * Ensures that the built wallet uses a given variant, built from a configuration of its own.
+   *
+   * @remarks
+   *   The variant is settled at registration, so nothing about it is left for `build` to ask for. Use this where two
+   *   variants cannot share one configuration — the same key meaning different, mutually unassignable things on either
+   *   side of a protocol boundary — and where a caller would otherwise have to invent a merged configuration that no
+   *   single variant can consume.
+   * @param sinceVersion The Midnight protocol version that the variant should operate from.
+   * @param variantBuilder A {@link VariantBuilder} that builds the variant.
+   * @param configuration The configuration to build this variant, and only this variant, from.
+   * @returns A new {@link WalletBuilder} that uses the variant that will be built from `variantBuilder`.
+   */
+  withVariant<TBuilder extends VariantBuilder.AnyVariantBuilder>(
+    sinceVersion: ProtocolVersion.ProtocolVersion,
+    variantBuilder: TBuilder,
+    configuration: VariantBuilder.ConfigurationOf<TBuilder>,
+  ): WalletBuilder<HList.Append<TBuilders, VariantBuilder.SelfConfiguredVariantBuilder<TBuilder>>>;
+  withVariant<TBuilder extends VariantBuilder.AnyVariantBuilder>(
+    sinceVersion: ProtocolVersion.ProtocolVersion,
+    variantBuilder: TBuilder,
+    configuration?: VariantBuilder.ConfigurationOf<TBuilder>,
+  ): WalletBuilder<HList.Append<TBuilders, VariantBuilder.AnyVersionedVariantBuilder>> {
     const { sinceVersion: previousVersion } = this.#buildState.variants.at(-1) ?? {
       sinceVersion: ProtocolVersion.ProtocolVersion(-1n),
     };
@@ -56,9 +79,10 @@ export class WalletBuilder<TBuilders extends VariantBuilder.AnyVersionedVariantB
       throw new Error('ProtocolMismatch: sinceVersion is prior to previously registered version');
     }
 
-    const newBuilder: VariantBuilder.VersionedVariantBuilder<TBuilder> = { sinceVersion, variantBuilder };
+    const newBuilder: VariantBuilder.AnyVersionedVariantBuilder =
+      configuration === undefined ? { sinceVersion, variantBuilder } : { sinceVersion, variantBuilder, configuration };
 
-    return new WalletBuilder<HList.Append<TBuilders, VariantBuilder.VersionedVariantBuilder<TBuilder>>>({
+    return new WalletBuilder<HList.Append<TBuilders, VariantBuilder.AnyVersionedVariantBuilder>>({
       variants: HList.append(this.#buildState.variants, newBuilder),
     });
   }
@@ -77,9 +101,13 @@ export class WalletBuilder<TBuilders extends VariantBuilder.AnyVersionedVariantB
     }
 
     const variants: Variants = this.#buildState.variants.map(
-      ({ sinceVersion, variantBuilder }): Variant.VersionedVariant<Variant.AnyVariant> => ({
-        sinceVersion,
-        variant: variantBuilder.build(maybeConfiguration ?? {}),
+      (registered): Variant.VersionedVariant<Variant.AnyVariant> => ({
+        sinceVersion: registered.sinceVersion,
+        // A variant registered with its own configuration is built from that and nothing else: what
+        // `build` was handed is, by construction, not addressed to it.
+        variant: registered.variantBuilder.build(
+          'configuration' in registered ? registered.configuration : (maybeConfiguration ?? {}),
+        ),
       }),
     ) as Variants;
 
@@ -183,7 +211,6 @@ export declare namespace WalletBuilder {
 
   type VoidIfEmpty<TObject> = keyof TObject extends never ? undefined : TObject;
 
-  type Configurations<TBuilders extends VariantBuilder.AnyVersionedVariantBuilder[]> = VariantBuilder.ConfigurationOf<
-    HList.Each<TBuilders>
-  >;
+  type Configurations<TBuilders extends VariantBuilder.AnyVersionedVariantBuilder[]> =
+    VariantBuilder.PendingConfigurationOf<HList.Each<TBuilders>>;
 }

--- a/packages/runtime/src/abstractions/Variant.ts
+++ b/packages/runtime/src/abstractions/Variant.ts
@@ -11,11 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 /* eslint-disable @typescript-eslint/no-explicit-any -- unknown does not work well as a default, because it causes assignability issues */
-import { type Scope, type SubscriptionRef } from 'effect';
+import { Either, Option, type Scope, type SubscriptionRef } from 'effect';
 import type { Effect } from 'effect/Effect';
 import type { Stream } from 'effect/Stream';
-import { Poly } from '@midnightntwrk/wallet-sdk-utilities';
-import type { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type HList, Poly } from '@midnightntwrk/wallet-sdk-utilities';
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type WalletRuntimeError } from './WalletRuntimeError.js';
 import type * as StateChange from './StateChange.js';
 
@@ -127,8 +127,16 @@ export type VariantRecord<Variants> = Variants extends [infer THead, ...infer TR
   : Variants extends []
     ? object
     : never;
-export const getVersionedVariantTag = <Variant extends AnyVariant>(v: VersionedVariant<Variant>): VariantTag<Variant> =>
-  Poly.getTag(v.variant) as VariantTag<Variant>;
+/**
+ * Reads the tag of the variant a {@link VersionedVariant} wraps.
+ *
+ * @remarks
+ *   Generic over the versioned variant rather than over the variant inside it, so that a union — what
+ *   {@link selectByRange} resolves to — yields the union of its tags instead of collapsing to the first member's.
+ */
+export const getVersionedVariantTag = <TVersionedVariant extends AnyVersionedVariant>(
+  v: TVersionedVariant,
+): VariantTag<TVersionedVariant> => Poly.getTag(v.variant) as VariantTag<TVersionedVariant>;
 export const makeVersionedRecord = <Variants extends AnyVersionedVariantArray>(
   variants: Variants,
 ): VariantRecord<Variants> => {
@@ -136,3 +144,32 @@ export const makeVersionedRecord = <Variants extends AnyVersionedVariantArray>(
     return { ...acc, [getVersionedVariantTag(variant)]: variant };
   }, {}) as VariantRecord<Variants>;
 };
+
+/**
+ * Finds the variant that is active for a given protocol version.
+ *
+ * @remarks
+ *   Registration says only which version a variant starts answering for, so the range it owns is `[sinceVersion,
+ *   nextVariantSinceVersion)` — the same half-open window the runtime hands a starting variant as
+ *   {@link VariantContext.activationRange}, derived here through the shared
+ *   {@link ProtocolVersion.makeRegistryFromActivations} so the two cannot disagree.
+ *
+ *   Selection is total: a version below the first registration, or a registration order the builder would have rejected
+ *   anyway (`withVariant` throws on a version that is not strictly ascending), selects nothing rather than throwing.
+ *   Callers decide what a miss means — for restoring a snapshot it is an unsupported snapshot version, not a defect.
+ * @param variants The registered variants, in ascending order of `sinceVersion`.
+ * @param version The protocol version to resolve.
+ * @returns The versioned variant whose activation range contains `version`, if there is one.
+ */
+export const selectByRange = <Variants extends AnyVersionedVariantArray>(
+  variants: Variants,
+  version: ProtocolVersion.ProtocolVersion,
+): Option.Option<HList.Each<Variants>> =>
+  ProtocolVersion.makeRegistryFromActivations(
+    variants.map((variant: HList.Each<Variants>) => ({ sinceVersion: variant.sinceVersion, value: variant })),
+  ).pipe(
+    Either.match({
+      onLeft: (): Option.Option<HList.Each<Variants>> => Option.none(),
+      onRight: (registry) => ProtocolVersion.select(registry, version),
+    }),
+  );

--- a/packages/runtime/src/abstractions/VariantBuilder.ts
+++ b/packages/runtime/src/abstractions/VariantBuilder.ts
@@ -49,6 +49,25 @@ export type VersionedVariantBuilder<TBuilder extends AnyVariantBuilder> = Readon
   variantBuilder: TBuilder;
 }>;
 
+/**
+ * A {@link VersionedVariantBuilder} registered together with the configuration it is to be built from.
+ *
+ * @remarks
+ *   A wallet's build-time configuration is the intersection of what its variants need, which works only while every
+ *   variant means the same thing by a given key. Across a protocol boundary they need not: two variants speaking
+ *   different ledgers can both want a `simulator`, or a `dustParameters`, of mutually unassignable types. Registering a
+ *   variant with its own configuration settles that at registration instead, and takes it out of the intersection —
+ *   nothing about it is left for `build` to ask for.
+ */
+export type SelfConfiguredVariantBuilder<TBuilder extends AnyVariantBuilder> = Readonly<{
+  sinceVersion: ProtocolVersion.ProtocolVersion;
+  variantBuilder: TBuilder;
+  configuration: ConfigurationOf<TBuilder>;
+}>;
+
+/** A utility type that represents any {@link SelfConfiguredVariantBuilder}. */
+export type AnySelfConfiguredVariantBuilder = SelfConfiguredVariantBuilder<AnyVariantBuilder>;
+
 export type VariantsOf<T> = T extends [infer THead, ...infer TRest]
   ? [VariantOf<THead>, ...VariantsOf<TRest>]
   : T extends []
@@ -69,5 +88,11 @@ export type ConfigurationOf<T> =
       ? ConfigurationOf<Builder>
       : never;
 
+/**
+ * The part of a registered variant's configuration that is still owed at build time: nothing at all, once the variant
+ * has been registered with its own.
+ */
+export type PendingConfigurationOf<T> = T extends AnySelfConfiguredVariantBuilder ? never : ConfigurationOf<T>;
+
 /** A type that associates a {@link VariantBuilder} with a given version of the Midnight protocol. */
-export type AnyVersionedVariantBuilder = VersionedVariantBuilder<AnyVariantBuilder>;
+export type AnyVersionedVariantBuilder = VersionedVariantBuilder<AnyVariantBuilder> | AnySelfConfiguredVariantBuilder;

--- a/packages/runtime/src/abstractions/WalletLike.ts
+++ b/packages/runtime/src/abstractions/WalletLike.ts
@@ -11,12 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { type Scope } from 'effect';
+import { type Option, type Scope } from 'effect';
 import { type Observable } from 'rxjs';
 import { type Runtime } from '../Runtime.js';
 import { type AnyVersionedVariantArray, type StateOf, type VariantRecord } from './Variant.js';
 import { type HList, type Poly } from '@midnightntwrk/wallet-sdk-utilities';
-import { type ProtocolState } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ProtocolState, type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 
 /** Defines the static portion of base wallet class definition */
 export interface BaseWalletClass<TVariants extends AnyVersionedVariantArray, TConfiguration = object> {
@@ -24,6 +24,15 @@ export interface BaseWalletClass<TVariants extends AnyVersionedVariantArray, TCo
   new (runtime: Runtime<TVariants>, scope: Scope.CloseableScope): WalletLike<TVariants>;
   allVariants(): TVariants;
   allVariantsRecord(): VariantRecord<TVariants>;
+  /**
+   * Resolves the variant that is active for a given protocol version, so a caller holding only a version — a snapshot's
+   * envelope, the chain's current version — can address {@link start} by the tag of the variant that owns it.
+   *
+   * @param version The protocol version to resolve.
+   * @returns The versioned variant whose activation range contains `version`, or `Option.none()` when no registered
+   *   variant covers it.
+   */
+  variantFor(version: ProtocolVersion.ProtocolVersion): Option.Option<HList.Each<TVariants>>;
   startEmpty<T extends WalletClassLike<TVariants, any>>(walletClass: T): WalletOf<T>;
   startFirst<T extends WalletClassLike<TVariants, any>>(
     walletClass: T,

--- a/packages/runtime/src/abstractions/WalletLike.ts
+++ b/packages/runtime/src/abstractions/WalletLike.ts
@@ -13,10 +13,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { type Option, type Scope } from 'effect';
 import { type Observable } from 'rxjs';
-import { type Runtime } from '../Runtime.js';
+import { type Runtime, type RuntimeState } from '../Runtime.js';
 import { type AnyVersionedVariantArray, type StateOf, type VariantRecord } from './Variant.js';
 import { type HList, type Poly } from '@midnightntwrk/wallet-sdk-utilities';
-import { type ProtocolState, type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 
 /** Defines the static portion of base wallet class definition */
 export interface BaseWalletClass<TVariants extends AnyVersionedVariantArray, TConfiguration = object> {
@@ -66,7 +66,7 @@ export interface WalletLike<TVariants extends AnyVersionedVariantArray> {
   readonly runtimeScope: Scope.CloseableScope;
 
   /** A stream of state changes over any amount of time that have been processed by the wallet. */
-  readonly rawState: Observable<ProtocolState.ProtocolState<StateOf<HList.Each<TVariants>>>>;
+  readonly rawState: Observable<RuntimeState<TVariants>>;
 
   /** Stops the wallet */
   stop(): Promise<void>;

--- a/packages/runtime/src/abstractions/test/variant.test.ts
+++ b/packages/runtime/src/abstractions/test/variant.test.ts
@@ -216,10 +216,13 @@ describe('Variant', () => {
     });
 
     it('infers the union of the registered variants', () => {
-      const selected = selectByRange(variants, ProtocolVersion.ProtocolVersion(100n));
+      const _selected = selectByRange(variants, ProtocolVersion.ProtocolVersion(100n));
 
       type _1 = Expect<
-        Equal<typeof selected, Option.Option<VersionedVariant<NumericRange> | VersionedVariant<NumericRangeMultiplier>>>
+        Equal<
+          typeof _selected,
+          Option.Option<VersionedVariant<NumericRange> | VersionedVariant<NumericRangeMultiplier>>
+        >
       >;
     });
   });

--- a/packages/runtime/src/abstractions/test/variant.test.ts
+++ b/packages/runtime/src/abstractions/test/variant.test.ts
@@ -13,6 +13,7 @@
 import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type HList, type Poly } from '@midnightntwrk/wallet-sdk-utilities';
 import type { Expect, Equal, CanAssign } from '@midnightntwrk/wallet-sdk-utilities/types';
+import { Option } from 'effect';
 import { describe, expect, it } from 'vitest';
 import {
   type InterceptingRunningVariant,
@@ -26,6 +27,7 @@ import {
   makeVersionedRecord,
   type RunningVariant,
   type RunningVariantOf,
+  selectByRange,
   type StateOf,
   type VersionedVariant,
 } from '../Variant.js';
@@ -172,6 +174,52 @@ describe('Variant', () => {
           },
           typeof record
         >
+      >;
+    });
+  });
+
+  describe('selecting by protocol version', () => {
+    const preFork: VersionedVariant<NumericRange> = {
+      sinceVersion: ProtocolVersion.ProtocolVersion(10n),
+      variant: new NumericRange({ min: 0, max: 1 }, 1, false),
+    };
+    const postFork: VersionedVariant<NumericRangeMultiplier> = {
+      sinceVersion: ProtocolVersion.ProtocolVersion(100n),
+      variant: new NumericRangeMultiplier({ min: 0, max: 1, multiplier: 2 }),
+    };
+    const variants = [preFork, postFork] as [typeof preFork, typeof postFork];
+
+    it('selects the variant registered for the version', () => {
+      expect(selectByRange(variants, ProtocolVersion.ProtocolVersion(10n))).toStrictEqual(Option.some(preFork));
+      expect(selectByRange(variants, ProtocolVersion.ProtocolVersion(99n))).toStrictEqual(Option.some(preFork));
+    });
+
+    it('hands a version over to the next variant exactly at its registration version', () => {
+      expect(selectByRange(variants, ProtocolVersion.ProtocolVersion(100n))).toStrictEqual(Option.some(postFork));
+    });
+
+    it('leaves the last registered variant answering for every version above it', () => {
+      expect(selectByRange(variants, ProtocolVersion.ProtocolVersion(1_000_000n))).toStrictEqual(Option.some(postFork));
+    });
+
+    it('selects nothing below the first registration', () => {
+      expect(selectByRange(variants, ProtocolVersion.ProtocolVersion(9n))).toStrictEqual(Option.none());
+      expect(selectByRange(variants, ProtocolVersion.MinSupportedVersion)).toStrictEqual(Option.none());
+    });
+
+    it('selects nothing at all when nothing is registered', () => {
+      expect(selectByRange([], ProtocolVersion.MinSupportedVersion)).toStrictEqual(Option.none());
+    });
+
+    it('selects nothing at the maximum supported version, which bounds the last range', () => {
+      expect(selectByRange(variants, ProtocolVersion.MaxSupportedVersion)).toStrictEqual(Option.none());
+    });
+
+    it('infers the union of the registered variants', () => {
+      const selected = selectByRange(variants, ProtocolVersion.ProtocolVersion(100n));
+
+      type _1 = Expect<
+        Equal<typeof selected, Option.Option<VersionedVariant<NumericRange> | VersionedVariant<NumericRangeMultiplier>>>
       >;
     });
   });

--- a/packages/runtime/src/test/runtime.test.ts
+++ b/packages/runtime/src/test/runtime.test.ts
@@ -70,16 +70,16 @@ describe('Wallet runtime', () => {
     // state, but may skip intermediate states when it lags behind the producer. Collect until the
     // terminal state arrives and assert order-preserving delivery against the full emission.
     const fullStateSequence = [
-      { version: ProtocolVersion.MinSupportedVersion, state: 0 },
-      { version: ProtocolVersion.MinSupportedVersion, state: 0 },
-      { version: ProtocolVersion.MinSupportedVersion, state: 1 },
-      { version: ProtocolVersion.ProtocolVersion(50n), state: 1 }, // This is expected to be emitted by the intercepting variant
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 4 }, // This is the rest
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 6 },
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 8 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 0 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 0 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 1 },
+      { version: ProtocolVersion.ProtocolVersion(50n), variantTag: interceptingTag, state: 1 }, // This is expected to be emitted by the intercepting variant
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 4 }, // This is the rest
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 6 },
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 8 },
     ];
-    const allCollectedState = toProtocolStateArray<number>(
-      wallet.rawState.pipe(rx.takeWhile(({ state }: ProtocolState.ProtocolState<number>) => state !== 8, true)),
+    const allCollectedState = toProtocolStateArray(
+      wallet.rawState.pipe(rx.takeWhile(({ state }) => state !== 8, true)),
     );
 
     // Let's wait for the intercepting variant to be initiated to remove any chance of races
@@ -100,7 +100,11 @@ describe('Wallet runtime', () => {
 
     expect(dispatchResult).toBe(true);
     const receivedStates = await allCollectedState;
-    expect(receivedStates.at(-1)).toEqual({ version: ProtocolVersion.ProtocolVersion(100n), state: 8 });
+    expect(receivedStates.at(-1)).toEqual({
+      version: ProtocolVersion.ProtocolVersion(100n),
+      variantTag: NumericMultiplier,
+      state: 8,
+    });
     expect(receivedStates).toSatisfy((received: typeof receivedStates) =>
       isOrderedSubsequenceOf(received, fullStateSequence, protocolStateEquals),
     );
@@ -129,19 +133,23 @@ describe('Wallet runtime', () => {
     // Latest-value semantics: intermediate states may be skipped, but order is preserved and the
     // stream converges on the terminal state.
     const fullStateSequence = [
-      { version: ProtocolVersion.MinSupportedVersion, state: 42 },
-      { version: ProtocolVersion.MinSupportedVersion, state: 42 },
-      { version: ProtocolVersion.MinSupportedVersion, state: 43 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 42 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 42 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 43 },
       // The second variant starts applying the multiplier to the state (represents a protocol change).
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 88 },
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 90 },
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 92 },
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 88 },
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 90 },
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 92 },
     ];
     const receivedStates = await toProtocolStateArray(
-      wallet.rawState.pipe(rx.takeWhile(({ state }: ProtocolState.ProtocolState<number>) => state !== 92, true)),
+      wallet.rawState.pipe(rx.takeWhile(({ state }) => state !== 92, true)),
     );
 
-    expect(receivedStates.at(-1)).toEqual({ version: ProtocolVersion.ProtocolVersion(100n), state: 92 });
+    expect(receivedStates.at(-1)).toEqual({
+      version: ProtocolVersion.ProtocolVersion(100n),
+      variantTag: NumericMultiplier,
+      state: 92,
+    });
     expect(receivedStates).toSatisfy((received: typeof receivedStates) =>
       isOrderedSubsequenceOf(received, fullStateSequence, protocolStateEquals),
     );
@@ -166,13 +174,13 @@ describe('Wallet runtime', () => {
     // Latest-value semantics: intermediate states may be skipped, but order is preserved and the
     // stream converges on the terminal state.
     const fullStateSequence = [
-      { version: ProtocolVersion.ProtocolVersion(50n), state: 42 }, // this is the state we provided, and runtime automatically emits it
-      { version: ProtocolVersion.ProtocolVersion(50n), state: 42 }, // the intercepting variant emits it again on start
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 86 },
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 88 },
+      { version: ProtocolVersion.ProtocolVersion(50n), variantTag: Intercepting, state: 42 }, // this is the state we provided, and runtime automatically emits it
+      { version: ProtocolVersion.ProtocolVersion(50n), variantTag: Intercepting, state: 42 }, // the intercepting variant emits it again on start
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 86 },
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 88 },
     ];
-    const allCollectedState = toProtocolStateArray<number>(
-      wallet.rawState.pipe(rx.takeWhile(({ state }: ProtocolState.ProtocolState<number>) => state !== 88, true)),
+    const allCollectedState = toProtocolStateArray(
+      wallet.rawState.pipe(rx.takeWhile(({ state }) => state !== 88, true)),
     );
 
     await wallet.runtime
@@ -185,7 +193,11 @@ describe('Wallet runtime', () => {
       .pipe(Effect.runPromise);
 
     const receivedStates = await allCollectedState;
-    expect(receivedStates.at(-1)).toEqual({ version: ProtocolVersion.ProtocolVersion(100n), state: 88 });
+    expect(receivedStates.at(-1)).toEqual({
+      version: ProtocolVersion.ProtocolVersion(100n),
+      variantTag: NumericMultiplier,
+      state: 88,
+    });
     expect(receivedStates).toSatisfy((received: typeof receivedStates) =>
       isOrderedSubsequenceOf(received, fullStateSequence, protocolStateEquals),
     );
@@ -206,19 +218,23 @@ describe('Wallet runtime', () => {
     // Latest-value semantics: intermediate states may be skipped, but order is preserved and the
     // stream converges on the terminal state.
     const fullStateSequence = [
-      { version: ProtocolVersion.MinSupportedVersion, state: 42 }, // The initial state is emitted both by runtime and the variant
-      { version: ProtocolVersion.MinSupportedVersion, state: 42 },
-      { version: ProtocolVersion.MinSupportedVersion, state: 43 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 42 }, // The initial state is emitted both by runtime and the variant
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 42 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 43 },
       // The second variant starts applying the multiplier to the state (represents a protocol change).
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 88 },
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 90 },
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 92 },
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 88 },
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 90 },
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 92 },
     ];
     const receivedStates = await toProtocolStateArray(
-      wallet.rawState.pipe(rx.takeWhile(({ state }: ProtocolState.ProtocolState<number>) => state !== 92, true)),
+      wallet.rawState.pipe(rx.takeWhile(({ state }) => state !== 92, true)),
     );
 
-    expect(receivedStates.at(-1)).toEqual({ version: ProtocolVersion.ProtocolVersion(100n), state: 92 });
+    expect(receivedStates.at(-1)).toEqual({
+      version: ProtocolVersion.ProtocolVersion(100n),
+      variantTag: NumericMultiplier,
+      state: 92,
+    });
     expect(receivedStates).toSatisfy((received: typeof receivedStates) =>
       isOrderedSubsequenceOf(received, fullStateSequence, protocolStateEquals),
     );
@@ -305,7 +321,11 @@ describe('Wallet runtime', () => {
     const stateAfterVersionChange = await rx.firstValueFrom(
       wallet.rawState.pipe(rx.filter(({ state }) => state === 42)),
     );
-    expect(stateAfterVersionChange).toEqual({ version: ProtocolVersion.ProtocolVersion(50n), state: 42 });
+    expect(stateAfterVersionChange).toEqual({
+      version: ProtocolVersion.ProtocolVersion(50n),
+      variantTag: interceptingTag,
+      state: 42,
+    });
 
     // Verify the variant was NOT migrated — we can still dispatch to the intercepting variant
     const stillIntercepting = await wallet.runtime
@@ -345,7 +365,11 @@ describe('Wallet runtime', () => {
 
     // State should still be annotated with the original version
     const stateAfter = await rx.firstValueFrom(wallet.rawState.pipe(rx.filter(({ state }) => state === 99)));
-    expect(stateAfter).toEqual({ version: ProtocolVersion.MinSupportedVersion, state: 99 });
+    expect(stateAfter).toEqual({
+      version: ProtocolVersion.MinSupportedVersion,
+      variantTag: interceptingTag,
+      state: 99,
+    });
 
     // Variant was not migrated — dispatching still reaches the intercepting variant
     const stillSoleVariant = await wallet.runtime

--- a/packages/runtime/src/test/walletBuilder.test.ts
+++ b/packages/runtime/src/test/walletBuilder.test.ts
@@ -120,22 +120,26 @@ describe('Wallet Builder', () => {
     >;
     type _2 = Expect<Equal<typeof wallet, WalletLike.WalletLike<[Variant.VersionedVariant<NumericRange>]>>>;
     type _3 = Expect<Equal<typeof wallet.runtime, Runtime<[Variant.VersionedVariant<NumericRange>]>>>;
-    type _4 = Expect<Equal<typeof wallet.rawState, rx.Observable<ProtocolState.ProtocolState<number>>>>;
+    type _4 = Expect<Equal<typeof wallet.rawState, rx.Observable<ProtocolState.ProtocolState<number, typeof Numeric>>>>;
 
     expect(wallet).toBeDefined();
 
     // Latest-value semantics: intermediate states may be skipped, but order is preserved and the
     // stream converges on the terminal state.
     const fullStateSequence = [
-      { version: ProtocolVersion.MinSupportedVersion, state: 0 },
-      { version: ProtocolVersion.MinSupportedVersion, state: 0 },
-      { version: ProtocolVersion.MinSupportedVersion, state: 1 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 0 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 0 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 1 },
     ];
     const receivedStates = await toProtocolStateArray(
-      wallet.rawState.pipe(rx.takeWhile(({ state }: ProtocolState.ProtocolState<number>) => state !== 1, true)),
+      wallet.rawState.pipe(rx.takeWhile(({ state }) => state !== 1, true)),
     );
 
-    expect(receivedStates.at(-1)).toEqual({ version: ProtocolVersion.MinSupportedVersion, state: 1 });
+    expect(receivedStates.at(-1)).toEqual({
+      version: ProtocolVersion.MinSupportedVersion,
+      variantTag: Numeric,
+      state: 1,
+    });
     expect(receivedStates).toSatisfy((received: typeof receivedStates) =>
       isOrderedSubsequenceOf(received, fullStateSequence, protocolStateEquals),
     );
@@ -157,26 +161,35 @@ describe('Wallet Builder', () => {
     type Variants = [Variant.VersionedVariant<NumericRange>, Variant.VersionedVariant<NumericRangeMultiplier>];
     type _1 = Expect<Equal<typeof wallet, WalletLike.WalletLike<Variants>>>;
     type _2 = Expect<Equal<typeof wallet.runtime, Runtime<Variants>>>;
-    type _3 = Expect<Equal<typeof wallet.rawState, rx.Observable<ProtocolState.ProtocolState<number>>>>;
+    type _3 = Expect<
+      Equal<
+        typeof wallet.rawState,
+        rx.Observable<ProtocolState.ProtocolState<number, typeof Numeric | typeof NumericMultiplier>>
+      >
+    >;
 
     expect(wallet).toBeDefined();
 
     // Latest-value semantics: intermediate states may be skipped, but order is preserved and the
     // stream converges on the terminal state.
     const fullStateSequence = [
-      { version: ProtocolVersion.MinSupportedVersion, state: 0 },
-      { version: ProtocolVersion.MinSupportedVersion, state: 0 },
-      { version: ProtocolVersion.MinSupportedVersion, state: 1 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 0 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 0 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 1 },
       // The second variant starts applying the multiplier to the state (represents a protocol change).
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 4 },
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 6 },
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 8 },
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 4 },
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 6 },
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 8 },
     ];
     const receivedStates = await toProtocolStateArray(
-      wallet.rawState.pipe(rx.takeWhile(({ state }: ProtocolState.ProtocolState<number>) => state !== 8, true)),
+      wallet.rawState.pipe(rx.takeWhile(({ state }) => state !== 8, true)),
     );
 
-    expect(receivedStates.at(-1)).toEqual({ version: ProtocolVersion.ProtocolVersion(100n), state: 8 });
+    expect(receivedStates.at(-1)).toEqual({
+      version: ProtocolVersion.ProtocolVersion(100n),
+      variantTag: NumericMultiplier,
+      state: 8,
+    });
     expect(receivedStates).toSatisfy((received: typeof receivedStates) =>
       isOrderedSubsequenceOf(received, fullStateSequence, protocolStateEquals),
     );
@@ -267,20 +280,24 @@ describe('Wallet Builder', () => {
     // Latest-value semantics: intermediate states may be skipped, but order is preserved and the
     // stream converges on the terminal state.
     const fullStateSequence = [
-      { version: ProtocolVersion.MinSupportedVersion, state: 0 },
-      { version: ProtocolVersion.MinSupportedVersion, state: 0 },
-      { version: ProtocolVersion.MinSupportedVersion, state: 1 },
-      { version: ProtocolVersion.ProtocolVersion(50n), state: 2 },
-      { version: ProtocolVersion.ProtocolVersion(50n), state: 3 },
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 8 },
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 10 },
-      { version: ProtocolVersion.ProtocolVersion(100n), state: 12 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 0 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 0 },
+      { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 1 },
+      { version: ProtocolVersion.ProtocolVersion(50n), variantTag: V2Tag, state: 2 },
+      { version: ProtocolVersion.ProtocolVersion(50n), variantTag: V2Tag, state: 3 },
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 8 },
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 10 },
+      { version: ProtocolVersion.ProtocolVersion(100n), variantTag: NumericMultiplier, state: 12 },
     ];
     const receivedStates = await toProtocolStateArray(
-      wallet.rawState.pipe(rx.takeWhile(({ state }: ProtocolState.ProtocolState<number>) => state !== 12, true)),
+      wallet.rawState.pipe(rx.takeWhile(({ state }) => state !== 12, true)),
     );
 
-    expect(receivedStates.at(-1)).toEqual({ version: ProtocolVersion.ProtocolVersion(100n), state: 12 });
+    expect(receivedStates.at(-1)).toEqual({
+      version: ProtocolVersion.ProtocolVersion(100n),
+      variantTag: NumericMultiplier,
+      state: 12,
+    });
     expect(receivedStates).toSatisfy((received: typeof receivedStates) =>
       isOrderedSubsequenceOf(received, fullStateSequence, protocolStateEquals),
     );

--- a/packages/runtime/src/test/walletBuilder.test.ts
+++ b/packages/runtime/src/test/walletBuilder.test.ts
@@ -17,7 +17,7 @@ import * as rx from 'rxjs';
 import { describe, expect, it } from 'vitest';
 import {
   StateChange,
-  type Variant,
+  Variant,
   type VariantBuilder,
   VersionChangeType,
   type WalletLike,
@@ -44,6 +44,44 @@ describe('Wallet Builder', () => {
     it('should not build a valid wallet', () => {
       //TODO: it should be possible to play with types to hide build method unless variant is registered
       expect(() => WalletBuilder.init().build()).toThrow();
+    });
+  });
+
+  describe('resolving a variant by protocol version', () => {
+    const Wallet = WalletBuilder.init()
+      .withVariant(ProtocolVersion.ProtocolVersion(10n), new NumericRangeBuilder(2))
+      .withVariant(ProtocolVersion.ProtocolVersion(100n), new NumericRangeMultiplierBuilder())
+      .build({ min: 0, max: 4, multiplier: 2 });
+
+    it('resolves the variant registered for a version', () => {
+      const [preFork, postFork] = Wallet.allVariants();
+
+      expect(Wallet.variantFor(ProtocolVersion.ProtocolVersion(10n))).toStrictEqual(Option.some(preFork));
+      expect(Wallet.variantFor(ProtocolVersion.ProtocolVersion(99n))).toStrictEqual(Option.some(preFork));
+      expect(Wallet.variantFor(ProtocolVersion.ProtocolVersion(100n))).toStrictEqual(Option.some(postFork));
+      expect(Wallet.variantFor(ProtocolVersion.ProtocolVersion(4_000n))).toStrictEqual(Option.some(postFork));
+    });
+
+    it('reports a miss rather than throwing for a version nothing is registered for', () => {
+      expect(Wallet.variantFor(ProtocolVersion.ProtocolVersion(9n))).toStrictEqual(Option.none());
+      expect(Wallet.variantFor(ProtocolVersion.MinSupportedVersion)).toStrictEqual(Option.none());
+    });
+
+    it('resolves to a variant whose tag addresses the variant record', () => {
+      const resolved = Wallet.variantFor(ProtocolVersion.ProtocolVersion(100n)).pipe(Option.getOrThrow);
+
+      expect(Wallet.allVariantsRecord()[Variant.getVersionedVariantTag(resolved)]).toBe(resolved);
+    });
+
+    it('infers the union of the registered variants', () => {
+      const resolved = Wallet.variantFor(ProtocolVersion.ProtocolVersion(100n));
+
+      type _1 = Expect<
+        Equal<
+          typeof resolved,
+          Option.Option<Variant.VersionedVariant<NumericRange> | Variant.VersionedVariant<NumericRangeMultiplier>>
+        >
+      >;
     });
   });
 

--- a/packages/runtime/src/test/walletBuilder.test.ts
+++ b/packages/runtime/src/test/walletBuilder.test.ts
@@ -74,11 +74,11 @@ describe('Wallet Builder', () => {
     });
 
     it('infers the union of the registered variants', () => {
-      const resolved = Wallet.variantFor(ProtocolVersion.ProtocolVersion(100n));
+      const _resolved = Wallet.variantFor(ProtocolVersion.ProtocolVersion(100n));
 
       type _1 = Expect<
         Equal<
-          typeof resolved,
+          typeof _resolved,
           Option.Option<Variant.VersionedVariant<NumericRange> | Variant.VersionedVariant<NumericRangeMultiplier>>
         >
       >;

--- a/packages/runtime/src/test/walletBuilder.test.ts
+++ b/packages/runtime/src/test/walletBuilder.test.ts
@@ -88,6 +88,105 @@ describe('Wallet Builder', () => {
     });
   });
 
+  describe('registering a variant with its own configuration', () => {
+    it('builds the variant from that configuration and asks for none at build time', async () => {
+      const Wallet = WalletBuilder.init()
+        .withVariant(ProtocolVersion.MinSupportedVersion, new NumericRangeBuilder(), { min: 0, max: 2 })
+        .build();
+      const wallet = Wallet.startEmpty(Wallet);
+
+      const receivedStates = await toProtocolStateArray(
+        wallet.rawState.pipe(rx.takeWhile(({ state }) => state !== 2, true)),
+      );
+
+      expect(receivedStates.at(-1)).toEqual({
+        version: ProtocolVersion.MinSupportedVersion,
+        variantTag: Numeric,
+        state: 2,
+      });
+    });
+
+    it('keeps each variant on its own configuration when both carry one', async () => {
+      // The two configurations name the same keys with values only one variant can use — the shape
+      // a fork wallet has, where each side is configured for its own ledger. Merging them would put
+      // `multiplier: 5` out of reach of the variant that needs it.
+      const Wallet = WalletBuilder.init()
+        .withVariant(ProtocolVersion.MinSupportedVersion, new NumericRangeBuilder(2), { min: 0, max: 4 })
+        .withVariant(ProtocolVersion.ProtocolVersion(100n), new NumericRangeMultiplierBuilder(), {
+          min: 0,
+          max: 2,
+          multiplier: 5,
+        })
+        .build();
+      const wallet = Wallet.startEmpty(Wallet);
+
+      const receivedStates = await toProtocolStateArray(
+        wallet.rawState.pipe(rx.takeWhile(({ state }) => state !== 10, true)),
+      );
+
+      expect(receivedStates.at(-1)).toEqual({
+        version: ProtocolVersion.ProtocolVersion(100n),
+        variantTag: NumericMultiplier,
+        state: 10,
+      });
+    });
+
+    it('still takes the configuration of the variants that carry none', async () => {
+      const Wallet = WalletBuilder.init()
+        .withVariant(ProtocolVersion.MinSupportedVersion, new NumericRangeBuilder(2))
+        .withVariant(ProtocolVersion.ProtocolVersion(100n), new NumericRangeMultiplierBuilder(), {
+          min: 0,
+          max: 2,
+          multiplier: 5,
+        })
+        .build({ min: 0, max: 4 });
+      const wallet = Wallet.startEmpty(Wallet);
+
+      const receivedStates = await toProtocolStateArray(
+        wallet.rawState.pipe(rx.takeWhile(({ state }) => state !== 10, true)),
+      );
+
+      expect(receivedStates.at(-1)).toEqual({
+        version: ProtocolVersion.ProtocolVersion(100n),
+        variantTag: NumericMultiplier,
+        state: 10,
+      });
+    });
+
+    it('reports the configuration it was built with, without the self-configured variants', () => {
+      const Wallet = WalletBuilder.init()
+        .withVariant(ProtocolVersion.MinSupportedVersion, new NumericRangeBuilder(2))
+        .withVariant(ProtocolVersion.ProtocolVersion(100n), new NumericRangeMultiplierBuilder(), {
+          min: 0,
+          max: 2,
+          multiplier: 5,
+        })
+        .build({ min: 0, max: 4 });
+
+      expect(Wallet.configuration).toEqual({ min: 0, max: 4 });
+      type _1 = Expect<Equal<typeof Wallet.configuration, Readonly<RangeConfig>>>;
+    });
+
+    it('rejects a variant registered out of protocol version order, configuration or not', () => {
+      const builder = WalletBuilder.init().withVariant(
+        ProtocolVersion.ProtocolVersion(50n),
+        new NumericRangeBuilder(),
+        {
+          min: 0,
+          max: 1,
+        },
+      );
+
+      expect(() =>
+        builder.withVariant(ProtocolVersion.ProtocolVersion(10n), new NumericRangeMultiplierBuilder(), {
+          min: 0,
+          max: 1,
+          multiplier: 2,
+        }),
+      ).toThrow('ProtocolMismatch: sinceVersion is prior to previously registered version');
+    });
+  });
+
   describe('protocol version ordering', () => {
     it('should reject adding a variant with the same protocol version as the previous one', () => {
       const version = ProtocolVersion.ProtocolVersion(10n);

--- a/packages/runtime/src/test/walletBuilder.test.ts
+++ b/packages/runtime/src/test/walletBuilder.test.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type HList } from '@midnightntwrk/wallet-sdk-utilities';
 import { type Equal, type Expect } from '@midnightntwrk/wallet-sdk-utilities/types';
 import { Effect, Option, PubSub, Scope, Stream } from 'effect';
 import * as rx from 'rxjs';
@@ -31,6 +32,8 @@ import {
   toProtocolStateArray,
 } from '../testing/utils.js';
 import {
+  Numeric,
+  NumericMultiplier,
   type NumericRange,
   NumericRangeBuilder,
   type NumericRangeMultiplier,
@@ -177,6 +180,43 @@ describe('Wallet Builder', () => {
     expect(receivedStates).toSatisfy((received: typeof receivedStates) =>
       isOrderedSubsequenceOf(received, fullStateSequence, protocolStateEquals),
     );
+  });
+
+  it('stamps every state emission with the tag of the variant that produced it', async () => {
+    const Wallet = WalletBuilder.init()
+      // Have the first variant complete after producing two values, signifying a protocol change.
+      .withVariant(ProtocolVersion.MinSupportedVersion, new NumericRangeBuilder(2))
+      .withVariant(ProtocolVersion.ProtocolVersion(100n), new NumericRangeMultiplierBuilder())
+      .build({ min: 0, max: 4, multiplier: 2 });
+    const wallet = Wallet.startEmpty(Wallet);
+
+    type Variants = [Variant.VersionedVariant<NumericRange>, Variant.VersionedVariant<NumericRangeMultiplier>];
+    type _1 = Expect<
+      Equal<
+        typeof wallet.rawState,
+        rx.Observable<ProtocolState.ProtocolState<number, Variant.VariantTag<HList.Each<Variants>>>>
+      >
+    >;
+
+    const receivedStates = await toProtocolStateArray(
+      wallet.rawState.pipe(rx.takeWhile(({ state }) => state !== 8, true)),
+    );
+
+    // The tag travels with the emission, so a reader can pick the right capabilities for a state
+    // without inferring the producing variant from the version.
+    expect(receivedStates.filter(({ version }) => version === ProtocolVersion.MinSupportedVersion)).toSatisfy(
+      (preFork: typeof receivedStates) =>
+        preFork.length > 0 && preFork.every(({ variantTag }) => variantTag === Numeric),
+    );
+    expect(receivedStates.filter(({ version }) => version === ProtocolVersion.ProtocolVersion(100n))).toSatisfy(
+      (postFork: typeof receivedStates) =>
+        postFork.length > 0 && postFork.every(({ variantTag }) => variantTag === NumericMultiplier),
+    );
+    expect(receivedStates.at(-1)).toEqual({
+      version: ProtocolVersion.ProtocolVersion(100n),
+      variantTag: NumericMultiplier,
+      state: 8,
+    });
   });
 
   it('should support three sequential variant migrations', async () => {

--- a/packages/runtime/src/test/walletBuilderType.test.ts
+++ b/packages/runtime/src/test/walletBuilderType.test.ts
@@ -20,6 +20,7 @@ import {
   type RangeConfig,
   type RangeMultiplierConfig,
 } from '../testing/variants.js';
+
 import { describe, it } from 'vitest';
 
 describe('WalletBuilder', () => {
@@ -68,6 +69,71 @@ describe('WalletBuilder', () => {
               VariantBuilder.VersionedVariantBuilder<NumericRangeMultiplierBuilder>,
             ]
           >
+        >
+      >;
+    });
+  });
+
+  describe('inferring configuration type with self-configured variants', () => {
+    it('leaves a self-configured variant out of the intersection entirely', () => {
+      // Nothing is left to ask for, which is the same answer as for a wallet with no variants at all.
+      type _1 = Expect<
+        Equal<
+          WalletBuilder.FullConfiguration<[VariantBuilder.SelfConfiguredVariantBuilder<NumericRangeBuilder>]>,
+          unknown
+        >
+      >;
+    });
+
+    it('keeps only the configuration of variants that carry none of their own', () => {
+      type _1 = Expect<
+        Equal<
+          WalletBuilder.FullConfiguration<
+            [
+              VariantBuilder.SelfConfiguredVariantBuilder<NumericRangeBuilder>,
+              VariantBuilder.VersionedVariantBuilder<NumericRangeMultiplierBuilder>,
+            ]
+          >,
+          RangeMultiplierConfig
+        >
+      >;
+      type _2 = Expect<
+        Equal<
+          WalletBuilder.FullConfiguration<
+            [
+              VariantBuilder.VersionedVariantBuilder<NumericRangeBuilder>,
+              VariantBuilder.SelfConfiguredVariantBuilder<NumericRangeMultiplierBuilder>,
+            ]
+          >,
+          RangeConfig
+        >
+      >;
+    });
+
+    it('asks for no build parameters when every variant is self-configured', () => {
+      type _1 = Expect<
+        Equal<
+          WalletBuilder.BuildArguments<
+            [
+              VariantBuilder.SelfConfiguredVariantBuilder<NumericRangeBuilder>,
+              VariantBuilder.SelfConfiguredVariantBuilder<NumericRangeMultiplierBuilder>,
+            ]
+          >,
+          []
+        >
+      >;
+    });
+
+    it('asks only for what the remaining variants need', () => {
+      type _1 = Expect<
+        Equal<
+          WalletBuilder.BuildArguments<
+            [
+              VariantBuilder.SelfConfiguredVariantBuilder<NumericRangeMultiplierBuilder>,
+              VariantBuilder.VersionedVariantBuilder<NumericRangeBuilder>,
+            ]
+          >,
+          [RangeConfig]
         >
       >;
     });

--- a/packages/runtime/src/test/walletState.test.ts
+++ b/packages/runtime/src/test/walletState.test.ts
@@ -14,7 +14,7 @@ import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import * as rx from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 import { toProtocolStateArray } from '../testing/utils.js';
-import { NumericRangeBuilder } from '../testing/variants.js';
+import { Numeric, NumericRangeBuilder } from '../testing/variants.js';
 import { WalletBuilder } from '../WalletBuilder.js';
 
 describe('Wallet', () => {
@@ -32,12 +32,13 @@ describe('Wallet', () => {
       expect(wallet).toBeDefined();
 
       const errorHandler = vi.fn();
-      const receivedStates = await toProtocolStateArray<number>(wallet.rawState.pipe(rx.take(4)), errorHandler);
+      const receivedStates = await toProtocolStateArray(wallet.rawState.pipe(rx.take(4)), errorHandler);
 
       expect(receivedStates).toEqual([
-        { version: ProtocolVersion.MinSupportedVersion, state: 0 }, // The initial state is emitted both by runtime and the variant
-        { version: ProtocolVersion.MinSupportedVersion, state: 0 },
-        { version: ProtocolVersion.MinSupportedVersion, state: 1 },
+        // The initial state is emitted both by runtime and the variant
+        { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 0 },
+        { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 0 },
+        { version: ProtocolVersion.MinSupportedVersion, variantTag: Numeric, state: 1 },
       ]);
       expect(errorHandler).toHaveBeenCalled();
     });

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -10,7 +10,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { type ProtocolState, ProtocolVersion, type SyncProgress } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  type NetworkId,
+  type ProtocolState,
+  ProtocolVersion,
+  type SyncProgress,
+} from '@midnightntwrk/wallet-sdk-abstractions';
 import {
   type BaseV2Configuration,
   type DefaultV2Configuration,
@@ -21,11 +26,10 @@ import {
   CoreWallet,
 } from './v2/index.js';
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { Effect, Either, Option, Ref, type Scope } from 'effect';
+import { type Duration, Effect, Either, Option, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
 import { type BalancingResult } from './v2/Transacting.js';
 import { type SerializationCapability } from './v2/Serialization.js';
-import { type TransactionHistoryService } from './v2/TransactionHistory.js';
 import { type AvailableCoin, type CoinsAndBalancesCapability, type PendingCoin } from './v2/CoinsAndBalances.js';
 import { type KeysCapability } from './v2/Keys.js';
 import {
@@ -34,7 +38,8 @@ import {
   type ShieldedEncryptionPublicKey,
 } from '@midnightntwrk/wallet-sdk-address-format';
 import { type TokenTransfer } from './v2/Transacting.js';
-import { type WalletSyncUpdate } from './v2/Sync.js';
+import { type BatchUpdatesConfig, type IndexerClientConnection, type WalletSyncUpdate } from './v2/Sync.js';
+import { type ShieldedHistoryStorage, type TransactionHistoryService } from './v2/TransactionHistory.js';
 import { type Variant, type VariantBuilder, type WalletLike } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
 
@@ -173,7 +178,25 @@ export type CustomizedShieldedWallet<
 > = ShieldedWalletAPI<TStartAux, TTransaction, TSerialized> &
   WalletLike.WalletLike<[Variant.VersionedVariant<V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>>]>;
 
-export type DefaultShieldedConfiguration = DefaultV2Configuration;
+/**
+ * The configuration a default {@link ShieldedWallet} is built from.
+ *
+ * @remarks
+ *   Declared by this package rather than aliased to a variant's configuration. A wallet that spans a protocol boundary is
+ *   built from more than one variant, so no single variant's configuration can be the wallet's public contract: the
+ *   package states what it asks an application for, and maps it onto whichever variants it registers.
+ *
+ *   The field types are still the ones the variants declare, because they are version-agnostic — `configuration.test.ts`
+ *   asserts that this type remains interchangeable with what _both_ variants are built from, so a divergence surfaces
+ *   as a compile error here instead of as a wallet that cannot be built for one of its variants.
+ */
+export type DefaultShieldedConfiguration = {
+  networkId: NetworkId.NetworkId;
+  indexerClientConnection: IndexerClientConnection;
+  batchUpdates?: BatchUpdatesConfig;
+  txHistoryStorage: ShieldedHistoryStorage;
+  transactionDetailsRetryWindow?: Duration.DurationInput;
+};
 
 export interface CustomizedShieldedWalletClass<
   TStartAux = ledger.ZswapSecretKeys,
@@ -192,7 +215,7 @@ export interface CustomizedShieldedWalletClass<
   restore(serializedState: TSerialized): CustomizedShieldedWallet<TStartAux, TTransaction, TSyncUpdate, TSerialized>;
 }
 
-export function ShieldedWallet(configuration: DefaultV2Configuration): ShieldedWalletClass {
+export function ShieldedWallet(configuration: DefaultShieldedConfiguration): ShieldedWalletClass {
   return CustomShieldedWallet(configuration, new V2Builder().withDefaults());
 }
 

--- a/packages/shielded-wallet/src/test/configuration.test.ts
+++ b/packages/shielded-wallet/src/test/configuration.test.ts
@@ -1,0 +1,47 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type CanAssign, type Equal, type Expect } from '@midnightntwrk/wallet-sdk-utilities/types';
+import { type Duration } from 'effect';
+import { describe, it } from 'vitest';
+import { type DefaultShieldedConfiguration } from '../ShieldedWallet.js';
+import { type DefaultV1Configuration } from '../v1/index.js';
+import {
+  type DefaultV2Configuration,
+  type Sync as V2Sync,
+  type TransactionHistory as V2TransactionHistory,
+} from '../v2/index.js';
+
+describe('DefaultShieldedConfiguration', () => {
+  it('is a configuration the package declares itself, not the head variant s', () => {
+    type _1 = Expect<
+      Equal<
+        DefaultShieldedConfiguration,
+        {
+          networkId: NetworkId.NetworkId;
+          indexerClientConnection: V2Sync.IndexerClientConnection;
+          batchUpdates?: V2Sync.BatchUpdatesConfig;
+          txHistoryStorage: V2TransactionHistory.ShieldedHistoryStorage;
+          transactionDetailsRetryWindow?: Duration.DurationInput;
+        }
+      >
+    >;
+  });
+
+  it('stays interchangeable with what either variant is built from', () => {
+    type _1 = Expect<CanAssign<DefaultShieldedConfiguration, DefaultV2Configuration>>;
+    type _2 = Expect<CanAssign<DefaultV2Configuration, DefaultShieldedConfiguration>>;
+    type _3 = Expect<CanAssign<DefaultShieldedConfiguration, DefaultV1Configuration>>;
+    type _4 = Expect<CanAssign<DefaultV1Configuration, DefaultShieldedConfiguration>>;
+  });
+});

--- a/packages/unshielded-wallet/src/UnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/UnshieldedWallet.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { type ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type NetworkId, type ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import {
   type BaseV2Configuration,
   type DefaultV2Configuration,
@@ -24,7 +24,8 @@ import type * as ledger from '@midnightntwrk/ledger-v9';
 import { Effect, Either, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
 import { type SerializationCapability } from './v2/Serialization.js';
-import { type TransactionHistoryService } from './v2/TransactionHistory.js';
+import { type TransactionHistoryService, type UnshieldedHistoryStorage } from './v2/TransactionHistory.js';
+import { type IndexerClientConnection } from './v2/Sync.js';
 import { type CoinsAndBalancesCapability } from './v2/CoinsAndBalances.js';
 import { type KeysCapability } from './v2/Keys.js';
 import {
@@ -109,7 +110,23 @@ export class UnshieldedWalletState<TSerialized = string> {
 
 export type UnshieldedWallet = CustomizedUnshieldedWallet<WalletSyncUpdate, string>;
 
-export type DefaultUnshieldedConfiguration = DefaultV2Configuration;
+/**
+ * The configuration a default {@link UnshieldedWallet} is built from.
+ *
+ * @remarks
+ *   Declared by this package rather than aliased to a variant's configuration. A wallet that spans a protocol boundary is
+ *   built from more than one variant, so no single variant's configuration can be the wallet's public contract: the
+ *   package states what it asks an application for, and maps it onto whichever variants it registers.
+ *
+ *   The field types are still the ones the variants declare, because they are version-agnostic — `configuration.test.ts`
+ *   asserts that this type remains interchangeable with what _both_ variants are built from, so a divergence surfaces
+ *   as a compile error here instead of as a wallet that cannot be built for one of its variants.
+ */
+export type DefaultUnshieldedConfiguration = {
+  networkId: NetworkId.NetworkId;
+  indexerClientConnection: IndexerClientConnection;
+  txHistoryStorage: UnshieldedHistoryStorage;
+};
 
 export type UnshieldedWalletClass = CustomizedUnshieldedWalletClass<
   WalletSyncUpdate,
@@ -185,7 +202,7 @@ export interface CustomizedUnshieldedWalletClass<
   restore(serializedState: TSerialized): CustomizedUnshieldedWallet<TSyncUpdate, TSerialized>;
 }
 
-export function UnshieldedWallet(configuration: DefaultV2Configuration): UnshieldedWalletClass {
+export function UnshieldedWallet(configuration: DefaultUnshieldedConfiguration): UnshieldedWalletClass {
   return CustomUnshieldedWallet(configuration, new V2Builder().withDefaults());
 }
 

--- a/packages/unshielded-wallet/src/test/configuration.test.ts
+++ b/packages/unshielded-wallet/src/test/configuration.test.ts
@@ -1,0 +1,44 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type CanAssign, type Equal, type Expect } from '@midnightntwrk/wallet-sdk-utilities/types';
+import { describe, it } from 'vitest';
+import { type DefaultUnshieldedConfiguration } from '../UnshieldedWallet.js';
+import { type DefaultV1Configuration } from '../v1/index.js';
+import {
+  type DefaultV2Configuration,
+  type Sync as V2Sync,
+  type TransactionHistory as V2TransactionHistory,
+} from '../v2/index.js';
+
+describe('DefaultUnshieldedConfiguration', () => {
+  it('is a configuration the package declares itself, not the head variant s', () => {
+    type _1 = Expect<
+      Equal<
+        DefaultUnshieldedConfiguration,
+        {
+          networkId: NetworkId.NetworkId;
+          indexerClientConnection: V2Sync.IndexerClientConnection;
+          txHistoryStorage: V2TransactionHistory.UnshieldedHistoryStorage;
+        }
+      >
+    >;
+  });
+
+  it('stays interchangeable with what either variant is built from', () => {
+    type _1 = Expect<CanAssign<DefaultUnshieldedConfiguration, DefaultV2Configuration>>;
+    type _2 = Expect<CanAssign<DefaultV2Configuration, DefaultUnshieldedConfiguration>>;
+    type _3 = Expect<CanAssign<DefaultUnshieldedConfiguration, DefaultV1Configuration>>;
+    type _4 = Expect<CanAssign<DefaultV1Configuration, DefaultUnshieldedConfiguration>>;
+  });
+});


### PR DESCRIPTION
First increment of the dual-ledger public API redesign (plan of record: workspace-local `api-redesign.md`; work packages WP-1–4). Stacked on #672. No public-surface flows change yet — this PR builds the version-dispatch primitives every later increment (restore routing, versioned codecs/proving/pending, two-variant registration) selects on.

## What's here

- **WP-1 — protocol-version-keyed registry** (`abstractions`): `ProtocolVersion.Registry<T>` with `makeRegistry` / `makeRegistryFromActivations` (overlap-rejecting, `Either`), and total `select` / `selectEntry` returning `Option`. Half-open ranges, same semantics as the existing `withinRange`.
- **WP-2 — variant resolution** (`runtime`): `Variant.selectByRange(variants, version)` and `BaseWalletClass.variantFor(version)` resolve which registered variant owns a `ProtocolVersion`, deriving boundaries exactly the way the runtime derives `VariantContext.activationRange` (implemented on the WP-1 registry). Typed miss (`Option`), never throws.
- **WP-3 — `ProtocolState.variantTag`**: the runtime now hands over the tag of the variant that produced each state emission (`RuntimeState` types it as the union of registered tags), so downstream per-emission capability selection needs no casts. `ProtocolState.getEquivalence` compares the tag strictly.
- **WP-4 — configuration namespacing**: `withVariant(sinceVersion, builder, configuration)` overload — a self-configured variant drops out of the builder's configuration intersection (all-self-configured ⇒ `build()` takes no configuration). On top of that, each wallet package now **owns** its `DefaultShieldedConfiguration` / `DefaultDustConfiguration` / `DefaultUnshieldedConfiguration` instead of aliasing the v2 variant's configuration type.

## Breaking notes (loud in the changesets)

- `ProtocolState` gains a **required** `variantTag` — anything constructing one (including tests) must supply it. Runtime consumers only reading states get the extra field additively.
- The wallet packages' `Default*Configuration` are no longer type-aliases of `DefaultV2Configuration` (same declared shape today; the alias identity is the break). `DefaultV1/V2Configuration` remain exported from `./v1` / `./v2` unchanged.

## Notable finding

The plan's claim F3 ("production variant configurations are structurally identical **and ledger-free**") is half-stale: dust's variant configs carry `dustParameters?: DustParameters` from their respective ledgers. One package-owned config works only because v8 and v9 `DustParameters` are structurally identical — that coincidence is now **pinned by `dust-wallet/src/test/configuration.test.ts`**, so a future divergence surfaces as a compile error instead of a wallet that cannot be built for one variant.

## Tests & gate

Red-first TDD throughout (each `feat`/`refactor` commit is preceded by its failing-spec commit): 18 registry tests, 5 `ProtocolState`, 7 `selectByRange`, 14 builder (`variantFor` / `variantTag` / self-configuration, incl. type-level), 3× package config guards. Gate: dist 17/17, typecheck 37/37, lint 58/58, unit 53/53 tasks (899 passed / 22 skipped), effect-language-service clean on all changed files (the two `Runtime.ts` hits pre-exist on the base branch), `format:check` + `changeset:check` green.