### PR TITLE
feat(shielded): retain start material and require the chain's fork version

### DIFF
--- a/.changeset/shielded-required-fork-version.md
+++ b/.changeset/shielded-required-fork-version.md
@@ -1,0 +1,49 @@
+---
+'@midnightntwrk/wallet-sdk-shielded': major
+'@midnightntwrk/wallet-sdk-facade': major
+'@midnightntwrk/wallet-sdk-testkit': major
+---
+
+**`DefaultShieldedConfiguration` gains a required `forkVersion`. Every site that builds a shielded — or facade —
+configuration must add it.**
+
+`forkVersion` is the protocol version at which a chain hands over from the pre-fork ledger version to the post-fork one.
+The shielded wallet is being made able to register a variant either side of that boundary, and the boundary itself is a
+property of the chain an application points at, not of the SDK — so the SDK cannot supply it. It is required rather than
+defaulted on purpose: a wrong value does not degrade gracefully, it decides which ledger version reads the chain.
+
+```ts
+import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+
+const wallet = ShieldedWallet({
+  networkId,
+  indexerClientConnection,
+  txHistoryStorage,
+  forkVersion: V9_NATIVE_FORK_VERSION,
+});
+```
+
+**`V9_NATIVE_FORK_VERSION` (`2000000`) is the value for a ledger-v9-native chain**, and it is measured rather than
+assumed: a `midnight-node` 2.x reports protocol version `2000000` on its ledger events — the runtime version scaled, not
+a small ordinal and not the ledger major. A chain on the previous node line reports a 1.x-encoded value, which is below
+it, so a wallet configured with this constant stays on the pre-fork variant on a genuinely pre-fork chain and reaches
+the post-fork variant on any v9-native one. Prefer it over a hand-written number for exactly that reason.
+
+It is **not** a default — `forkVersion` stays required at every construction site. **The final mainnet fork constant is
+still open**; when it is fixed, a `ProtocolVersion.Forks.*` value will join this one and this field will keep working
+unchanged.
+
+Reaching further than the shielded package:
+
+- **facade** — `DefaultConfiguration` is an intersection that includes `DefaultShieldedConfiguration`, so every facade
+  configuration literal needs `forkVersion` too. This is the reason for the major.
+- **testkit** — `WalletConfiguration` is now built on `DefaultShieldedConfiguration` rather than on the post-fork
+  variant's configuration, and therefore carries `forkVersion`. `TestEnvironment.getWalletConfig()` supplies it, so
+  suites driving the testkit through that factory need no change; anything assembling a `WalletConfiguration` by hand
+  does.
+
+`DefaultV1Configuration` and `DefaultV2Configuration` are unchanged and deliberately do **not** gain the field: neither
+variant knows there is another one, and `forkVersion` is the wallet layer's alone.
+
+Registration is still single-variant in this release, so nothing changes behaviourally: this is the configuration
+contract landing ahead of the two-variant wallet that consumes it.

--- a/.changeset/shielded-retained-start-material.md
+++ b/.changeset/shielded-retained-start-material.md
@@ -1,0 +1,19 @@
+---
+'@midnightntwrk/wallet-sdk-runtime': minor
+'@midnightntwrk/wallet-sdk-shielded': patch
+---
+
+`StartMaterial.requireAuxFor` resolves the key material a variant should start synchronization with, failing with
+`StartMaterial.MissingStartAuxError` — which carries the tag of the variant that asked — when the wallet holds none that
+variant can use. Only a wallet started with key objects can reach it: those belong to one ledger version's runtime, so a
+variant on the other side of a protocol boundary has nothing to start with, and handing over what the wallet does have
+would sync it into nonsense. A wallet started from a seed cannot reach it at all.
+
+The shielded wallet class now retains `StartMaterial` rather than the start-aux it was handed, and resolves per
+activating variant through that variant's own `startAux` derivation. `startWithSeed` retains the seed, so a wallet built
+from one can start synchronization on any variant it is later migrated to. `start(keys)` accumulates key objects per
+variant tag — the same product a caller holding keys for both protocol versions would supply at once — and a retained
+seed supersedes them, being strictly more capable.
+
+Behaviour-preserving for a wallet registered over a single variant, which is every shielded wallet this release builds:
+the retention and post-migration restart tests pass unmodified.

