### PR TITLE
feat(runtime,shielded,facade): wallet-layer start material and version-routed restore

### DIFF
--- a/.changeset/facade-protocol-version.md
+++ b/.changeset/facade-protocol-version.md
@@ -1,0 +1,15 @@
+---
+'@midnightntwrk/wallet-sdk-facade': minor
+---
+
+`FacadeState` gains two additive readings of where the wallets are in the protocol timeline.
+
+`protocolVersion` reports the version each of the three wallets has reached. `activeProtocolVersion` is the lowest of
+them: the three follow the same chain but not in lock-step — each recognises a protocol version change when its own
+synchronization reaches it — so around a fork they disagree for a while, and a transaction needs all three. The lowest
+is the version every wallet is known to understand.
+
+`WalletProtocolVersions` and `lowestProtocolVersion` are exported for callers that want the same rule over versions they
+hold themselves.
+
+Purely additive: nothing consumers read today changes shape.

--- a/.changeset/shielded-start-aux-and-restore-routing.md
+++ b/.changeset/shielded-start-aux-and-restore-routing.md
@@ -1,0 +1,33 @@
+---
+'@midnightntwrk/wallet-sdk-shielded': major
+---
+
+**Both shielded variants now derive their own key material from a seed, and restoring a snapshot routes on the protocol
+version it declares.**
+
+**Breaking for anyone composing a `V1Builder`/`V2Builder` chain by hand: `withStartAux` is required.** Each variant
+carries a `startAux` capability — given the seed the application started the wallet from, it produces the key material
+its own ledger version's sync expects. This is what makes a seed the only key material a wallet needs to hold in order
+to cross a protocol boundary: key objects belong to one ledger's runtime and cannot be re-handed to the variant on the
+other side, even though the public keys they yield are identical.
+
+`withDefaults()` already includes it, so `ShieldedWallet(config)` and `CustomShieldedWallet(config, new
+V2Builder().withDefaults())` need no change. A chain that names its steps individually must add
+`.withStartAuxDefaults()` (this ledger version's derivation) or `.withStartAux({ fromSeed })` (its own). It is required
+rather than defaulted because the default derivation is only correct for a builder whose sync service expects this
+ledger's `ZswapSecretKeys`; a builder that replaced sync is told at build time rather than handed key objects of the
+wrong shape at the first migration. `withSync` drops a derivation typed against the previous start-aux parameter, as
+`withMigration` already does for the previous-state parameter.
+
+**Restore routes on the snapshot's declared protocol version.** `restore(serializedState)` now peeks at the serialized
+envelope and restores into the variant registered for the version it declares, instead of assuming the head variant
+wrote it. The peek is deliberately permissive — one optional field, every other ignored — so anything it cannot read is
+reported as "no version declared" and the deserializer keeps producing the precise error. A snapshot that declares no
+version restores into the head variant, which is what every restore did before there was a choice. A version no
+registered variant owns now raises `Restore.UnsupportedSnapshotVersionError`, which carries the version.
+
+**The serialized format is unchanged.** Snapshots already declared their protocol version; nothing written by an earlier
+version of this package needs migrating, and nothing this version writes is unreadable by an earlier one.
+
+`peekProtocolVersion` and `variantForSnapshot` are exported from the package root for callers that want to route a
+snapshot themselves.

--- a/.changeset/wallet-layer-start-material-and-restore-routing.md
+++ b/.changeset/wallet-layer-start-material-and-restore-routing.md
@@ -1,0 +1,27 @@
+---
+'@midnightntwrk/wallet-sdk-runtime': minor
+---
+
+Three additions the wallet layer needs to run more than one variant.
+
+**`StartMaterial` — what a wallet retains so it can start sync on any variant.** A wallet that follows the chain across a
+protocol boundary starts synchronization more than once, and sync needs key material that is deliberately absent from
+anything the wallet serializes. `StartMaterial.fromSeed(seed)` retains the seed every variant derives its own key
+material from; `StartMaterial.forVariant(tag, aux)` / `forVariants(entries)` retain key objects per variant.
+`StartMaterial.auxFor(material, tag, deriveFromSeed)` produces what a given variant should start with, reporting
+`Option.none()` when the wallet holds nothing that variant can use — key objects belong to one ledger version's runtime,
+so handing another variant's over would be a wrong answer rather than a missing one. `StartAuxCapability` is the
+derivation itself, implemented by a variant because only it knows which key type its sync expects.
+
+**`BaseWalletClass.startAtVariant(walletClass, variant, state)` — starting on a variant resolved at runtime.** The
+sibling `start` addresses a variant by a statically known tag, which is what lets it demand exactly that variant's state
+type. A tag recovered from data — a snapshot's protocol version, the chain's current version — carries no such static
+knowledge, and `HList.Find` over a union of tags resolves to the first registration or to `never`, so the state
+parameter it computes is not the one the caller holds. Passing the variant `variantFor` resolved keeps both ends of the
+pairing together, and the state is typed as the union of the registered variants' states.
+
+**`RuntimeState` is now distributed over the registered variants** — one `ProtocolState` per variant, rather than one
+formed from two unions. `variantTag` is therefore a genuine discriminant: branching on it narrows `state` to what that
+variant produces, so selecting the capabilities that understand a state needs no cast. The values published are
+unchanged, and an annotation naming the wider form still accepts them; code that asserted the *exact* previous type
+shape needs the distributed form instead.

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -53,7 +53,7 @@ import { Clock } from '@midnightntwrk/wallet-sdk-utilities';
 import { FetchTermsAndConditions as FetchTermsAndConditionsQuery } from '@midnightntwrk/wallet-sdk-indexer-client';
 import { QueryRunner } from '@midnightntwrk/wallet-sdk-indexer-client/effect';
 import { Array as Arr, pipe, Schema } from 'effect';
-import { TransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ProtocolVersion, TransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
 import { combineLatest, map, type Observable, firstValueFrom, type Subscription, concatMap } from 'rxjs';
 import {
   type DefaultPendingTransactionsServiceConfiguration,
@@ -282,11 +282,53 @@ export type UtxoWithMeta = {
   };
 };
 
+/** The protocol version each of the three wallets has reached. */
+export type WalletProtocolVersions = Readonly<{
+  shielded: ProtocolVersion.ProtocolVersion;
+  unshielded: ProtocolVersion.ProtocolVersion;
+  dust: ProtocolVersion.ProtocolVersion;
+}>;
+
+/**
+ * The lowest of the protocol versions the three wallets have reached.
+ *
+ * @remarks
+ *   The three wallets follow the same chain but not in lock-step: each recognises a protocol version change when its own
+ *   synchronization reaches it, so around a fork they disagree for a while. A transaction spans all three, so the one
+ *   still behind is what bounds the facade as a whole — the highest version every wallet is known to be at.
+ * @param versions The version each wallet has reached.
+ * @returns The lowest of the three.
+ */
+export const lowestProtocolVersion = (versions: WalletProtocolVersions): ProtocolVersion.ProtocolVersion =>
+  [versions.shielded, versions.unshielded, versions.dust].reduce((lowest, candidate) =>
+    candidate < lowest ? candidate : lowest,
+  );
+
 export class FacadeState {
   public readonly shielded: ShieldedWalletState;
   public readonly unshielded: UnshieldedWalletState;
   public readonly dust: DustWalletState;
   public readonly pending: PendingTransactions.PendingTransactions<ledger.FinalizedTransaction>;
+
+  /** The protocol version each of the three wallets has reached. */
+  public get protocolVersion(): WalletProtocolVersions {
+    return {
+      shielded: this.shielded.protocolVersion,
+      unshielded: this.unshielded.protocolVersion,
+      dust: this.dust.protocolVersion,
+    };
+  }
+
+  /**
+   * The protocol version the facade as a whole can act at: the lowest the three wallets have reached.
+   *
+   * @remarks
+   *   Around a protocol boundary the three wallets cross at slightly different moments, and a transaction needs all
+   *   three. This is the version every one of them is known to understand.
+   */
+  public get activeProtocolVersion(): ProtocolVersion.ProtocolVersion {
+    return lowestProtocolVersion(this.protocolVersion);
+  }
 
   public get isSynced(): boolean {
     return (

--- a/packages/facade/test/protocolVersion.test.ts
+++ b/packages/facade/test/protocolVersion.test.ts
@@ -1,0 +1,46 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { describe, expect, it } from 'vitest';
+import { lowestProtocolVersion, type WalletProtocolVersions } from '../src/index.js';
+
+const version = (value: bigint): ProtocolVersion.ProtocolVersion => ProtocolVersion.ProtocolVersion(value);
+
+const versions = (shielded: bigint, unshielded: bigint, dust: bigint): WalletProtocolVersions => ({
+  shielded: version(shielded),
+  unshielded: version(unshielded),
+  dust: version(dust),
+});
+
+describe('lowestProtocolVersion', () => {
+  it('is the version all three wallets have reached when they agree', () => {
+    expect(lowestProtocolVersion(versions(9n, 9n, 9n))).toBe(version(9n));
+  });
+
+  it('is the lowest of the three while they disagree, whichever wallet is behind', () => {
+    // A transaction spans all three wallets, so the one still on the older protocol version bounds
+    // what the facade as a whole can do — no matter which one it is.
+    expect(lowestProtocolVersion(versions(8n, 9n, 9n))).toBe(version(8n));
+    expect(lowestProtocolVersion(versions(9n, 8n, 9n))).toBe(version(8n));
+    expect(lowestProtocolVersion(versions(9n, 9n, 8n))).toBe(version(8n));
+  });
+
+  it('is the lowest even when more than one wallet is behind', () => {
+    expect(lowestProtocolVersion(versions(8n, 8n, 9n))).toBe(version(8n));
+    expect(lowestProtocolVersion(versions(2n, 5n, 3n))).toBe(version(2n));
+  });
+
+  it('handles the minimum supported version without treating it as absent', () => {
+    expect(lowestProtocolVersion(versions(0n, 9n, 9n))).toBe(ProtocolVersion.MinSupportedVersion);
+  });
+});

--- a/packages/facade/test/utils/helpers.ts
+++ b/packages/facade/test/utils/helpers.ts
@@ -203,6 +203,7 @@ export const createSimulatorWalletFactories = (config: SimulatorConfig): Simulat
       .withCoinsAndBalancesDefaults()
       .withTransactionHistory(ShieldedTransactionHistory.makeSimulatorTransactionHistoryService)
       .withKeysDefaults()
+      .withStartAuxDefaults()
       .withCoinSelectionDefaults(),
   );
 

--- a/packages/runtime/src/Runtime.ts
+++ b/packages/runtime/src/Runtime.ts
@@ -15,11 +15,18 @@ import { type ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-a
 import { StateChange, type Variant, VersionChangeType, WalletRuntimeError } from './abstractions/index.js';
 import { EitherOps, HList, Poly } from '@midnightntwrk/wallet-sdk-utilities';
 
-/** The state a {@link Runtime} publishes: the variant's state, the protocol version, and the variant that produced it. */
-export type RuntimeState<Variants extends Variant.AnyVersionedVariantArray> = ProtocolState.ProtocolState<
-  Variant.StateOf<HList.Each<Variants>>,
-  Variant.VariantTag<HList.Each<Variants>>
->;
+/**
+ * The state a {@link Runtime} publishes: the variant's state, the protocol version, and the variant that produced it.
+ *
+ * @remarks
+ *   Distributed over the registered variants rather than formed as one `ProtocolState` of two unions, so that
+ *   `variantTag` is a genuine discriminant: branching on it narrows `state` to what that variant actually produces.
+ *   Pairing them any more loosely would leave every reader to re-establish the correspondence with a cast, which is the
+ *   cost the tag exists to remove.
+ */
+export type RuntimeState<Variants extends Variant.AnyVersionedVariantArray> = {
+  [K in keyof Variants]: ProtocolState.ProtocolState<Variant.StateOf<Variants[K]>, Variant.VariantTag<Variants[K]>>;
+}[number];
 
 /** The {@link Runtime} service type. */
 export interface Runtime<Variants extends Variant.AnyVersionedVariantArray> {

--- a/packages/runtime/src/WalletBuilder.ts
+++ b/packages/runtime/src/WalletBuilder.ts
@@ -153,6 +153,28 @@ export class WalletBuilder<TBuilders extends VariantBuilder.AnyVersionedVariantB
         }).pipe(Effect.runSync);
       }
 
+      static startAtVariant<T extends WalletLike.AnyWalletClass<Variants>, TVariant extends HList.Each<Variants>>(
+        WalletClass: T,
+        variant: TVariant,
+        state: Variant.StateOf<TVariant>,
+      ): WalletLike.WalletOf<T> {
+        return Effect.gen(this, function* () {
+          const scope = yield* Scope.make();
+
+          const runtime = yield* Runtime.init({
+            variants,
+            tag: Variant.getVersionedVariantTag(variant),
+            // Type cast required because: `Runtime.init` types the state through `HList.Find` on the tag, which can
+            // only resolve a tag the compiler knows statically. Here the variant is runtime data. The pairing holds by
+            // construction — the state is the one this very variant produced, by deserializing or migrating — and
+            // `startAtVariant`'s own signature is what states that; there is nothing left for the compiler to check.
+            state: state as never,
+          }).pipe(Effect.provideService(Scope.Scope, scope));
+
+          return new WalletClass(runtime, scope) as WalletLike.WalletOf<T>;
+        }).pipe(Effect.runSync);
+      }
+
       static start<T extends WalletLike.AnyWalletClass<Variants>, Tag extends string | symbol>(
         WalletClass: T,
         tag: Tag,

--- a/packages/runtime/src/abstractions/StartMaterial.ts
+++ b/packages/runtime/src/abstractions/StartMaterial.ts
@@ -1,0 +1,102 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { type WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Option } from 'effect';
+
+/**
+ * How a variant produces the key material its own sync needs from a seed.
+ *
+ * @remarks
+ *   The seed is the only key material that crosses a protocol boundary. Key _objects_ do not: they belong to one ledger
+ *   version's runtime, and the variant on the other side of a fork cannot use them even though the public keys they
+ *   yield are identical. So each variant is asked to derive its own, and the wallet layer never names a ledger.
+ * @typeParam TStartAux The key material this variant's sync is started with.
+ */
+export type StartAuxCapability<TStartAux> = {
+  /**
+   * Derives this variant's start-auxiliary data from a seed.
+   *
+   * @param seed The seed the application started the wallet from.
+   * @returns The key material this variant's sync service expects.
+   */
+  fromSeed(seed: WalletSeed.WalletSeed): TStartAux;
+};
+
+/**
+ * What a wallet retains so it can start synchronization on whichever variant becomes current.
+ *
+ * @remarks
+ *   A wallet that follows the chain across a protocol boundary starts sync more than once: the variant it began on, and
+ *   then every variant a migration activates. Sync needs key material, which is deliberately absent from anything the
+ *   wallet serializes, so the wallet holds on to whatever the application started it with — and what it holds decides
+ *   whether it can answer for a variant it has not met yet.
+ *
+ *   `FromSeed` can: every variant derives its own. `ForVariants` can only answer for the variants it was given key
+ *   objects for, which is why it is a map rather than a single value — a caller that insists on holding key objects has
+ *   to hold one per protocol version, and a partial set is a miss rather than a wrong answer.
+ * @typeParam TStartAux The key material a variant's sync is started with.
+ */
+export type StartMaterial<TStartAux> =
+  | Readonly<{ _tag: 'FromSeed'; seed: WalletSeed.WalletSeed }>
+  | Readonly<{ _tag: 'ForVariants'; byTag: ReadonlyMap<string | symbol, TStartAux> }>;
+
+/**
+ * Retains a seed, from which every variant derives its own key material.
+ *
+ * @param seed The seed the application started the wallet from.
+ * @returns Start material that answers for any variant.
+ */
+export const fromSeed = <TStartAux>(seed: WalletSeed.WalletSeed): StartMaterial<TStartAux> => ({
+  _tag: 'FromSeed',
+  seed,
+});
+
+/**
+ * Retains key objects supplied per variant.
+ *
+ * @param entries The key material, paired with the tag of the variant it belongs to.
+ * @returns Start material that answers only for the variants named in `entries`.
+ */
+export const forVariants = <TStartAux>(
+  entries: Iterable<readonly [string | symbol, TStartAux]>,
+): StartMaterial<TStartAux> => ({
+  _tag: 'ForVariants',
+  byTag: new Map(entries),
+});
+
+/**
+ * Retains key objects for a single variant.
+ *
+ * @param variantTag The tag of the variant the key material belongs to.
+ * @param aux The key material.
+ * @returns Start material that answers only for `variantTag`.
+ */
+export const forVariant = <TStartAux>(variantTag: string | symbol, aux: TStartAux): StartMaterial<TStartAux> =>
+  forVariants([[variantTag, aux]]);
+
+/**
+ * Produces the key material a given variant should start its synchronization with.
+ *
+ * @param material What the wallet retained when the application started it.
+ * @param variantTag The tag of the variant asking.
+ * @param deriveFromSeed That variant's own derivation, consulted only for retained seeds.
+ * @returns The key material, or `Option.none()` when the wallet holds nothing that variant can use.
+ */
+export const auxFor = <TStartAux>(
+  material: StartMaterial<TStartAux>,
+  variantTag: string | symbol,
+  deriveFromSeed: (seed: WalletSeed.WalletSeed) => TStartAux,
+): Option.Option<TStartAux> =>
+  material._tag === 'FromSeed'
+    ? Option.some(deriveFromSeed(material.seed))
+    : Option.fromNullable(material.byTag.get(variantTag));

--- a/packages/runtime/src/abstractions/WalletLike.ts
+++ b/packages/runtime/src/abstractions/WalletLike.ts
@@ -43,6 +43,28 @@ export interface BaseWalletClass<TVariants extends AnyVersionedVariantArray, TCo
     tag: Tag,
     state: StateOf<HList.Find<TVariants, { variant: Poly.WithTag<Tag> }>>,
   ): WalletOf<T>;
+  /**
+   * Starts a wallet on a variant that was resolved at runtime, with the state that variant produced.
+   *
+   * @remarks
+   *   The sibling {@link start} addresses a variant by a tag known statically, which is what lets it demand exactly that
+   *   variant's state type. A tag recovered from data — a snapshot's protocol version, the chain's current version —
+   *   carries no such static knowledge, and `HList.Find` over a union of tags cannot recover it: it resolves to the
+   *   first matching registration, or to `never`, so the state parameter it computes is not the one the caller holds.
+   *
+   *   Passing the resolved variant itself instead keeps the two ends of the pairing together. The state is typed as that
+   *   variant's, which for a `variantFor` result is the union of the registered variants' states — the honest guarantee
+   *   when the version is runtime data, and enough to make the call type-check without a cast at the call site.
+   * @param walletClass The wallet class to construct.
+   * @param variant The versioned variant to start on, as resolved by {@link variantFor}.
+   * @param state The state that variant is to start from.
+   * @returns The started wallet.
+   */
+  startAtVariant<T extends WalletClassLike<TVariants, any>, TVariant extends HList.Each<TVariants>>(
+    walletClass: T,
+    variant: TVariant,
+    state: StateOf<TVariant>,
+  ): WalletOf<T>;
 }
 
 /** Defines the static portion of wallet-like definition */

--- a/packages/runtime/src/abstractions/index.ts
+++ b/packages/runtime/src/abstractions/index.ts
@@ -10,6 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+export * as StartMaterial from './StartMaterial.js';
 export * as Variant from './Variant.js';
 export * as VariantBuilder from './VariantBuilder.js';
 export * as WalletLike from './WalletLike.js';

--- a/packages/runtime/src/abstractions/test/startMaterial.test.ts
+++ b/packages/runtime/src/abstractions/test/startMaterial.test.ts
@@ -1,0 +1,93 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import * as StartMaterial from '../StartMaterial.js';
+
+/** Stands in for a ledger's key object: what a variant derives from the seed it is handed. */
+type Keys = Readonly<{ derivedFrom: string; ledger: string }>;
+
+const seed = WalletSeed.fromString('00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff');
+const otherSeed = WalletSeed.fromString('ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100');
+
+const preForkTag = Symbol('pre-fork');
+const postForkTag = Symbol('post-fork');
+
+/** Each variant derives its own ledger's key type from whatever seed it is given. */
+const derivedBy =
+  (ledger: string) =>
+  (given: WalletSeed.WalletSeed): Keys => ({ derivedFrom: Buffer.from(given).toString('hex'), ledger });
+
+const neverDerives = (): Keys => {
+  throw new Error('The derivation must not be consulted for material that already carries key objects');
+};
+
+describe('StartMaterial', () => {
+  describe('retained as a seed', () => {
+    it('derives key material for whichever variant asks, using that variant s own derivation', () => {
+      const retained = StartMaterial.fromSeed<Keys>(seed);
+
+      expect(StartMaterial.auxFor(retained, preForkTag, derivedBy('v8'))).toStrictEqual(
+        Option.some({ derivedFrom: Buffer.from(seed).toString('hex'), ledger: 'v8' }),
+      );
+      expect(StartMaterial.auxFor(retained, postForkTag, derivedBy('v9'))).toStrictEqual(
+        Option.some({ derivedFrom: Buffer.from(seed).toString('hex'), ledger: 'v9' }),
+      );
+    });
+
+    it('hands over the seed it retained, not some other one', () => {
+      const retained = StartMaterial.fromSeed<Keys>(otherSeed);
+
+      expect(StartMaterial.auxFor(retained, postForkTag, derivedBy('v9'))).toStrictEqual(
+        Option.some({ derivedFrom: Buffer.from(otherSeed).toString('hex'), ledger: 'v9' }),
+      );
+    });
+
+    it('answers for a variant that was never named, which is the point of retaining a seed', () => {
+      const retained = StartMaterial.fromSeed<Keys>(seed);
+
+      expect(
+        Option.isSome(StartMaterial.auxFor(retained, Symbol('a variant nobody has heard of'), derivedBy('vN'))),
+      ).toBe(true);
+    });
+  });
+
+  describe('retained as key objects', () => {
+    it('returns the key material registered for the variant that asks', () => {
+      const preForkKeys: Keys = { derivedFrom: 'elsewhere', ledger: 'v8' };
+      const postForkKeys: Keys = { derivedFrom: 'elsewhere', ledger: 'v9' };
+      const retained = StartMaterial.forVariants<Keys>([
+        [preForkTag, preForkKeys],
+        [postForkTag, postForkKeys],
+      ]);
+
+      expect(StartMaterial.auxFor(retained, preForkTag, neverDerives)).toStrictEqual(Option.some(preForkKeys));
+      expect(StartMaterial.auxFor(retained, postForkTag, neverDerives)).toStrictEqual(Option.some(postForkKeys));
+    });
+
+    it('reports a miss for a variant it holds no key material for, rather than handing over another variant s', () => {
+      const retained = StartMaterial.forVariant<Keys>(preForkTag, { derivedFrom: 'elsewhere', ledger: 'v8' });
+
+      expect(StartMaterial.auxFor(retained, postForkTag, neverDerives)).toStrictEqual(Option.none());
+    });
+
+    it('treats a single variant s key material as the one-entry case', () => {
+      const keys: Keys = { derivedFrom: 'elsewhere', ledger: 'v9' };
+
+      expect(StartMaterial.forVariant<Keys>(postForkTag, keys)).toStrictEqual(
+        StartMaterial.forVariants<Keys>([[postForkTag, keys]]),
+      );
+    });
+  });
+});

--- a/packages/runtime/src/test/walletBuilder.test.ts
+++ b/packages/runtime/src/test/walletBuilder.test.ts
@@ -225,6 +225,21 @@ describe('Wallet Builder', () => {
       await wallet.stop();
     });
 
+    it('narrows an emission s state to the variant its tag names', async () => {
+      const Wallet = walletOverTwoStateTypes();
+      const resolved = Wallet.variantFor(ProtocolVersion.MinSupportedVersion).pipe(Option.getOrThrow);
+      const wallet = Wallet.startAtVariant(Wallet, resolved, 'restored');
+
+      const emission = await rx.firstValueFrom(wallet.rawState);
+
+      // Only compiles if `variantTag` discriminates `state`: a string operation on one side of the
+      // branch, arithmetic on the other. That is the zero-cast capability selection the tag exists for.
+      const described = emission.variantTag === 'pre' ? emission.state.toUpperCase() : emission.state + 1;
+
+      expect(described).toBe('RESTORED');
+      await wallet.stop();
+    });
+
     it('takes the union of the registered variants states, so a resolved variant is callable at all', () => {
       const Wallet = walletOverTwoStateTypes();
       const resolved = Wallet.variantFor(ProtocolVersion.MinSupportedVersion).pipe(Option.getOrThrow);

--- a/packages/runtime/src/test/walletBuilder.test.ts
+++ b/packages/runtime/src/test/walletBuilder.test.ts
@@ -32,6 +32,7 @@ import {
   toProtocolStateArray,
 } from '../testing/utils.js';
 import {
+  InterceptingVariantBuilder,
   Numeric,
   NumericMultiplier,
   type NumericRange,
@@ -184,6 +185,55 @@ describe('Wallet Builder', () => {
           multiplier: 2,
         }),
       ).toThrow('ProtocolMismatch: sinceVersion is prior to previously registered version');
+    });
+  });
+
+  describe('starting at a variant resolved from a protocol version', () => {
+    // The two variants deliberately keep different state types: a tag alone cannot say which of them a
+    // state belongs to once the version is runtime data, which is exactly what this entry point is for.
+    const walletOverTwoStateTypes = () =>
+      WalletBuilder.init()
+        .withVariant(ProtocolVersion.MinSupportedVersion, new InterceptingVariantBuilder<'pre', string>('pre'))
+        .withVariant(ProtocolVersion.ProtocolVersion(100n), new NumericRangeBuilder(10))
+        .build({ min: 0, max: 2 });
+
+    it('starts on the resolved variant, at the version that variant was registered from', async () => {
+      const Wallet = walletOverTwoStateTypes();
+      const resolved = Wallet.variantFor(ProtocolVersion.ProtocolVersion(120n)).pipe(Option.getOrThrow);
+
+      const wallet = Wallet.startAtVariant(Wallet, resolved, 0);
+
+      expect(await rx.firstValueFrom(wallet.rawState)).toEqual({
+        version: ProtocolVersion.ProtocolVersion(100n),
+        variantTag: Numeric,
+        state: 0,
+      });
+      await wallet.stop();
+    });
+
+    it('starts on the head variant when that is the one resolved, taking its own state type', async () => {
+      const Wallet = walletOverTwoStateTypes();
+      const resolved = Wallet.variantFor(ProtocolVersion.MinSupportedVersion).pipe(Option.getOrThrow);
+
+      const wallet = Wallet.startAtVariant(Wallet, resolved, 'restored');
+
+      expect(await rx.firstValueFrom(wallet.rawState)).toEqual({
+        version: ProtocolVersion.MinSupportedVersion,
+        variantTag: 'pre',
+        state: 'restored',
+      });
+      await wallet.stop();
+    });
+
+    it('takes the union of the registered variants states, so a resolved variant is callable at all', () => {
+      const Wallet = walletOverTwoStateTypes();
+      const resolved = Wallet.variantFor(ProtocolVersion.MinSupportedVersion).pipe(Option.getOrThrow);
+
+      type _1 = Expect<
+        Equal<Parameters<typeof Wallet.startAtVariant<typeof Wallet, typeof resolved>>[2], string | number>
+      >;
+
+      expect(Option.isSome(Wallet.variantFor(ProtocolVersion.MinSupportedVersion))).toBe(true);
     });
   });
 

--- a/packages/runtime/src/test/walletBuilder.test.ts
+++ b/packages/runtime/src/test/walletBuilder.test.ts
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
-import { type HList } from '@midnightntwrk/wallet-sdk-utilities';
 import { type Equal, type Expect } from '@midnightntwrk/wallet-sdk-utilities/types';
 import { Effect, Option, PubSub, Scope, Stream } from 'effect';
 import * as rx from 'rxjs';
@@ -23,7 +22,8 @@ import {
   VersionChangeType,
   type WalletLike,
 } from '../abstractions/index.js';
-import { type Runtime } from '../Runtime.js';
+import type * as Runtime from '../Runtime.js';
+import { type Runtime as RuntimeService } from '../Runtime.js';
 import {
   isOrderedSubsequenceOf,
   isRange,
@@ -242,10 +242,10 @@ describe('Wallet Builder', () => {
 
     it('takes the union of the registered variants states, so a resolved variant is callable at all', () => {
       const Wallet = walletOverTwoStateTypes();
-      const resolved = Wallet.variantFor(ProtocolVersion.MinSupportedVersion).pipe(Option.getOrThrow);
+      const _resolved = Wallet.variantFor(ProtocolVersion.MinSupportedVersion).pipe(Option.getOrThrow);
 
       type _1 = Expect<
-        Equal<Parameters<typeof Wallet.startAtVariant<typeof Wallet, typeof resolved>>[2], string | number>
+        Equal<Parameters<typeof Wallet.startAtVariant<typeof Wallet, typeof _resolved>>[2], string | number>
       >;
 
       expect(Option.isSome(Wallet.variantFor(ProtocolVersion.MinSupportedVersion))).toBe(true);
@@ -283,7 +283,7 @@ describe('Wallet Builder', () => {
       Equal<typeof Wallet, WalletLike.BaseWalletClass<[Variant.VersionedVariant<NumericRange>], RangeConfig>>
     >;
     type _2 = Expect<Equal<typeof wallet, WalletLike.WalletLike<[Variant.VersionedVariant<NumericRange>]>>>;
-    type _3 = Expect<Equal<typeof wallet.runtime, Runtime<[Variant.VersionedVariant<NumericRange>]>>>;
+    type _3 = Expect<Equal<typeof wallet.runtime, RuntimeService<[Variant.VersionedVariant<NumericRange>]>>>;
     type _4 = Expect<Equal<typeof wallet.rawState, rx.Observable<ProtocolState.ProtocolState<number, typeof Numeric>>>>;
 
     expect(wallet).toBeDefined();
@@ -324,11 +324,14 @@ describe('Wallet Builder', () => {
 
     type Variants = [Variant.VersionedVariant<NumericRange>, Variant.VersionedVariant<NumericRangeMultiplier>];
     type _1 = Expect<Equal<typeof wallet, WalletLike.WalletLike<Variants>>>;
-    type _2 = Expect<Equal<typeof wallet.runtime, Runtime<Variants>>>;
+    type _2 = Expect<Equal<typeof wallet.runtime, RuntimeService<Variants>>>;
     type _3 = Expect<
       Equal<
         typeof wallet.rawState,
-        rx.Observable<ProtocolState.ProtocolState<number, typeof Numeric | typeof NumericMultiplier>>
+        rx.Observable<
+          | ProtocolState.ProtocolState<number, typeof Numeric>
+          | ProtocolState.ProtocolState<number, typeof NumericMultiplier>
+        >
       >
     >;
 
@@ -368,12 +371,7 @@ describe('Wallet Builder', () => {
     const wallet = Wallet.startEmpty(Wallet);
 
     type Variants = [Variant.VersionedVariant<NumericRange>, Variant.VersionedVariant<NumericRangeMultiplier>];
-    type _1 = Expect<
-      Equal<
-        typeof wallet.rawState,
-        rx.Observable<ProtocolState.ProtocolState<number, Variant.VariantTag<HList.Each<Variants>>>>
-      >
-    >;
+    type _1 = Expect<Equal<typeof wallet.rawState, rx.Observable<Runtime.RuntimeState<Variants>>>>;
 
     const receivedStates = await toProtocolStateArray(
       wallet.rawState.pipe(rx.takeWhile(({ state }) => state !== 8, true)),

--- a/packages/shielded-wallet/src/Restore.ts
+++ b/packages/shielded-wallet/src/Restore.ts
@@ -1,0 +1,84 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Data, Either, Option, Schema } from 'effect';
+
+/**
+ * Raised when a snapshot declares a protocol version that no registered variant is able to read.
+ *
+ * @remarks
+ *   A wallet built for one range of protocol versions cannot invent a reader for a snapshot written outside it, and
+ *   guessing — handing the bytes to whichever variant happens to be registered — would decode them with the wrong
+ *   ledger. The version is carried on the error so an application can say which one it was.
+ */
+export class UnsupportedSnapshotVersionError extends Data.TaggedError(
+  '@midnightntwrk/wallet-sdk-shielded/Restore/UnsupportedSnapshotVersionError',
+)<{
+  readonly message: string;
+  readonly protocolVersion: ProtocolVersion.ProtocolVersion;
+}> {}
+
+/**
+ * The envelope the peek reads.
+ *
+ * @remarks
+ *   Deliberately the smallest possible description of a snapshot: one optional field, every other ignored. It has to read
+ *   snapshots written by _any_ variant, including ones whose full schema this build does not have, so it must not
+ *   assert anything it does not need. Everything it cannot make sense of is reported as "no version declared", leaving
+ *   the real diagnosis to the deserializer that eventually reads the whole thing.
+ */
+const EnvelopeSchema = Schema.Struct({
+  protocolVersion: Schema.optional(ProtocolVersion.ProtocolVersionSchema),
+});
+
+/**
+ * Reads the protocol version a serialized wallet snapshot declares.
+ *
+ * @param serialized The serialized wallet state.
+ * @returns The declared version, or `Option.none()` when the snapshot declares none or cannot be read at all.
+ */
+export const peekProtocolVersion = (serialized: string): Option.Option<ProtocolVersion.ProtocolVersion> =>
+  Schema.decodeUnknownOption(Schema.parseJson(EnvelopeSchema))(serialized).pipe(
+    Option.flatMap((envelope) => Option.fromNullable(envelope.protocolVersion)),
+  );
+
+/**
+ * Chooses the variant that should read a serialized wallet snapshot.
+ *
+ * @remarks
+ *   A snapshot that declares no version predates snapshots declaring one, and can only have been written by the variant
+ *   that shipped before the question arose — the head variant. The same fallback covers an envelope this function
+ *   cannot read at all: refusing it here would replace the deserializer's precise error with a vaguer one.
+ * @param serialized The serialized wallet state.
+ * @param variantFor Resolves the variant registered for a protocol version.
+ * @param headVariant The variant a snapshot with no declared version is restored into.
+ * @returns The variant to restore with, or {@link UnsupportedSnapshotVersionError} when the declared version is one no
+ *   registered variant owns.
+ */
+export const variantForSnapshot = <TVariant>(
+  serialized: string,
+  variantFor: (version: ProtocolVersion.ProtocolVersion) => Option.Option<TVariant>,
+  headVariant: TVariant,
+): Either.Either<TVariant, UnsupportedSnapshotVersionError> =>
+  Option.match(peekProtocolVersion(serialized), {
+    onNone: () => Either.right(headVariant),
+    onSome: (protocolVersion) =>
+      Either.fromOption(
+        variantFor(protocolVersion),
+        () =>
+          new UnsupportedSnapshotVersionError({
+            message: `No registered variant reads shielded wallet snapshots of protocol version ${protocolVersion}.`,
+            protocolVersion,
+          }),
+      ),
+  });

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -42,6 +42,8 @@ import { type BatchUpdatesConfig, type IndexerClientConnection, type WalletSyncU
 import { type ShieldedHistoryStorage, type TransactionHistoryService } from './v2/TransactionHistory.js';
 import { type Variant, type VariantBuilder, type WalletLike } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
+import { HList } from '@midnightntwrk/wallet-sdk-utilities';
+import { variantForSnapshot } from './Restore.js';
 
 export type ShieldedWalletCapabilities<TSerialized = string> = {
   serialization: SerializationCapability<CoreWallet, null, TSerialized>;
@@ -259,11 +261,39 @@ export function CustomShieldedWallet<
       return CustomShieldedWalletImplementation.startWithSecretKeys(secretKeys);
     }
 
+    /**
+     * Restores a wallet from a snapshot, into whichever registered variant wrote it.
+     *
+     * @remarks
+     *   The snapshot declares the protocol version it was written at, so the variant that can read it is a lookup rather
+     *   than an assumption. A snapshot written before snapshots declared a version, or a serialization format this
+     *   wallet does not recognise as an envelope at all, restores into the head variant — which is what every restore
+     *   did before there was more than one variant to choose between.
+     * @param serializedState The serialized wallet state.
+     * @returns A wallet started from that state, on the variant that owns its protocol version.
+     * @throws UnsupportedSnapshotVersionError if the snapshot declares a version no registered variant reads.
+     */
     static restore(serializedState: TSerialized): CustomShieldedWalletImplementation {
-      const deserialized: CoreWallet = CustomShieldedWalletImplementation.allVariantsRecord()
-        [V2Tag].variant.deserializeState(serializedState)
-        .pipe(Either.getOrThrow);
-      return CustomShieldedWalletImplementation.startFirst(CustomShieldedWalletImplementation, deserialized);
+      const headVariant = HList.head(CustomShieldedWalletImplementation.allVariants());
+      const routed =
+        // Routing reads a serialized envelope, which only a wallet keeping the default string serialization has. A
+        // custom format is left with the behaviour it has always had.
+        typeof serializedState === 'string'
+          ? variantForSnapshot(
+              serializedState,
+              (version) => CustomShieldedWalletImplementation.variantFor(version),
+              headVariant,
+            )
+          : Either.right(headVariant);
+
+      const variant = routed.pipe(Either.getOrThrow);
+      const deserialized = variant.variant.deserializeState(serializedState).pipe(Either.getOrThrow);
+
+      return CustomShieldedWalletImplementation.startAtVariant(
+        CustomShieldedWalletImplementation,
+        variant,
+        deserialized,
+      );
     }
 
     readonly state: rx.Observable<ShieldedWalletState<TSerialized>>;

--- a/packages/shielded-wallet/src/index.ts
+++ b/packages/shielded-wallet/src/index.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 export * from './ShieldedWallet.js';
+export * as Restore from './Restore.js';
 export {
   type ShieldedTransactionHistoryEntry,
   ShieldedSectionSchema,

--- a/packages/shielded-wallet/src/test/forkWallet.ts
+++ b/packages/shielded-wallet/src/test/forkWallet.ts
@@ -246,6 +246,7 @@ export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
     .withCoinsAndBalancesDefaults()
     .withTransactionHistory(() => noOpPreForkHistory)
     .withKeysDefaults()
+    .withStartAuxDefaults()
     .withCoinSelectionDefaults();
 
   const postForkBuilder = new V2.V2Builder()
@@ -256,6 +257,7 @@ export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
     .withCoinsAndBalancesDefaults()
     .withTransactionHistory(() => noOpPostForkHistory)
     .withKeysDefaults()
+    .withStartAuxDefaults()
     .withCoinSelectionDefaults()
     .withMigration(() => capturingCrossLedgerMigration(captured));
 

--- a/packages/shielded-wallet/src/test/restore.test.ts
+++ b/packages/shielded-wallet/src/test/restore.test.ts
@@ -1,0 +1,97 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Either, Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { peekProtocolVersion, UnsupportedSnapshotVersionError, variantForSnapshot } from '../Restore.js';
+
+/** A snapshot envelope carrying a declared protocol version, plus the fields the peek must ignore. */
+const envelope = (protocolVersion: string): string =>
+  JSON.stringify({
+    publicKeys: { coinPublicKey: 'aa', encryptionPublicKey: 'bb' },
+    state: 'deadbeef',
+    protocolVersion,
+    networkId: 'undeployed',
+    coinHashes: {},
+  });
+
+/** The same envelope as written before snapshots declared a version at all. */
+const legacyEnvelope = JSON.stringify({
+  publicKeys: { coinPublicKey: 'aa', encryptionPublicKey: 'bb' },
+  state: 'deadbeef',
+  networkId: 'undeployed',
+  coinHashes: {},
+});
+
+const preFork = { name: 'pre-fork variant' };
+const postFork = { name: 'post-fork variant' };
+
+/** Stands in for `BaseWalletClass.variantFor`: pre-fork below 100, post-fork from 100, nothing above 1000. */
+const registered = (version: ProtocolVersion.ProtocolVersion): Option.Option<typeof preFork> =>
+  version >= 1000n ? Option.none() : Option.some(version >= 100n ? postFork : preFork);
+
+const neverResolves = (): Option.Option<typeof preFork> => {
+  throw new Error('A snapshot that declares no version must not be routed by version');
+};
+
+describe('peekProtocolVersion', () => {
+  it('reads the version a snapshot declares, ignoring every other field', () => {
+    expect(peekProtocolVersion(envelope('100'))).toStrictEqual(Option.some(ProtocolVersion.ProtocolVersion(100n)));
+  });
+
+  it('reads a version from an envelope carrying nothing else', () => {
+    expect(peekProtocolVersion(JSON.stringify({ protocolVersion: '7' }))).toStrictEqual(
+      Option.some(ProtocolVersion.ProtocolVersion(7n)),
+    );
+  });
+
+  it('finds nothing in a snapshot written before snapshots declared a version', () => {
+    expect(peekProtocolVersion(legacyEnvelope)).toStrictEqual(Option.none());
+  });
+
+  it('finds nothing, rather than throwing, in something that is not a snapshot envelope at all', () => {
+    expect(peekProtocolVersion('not json at all')).toStrictEqual(Option.none());
+    expect(peekProtocolVersion('[]')).toStrictEqual(Option.none());
+    expect(peekProtocolVersion('"a string"')).toStrictEqual(Option.none());
+    expect(peekProtocolVersion('')).toStrictEqual(Option.none());
+  });
+
+  it('finds nothing when the declared version is not a version', () => {
+    expect(peekProtocolVersion(JSON.stringify({ protocolVersion: 'tomorrow' }))).toStrictEqual(Option.none());
+    expect(peekProtocolVersion(JSON.stringify({ protocolVersion: null }))).toStrictEqual(Option.none());
+  });
+});
+
+describe('variantForSnapshot', () => {
+  it('routes a snapshot to the variant that owns the version it declares', () => {
+    expect(variantForSnapshot(envelope('100'), registered, preFork)).toStrictEqual(Either.right(postFork));
+    expect(variantForSnapshot(envelope('99'), registered, preFork)).toStrictEqual(Either.right(preFork));
+  });
+
+  it('falls back to the head variant for a snapshot that declares no version', () => {
+    expect(variantForSnapshot(legacyEnvelope, neverResolves, preFork)).toStrictEqual(Either.right(preFork));
+  });
+
+  it('falls back to the head variant for an envelope it cannot read, leaving the real error to deserialization', () => {
+    expect(variantForSnapshot('not json at all', neverResolves, preFork)).toStrictEqual(Either.right(preFork));
+  });
+
+  it('reports a version no registered variant owns, naming it', () => {
+    const routed = variantForSnapshot(envelope('4000'), registered, preFork);
+
+    const error = routed.pipe(Either.flip, Either.getOrThrow);
+    expect(error).toBeInstanceOf(UnsupportedSnapshotVersionError);
+    expect(error._tag).toBe('@midnightntwrk/wallet-sdk-shielded/Restore/UnsupportedSnapshotVersionError');
+    expect(error.protocolVersion).toBe(ProtocolVersion.ProtocolVersion(4000n));
+  });
+});

--- a/packages/shielded-wallet/src/v1/V1Builder.ts
+++ b/packages/shielded-wallet/src/v1/V1Builder.ts
@@ -10,10 +10,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import type * as ledger from '@midnight-ntwrk/ledger-v8';
+import * as ledger from '@midnight-ntwrk/ledger-v8';
 import { Effect, type Either, Scope, type Types } from 'effect';
 import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
-import { type Variant, type VariantBuilder, WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import {
+  type Variant,
+  type VariantBuilder,
+  WalletRuntimeError,
+  type StartMaterial,
+} from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type EmptyWalletMigrationConfiguration, type StateMigration, makeEmptyWalletMigration } from './Migration.js';
 import { RunningV1Variant, V1Tag } from './RunningV1Variant.js';
 import { makeDefaultV1SerializationCapability, type SerializationCapability } from './Serialization.js';
@@ -71,6 +76,7 @@ export type V1Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData, TPreviou
   keys: KeysCapability<CoreWallet>;
   serialization: SerializationCapability<CoreWallet, null, TSerialized>;
   transactionHistory: TransactionHistoryService;
+  startAux: StartMaterial.StartAuxCapability<TAuxData>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -143,6 +149,7 @@ export class V1Builder<
         .withCoinsAndBalancesDefaults()
         .withTransactionHistoryDefaults()
         .withKeysDefaults()
+        .withStartAuxDefaults()
         // Type cast required because: the chain accumulates `TContext` as an intersection of the individual
         // `Default*Context` fragments, which is a structurally weaker type than the complete
         // `RunningV1Variant.Context` that `DefaultV1Builder` names — the defaults do produce a full context, but the
@@ -227,6 +234,9 @@ export class V1Builder<
       ...this.#buildState,
       syncService,
       syncCapability,
+      // The derivation is typed against the *old* start-aux parameter, so it cannot ride along into a builder whose
+      // sync service expects something else — exactly as the migration cannot ride along through `withMigration`.
+      startAux: undefined,
     });
   }
 
@@ -462,6 +472,35 @@ export class V1Builder<
   }
 
   /**
+   * Uses the default start-aux derivation: this ledger version's Zswap secret keys, derived from the seed.
+   *
+   * @remarks
+   *   The seed is the only key material that crosses a protocol boundary, so every variant must be able to produce its
+   *   own from one. This is that derivation for this ledger version; a builder whose sync service expects something
+   *   else supplies its own with {@link V1Builder.withStartAux}.
+   */
+  withStartAuxDefaults(
+    this: V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, ledger.ZswapSecretKeys, TPreviousState>,
+  ): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, ledger.ZswapSecretKeys, TPreviousState> {
+    return this.withStartAux({ fromSeed: (seed) => ledger.ZswapSecretKeys.fromSeed(seed) });
+  }
+
+  /**
+   * Chooses how this variant derives the key material its synchronization is started with from a seed.
+   *
+   * @param startAux The derivation.
+   * @returns A builder that produces a variant able to start sync from a seed alone.
+   */
+  withStartAux(
+    startAux: StartMaterial.StartAuxCapability<TStartAux>,
+  ): V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState> {
+    return new V1Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState>({
+      ...this.#buildState,
+      startAux,
+    });
+  }
+
+  /**
    * Uses the default migration: an empty wallet built from nothing.
    *
    * @remarks
@@ -565,6 +604,7 @@ export class V1Builder<
       keys: v1Context.keysCapability,
       serialization: v1Context.serializationCapability,
       transactionHistory: v1Context.transactionHistoryService,
+      startAux: this.#resolveStartAux(),
       start(
         context: Variant.VariantContext<CoreWallet>,
       ): Effect.Effect<
@@ -606,6 +646,23 @@ export class V1Builder<
    *   value could only be widened to `StateMigration<TPreviousState>` through a cast. Declaring no parameter says the
    *   same thing to the type system without one.
    */
+  /**
+   * Resolves the configured start-aux derivation.
+   *
+   * @remarks
+   *   Unlike the migration there is no sensible fallback: the default derivation produces this ledger version's secret
+   *   keys, which is only correct for a builder that kept a sync service expecting them. A builder that replaced sync
+   *   and did not say how to derive its own key material is misconfigured, and is told so at build time rather than
+   *   silently handed key objects of the wrong shape at the first migration.
+   */
+  #resolveStartAux(): StartMaterial.StartAuxCapability<TStartAux> {
+    const configured = this.#buildState.startAux;
+    if (configured === undefined) {
+      throw new Error('Not all components are configured in V1 Builder: startAux');
+    }
+    return configured;
+  }
+
   #resolveMigration(configuration: TConfig, getContext: () => TContext): StateMigration<TPreviousState> {
     const configured = this.#buildState.migration;
     return configured === undefined
@@ -724,6 +781,14 @@ declare namespace V1Builder {
    * behaviour every builder had before migrations were configurable, so a builder that never mentions migration must
    * still be considered complete.
    */
+  /**
+   * The start-aux entry, kept out of {@link FullBuildState} because it is not one of the context-producing capabilities:
+   * it takes neither configuration nor sibling capabilities, only a seed.
+   */
+  type HasStartAux<TStartAux> = {
+    readonly startAux: StartMaterial.StartAuxCapability<TStartAux>;
+  };
+
   type HasMigration<TConfig, TContext, TPreviousState> = {
     readonly migration: (configuration: TConfig, getContext: () => TContext) => StateMigration<TPreviousState>;
   };
@@ -750,9 +815,14 @@ declare namespace V1Builder {
     TStartAux = object,
     TPreviousState = null,
   > = {
-    [K in keyof (FullBuildState<never, never, never, never, never, never> & HasMigration<never, never, never>)]?:
+    [
+      K in keyof (FullBuildState<never, never, never, never, never, never> &
+        HasMigration<never, never, never> &
+        HasStartAux<never>)
+    ]?:
       | (FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> &
-          HasMigration<TConfig, TContext, TPreviousState>)[K]
+          HasMigration<TConfig, TContext, TPreviousState> &
+          HasStartAux<TStartAux>)[K]
       | undefined;
   };
 

--- a/packages/shielded-wallet/src/v1/test/startAux.test.ts
+++ b/packages/shielded-wallet/src/v1/test/startAux.test.ts
@@ -1,0 +1,56 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { InMemoryTransactionHistoryStorage, NetworkId, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
+import { describe, expect, it } from 'vitest';
+import { ShieldedTransactionHistoryEntrySchema } from '../TransactionHistory.js';
+import { type DefaultV1Configuration, V1Builder } from '../V1Builder.js';
+
+const configuration: DefaultV1Configuration = {
+  networkId: NetworkId.NetworkId.Undeployed,
+  indexerClientConnection: { indexerHttpUrl: 'http://unused:0' },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(ShieldedTransactionHistoryEntrySchema),
+};
+
+const seed = WalletSeed.fromString('00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff');
+
+describe('start-aux capability', () => {
+  it('derives this ledger version s secret keys from a seed', () => {
+    const variant = new V1Builder().withDefaults().build(configuration);
+    const expected = ledger.ZswapSecretKeys.fromSeed(seed);
+
+    const derived = variant.startAux.fromSeed(seed);
+
+    expect(derived.coinPublicKey).toBe(expected.coinPublicKey);
+    expect(derived.encryptionPublicKey).toBe(expected.encryptionPublicKey);
+  });
+
+  it('derives different key material from a different seed', () => {
+    const variant = new V1Builder().withDefaults().build(configuration);
+    const otherSeed = WalletSeed.fromString('ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100');
+
+    expect(variant.startAux.fromSeed(seed).coinPublicKey).not.toBe(variant.startAux.fromSeed(otherSeed).coinPublicKey);
+  });
+
+  it('lets a builder supply its own derivation', () => {
+    const fixed = ledger.ZswapSecretKeys.fromSeed(
+      WalletSeed.fromString('0000000000000000000000000000000000000000000000000000000000000001'),
+    );
+    const variant = new V1Builder()
+      .withDefaults()
+      .withStartAux({ fromSeed: () => fixed })
+      .build(configuration);
+
+    expect(variant.startAux.fromSeed(seed).coinPublicKey).toBe(fixed.coinPublicKey);
+  });
+});

--- a/packages/shielded-wallet/src/v2/V2Builder.ts
+++ b/packages/shielded-wallet/src/v2/V2Builder.ts
@@ -10,10 +10,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import type * as ledger from '@midnightntwrk/ledger-v9';
+import * as ledger from '@midnightntwrk/ledger-v9';
 import { Effect, type Either, Scope, type Types } from 'effect';
 import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
-import { type Variant, type VariantBuilder, WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import {
+  type Variant,
+  type VariantBuilder,
+  WalletRuntimeError,
+  type StartMaterial,
+} from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type EmptyWalletMigrationConfiguration, type StateMigration, makeEmptyWalletMigration } from './Migration.js';
 import { RunningV2Variant, V2Tag } from './RunningV2Variant.js';
 import { makeDefaultV2SerializationCapability, type SerializationCapability } from './Serialization.js';
@@ -71,6 +76,7 @@ export type V2Variant<TSerialized, TSyncUpdate, TTransaction, TAuxData, TPreviou
   keys: KeysCapability<CoreWallet>;
   serialization: SerializationCapability<CoreWallet, null, TSerialized>;
   transactionHistory: TransactionHistoryService;
+  startAux: StartMaterial.StartAuxCapability<TAuxData>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -143,6 +149,7 @@ export class V2Builder<
         .withCoinsAndBalancesDefaults()
         .withTransactionHistoryDefaults()
         .withKeysDefaults()
+        .withStartAuxDefaults()
         // Type cast required because: the chain accumulates `TContext` as an intersection of the individual
         // `Default*Context` fragments, which is a structurally weaker type than the complete
         // `RunningV2Variant.Context` that `DefaultV2Builder` names — the defaults do produce a full context, but the
@@ -227,6 +234,9 @@ export class V2Builder<
       ...this.#buildState,
       syncService,
       syncCapability,
+      // The derivation is typed against the *old* start-aux parameter, so it cannot ride along into a builder whose
+      // sync service expects something else — exactly as the migration cannot ride along through `withMigration`.
+      startAux: undefined,
     });
   }
 
@@ -462,6 +472,35 @@ export class V2Builder<
   }
 
   /**
+   * Uses the default start-aux derivation: this ledger version's Zswap secret keys, derived from the seed.
+   *
+   * @remarks
+   *   The seed is the only key material that crosses a protocol boundary, so every variant must be able to produce its
+   *   own from one. This is that derivation for this ledger version; a builder whose sync service expects something
+   *   else supplies its own with {@link V2Builder.withStartAux}.
+   */
+  withStartAuxDefaults(
+    this: V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, ledger.ZswapSecretKeys, TPreviousState>,
+  ): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, ledger.ZswapSecretKeys, TPreviousState> {
+    return this.withStartAux({ fromSeed: (seed) => ledger.ZswapSecretKeys.fromSeed(seed) });
+  }
+
+  /**
+   * Chooses how this variant derives the key material its synchronization is started with from a seed.
+   *
+   * @param startAux The derivation.
+   * @returns A builder that produces a variant able to start sync from a seed alone.
+   */
+  withStartAux(
+    startAux: StartMaterial.StartAuxCapability<TStartAux>,
+  ): V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState> {
+    return new V2Builder<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux, TPreviousState>({
+      ...this.#buildState,
+      startAux,
+    });
+  }
+
+  /**
    * Uses the default migration: an empty wallet built from nothing.
    *
    * @remarks
@@ -565,6 +604,7 @@ export class V2Builder<
       keys: v2Context.keysCapability,
       serialization: v2Context.serializationCapability,
       transactionHistory: v2Context.transactionHistoryService,
+      startAux: this.#resolveStartAux(),
       start(
         context: Variant.VariantContext<CoreWallet>,
       ): Effect.Effect<
@@ -606,6 +646,23 @@ export class V2Builder<
    *   value could only be widened to `StateMigration<TPreviousState>` through a cast. Declaring no parameter says the
    *   same thing to the type system without one.
    */
+  /**
+   * Resolves the configured start-aux derivation.
+   *
+   * @remarks
+   *   Unlike the migration there is no sensible fallback: the default derivation produces this ledger version's secret
+   *   keys, which is only correct for a builder that kept a sync service expecting them. A builder that replaced sync
+   *   and did not say how to derive its own key material is misconfigured, and is told so at build time rather than
+   *   silently handed key objects of the wrong shape at the first migration.
+   */
+  #resolveStartAux(): StartMaterial.StartAuxCapability<TStartAux> {
+    const configured = this.#buildState.startAux;
+    if (configured === undefined) {
+      throw new Error('Not all components are configured in V2 Builder: startAux');
+    }
+    return configured;
+  }
+
   #resolveMigration(configuration: TConfig, getContext: () => TContext): StateMigration<TPreviousState> {
     const configured = this.#buildState.migration;
     return configured === undefined
@@ -724,6 +781,14 @@ declare namespace V2Builder {
    * behaviour every builder had before migrations were configurable, so a builder that never mentions migration must
    * still be considered complete.
    */
+  /**
+   * The start-aux entry, kept out of {@link FullBuildState} because it is not one of the context-producing capabilities:
+   * it takes neither configuration nor sibling capabilities, only a seed.
+   */
+  type HasStartAux<TStartAux> = {
+    readonly startAux: StartMaterial.StartAuxCapability<TStartAux>;
+  };
+
   type HasMigration<TConfig, TContext, TPreviousState> = {
     readonly migration: (configuration: TConfig, getContext: () => TContext) => StateMigration<TPreviousState>;
   };
@@ -750,9 +815,14 @@ declare namespace V2Builder {
     TStartAux = object,
     TPreviousState = null,
   > = {
-    [K in keyof (FullBuildState<never, never, never, never, never, never> & HasMigration<never, never, never>)]?:
+    [
+      K in keyof (FullBuildState<never, never, never, never, never, never> &
+        HasMigration<never, never, never> &
+        HasStartAux<never>)
+    ]?:
       | (FullBuildState<TConfig, TContext, TSerialized, TSyncUpdate, TTransaction, TStartAux> &
-          HasMigration<TConfig, TContext, TPreviousState>)[K]
+          HasMigration<TConfig, TContext, TPreviousState> &
+          HasStartAux<TStartAux>)[K]
       | undefined;
   };
 

--- a/packages/shielded-wallet/src/v2/test/startAux.test.ts
+++ b/packages/shielded-wallet/src/v2/test/startAux.test.ts
@@ -1,0 +1,56 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { InMemoryTransactionHistoryStorage, NetworkId, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
+import { describe, expect, it } from 'vitest';
+import { ShieldedTransactionHistoryEntrySchema } from '../TransactionHistory.js';
+import { type DefaultV2Configuration, V2Builder } from '../V2Builder.js';
+
+const configuration: DefaultV2Configuration = {
+  networkId: NetworkId.NetworkId.Undeployed,
+  indexerClientConnection: { indexerHttpUrl: 'http://unused:0' },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(ShieldedTransactionHistoryEntrySchema),
+};
+
+const seed = WalletSeed.fromString('00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff');
+
+describe('start-aux capability', () => {
+  it('derives this ledger version s secret keys from a seed', () => {
+    const variant = new V2Builder().withDefaults().build(configuration);
+    const expected = ledger.ZswapSecretKeys.fromSeed(seed);
+
+    const derived = variant.startAux.fromSeed(seed);
+
+    expect(derived.coinPublicKey).toBe(expected.coinPublicKey);
+    expect(derived.encryptionPublicKey).toBe(expected.encryptionPublicKey);
+  });
+
+  it('derives different key material from a different seed', () => {
+    const variant = new V2Builder().withDefaults().build(configuration);
+    const otherSeed = WalletSeed.fromString('ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100');
+
+    expect(variant.startAux.fromSeed(seed).coinPublicKey).not.toBe(variant.startAux.fromSeed(otherSeed).coinPublicKey);
+  });
+
+  it('lets a builder supply its own derivation', () => {
+    const fixed = ledger.ZswapSecretKeys.fromSeed(
+      WalletSeed.fromString('0000000000000000000000000000000000000000000000000000000000000001'),
+    );
+    const variant = new V2Builder()
+      .withDefaults()
+      .withStartAux({ fromSeed: () => fixed })
+      .build(configuration);
+
+    expect(variant.startAux.fromSeed(seed).coinPublicKey).toBe(fixed.coinPublicKey);
+  });
+});


### PR DESCRIPTION
Second increment of the dual-ledger public API redesign (WP-5a/b, WP-6, WP-7 runtime half + facade). Stacked on #675. This PR builds the wallet-layer machinery for starting and restoring across variants; the production two-variant registration flip is deliberately NOT here (next PR — see below).

## What's here

- **WP-5a — `StartMaterial`** (`runtime`): what a wallet retains so *any* variant can start sync — `FromSeed { seed }` or `ForVariants { byTag }` (the latter is the generalized both-keys product from the key-decision: a partial set is a typed miss, never wrong-ledger keys). `auxFor(material, tag, deriveFromSeed)` resolves per activation.
- **WP-5b — `startAux` variant capability** (`shielded`): both variants gain `startAux.fromSeed(seed)` deriving their **own** ledger's `ZswapSecretKeys` (plan axiom: the seed is the only key material that crosses the fork). Required on the builder — `withStartAuxDefaults()` in `withDefaults()`, `withStartAux(cap)` for custom chains, resolved at build time with a hard error rather than silent wrong-ledger keys. `withSync` drops a stale derivation, mirroring `withMigration`.
- **WP-6 — restore routing, complete**: `Restore.peekProtocolVersion` (permissive envelope peek) → `variantFor(version)` → new `BaseWalletClass.startAtVariant(class, variant, state)`. A snapshot whose *readable* version no registered variant owns fails with typed `UnsupportedSnapshotVersionError`; a legacy envelope (version absent, unreadable, or payload not a JSON object) falls back to the head variant, leaving real diagnosis to the deserializer. **Serialized format unchanged** — `protocolVersion` was already a required snapshot field.
- **WP-7 (runtime half)**: `RuntimeState` is now a *distributed* union, so `variantTag` is a genuine discriminant — narrowing on it narrows the state type with zero casts (pinned by test). Facade gains additive `FacadeState.protocolVersion` (per wallet) and `activeProtocolVersion` (min of the three).

## Design note: variant-addressed, not tag-addressed, start

`HList.Find` cannot recover a state type from a runtime-derived tag (it collapses to `never`), so instead of weakening the tag-addressed `start`, restore routing hands the **resolved variant** to `startAtVariant` — `StateOf<TVariant>` distributes over the union, callable from a `variantFor` result with no cast at the call site (one justified internal cast at the `Runtime.init` boundary, documented).

## Deliberately deferred (atomic trio, next PR)

The wallet class still retains start-aux directly (WP-5c), state wrappers are still v2-pinned (WP-7b), and `ShieldedWallet(config)` still registers one variant (WP-8). Those three are only *observable* together with two variants registered, and WP-8 drags a ~20-site required-`forkVersion` sweep across 8 packages — landing them as one dedicated PR keeps both PRs honest and reviewable. `src/test/forkWallet.ts` and its remaining workarounds stand until then; the fork-simulation regression tests pass here **unmodified**.

## Plan claim F2 — confirmed, with a caveat

Every scalar the shielded state wrapper projects is a `string` alias in both ledgers, and the coin shapes are byte-identical declarations (`diff` of the two `.d.ts` ranges); the only version-bound member is `CoreWallet.state` + `serialize()` input — exactly as claimed. Caveat carried into WP-7b: identical shape ≠ identical declared type, so capability and state must be selected together inside a `variantTag`-narrowed branch; pairing a V2 capability with a union state would type-check via method bivariance while being wrong.

## Tests & gate

Red-first throughout: `startMaterial` (6), `startAux` v2+v1 mirrors (3+3), `restore` (9), facade `protocolVersion` (4), +4 builder tests. Gate: dist 17/17, typecheck 37/37, lint 58/58, unit 53/53 tasks (928 passed / 22 skipped), effect-language-service clean on changed files (the two `Runtime.ts` hits pre-exist on base), `format:check` + `changeset:check` green. Changesets: runtime minor, shielded **major** (hand-composed builder chains must add `withStartAux`/`withStartAuxDefaults`), facade minor.