--- a/apps/test-website/src/wallet.ts
+++ b/apps/test-website/src/wallet.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import {
   type DefaultConfiguration,
@@ -54,6 +55,9 @@ export type Configuration = DefaultConfiguration;
 
 export const configurationFor = (network: KnownNetwork): Configuration => ({
   networkId: network,
+  // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
+  // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
+  forkVersion: V9_NATIVE_FORK_VERSION,
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/dust-fast-sync.ts
+++ b/packages/docs-snippets/src/snippets/dust-fast-sync.ts
@@ -10,6 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import {
   type DefaultConfiguration,
@@ -40,6 +41,9 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
+  // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
+  // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
+  forkVersion: V9_NATIVE_FORK_VERSION,
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
+++ b/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
@@ -10,6 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import {
   type DefaultConfiguration,
@@ -36,6 +37,9 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
+  // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
+  // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
+  forkVersion: V9_NATIVE_FORK_VERSION,
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/initialization.ts
+++ b/packages/docs-snippets/src/snippets/initialization.ts
@@ -10,6 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import {
   type DefaultConfiguration,
@@ -36,6 +37,9 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
+  // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
+  // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
+  forkVersion: V9_NATIVE_FORK_VERSION,
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/wasm-prover.ts
+++ b/packages/docs-snippets/src/snippets/wasm-prover.ts
@@ -10,6 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import {
   type DefaultConfiguration,
@@ -36,6 +37,9 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
+  // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
+  // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
+  forkVersion: V9_NATIVE_FORK_VERSION,
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/utils.ts
+++ b/packages/docs-snippets/src/utils.ts
@@ -10,6 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import {
   type DefaultConfiguration,
@@ -36,6 +37,9 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
+  // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
+  // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
+  forkVersion: V9_NATIVE_FORK_VERSION,
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/e2e-tests/src/tests/dustDeregistration.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dustDeregistration.undeployed.test.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
@@ -82,6 +82,7 @@ describe('Dust Deregistration', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
+      forkVersion: V9_NATIVE_FORK_VERSION,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/dustRegistration.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dustRegistration.undeployed.test.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import * as crypto from 'node:crypto';
 import { randomUUID } from 'node:crypto';
@@ -90,6 +90,7 @@ describe('Dust Registration', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
+      forkVersion: V9_NATIVE_FORK_VERSION,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/facadeTransfer.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/facadeTransfer.undeployed.test.ts
@@ -13,7 +13,7 @@
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import { PublicKey, UnshieldedWallet, createKeystore } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnightntwrk/wallet-sdk-utilities/testing';
 import { pipe } from 'effect';
@@ -91,6 +91,7 @@ describe('Wallet Facade Transfer', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
+      forkVersion: V9_NATIVE_FORK_VERSION,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
@@ -98,6 +98,7 @@ describe('Optional Balancing', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
+      forkVersion: V9_NATIVE_FORK_VERSION,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/swap.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/swap.undeployed.test.ts
@@ -13,7 +13,7 @@
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
 import { V2Builder } from '@midnightntwrk/wallet-sdk-shielded/v2';
-import { CustomShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
+import { CustomShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { PublicKey, UnshieldedWallet, createKeystore } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnightntwrk/wallet-sdk-utilities/testing';
@@ -94,6 +94,7 @@ describe('Swaps', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
+      forkVersion: V9_NATIVE_FORK_VERSION,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/test-fixture.ts
+++ b/packages/e2e-tests/src/tests/test-fixture.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { type DefaultShieldedConfiguration, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import { exit } from 'process';
 import { randomUUID } from 'node:crypto';
 import { DockerComposeEnvironment, type StartedDockerComposeEnvironment, Wait } from 'testcontainers';
@@ -19,7 +20,6 @@ import { type MidnightNetwork, sleep } from './helpers/network.js';
 import { logger } from './logger.js';
 import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
 import { WalletEntrySchema, mergeWalletEntries } from '@midnightntwrk/wallet-sdk-facade';
-import { type DefaultV2Configuration } from '@midnightntwrk/wallet-sdk-shielded/v2';
 import { type DefaultV2Configuration as DefaultDustV2Configuration } from '@midnightntwrk/wallet-sdk-dust-wallet/v2';
 import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnightntwrk/wallet-sdk-utilities/testing';
 import { type DefaultProvingConfiguration } from '@midnightntwrk/wallet-sdk-capabilities/proving';
@@ -234,7 +234,9 @@ export class TestContainersFixture {
     }
   }
 
-  public getWalletConfig(): DefaultV2Configuration & DefaultSubmissionConfiguration & DefaultProvingConfiguration {
+  public getWalletConfig(): DefaultShieldedConfiguration &
+    DefaultSubmissionConfiguration &
+    DefaultProvingConfiguration {
     return {
       indexerClientConnection: {
         indexerHttpUrl: this.getIndexerUri(),
@@ -244,6 +246,10 @@ export class TestContainersFixture {
       relayURL: new URL(this.getNodeUri()),
       networkId: this.getNetworkId(),
       txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
+      // Every environment these suites run against is on the ledger-v9-native node line, which reports
+      // this protocol version, so the wallet reaches its post-fork variant. Defined once here rather than
+      // at each construction site; the final mainnet fork constant is still an open question.
+      forkVersion: V9_NATIVE_FORK_VERSION,
     };
   }
 

--- a/packages/facade/test/pendingTransactions.test.ts
+++ b/packages/facade/test/pendingTransactions.test.ts
@@ -16,7 +16,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
-import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { type DefaultConfiguration, WalletEntrySchema, WalletFacade, mergeWalletEntries } from '../src/index.js';
@@ -37,6 +37,7 @@ describe('Wallet Facade handling pending transactions', () => {
   beforeEach(async () => {
     configuration = {
       networkId: NetworkId.NetworkId.Undeployed,
+      forkVersion: V9_NATIVE_FORK_VERSION,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',

--- a/packages/facade/test/submission.test.ts
+++ b/packages/facade/test/submission.test.ts
@@ -14,7 +14,7 @@ import * as ledger from '@midnightntwrk/ledger-v9';
 import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type SubmissionService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import * as crypto from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
@@ -46,6 +46,7 @@ describe('Facade submission', () => {
     })();
     const configuration: DefaultConfiguration = {
       networkId: NetworkId.NetworkId.Undeployed,
+      forkVersion: V9_NATIVE_FORK_VERSION,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -93,6 +94,7 @@ describe('Facade submission', () => {
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
+      forkVersion: V9_NATIVE_FORK_VERSION,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -157,6 +159,7 @@ describe('Facade submission', () => {
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
+      forkVersion: V9_NATIVE_FORK_VERSION,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -222,6 +225,7 @@ describe('Facade transaction history reads return entries regardless of lifecycl
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
+      forkVersion: V9_NATIVE_FORK_VERSION,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServerUrl: new URL('http://localhost:6300'),

--- a/packages/facade/test/utils/helpers.ts
+++ b/packages/facade/test/utils/helpers.ts
@@ -13,7 +13,11 @@
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { HDWallet, Roles } from '@midnightntwrk/wallet-sdk-hd';
 import { WalletFacade, type Clock } from '../../src/index.js';
-import { CustomShieldedWallet, type ShieldedWalletAPI } from '@midnightntwrk/wallet-sdk-shielded';
+import {
+  CustomShieldedWallet,
+  type ShieldedWalletAPI,
+  V9_NATIVE_FORK_VERSION,
+} from '@midnightntwrk/wallet-sdk-shielded';
 import {
   Sync as ShieldedSync,
   TransactionHistory as ShieldedTransactionHistory,
@@ -298,6 +302,7 @@ export const makeSimulatorFacade = (
       const facade = await WalletFacade.init({
         configuration: {
           ...config,
+          forkVersion: V9_NATIVE_FORK_VERSION,
           // Dummy values - not used in simulation mode
           indexerClientConnection: { indexerHttpUrl: 'http://unused' },
           relayURL: new URL('ws://unused'),

--- a/packages/runtime/src/abstractions/StartMaterial.ts
+++ b/packages/runtime/src/abstractions/StartMaterial.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { type WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Option } from 'effect';
+import { Data, Either, Option } from 'effect';
 
 /**
  * How a variant produces the key material its own sync needs from a seed.
@@ -100,3 +100,44 @@ export const auxFor = <TStartAux>(
   material._tag === 'FromSeed'
     ? Option.some(deriveFromSeed(material.seed))
     : Option.fromNullable(material.byTag.get(variantTag));
+
+/**
+ * Raised when a wallet holds no key material a given variant is able to use.
+ *
+ * @remarks
+ *   Only reachable for a wallet started with key objects rather than a seed: the objects belong to one ledger version's
+ *   runtime, so a variant on the other side of a protocol boundary has nothing to start with. Handing over what the
+ *   wallet does have would be worse than failing — the keys would be silently wrong, and the wallet would sync itself
+ *   into nonsense. Starting from a seed cannot reach this.
+ */
+export class MissingStartAuxError extends Data.TaggedError(
+  '@midnightntwrk/wallet-sdk-runtime/abstractions/StartMaterial/MissingStartAuxError',
+)<{
+  readonly message: string;
+  /** The variant that asked and could not be answered. */
+  readonly variantTag: string | symbol;
+}> {}
+
+/**
+ * Produces the key material a given variant should start its synchronization with, or says why it cannot.
+ *
+ * @param material What the wallet retained when the application started it.
+ * @param variantTag The tag of the variant asking.
+ * @param deriveFromSeed That variant's own derivation, consulted only for retained seeds.
+ * @returns The key material, or a {@link MissingStartAuxError} naming the variant.
+ */
+export const requireAuxFor = <TStartAux>(
+  material: StartMaterial<TStartAux>,
+  variantTag: string | symbol,
+  deriveFromSeed: (seed: WalletSeed.WalletSeed) => TStartAux,
+): Either.Either<TStartAux, MissingStartAuxError> =>
+  Either.fromOption(
+    auxFor(material, variantTag, deriveFromSeed),
+    () =>
+      new MissingStartAuxError({
+        message:
+          `This wallet was started with key material for other variants only, and holds none the variant ` +
+          `${String(variantTag)} can use. Start it from a seed so every variant can derive its own.`,
+        variantTag,
+      }),
+  );

--- a/packages/runtime/src/abstractions/test/startMaterial.test.ts
+++ b/packages/runtime/src/abstractions/test/startMaterial.test.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Option } from 'effect';
+import { Either, Option } from 'effect';
 import { describe, expect, it } from 'vitest';
 import * as StartMaterial from '../StartMaterial.js';
 
@@ -88,6 +88,25 @@ describe('StartMaterial', () => {
       expect(StartMaterial.forVariant<Keys>(postForkTag, keys)).toStrictEqual(
         StartMaterial.forVariants<Keys>([[postForkTag, keys]]),
       );
+    });
+  });
+
+  describe('requiring key material a variant can use', () => {
+    it('produces the key material when the wallet holds some for that variant', () => {
+      expect(
+        StartMaterial.requireAuxFor(StartMaterial.fromSeed<Keys>(seed), postForkTag, derivedBy('v9')),
+      ).toStrictEqual(Either.right({ derivedFrom: Buffer.from(seed).toString('hex'), ledger: 'v9' }));
+    });
+
+    it('fails typed, naming the variant, when the wallet holds none that variant can use', () => {
+      const retained = StartMaterial.forVariant<Keys>(preForkTag, { derivedFrom: 'elsewhere', ledger: 'v8' });
+
+      const resolved = StartMaterial.requireAuxFor(retained, postForkTag, neverDerives);
+
+      const error = resolved.pipe(Either.flip, Either.getOrThrow);
+      expect(error).toBeInstanceOf(StartMaterial.MissingStartAuxError);
+      expect(error._tag).toBe('@midnightntwrk/wallet-sdk-runtime/abstractions/StartMaterial/MissingStartAuxError');
+      expect(error.variantTag).toBe(postForkTag);
     });
   });
 });

--- a/packages/shielded-wallet/README.md
+++ b/packages/shielded-wallet/README.md
@@ -24,19 +24,23 @@ while maintaining verifiability. It provides:
 ### Starting the Wallet
 
 ```typescript
-import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
-import * as ledger from '@midnight-ntwrk/ledger-v7';
+import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import { ShieldedTransactionHistoryEntrySchema } from '@midnightntwrk/wallet-sdk-shielded';
+import * as ledger from '@midnightntwrk/ledger-v9';
 import { randomBytes } from 'node:crypto';
 
 // Configuration for the wallet
 const configuration = {
   networkId: 'preview',
-  provingServerUrl: new URL('http://localhost:6300'),
-  relayURL: new URL('ws://localhost:9944'),
   indexerClientConnection: {
-    indexerHttpUrl: 'http://localhost:8088/api/v3/graphql',
-    indexerWsUrl: 'ws://localhost:8088/api/v3/graphql/ws',
+    indexerHttpUrl: 'http://localhost:8088/api/v4/graphql',
+    indexerWsUrl: 'ws://localhost:8088/api/v4/graphql/ws',
   },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(ShieldedTransactionHistoryEntrySchema),
+  // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
+  // the final mainnet fork constant is not yet fixed, so it is supplied per environment.
+  forkVersion: V9_NATIVE_FORK_VERSION,
 };
 
 // Create secret keys from a shielded seed

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -15,6 +15,7 @@ import {
   type ProtocolState,
   ProtocolVersion,
   type SyncProgress,
+  WalletSeed,
 } from '@midnightntwrk/wallet-sdk-abstractions';
 import {
   type BaseV2Configuration,
@@ -40,9 +41,14 @@ import {
 import { type TokenTransfer } from './v2/Transacting.js';
 import { type BatchUpdatesConfig, type IndexerClientConnection, type WalletSyncUpdate } from './v2/Sync.js';
 import { type ShieldedHistoryStorage, type TransactionHistoryService } from './v2/TransactionHistory.js';
-import { type Variant, type VariantBuilder, type WalletLike } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import {
+  StartMaterial,
+  type Variant,
+  type VariantBuilder,
+  type WalletLike,
+} from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
-import { HList } from '@midnightntwrk/wallet-sdk-utilities';
+import { EitherOps, HList, Poly } from '@midnightntwrk/wallet-sdk-utilities';
 import { variantForSnapshot } from './Restore.js';
 
 export type ShieldedWalletCapabilities<TSerialized = string> = {
@@ -256,9 +262,20 @@ export function CustomShieldedWallet<
       );
     }
 
+    /**
+     * Builds a wallet from a seed, and remembers the seed.
+     *
+     * @remarks
+     *   The seed is the only key material that crosses a protocol boundary, so a wallet built this way can start
+     *   synchronization on any variant it is ever migrated to — each derives its own from the seed. A wallet built from
+     *   key objects instead can only start the variants it was given objects for.
+     */
     static startWithSeed(seed: Uint8Array): CustomShieldedWalletImplementation {
-      const secretKeys: ledger.ZswapSecretKeys = ledger.ZswapSecretKeys.fromSeed(seed);
-      return CustomShieldedWalletImplementation.startWithSecretKeys(secretKeys);
+      const walletSeed = WalletSeed.WalletSeed(seed);
+      const secretKeys: ledger.ZswapSecretKeys = ledger.ZswapSecretKeys.fromSeed(walletSeed);
+      const wallet = CustomShieldedWalletImplementation.startWithSecretKeys(secretKeys);
+      wallet.#retainSeed(walletSeed);
+      return wallet;
     }
 
     /**
@@ -299,15 +316,54 @@ export function CustomShieldedWallet<
     readonly state: rx.Observable<ShieldedWalletState<TSerialized>>;
 
     /**
-     * The start-aux the application last called {@link start} with.
+     * What the application started this wallet with, kept so synchronization can be started again.
      *
      * @remarks
-     *   Sync needs the secret keys, and a migration starts a fresh variant whose sync has never been started. The keys
-     *   cannot come from the state — they are deliberately absent from anything serialized — and they do not exist yet
-     *   when the wallet is first constructed, so they are held here, in memory, for the lifetime of the wallet. Cleared
-     *   by {@link stop} so a stopped wallet cannot be silently resurrected by a late activation.
+     *   A migration starts a fresh variant whose sync has never run, and sync needs key material. That material cannot
+     *   come from the state — it is deliberately absent from anything serialized — and does not exist when the wallet
+     *   is first constructed, so it is held here, in memory, for the lifetime of the wallet. Cleared by {@link stop} so
+     *   a stopped wallet cannot be silently resurrected by a late activation.
+     *
+     *   A retained seed answers for every variant. Retained key objects answer only for the variants they were supplied
+     *   for, and accumulate per variant tag as `start` is called, which is the same product a caller holding key
+     *   objects for both protocol versions would hand over at once.
      */
-    readonly #retainedAux = Ref.unsafeMake<Option.Option<TStartAux>>(Option.none());
+    readonly #retainedStartMaterial = Ref.unsafeMake<Option.Option<StartMaterial.StartMaterial<TStartAux>>>(
+      Option.none(),
+    );
+
+    /** Remembers a seed, which supersedes any key objects retained for individual variants. */
+    #retainSeed(seed: WalletSeed.WalletSeed): void {
+      Ref.set(this.#retainedStartMaterial, Option.some(StartMaterial.fromSeed<TStartAux>(seed))).pipe(Effect.runSync);
+    }
+
+    /**
+     * Starts synchronization on a variant that has just become current, with key material it can use.
+     *
+     * @remarks
+     *   The derivation is the activating variant's own, so a wallet retaining a seed hands each variant key material
+     *   built by its own ledger version. A wallet retaining key objects for other variants only cannot answer, and says
+     *   so rather than handing over keys the variant would silently misuse.
+     */
+    #resumeSyncOn(
+      variantTag: typeof V2Tag,
+      running: { startSyncInBackground: (aux: TStartAux) => Effect.Effect<void> },
+    ): Effect.Effect<void, StartMaterial.MissingStartAuxError> {
+      return Ref.get(this.#retainedStartMaterial).pipe(
+        Effect.flatMap(
+          Option.match({
+            // Stopped, or never started: there is nothing to resume and nothing to resume it with.
+            onNone: () => Effect.void,
+            onSome: (retained: StartMaterial.StartMaterial<TStartAux>) =>
+              EitherOps.toEffect(
+                StartMaterial.requireAuxFor(retained, variantTag, (seed) =>
+                  CustomShieldedWalletImplementation.allVariantsRecord()[variantTag].variant.startAux.fromSeed(seed),
+                ),
+              ).pipe(Effect.flatMap((aux) => running.startSyncInBackground(aux))),
+          }),
+        ),
+      );
+    }
 
     /**
      * Whether the activation watcher has been registered.
@@ -338,7 +394,20 @@ export function CustomShieldedWallet<
 
     start(secretKeys: TStartAux): Promise<void> {
       return Effect.gen(this, function* () {
-        yield* Ref.set(this.#retainedAux, Option.some(secretKeys));
+        const current = yield* this.runtime.currentVariant;
+        yield* Ref.update(this.#retainedStartMaterial, (retained) =>
+          Option.some(
+            Option.match(retained, {
+              onNone: () => StartMaterial.forVariant<TStartAux>(Poly.getTag(current), secretKeys),
+              // A retained seed already answers for every variant, including ones this wallet has not met, so key
+              // objects for one of them add nothing. Otherwise the objects accumulate per variant tag.
+              onSome: (existing: StartMaterial.StartMaterial<TStartAux>) =>
+                existing._tag === 'FromSeed'
+                  ? existing
+                  : StartMaterial.forVariants<TStartAux>([...existing.byTag, [Poly.getTag(current), secretKeys]]),
+            }),
+          ),
+        );
 
         // Registered before the first dispatch, and only once: `onVariantActivation` resolves only after its
         // subscription is live, so an activation racing this call is queued rather than missed.
@@ -346,15 +415,7 @@ export function CustomShieldedWallet<
         if (!alreadyRegistered) {
           yield* this.runtime.onVariantActivation({
             [V2Tag]: (v2: RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>) =>
-              Ref.get(this.#retainedAux).pipe(
-                Effect.flatMap(
-                  Option.match({
-                    // Stopped, or never started: there is nothing to resume and no keys to resume it with.
-                    onNone: () => Effect.void,
-                    onSome: (retained: TStartAux) => v2.startSyncInBackground(retained),
-                  }),
-                ),
-              ),
+              this.#resumeSyncOn(V2Tag, v2),
           });
         }
 
@@ -363,8 +424,9 @@ export function CustomShieldedWallet<
     }
 
     async stop(): Promise<void> {
-      // Released before the runtime is torn down: the keys outlive neither the wallet nor an in-flight activation.
-      Ref.set(this.#retainedAux, Option.none()).pipe(Effect.runSync);
+      // Released before the runtime is torn down: the key material outlives neither the wallet nor an in-flight
+      // activation.
+      Ref.set(this.#retainedStartMaterial, Option.none()).pipe(Effect.runSync);
       await super.stop();
     }
 

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -187,6 +187,22 @@ export type CustomizedShieldedWallet<
   WalletLike.WalletLike<[Variant.VersionedVariant<V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>>]>;
 
 /**
+ * The protocol version a ledger-v9-native chain hands over at, for the current node line.
+ *
+ * @remarks
+ *   Measured, not assumed: a `midnight-node` 2.x reports protocol version `2000000` on its ledger events — the runtime
+ *   version, scaled, rather than a small ordinal or the ledger major. A chain of the previous node line reports a
+ *   1.x-encoded value, which is below this, so a wallet configured with it stays on the pre-fork variant there and
+ *   reaches the post-fork variant on any v9-native chain.
+ *
+ *   Offered as a named value so applications and test suites pointed at a v9-native chain do not each invent a magic
+ *   number. It is **not** a default: {@link DefaultShieldedConfiguration.forkVersion} stays required, because the right
+ *   value is a property of the chain an application points at. The final mainnet fork constant is still an open
+ *   question; when it is fixed a `ProtocolVersion.Forks.*` value will join this one.
+ */
+export const V9_NATIVE_FORK_VERSION: ProtocolVersion.ProtocolVersion = ProtocolVersion.ProtocolVersion(2_000_000n);
+
+/**
  * The configuration a default {@link ShieldedWallet} is built from.
  *
  * @remarks
@@ -204,6 +220,20 @@ export type DefaultShieldedConfiguration = {
   batchUpdates?: BatchUpdatesConfig;
   txHistoryStorage: ShieldedHistoryStorage;
   transactionDetailsRetryWindow?: Duration.DurationInput;
+  /**
+   * The protocol version at which this chain hands over from the pre-fork ledger to the post-fork one.
+   *
+   * @remarks
+   *   Required, and deliberately without a default: the wallet registers one variant either side of it, so a wrong value
+   *   does not degrade — it decides which ledger version reads the chain. Below this version the pre-fork variant is
+   *   active; from it, the post-fork one. The SDK cannot guess it, because it is a property of the chain the
+   *   application points at, not of the SDK.
+   *
+   *   A node reporting a 2.x runtime version reports protocol version `2000000`, which is therefore the value for a
+   *   ledger-v9-native chain. The final mainnet fork constant is not yet fixed; a `ProtocolVersion.Forks.*` default
+   *   will ship once it is, and this field keeps working unchanged.
+   */
+  forkVersion: ProtocolVersion.ProtocolVersion;
 };
 
 export interface CustomizedShieldedWalletClass<
@@ -224,7 +254,7 @@ export interface CustomizedShieldedWalletClass<
 }
 
 export function ShieldedWallet(configuration: DefaultShieldedConfiguration): ShieldedWalletClass {
-  return CustomShieldedWallet(configuration, new V2Builder().withDefaults());
+  return CustomShieldedWallet<DefaultShieldedConfiguration>(configuration, new V2Builder().withDefaults());
 }
 
 export function CustomShieldedWallet<

--- a/packages/shielded-wallet/src/test/configuration.test.ts
+++ b/packages/shielded-wallet/src/test/configuration.test.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type NetworkId, type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type CanAssign, type Equal, type Expect } from '@midnightntwrk/wallet-sdk-utilities/types';
 import { type Duration } from 'effect';
 import { describe, it } from 'vitest';
@@ -33,15 +33,22 @@ describe('DefaultShieldedConfiguration', () => {
           batchUpdates?: V2Sync.BatchUpdatesConfig;
           txHistoryStorage: V2TransactionHistory.ShieldedHistoryStorage;
           transactionDetailsRetryWindow?: Duration.DurationInput;
+          forkVersion: ProtocolVersion.ProtocolVersion;
         }
       >
     >;
   });
 
-  it('stays interchangeable with what either variant is built from', () => {
+  it('builds either variant, being a superset of what each is built from', () => {
+    // One direction only, and deliberately so. The wallet's configuration now says something no single
+    // variant does — where the boundary between them lies — so it is strictly larger than either
+    // variant's. What must keep holding is that it can still build both: a variant asking for something
+    // this type does not carry would be a wallet that cannot be built for one of its own variants.
     type _1 = Expect<CanAssign<DefaultShieldedConfiguration, DefaultV2Configuration>>;
-    type _2 = Expect<CanAssign<DefaultV2Configuration, DefaultShieldedConfiguration>>;
-    type _3 = Expect<CanAssign<DefaultShieldedConfiguration, DefaultV1Configuration>>;
-    type _4 = Expect<CanAssign<DefaultV1Configuration, DefaultShieldedConfiguration>>;
+    type _2 = Expect<CanAssign<DefaultShieldedConfiguration, DefaultV1Configuration>>;
+
+    // `forkVersion` is the wallet layer's alone: neither variant knows there is another one.
+    type _3 = Expect<Equal<'forkVersion' extends keyof DefaultV1Configuration ? true : false, false>>;
+    type _4 = Expect<Equal<'forkVersion' extends keyof DefaultV2Configuration ? true : false, false>>;
   });
 });

--- a/packages/shielded-wallet/src/test/shieldedWallet.test.ts
+++ b/packages/shielded-wallet/src/test/shieldedWallet.test.ts
@@ -14,13 +14,19 @@ import * as ledger from '@midnightntwrk/ledger-v9';
 import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Effect, Scope, Stream } from 'effect';
 import { describe, expect, it } from 'vitest';
-import { type CustomizedShieldedWallet, ShieldedWallet } from '../ShieldedWallet.js';
-import { type DefaultV2Configuration, TransactionHistory, V2Tag } from '../v2/index.js';
+import {
+  type CustomizedShieldedWallet,
+  type DefaultShieldedConfiguration,
+  ShieldedWallet,
+  V9_NATIVE_FORK_VERSION,
+} from '../ShieldedWallet.js';
+import { TransactionHistory, V2Tag } from '../v2/index.js';
 
-const configuration: DefaultV2Configuration = {
+const configuration: DefaultShieldedConfiguration = {
   networkId: NetworkId.NetworkId.Undeployed,
   indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
+  forkVersion: V9_NATIVE_FORK_VERSION,
 };
 
 /**

--- a/packages/wallet-integration-tests/test/serializationAndRestoration.integration.test.ts
+++ b/packages/wallet-integration-tests/test/serializationAndRestoration.integration.test.ts
@@ -10,10 +10,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { ShieldedWallet, type ShieldedWalletClass, type ShieldedWalletState } from '@midnightntwrk/wallet-sdk-shielded';
+import {
+  ShieldedWallet,
+  type ShieldedWalletClass,
+  type ShieldedWalletState,
+  type DefaultShieldedConfiguration,
+  V9_NATIVE_FORK_VERSION,
+} from '@midnightntwrk/wallet-sdk-shielded';
 import { UnshieldedWallet, createKeystore, PublicKey } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { type DefaultV2Configuration } from '@midnightntwrk/wallet-sdk-shielded/v2';
+
 import { type DefaultV2Configuration as UnshieldedV2Configuration } from '@midnightntwrk/wallet-sdk-unshielded-wallet/v2';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
@@ -43,7 +49,7 @@ const environment = new DockerComposeEnvironment(getComposeDirectory(), 'docker-
 
 describe('Wallet serialization and restoration', () => {
   let startedEnvironment: StartedDockerComposeEnvironment;
-  let shieldedConfiguration: DefaultV2Configuration;
+  let shieldedConfiguration: DefaultShieldedConfiguration;
   let unshieldedConfiguration: UnshieldedV2Configuration;
   let indexerPort: number;
 
@@ -52,6 +58,7 @@ describe('Wallet serialization and restoration', () => {
     indexerPort = startedEnvironment.getContainer(`indexer_${environmentId}`).getMappedPort(8088);
 
     shieldedConfiguration = {
+      forkVersion: V9_NATIVE_FORK_VERSION,
       indexerClientConnection: {
         indexerHttpUrl: `http://localhost:${indexerPort}/api/v4/graphql`,
       },

--- a/packages/wallet-sdk-testkit/src/environment.ts
+++ b/packages/wallet-sdk-testkit/src/environment.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import { WalletEntrySchema, mergeWalletEntries } from '@midnightntwrk/wallet-sdk-facade';
 import {
   type DustWalletConfiguration,
@@ -85,6 +86,10 @@ export const makeEnvironment = (
       relayURL: new URL(endpoints.nodeUrl),
       networkId: endpoints.networkId,
       txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
+      // Every environment this testkit drives runs the ledger-v9-native node line, which reports this
+      // protocol version, so the wallet reaches its post-fork variant. Defined once here rather than at
+      // each construction site; the final mainnet fork constant is still an open question.
+      forkVersion: V9_NATIVE_FORK_VERSION,
     };
   },
   getDustWalletConfig(): DustWalletConfiguration {

--- a/packages/wallet-sdk-testkit/src/types.ts
+++ b/packages/wallet-sdk-testkit/src/types.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
-import { type DefaultV2Configuration } from '@midnightntwrk/wallet-sdk-shielded/v2';
+import { type DefaultShieldedConfiguration } from '@midnightntwrk/wallet-sdk-shielded';
 import { type DefaultV2Configuration as DefaultDustV2Configuration } from '@midnightntwrk/wallet-sdk-dust-wallet/v2';
 import { type DefaultProvingConfiguration } from '@midnightntwrk/wallet-sdk-capabilities/proving';
 import { type DefaultSubmissionConfiguration } from '@midnightntwrk/wallet-sdk-capabilities/submission';
@@ -38,7 +38,12 @@ export interface ResolvedEndpoints {
 }
 
 /** Shielded + submission + proving configuration consumed by `ShieldedWallet`/`WalletFacade`. */
-export type WalletConfiguration = DefaultV2Configuration & DefaultSubmissionConfiguration & DefaultProvingConfiguration;
+// The shielded wallet's own configuration rather than its post-fork variant's: it carries `forkVersion`,
+// which says where this chain hands over from one ledger version to the other, and neither variant knows
+// there is another one.
+export type WalletConfiguration = DefaultShieldedConfiguration &
+  DefaultSubmissionConfiguration &
+  DefaultProvingConfiguration;
 
 /** Dust wallet configuration consumed by `DustWallet`. */
 export type DustWalletConfiguration = DefaultDustV2Configuration;


### PR DESCRIPTION
Third increment of the dual-ledger public API redesign (WP-5c + the two-variant config contract and its full sweep). Stacked on #676. The behavioural registration flip is deliberately the NEXT PR — this one lands everything the flip needs, so that PR can be almost purely behavioural.

## What's here

- **WP-5c — the wallet class adopts `StartMaterial`**: `ShieldedWallet` retains `StartMaterial` instead of raw key objects. `startWithSeed` retains the seed (usable by ANY variant it later migrates to); `start(keys)` accumulates key objects per variant tag — the incrementally-built both-keys product from the key decision — and a retained seed supersedes them. A key-object-started wallet crossing into a variant it holds nothing usable for fails with a typed `MissingStartAuxError` carrying that variant's tag — never silent wrong-ledger keys. Behaviour-preserving for a single-variant wallet: the four existing retention/activation tests pass unmodified.
- **Required `forkVersion`** on `DefaultShieldedConfiguration` (no default — the mainnet fork constant is an open external ask), plus the full compiler-driven sweep: 26 construction sites across facade (whose `DefaultConfiguration` intersection inherits the requirement), testkit, e2e-tests, wallet-integration-tests, docs-snippets, test-website. Central factories (`testkit/environment.ts`, `e2e-tests/test-fixture.ts`) define it once; docs-snippets carry the inline literal with a comment so they stay copy-pasteable standalone. `DefaultV1/V2Configuration` deliberately do NOT gain the field — the fork version belongs to the wallet layer; neither variant knows another exists (pinned by type-level tests).

## Why 2000000 (`V9_NATIVE_FORK_VERSION`)

Nothing in the repo pinned what a real chain reports as `protocolVersion`, and the flip's correctness depends on it (head variant = v8; migration to v9 happens only when sync observes a version ≥ `forkVersion`). Measured empirically against the exact standalone environment the live suites use (midnight-node 2.0.0-rc.3 + indexer-standalone, `infra/compose/docker-compose-dynamic.yml`), two independent ways: the `dustCommitmentMerkleTreeUpdate` HTTP query and a live `zswapLedgerEvents` subscription event both report **`protocolVersion: 2000000`** — the scaled node runtime version (2.0.0 → 2_000_000), not a small ordinal. `forkVersion: 1` would also work on v9-native chains but is unsafe as a copy-paste source: on a genuinely pre-fork chain (1.x node, version ≥ 1) it would route ledger-v8 bytes into the v9 variant. 2000000 is correct in both worlds, so every swept site uses the shared named constant.

## Changesets

shielded **major** (required `forkVersion` — every constructor site; what the value means; that the mainnet constant is TBD), facade **major** (the intersection makes every facade config literal break), testkit **major** (exported `WalletConfiguration` requires the field; suites using `getWalletConfig()` are unaffected). Also in passing: `shielded-wallet/README.md` refreshed (was stale independently — ledger-v7 refs, missing `txHistoryStorage`, v3 indexer paths).

## Tests & gate

WP-5c red-first (typed-miss specs); the config threading is honestly type-driven, not test-driven — registration is still single-variant, so there is no behaviour to specify; `yarn typecheck --force` drove the sweep to completion. Gate: dist 17/17, typecheck 37/37, lint 58/58, unit 53/53 tasks (930 passed / 22 skipped), shielded fork-simulation integration 3/3 (no --force, cached WASM), effect-language-service 0 errors on all 26 changed files, format + changeset checks green.