### PR TITLE
feat(shielded)!: a genuinely two-variant production wallet

### DIFF
--- a/.changeset/shielded-bound-state-projections.md
+++ b/.changeset/shielded-bound-state-projections.md
@@ -1,0 +1,26 @@
+---
+'@midnightntwrk/wallet-sdk-runtime': minor
+'@midnightntwrk/wallet-sdk-shielded': major
+---
+
+Two changes that let one wallet read state produced by either of two variants.
+
+**`StartMaterial.requireDerivedAuxFor` / `StartMaterial.seedOf` (runtime).** A wallet's public API speaks one ledger
+version's key objects, but the variants either side of a protocol boundary do not agree on that type.
+`requireDerivedAuxFor` serves the odd one out from a retained seed, failing with `MissingStartAuxError` when the wallet
+holds key objects instead — there is nothing to convert, because key objects belong to one ledger version's runtime.
+`seedOf` exposes the seed arm directly.
+
+**Breaking (shielded): `ShieldedWalletState` no longer exposes `capabilities` or `services`.** It now holds projections
+already bound to the variant that produced the emission, rather than a capability set and a state side by side. The two
+variants' capability types are structurally identical, so a capability belonging to one type-checks against a state
+belonging to the other and would be silently wrong at runtime; binding them at the point where the producing variant is
+known takes the pairing out of the type system's hands. `ShieldedWalletState.mapState` is replaced by
+`ShieldedWalletState.fromVariant(variant, emission)`, which is generic over the state type so that the pairing is
+checked.
+
+**Everything observers read is unchanged** — `balances`, `totalCoins`, `availableCoins`, `pendingCoins`,
+`coinPublicKey`, `encryptionPublicKey`, `address`, `progress`, `protocolVersion` and `serialize()` keep their names,
+types and meaning, and their tests pass unmodified. The one widening is `state`, now the union of the two variants' core
+states (`ShieldedCoreState`) — the single member the ledger version surfaces on, everything else being version-agnostic
+plain data.

--- a/.changeset/shielded-defer-event-decoding.md
+++ b/.changeset/shielded-defer-event-decoding.md
@@ -1,0 +1,25 @@
+---
+'@midnightntwrk/wallet-sdk-shielded': major
+---
+
+**A shielded variant now reads only the events it is going to apply.** Without this a wallet cannot actually cross a
+hard fork on the indexer path, in either direction — which the two-variant wallet in this release depends on.
+
+`Sync.EventsSyncUpdate` carries the event as the indexer served it (`raw`, hex) instead of as a deserialized
+`ledger.Event`, and the sync capability deserializes the batch prefix it owns — after the version boundary split, and
+after skipping everything at or below its cursor. `Sync.readEvent(update)` is that deserialization, exported for custom
+capabilities.
+
+**Breaking for anyone constructing or reading `EventsSyncUpdate` values** — a custom `SyncCapability` over the indexer
+updates, or a test fixture building a batch. `update.event` becomes `Sync.readEvent(update)`; a constructed update
+carries `raw` rather than `event`. Everything else about the shape, including the per-item `protocolVersion` the
+boundary split keys off, is unchanged.
+
+Why it is a correctness fix rather than an optimization: the two ledger versions do not read each other's events — the
+serialization header names the version — and a variant meets the other version's bytes in the ordinary course of
+crossing a boundary. A pre-fork variant on a chain that has already forked is served post-fork events, which it must
+recognise as belonging to the next variant without decoding them; a post-fork variant that has just migrated resumes on
+the cursor it inherited, and the source re-delivers a pre-fork event at that position. Deserializing on arrival failed
+the whole batch in both cases, so the sync stream retried forever and the wallet never crossed. Reading only what the
+variant claims makes both cases ordinary, and an event a variant does claim but cannot read stays a genuine failure,
+surfaced as it was before.

--- a/.changeset/shielded-two-variant-wallet.md
+++ b/.changeset/shielded-two-variant-wallet.md
@@ -1,0 +1,51 @@
+---
+'@midnightntwrk/wallet-sdk-shielded': major
+---
+
+**`ShieldedWallet(configuration)` now registers a variant either side of the protocol boundary, and follows the chain
+across it.** Until this release it registered exactly one, and a wallet could not cross a fork.
+
+The pre-fork variant is registered from the minimum supported version and reads the chain with the ledger version that
+produced it; the post-fork variant is registered at `configuration.forkVersion` — required since the previous release —
+and takes over from there, with the cross-ledger migration that carries identity and a cursor onto a fresh state. The
+boundary is one number in one place: the version at which the runtime hands over is the version at which each variant
+stops applying.
+
+**Nothing an application calls changes shape.** `startWithSeed`, `restore`, `start(keys)`, the `state` observable and
+everything it projects, `waitForSyncedState`, `serializeState` and `getAddress` keep their signatures and meaning, and
+existing calls compile unchanged. What changes is what runs underneath, and three things worth knowing:
+
+- **A wallet starts on the pre-fork variant.** On a chain that has already forked it hands over on the first batch it
+  sees, having applied nothing — one migration per start, paid on chains that are entirely past the boundary. It is
+  accepted rather than hidden: removing it means asking the chain for its version before choosing a variant, which is
+  separate work. On a chain that has not forked, the wallet stays on the pre-fork variant until the chain reports a
+  version the post-fork one owns.
+- **`startWithSeed` is the only start that can follow the chain the whole way.** The seed is the one piece of key
+  material that crosses a boundary — each variant derives its own from it. `start(keys)` keeps working: the keys are
+  the post-fork ledger version's, so they are retained against that variant, and a wallet still on the pre-fork variant
+  is started from the seed it retained. A wallet built with `startWithSecretKeys` therefore starts **on the post-fork
+  variant** and stays there, because key objects belong to one ledger version's runtime and there is nothing to
+  convert; it cannot read a chain that is still pre-fork.
+- **Restoring routes on the snapshot's declared protocol version**, into whichever of the two variants wrote it. The
+  serialized format is unchanged.
+
+**Temporary: building a transaction is refused while the wallet is on the pre-fork variant**, with the typed
+`PreForkTransactingUnsupportedError` naming the operation (`balanceTransaction`, `transferTransaction`, `initSwap`).
+**This seam must not survive to general availability** — mainnet is pre-fork until the fork happens, so a wallet that
+cannot transact pre-fork cannot be the wallet that ships. It closes with the version-routed proving increment, which
+routes a recipe to the prover that speaks the protocol version it was built at; until then the only proving path this
+SDK has speaks the post-fork ledger version, and there is nothing honest for the pre-fork branch to return.
+Synchronization, the state observable and everything it projects, balances, coins, addresses, serialization, restoring
+and the migration itself all work on **both** sides of the boundary. `revertTransaction` is deliberately not part of the
+seam: it builds nothing, needs no proving, and on the pre-fork variant releases nothing, because that variant cannot
+have produced the transaction being reverted.
+
+**New entry points.** `CustomForkingShieldedWallet(configuration, preFork, postFork)` builds the same shape over
+variants of your choosing, each with **its own configuration** — two variants either side of a boundary can mean
+different, mutually unassignable things by the same key. `ForkingShieldedWalletClass`, `ForkingShieldedWallet`,
+`ForkingShieldedConfiguration`, `PreForkShieldedVariant`, `PostForkShieldedVariant` and `ForkingShieldedVariants` name
+the pieces. `ShieldedWallet` and `ShieldedWalletClass` are now aliases of the forking forms.
+
+**`CustomShieldedWallet(configuration, builder)` is unchanged** — a single variant, and therefore one ledger version:
+the composition for a wallet not expected to meet a protocol boundary. `CustomizedShieldedWallet` and
+`CustomizedShieldedWalletClass` remain its single-variant types.

--- a/.changeset/shielded-two-variant-wallet.md
+++ b/.changeset/shielded-two-variant-wallet.md
@@ -27,7 +27,12 @@ existing calls compile unchanged. What changes is what runs underneath, and thre
   variant** and stays there, because key objects belong to one ledger version's runtime and there is nothing to
   convert; it cannot read a chain that is still pre-fork.
 - **Restoring routes on the snapshot's declared protocol version**, into whichever of the two variants wrote it. The
-  serialized format is unchanged.
+  serialized format is unchanged, and snapshots written by this release round-trip: a wallet that has synced past the
+  boundary declares a version the post-fork variant owns, and one that has not was written by the pre-fork variant in
+  the first place. The exception is a snapshot from an **earlier beta**, where every wallet was the post-fork variant:
+  if it declares a version below `forkVersion` — which in practice means a wallet serialized before it had synced
+  anything, declaring `0` — it now routes to the pre-fork variant and fails to deserialize. Start such a wallet from
+  its seed instead; it has no state to lose.
 
 **Temporary: building a transaction is refused while the wallet is on the pre-fork variant**, with the typed
 `PreForkTransactingUnsupportedError` naming the operation (`balanceTransaction`, `transferTransaction`, `initSwap`).

--- a/packages/runtime/src/abstractions/StartMaterial.ts
+++ b/packages/runtime/src/abstractions/StartMaterial.ts
@@ -141,3 +141,40 @@ export const requireAuxFor = <TStartAux>(
         variantTag,
       }),
   );
+
+/**
+ * Produces key material for a variant whose key type is not the one the wallet retains.
+ *
+ * @remarks
+ *   A wallet's public API speaks one ledger version's key objects, but the variants either side of a protocol boundary do
+ *   not agree on that type. Only a retained seed can serve the odd one out: key objects belong to one ledger version's
+ *   runtime, so there is nothing to convert, and a wallet holding only those has nothing that variant can start with.
+ * @param material What the wallet retained when the application started it.
+ * @param variantTag The tag of the variant asking.
+ * @param deriveFromSeed That variant's own derivation.
+ * @returns The key material, or a {@link MissingStartAuxError} naming the variant.
+ */
+export const requireDerivedAuxFor = <TAux>(
+  material: StartMaterial<unknown>,
+  variantTag: string | symbol,
+  deriveFromSeed: (seed: WalletSeed.WalletSeed) => TAux,
+): Either.Either<TAux, MissingStartAuxError> =>
+  Either.fromOption(
+    Option.map(seedOf(material), deriveFromSeed),
+    () =>
+      new MissingStartAuxError({
+        message:
+          `This wallet was started with key material of another protocol version, which the variant ` +
+          `${String(variantTag)} cannot use. Start it from a seed so every variant can derive its own.`,
+        variantTag,
+      }),
+  );
+
+/**
+ * The seed a wallet retained, if it retained one rather than key objects.
+ *
+ * @param material What the wallet retained when the application started it.
+ * @returns The seed, or `Option.none()` when the wallet holds key objects instead.
+ */
+export const seedOf = <TStartAux>(material: StartMaterial<TStartAux>): Option.Option<WalletSeed.WalletSeed> =>
+  material._tag === 'FromSeed' ? Option.some(material.seed) : Option.none();

--- a/packages/runtime/src/abstractions/test/startMaterial.test.ts
+++ b/packages/runtime/src/abstractions/test/startMaterial.test.ts
@@ -109,4 +109,32 @@ describe('StartMaterial', () => {
       expect(error.variantTag).toBe(postForkTag);
     });
   });
+
+  describe('deriving for a variant whose key type differs from the retained one', () => {
+    it('derives from a retained seed, whatever the asking variant s key type is', () => {
+      const otherLedgerKeys = (given: WalletSeed.WalletSeed): string => `v8:${Buffer.from(given).toString('hex')}`;
+
+      const derived = StartMaterial.requireDerivedAuxFor(
+        StartMaterial.fromSeed<Keys>(seed),
+        preForkTag,
+        otherLedgerKeys,
+      );
+
+      expect(derived).toStrictEqual(Either.right(`v8:${Buffer.from(seed).toString('hex')}`));
+    });
+
+    it('fails typed when the wallet retained key objects rather than a seed', () => {
+      // Key objects belong to one ledger version's runtime. There is nothing to convert, so a variant
+      // speaking another one can only be served by re-deriving from a seed the wallet does not hold.
+      const retained = StartMaterial.forVariant<Keys>(postForkTag, { derivedFrom: 'elsewhere', ledger: 'v9' });
+
+      const derived = StartMaterial.requireDerivedAuxFor(retained, preForkTag, (): string => {
+        throw new Error('must not derive: nothing was retained to derive from');
+      });
+
+      const error = derived.pipe(Either.flip, Either.getOrThrow);
+      expect(error).toBeInstanceOf(StartMaterial.MissingStartAuxError);
+      expect(error.variantTag).toBe(preForkTag);
+    });
+  });
 });

--- a/packages/shielded-wallet/src/ForkingShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ForkingShieldedWallet.ts
@@ -1,0 +1,526 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * A shielded wallet that registers a variant either side of a protocol boundary and follows the chain across it.
+ *
+ * @remarks
+ *   One wallet, two ledger versions. Before the boundary the pre-fork variant reads the chain with the ledger version
+ *   that produced it; from the boundary the post-fork variant does, having been handed identity and a place in the
+ *   timeline and nothing else. Which one is running is the runtime's business, not the application's: the wallet's
+ *   public API speaks the post-fork ledger version throughout, and where the two sides genuinely differ — the key
+ *   material each variant's synchronization needs — the wallet resolves it per variant from what it retained.
+ */
+import * as v8 from '@midnight-ntwrk/ledger-v8';
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { type NetworkId, ProtocolVersion, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ShieldedAddress } from '@midnightntwrk/wallet-sdk-address-format';
+import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
+import {
+  StartMaterial,
+  type Variant,
+  type VariantBuilder,
+  type WalletLike,
+} from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { EitherOps, HList } from '@midnightntwrk/wallet-sdk-utilities';
+import { Data, Effect, Either, Option, Ref, type Scope } from 'effect';
+import * as rx from 'rxjs';
+import { variantForSnapshot } from './Restore.js';
+import { type DefaultShieldedConfiguration, ShieldedWalletState, type ShieldedWalletAPI } from './ShieldedWallet.js';
+import { CoreWallet as PreForkCoreWallet, V1Builder, V1Tag, type V1Variant } from './v1/index.js';
+import { type WalletSyncUpdate as PreForkSyncUpdate } from './v1/Sync.js';
+import { CoreWallet, Migration, V2Builder, V2Tag, type V2Variant } from './v2/index.js';
+import { type WalletSyncUpdate as PostForkSyncUpdate } from './v2/Sync.js';
+import { type BalancingResult, type TokenTransfer } from './v2/Transacting.js';
+import { type WalletError } from './v2/WalletError.js';
+
+/**
+ * Raised when a transaction is asked for while the wallet is still on the pre-fork protocol version.
+ *
+ * @remarks
+ *   **This seam is temporary and must not survive to general availability.** Mainnet is pre-fork until the fork happens,
+ *   so a wallet that cannot transact pre-fork cannot be the wallet that ships. It closes with the proving-routing
+ *   increment (WP-11 together with the carrier and author flows), which routes a recipe to the prover that speaks the
+ *   protocol version it was built at; until then the only proving path this SDK has speaks the post-fork ledger
+ *   version, and there is nothing honest for the pre-fork branch to return.
+ *
+ *   Everything else works on both sides of the boundary: synchronization, the state observable and everything it
+ *   projects, balances, coins, addresses, serialization, restoring a snapshot, and the migration itself. Transacting is
+ *   the single gated operation, and it fails loudly rather than producing a transaction nobody can prove.
+ */
+export class PreForkTransactingUnsupportedError extends Data.TaggedError(
+  '@midnightntwrk/wallet-sdk-shielded/ForkingShieldedWallet/PreForkTransactingUnsupportedError',
+)<{
+  readonly message: string;
+  /** The wallet operation that was asked for. */
+  readonly operation: string;
+}> {}
+
+/** What a transacting call can fail with: the post-fork variant's own errors, or the pre-fork variant's refusal. */
+type TransactingError = WalletError | PreForkTransactingUnsupportedError;
+
+const preForkTransactingUnsupported = (operation: string): Effect.Effect<never, PreForkTransactingUnsupportedError> =>
+  Effect.fail(
+    new PreForkTransactingUnsupportedError({
+      operation,
+      message:
+        `${operation} is not available while this wallet is on the pre-fork protocol version: it would produce a ` +
+        `transaction of the previous ledger version, which this release has no way to prove. Pre-fork transacting ` +
+        `arrives with version-routed proving; until then the post-fork path is the one that works. Synchronization, ` +
+        `balances, state and serialization are unaffected on either side of the boundary.`,
+    }),
+  );
+
+/** The pre-fork variant a forking shielded wallet registers: the one that reads the chain before the boundary. */
+export type PreForkShieldedVariant<TSyncUpdate> = V1Variant<
+  string,
+  TSyncUpdate,
+  v8.FinalizedTransaction,
+  v8.ZswapSecretKeys
+>;
+
+/** The post-fork variant a forking shielded wallet registers: the one the pre-fork wallet is migrated into. */
+export type PostForkShieldedVariant<TSyncUpdate> = V2Variant<
+  string,
+  TSyncUpdate,
+  ledger.FinalizedTransaction,
+  ledger.ZswapSecretKeys,
+  Migration.PreviousLedgerWallet
+>;
+
+/** The two variants a forking shielded wallet runs, in registration order. */
+export type ForkingShieldedVariants<TPreForkSyncUpdate, TPostForkSyncUpdate> = [
+  Variant.VersionedVariant<PreForkShieldedVariant<TPreForkSyncUpdate>>,
+  Variant.VersionedVariant<PostForkShieldedVariant<TPostForkSyncUpdate>>,
+];
+
+/**
+ * A variant builder registered together with the configuration it alone is built from.
+ *
+ * @remarks
+ *   Per-variant rather than shared, because two variants either side of a protocol boundary can mean different and
+ *   mutually unassignable things by the same configuration key — a `simulator` or an indexer connection belonging to
+ *   one ledger version or the other. A wallet-wide intersection of those is a configuration no single variant can
+ *   consume.
+ */
+export type SelfConfiguredShieldedVariant<
+  TVariant extends Variant.AnyVariant,
+  TConfiguration extends object,
+> = Readonly<{
+  builder: VariantBuilder.VariantBuilder<TVariant, TConfiguration>;
+  configuration: TConfiguration;
+}>;
+
+/** What a forking shielded wallet needs to know about itself, whatever its variants are built from. */
+export type ForkingShieldedConfiguration = {
+  networkId: NetworkId.NetworkId;
+  /** The protocol version at which the chain hands over from the pre-fork ledger version to the post-fork one. */
+  forkVersion: ProtocolVersion.ProtocolVersion;
+};
+
+/** A running shielded wallet that spans a protocol boundary. */
+export type ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate> = ShieldedWalletAPI<
+  ledger.ZswapSecretKeys,
+  ledger.FinalizedTransaction,
+  string
+> &
+  WalletLike.WalletLike<ForkingShieldedVariants<TPreForkSyncUpdate, TPostForkSyncUpdate>>;
+
+/** The class a forking shielded wallet is started from. */
+export interface ForkingShieldedWalletClass<
+  TPreForkSyncUpdate,
+  TPostForkSyncUpdate,
+  TConfiguration extends ForkingShieldedConfiguration = ForkingShieldedConfiguration,
+> extends WalletLike.BaseWalletClass<ForkingShieldedVariants<TPreForkSyncUpdate, TPostForkSyncUpdate>, TConfiguration> {
+  /**
+   * Builds a wallet from a seed, and remembers the seed.
+   *
+   * @remarks
+   *   The only start that can follow the chain the whole way. The seed is the one piece of key material that crosses a
+   *   protocol boundary — each variant derives its own from it — so a wallet built this way can synchronize on either
+   *   side of the fork. It begins on the pre-fork variant and is handed over when the chain reports a version the
+   *   post-fork variant owns, which on a chain that has already forked happens on the first batch it sees.
+   * @param seed The seed to derive both ledger versions' keys from.
+   * @returns A wallet started on the pre-fork variant.
+   */
+  startWithSeed(seed: Uint8Array): ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+  /**
+   * Builds a wallet from post-fork key objects, starting it on the post-fork variant.
+   *
+   * @remarks
+   *   Key objects belong to one ledger version's runtime, so they answer for one variant and no other: there is nothing
+   *   to convert, and the public keys being identical either side does not help — decryption needs the secret. A wallet
+   *   built this way therefore starts on the variant its keys belong to and stays there. It cannot read a chain that is
+   *   still pre-fork, which is the honest consequence of holding only post-fork keys; start from a seed to do that.
+   * @param secretKeys The post-fork ledger version's Zswap secret keys.
+   * @returns A wallet started on the post-fork variant.
+   */
+  startWithSecretKeys(
+    secretKeys: ledger.ZswapSecretKeys,
+  ): ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+  /**
+   * Restores a wallet from a snapshot, into whichever registered variant wrote it.
+   *
+   * @param serializedState The serialized wallet state.
+   * @returns A wallet started from that state, on the variant that owns its protocol version.
+   * @throws UnsupportedSnapshotVersionError if the snapshot declares a version no registered variant reads.
+   */
+  restore(serializedState: string): ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+}
+
+/**
+ * Builds a shielded wallet class over a variant either side of a protocol boundary.
+ *
+ * @remarks
+ *   The boundary is `configuration.forkVersion` and nothing else: the pre-fork variant is registered from the minimum
+ *   supported version and the post-fork one from the fork version, so the version at which the runtime hands over and
+ *   the version at which each variant stops applying are the same number, taken from one place.
+ *
+ *   Each variant is built from its own configuration. What the wallet layer needs — the network it is on and where the
+ *   boundary lies — it takes separately, because neither variant knows there is another one.
+ * @example
+ *   ```typescript
+ *   const Wallet = CustomForkingShieldedWallet(
+ *     { networkId, forkVersion },
+ *     { builder: new V1Builder().withDefaults(), configuration: preForkConfiguration },
+ *     { builder: new V2Builder().withDefaults().withMigration(makeCrossLedgerMigration), configuration: postForkConfiguration },
+ *   );
+ *   const wallet = Wallet.startWithSeed(seed);
+ *   ```;
+ *
+ * @param configuration What the wallet layer needs: the network, and where the boundary lies.
+ * @param preFork The variant that reads the chain below the boundary, with the configuration it is built from.
+ * @param postFork The variant that reads it from the boundary, with the configuration it is built from.
+ * @returns The wallet class.
+ */
+export function CustomForkingShieldedWallet<
+  TPreForkSyncUpdate,
+  TPostForkSyncUpdate,
+  TPreForkConfig extends object,
+  TPostForkConfig extends object,
+  TConfiguration extends ForkingShieldedConfiguration = ForkingShieldedConfiguration,
+>(
+  configuration: TConfiguration,
+  preFork: SelfConfiguredShieldedVariant<PreForkShieldedVariant<TPreForkSyncUpdate>, TPreForkConfig>,
+  postFork: SelfConfiguredShieldedVariant<PostForkShieldedVariant<TPostForkSyncUpdate>, TPostForkConfig>,
+): ForkingShieldedWalletClass<TPreForkSyncUpdate, TPostForkSyncUpdate, TConfiguration> {
+  type Variants = ForkingShieldedVariants<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+  type RetainedStartMaterial = StartMaterial.StartMaterial<ledger.ZswapSecretKeys>;
+
+  // Registered through the shape the builder states rather than through the one this function was handed. The two are
+  // the same builder; what is dropped is the configuration *type*, which the parameter types have already paired with
+  // its builder — and which, left generic, keeps `build`'s "nothing further is owed" argument list unresolvable.
+  const preForkBuilder: VariantBuilder.VariantBuilder<
+    PreForkShieldedVariant<TPreForkSyncUpdate>,
+    object
+  > = preFork.builder;
+  const postForkBuilder: VariantBuilder.VariantBuilder<
+    PostForkShieldedVariant<TPostForkSyncUpdate>,
+    object
+  > = postFork.builder;
+
+  const BaseWallet: WalletLike.BaseWalletClass<Variants> = WalletBuilder.init()
+    .withVariant(ProtocolVersion.MinSupportedVersion, preForkBuilder, preFork.configuration)
+    .withVariant(configuration.forkVersion, postForkBuilder, postFork.configuration)
+    .build();
+
+  const variants = BaseWallet.allVariantsRecord();
+
+  /**
+   * The pre-fork variant's key material, which only a retained seed can produce.
+   *
+   * @remarks
+   *   The wallet's public API speaks the post-fork ledger version's key objects, and the pre-fork variant cannot use one:
+   *   they belong to different ledger runtimes. So a wallet holding key objects has nothing this variant can start
+   *   with, and says so instead of handing over keys it would silently misuse.
+   */
+  const preForkAux = (
+    retained: RetainedStartMaterial,
+  ): Either.Either<v8.ZswapSecretKeys, StartMaterial.MissingStartAuxError> =>
+    StartMaterial.requireDerivedAuxFor(retained, V1Tag, (seed) => variants[V1Tag].variant.startAux.fromSeed(seed));
+
+  /** The post-fork variant's key material: what the application handed over, or the retained seed's derivation. */
+  const postForkAux = (
+    retained: RetainedStartMaterial,
+  ): Either.Either<ledger.ZswapSecretKeys, StartMaterial.MissingStartAuxError> =>
+    StartMaterial.requireAuxFor(retained, V2Tag, (seed) => variants[V2Tag].variant.startAux.fromSeed(seed));
+
+  return class ForkingShieldedWalletImplementation
+    extends BaseWallet
+    implements ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>
+  {
+    static readonly configuration: TConfiguration = configuration;
+
+    static startWithSeed(seed: Uint8Array): ForkingShieldedWalletImplementation {
+      const walletSeed = WalletSeed.WalletSeed(seed);
+      const wallet = ForkingShieldedWalletImplementation.startFirst(
+        ForkingShieldedWalletImplementation,
+        PreForkCoreWallet.initEmpty(variants[V1Tag].variant.startAux.fromSeed(walletSeed), configuration.networkId),
+      );
+      wallet.#retainSeed(walletSeed);
+      return wallet;
+    }
+
+    static startWithSecretKeys(secretKeys: ledger.ZswapSecretKeys): ForkingShieldedWalletImplementation {
+      return ForkingShieldedWalletImplementation.startAtVariant(
+        ForkingShieldedWalletImplementation,
+        variants[V2Tag],
+        // Stamped with the boundary version rather than left at the minimum: a variant that starts from a state
+        // outside its own activation range reports that on sight, which is how a stranded snapshot heals — and here
+        // there is no variant above this one to hand over to. The state does belong to this variant, so it says so.
+        CoreWallet.withProtocolVersion(
+          CoreWallet.initEmpty(secretKeys, configuration.networkId),
+          configuration.forkVersion,
+        ),
+      );
+    }
+
+    static restore(serializedState: string): ForkingShieldedWalletImplementation {
+      const headVariant = HList.head(ForkingShieldedWalletImplementation.allVariants());
+      const variant = variantForSnapshot(
+        serializedState,
+        (version) => ForkingShieldedWalletImplementation.variantFor(version),
+        headVariant,
+      ).pipe(Either.getOrThrow);
+      // Stated with its result type because the resolved variant is either of the two, so its deserializer is either
+      // of theirs: what comes back is a state of whichever one wrote the snapshot, which is what `startAtVariant`
+      // takes.
+      const deserialized = Either.getOrThrow<PreForkCoreWallet | CoreWallet, unknown>(
+        variant.variant.deserializeState(serializedState),
+      );
+
+      return ForkingShieldedWalletImplementation.startAtVariant(
+        ForkingShieldedWalletImplementation,
+        variant,
+        deserialized,
+      );
+    }
+
+    readonly state: rx.Observable<ShieldedWalletState<string>>;
+
+    /**
+     * What the application started this wallet with, kept so synchronization can be started again.
+     *
+     * @remarks
+     *   A migration starts a fresh variant whose sync has never run, and sync needs key material that is deliberately
+     *   absent from anything the wallet serializes. A retained seed answers for both variants; retained key objects
+     *   answer only for the post-fork one, which is the ledger version this wallet's public API speaks. Cleared by
+     *   {@link stop} so a stopped wallet cannot be resurrected by a late activation.
+     */
+    readonly #retainedStartMaterial = Ref.unsafeMake<Option.Option<RetainedStartMaterial>>(Option.none());
+
+    /** Remembers a seed, which supersedes any key objects retained for individual variants. */
+    #retainSeed(seed: WalletSeed.WalletSeed): void {
+      Ref.set(this.#retainedStartMaterial, Option.some(StartMaterial.fromSeed<ledger.ZswapSecretKeys>(seed))).pipe(
+        Effect.runSync,
+      );
+    }
+
+    /**
+     * Starts synchronization on a variant that has just become current, with key material it can use.
+     *
+     * @param running The variant to start.
+     * @param auxFor That variant's own resolution of what it can be started with.
+     */
+    #resumeSyncOn<TStartAux>(
+      running: { startSyncInBackground: (aux: TStartAux) => Effect.Effect<void> },
+      auxFor: (retained: RetainedStartMaterial) => Either.Either<TStartAux, StartMaterial.MissingStartAuxError>,
+    ): Effect.Effect<void, StartMaterial.MissingStartAuxError> {
+      return Ref.get(this.#retainedStartMaterial).pipe(
+        Effect.flatMap(
+          Option.match({
+            // Stopped, or never started: there is nothing to resume and nothing to resume it with.
+            onNone: () => Effect.void,
+            onSome: (retained: RetainedStartMaterial) =>
+              EitherOps.toEffect(auxFor(retained)).pipe(Effect.flatMap((aux) => running.startSyncInBackground(aux))),
+          }),
+        ),
+      );
+    }
+
+    /**
+     * Whether the activation watcher has been registered.
+     *
+     * @remarks
+     *   Registration is per wallet, not per `start`: watchers accumulate, so registering on every call would restart sync
+     *   once per historical `start` on the next activation. Flipped with `getAndSet` so concurrent `start` calls cannot
+     *   both observe it unset.
+     */
+    readonly #watcherRegistered = Ref.unsafeMake(false);
+
+    constructor(runtime: Runtime.Runtime<Variants>, scope: Scope.CloseableScope) {
+      super(runtime, scope);
+      this.state = this.rawState.pipe(
+        rx.map((emission) =>
+          // The capabilities that understand a state and the state itself are chosen together, in the branch where
+          // the producing variant is known. The two variants' capability types are structurally identical, so a
+          // capability of one would type-check against a state of the other and be wrong at runtime.
+          emission.variantTag === V2Tag
+            ? ShieldedWalletState.fromVariant(variants[V2Tag].variant, emission)
+            : ShieldedWalletState.fromVariant(variants[V1Tag].variant, emission),
+        ),
+        rx.shareReplay({ refCount: true, bufferSize: 1 }),
+      );
+    }
+
+    /**
+     * Starts background synchronization on whichever variant is current, and keeps the keys for the next one.
+     *
+     * @remarks
+     *   The keys are the post-fork ledger version's, so they are retained against that variant alone. A wallet still on
+     *   the pre-fork variant is started from what it retained instead — which a wallet built from a seed can always
+     *   answer, and a wallet built from key objects cannot.
+     * @param secretKeys The post-fork ledger version's Zswap secret keys.
+     */
+    start(secretKeys: ledger.ZswapSecretKeys): Promise<void> {
+      return Effect.gen(this, function* () {
+        yield* Ref.update(this.#retainedStartMaterial, (retained) =>
+          Option.some(
+            Option.match(retained, {
+              onNone: () => StartMaterial.forVariant<ledger.ZswapSecretKeys>(V2Tag, secretKeys),
+              // A retained seed already answers for every variant, including ones this wallet has not met, so key
+              // objects for one of them add nothing. Otherwise the objects accumulate per variant tag.
+              onSome: (existing: RetainedStartMaterial) =>
+                existing._tag === 'FromSeed'
+                  ? existing
+                  : StartMaterial.forVariants<ledger.ZswapSecretKeys>([...existing.byTag, [V2Tag, secretKeys]]),
+            }),
+          ),
+        );
+
+        // Registered before the first dispatch, and only once: `onVariantActivation` resolves only after its
+        // subscription is live, so an activation racing this call is queued rather than missed.
+        const alreadyRegistered = yield* Ref.getAndSet(this.#watcherRegistered, true);
+        if (!alreadyRegistered) {
+          yield* this.runtime.onVariantActivation({
+            [V1Tag]: (v1) => this.#resumeSyncOn(v1, preForkAux),
+            [V2Tag]: (v2) => this.#resumeSyncOn(v2, postForkAux),
+          });
+        }
+
+        yield* this.runtime.dispatch({
+          [V1Tag]: (v1) => this.#resumeSyncOn(v1, preForkAux),
+          [V2Tag]: (v2) => v2.startSyncInBackground(secretKeys),
+        });
+      }).pipe(Effect.runPromise);
+    }
+
+    async stop(): Promise<void> {
+      // Released before the runtime is torn down: the key material outlives neither the wallet nor an in-flight
+      // activation.
+      Ref.set(this.#retainedStartMaterial, Option.none()).pipe(Effect.runSync);
+      await super.stop();
+    }
+
+    balanceTransaction(
+      secretKeys: ledger.ZswapSecretKeys,
+      tx: ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>,
+    ): Promise<BalancingResult> {
+      return this.runtime
+        .dispatch<BalancingResult, TransactingError>({
+          [V1Tag]: () => preForkTransactingUnsupported('balanceTransaction'),
+          [V2Tag]: (v2) => v2.balanceTransaction(secretKeys, tx),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    transferTransaction(
+      secretKeys: ledger.ZswapSecretKeys,
+      outputs: readonly TokenTransfer[],
+    ): Promise<ledger.UnprovenTransaction> {
+      return this.runtime
+        .dispatch<ledger.UnprovenTransaction, TransactingError>({
+          [V1Tag]: () => preForkTransactingUnsupported('transferTransaction'),
+          [V2Tag]: (v2) => v2.transferTransaction(secretKeys, outputs),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    initSwap(
+      secretKeys: ledger.ZswapSecretKeys,
+      desiredInputs: Record<ledger.RawTokenType, bigint>,
+      desiredOutputs: readonly TokenTransfer[],
+    ): Promise<ledger.UnprovenTransaction> {
+      return this.runtime
+        .dispatch<ledger.UnprovenTransaction, TransactingError>({
+          [V1Tag]: () => preForkTransactingUnsupported('initSwap'),
+          [V2Tag]: (v2) => v2.initSwap(secretKeys, desiredInputs, desiredOutputs),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    revertTransaction(
+      transaction: ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>,
+    ): Promise<void> {
+      return this.runtime
+        .dispatch<void, TransactingError>({
+          [V1Tag]: () => preForkTransactingUnsupported('revertTransaction'),
+          [V2Tag]: (v2) => v2.revertTransaction(transaction),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    waitForSyncedState(allowedGap: bigint = 0n): Promise<ShieldedWalletState<string>> {
+      return rx.firstValueFrom(
+        this.state.pipe(rx.filter((state) => state.state.progress.isCompleteWithin(allowedGap))),
+      );
+    }
+
+    /**
+     * Serializes the most recent state. It's preferable to use [[ShieldedWalletState.serialize]] instead, to know
+     * exactly which state is serialized.
+     */
+    serializeState(): Promise<string> {
+      return rx.firstValueFrom(this.state).then((state) => state.serialize());
+    }
+
+    getAddress(): Promise<ShieldedAddress> {
+      return rx.firstValueFrom(this.state).then((state) => state.address);
+    }
+  };
+}
+
+/** A shielded wallet built the way this package ships it: one variant either side of the protocol boundary. */
+export type ShieldedWallet = ForkingShieldedWallet<PreForkSyncUpdate, PostForkSyncUpdate>;
+
+/** The class {@link ShieldedWallet} builds. */
+export type ShieldedWalletClass = ForkingShieldedWalletClass<
+  PreForkSyncUpdate,
+  PostForkSyncUpdate,
+  DefaultShieldedConfiguration
+>;
+
+/**
+ * Builds the shielded wallet this package ships: the default variant either side of `configuration.forkVersion`.
+ *
+ * @remarks
+ *   Both variants read the chain through the indexer and record transaction history in the same storage; each is built
+ *   from the same application configuration, because what they ask for happens to coincide. The post-fork variant is
+ *   registered with the cross-ledger migration, which is what makes the hand-over carry identity and a cursor onto a
+ *   fresh state rather than start a wallet from nothing.
+ *
+ *   **Transacting is available only once the wallet is on the post-fork variant** — see
+ *   {@link PreForkTransactingUnsupportedError}, a temporary seam that closes with version-routed proving.
+ * @param configuration What the wallet and both its variants are built from, including where the boundary lies.
+ * @returns The wallet class.
+ */
+export function ShieldedWallet(configuration: DefaultShieldedConfiguration): ShieldedWalletClass {
+  return CustomForkingShieldedWallet(
+    configuration,
+    { builder: new V1Builder().withDefaults(), configuration },
+    {
+      builder: new V2Builder().withDefaults().withMigration(() => Migration.makeCrossLedgerMigration()),
+      configuration,
+    },
+  );
+}

--- a/packages/shielded-wallet/src/ForkingShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ForkingShieldedWallet.ts
@@ -459,12 +459,23 @@ export function CustomForkingShieldedWallet<
         .pipe(Effect.runPromise);
     }
 
+    /**
+     * Un-records a transaction this wallet produced, releasing the coins it had booked.
+     *
+     * @remarks
+     *   Nothing to do on the pre-fork variant, and that is a fact about the wallet rather than a convenience: while
+     *   pre-fork transacting is unavailable that variant cannot have produced the transaction being reverted, so it
+     *   holds nothing of it to release. The parameter's type says the same thing — a post-fork transaction is not one
+     *   the pre-fork variant could have built. Unlike the operations that build transactions, this needs no proving, so
+     *   there is nothing here for version-routed proving to unlock later.
+     * @param transaction The transaction to un-record.
+     */
     revertTransaction(
       transaction: ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>,
     ): Promise<void> {
       return this.runtime
         .dispatch<void, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('revertTransaction'),
+          [V1Tag]: () => Effect.void,
           [V2Tag]: (v2) => v2.revertTransaction(transaction),
         })
         .pipe(Effect.runPromise);

--- a/packages/shielded-wallet/src/ForkingShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ForkingShieldedWallet.ts
@@ -21,8 +21,8 @@
  *   public API speaks the post-fork ledger version throughout, and where the two sides genuinely differ — the key
  *   material each variant's synchronization needs — the wallet resolves it per variant from what it retained.
  */
-import * as v8 from '@midnight-ntwrk/ledger-v8';
-import * as ledger from '@midnightntwrk/ledger-v9';
+import type * as v8 from '@midnight-ntwrk/ledger-v8';
+import type * as ledger from '@midnightntwrk/ledger-v9';
 import { type NetworkId, ProtocolVersion, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type ShieldedAddress } from '@midnightntwrk/wallet-sdk-address-format';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -41,6 +41,7 @@ import {
 import { type TokenTransfer } from './v2/Transacting.js';
 import { type BatchUpdatesConfig, type IndexerClientConnection, type WalletSyncUpdate } from './v2/Sync.js';
 import { type ShieldedHistoryStorage, type TransactionHistoryService } from './v2/TransactionHistory.js';
+import { type CoreWallet as V1CoreWallet } from './v1/CoreWallet.js';
 import {
   StartMaterial,
   type Variant,
@@ -63,46 +64,89 @@ export type ShieldedWalletServices = {
 
 export type UnboundTransaction = ledger.Transaction<ledger.SignatureEnabled, ledger.Proof, ledger.PreBinding>;
 
+/** The core state of whichever shielded variant produced an emission. */
+export type ShieldedCoreState = V1CoreWallet | CoreWallet;
+
+/**
+ * Everything a state emission projects, already bound to the variant that produced it.
+ *
+ * @remarks
+ *   Binding is the point. The capabilities that understand a state and the state itself must be chosen together, in the
+ *   branch where the producing variant is known; the two variants' capability types are structurally identical, so a
+ *   capability of one would type-check against a state of the other and be wrong at runtime. Once bound there is
+ *   nothing left to mis-pair, and everything below is version-agnostic plain data.
+ */
+type ShieldedProjections<TSerialized> = Readonly<{
+  balances: () => Record<ledger.RawTokenType, bigint>;
+  totalCoins: () => readonly (AvailableCoin | PendingCoin)[];
+  availableCoins: () => readonly AvailableCoin[];
+  pendingCoins: () => readonly PendingCoin[];
+  coinPublicKey: () => ShieldedCoinPublicKey;
+  encryptionPublicKey: () => ShieldedEncryptionPublicKey;
+  address: () => ShieldedAddress;
+  serialize: () => TSerialized;
+}>;
+
+/** The capability set a variant exposes for reading and serializing its own state. */
+type ShieldedStateCapabilities<TState, TSerialized> = Readonly<{
+  serialization: SerializationCapability<TState, null, TSerialized>;
+  coinsAndBalances: CoinsAndBalancesCapability<TState>;
+  keys: KeysCapability<TState>;
+}>;
+
 export class ShieldedWalletState<TSerialized = string, _TTransaction = ledger.FinalizedTransaction> {
-  static readonly mapState =
-    <TSerialized = string>(variant: ShieldedWalletCapabilities<TSerialized> & ShieldedWalletServices) =>
-    (state: ProtocolState.ProtocolState<CoreWallet>): ShieldedWalletState<TSerialized> => {
-      const { serialization, coinsAndBalances, keys } = variant;
-      const { transactionHistory } = variant;
-      return new ShieldedWalletState(state, { serialization, coinsAndBalances, keys }, { transactionHistory });
-    };
+  /**
+   * Wraps a state emission with the capabilities of the variant that produced it.
+   *
+   * @remarks
+   *   Call this inside a branch that has narrowed on the emission's `variantTag`, so `variant` and `state` are known to
+   *   belong together. It is generic over the state type precisely so that pairing is checked.
+   */
+  static readonly fromVariant = <TState, TSerialized = string>(
+    variant: ShieldedStateCapabilities<TState, TSerialized>,
+    state: ProtocolState.ProtocolState<TState>,
+  ): ShieldedWalletState<TSerialized> =>
+    new ShieldedWalletState<TSerialized>(state.version, state.state as ShieldedCoreState, {
+      balances: () => variant.coinsAndBalances.getAvailableBalances(state.state),
+      totalCoins: () => variant.coinsAndBalances.getTotalCoins(state.state),
+      availableCoins: () => variant.coinsAndBalances.getAvailableCoins(state.state),
+      pendingCoins: () => variant.coinsAndBalances.getPendingCoins(state.state),
+      coinPublicKey: () => variant.keys.getCoinPublicKey(state.state),
+      encryptionPublicKey: () => variant.keys.getEncryptionPublicKey(state.state),
+      address: () => variant.keys.getAddress(state.state),
+      serialize: () => variant.serialization.serialize(state.state),
+    });
 
   readonly protocolVersion: ProtocolVersion.ProtocolVersion;
-  readonly state: CoreWallet;
-  readonly capabilities: ShieldedWalletCapabilities<TSerialized>;
-  readonly services: ShieldedWalletServices;
+  readonly state: ShieldedCoreState;
+  readonly #projections: ShieldedProjections<TSerialized>;
 
   get balances(): Record<ledger.RawTokenType, bigint> {
-    return this.capabilities.coinsAndBalances.getAvailableBalances(this.state);
+    return this.#projections.balances();
   }
 
   get totalCoins(): readonly (AvailableCoin | PendingCoin)[] {
-    return this.capabilities.coinsAndBalances.getTotalCoins(this.state);
+    return this.#projections.totalCoins();
   }
 
   get availableCoins(): readonly AvailableCoin[] {
-    return this.capabilities.coinsAndBalances.getAvailableCoins(this.state);
+    return this.#projections.availableCoins();
   }
 
   get pendingCoins(): readonly PendingCoin[] {
-    return this.capabilities.coinsAndBalances.getPendingCoins(this.state);
+    return this.#projections.pendingCoins();
   }
 
   get coinPublicKey(): ShieldedCoinPublicKey {
-    return this.capabilities.keys.getCoinPublicKey(this.state);
+    return this.#projections.coinPublicKey();
   }
 
   get encryptionPublicKey(): ShieldedEncryptionPublicKey {
-    return this.capabilities.keys.getEncryptionPublicKey(this.state);
+    return this.#projections.encryptionPublicKey();
   }
 
   get address(): ShieldedAddress {
-    return this.capabilities.keys.getAddress(this.state);
+    return this.#projections.address();
   }
 
   get progress(): SyncProgress.SyncProgress {
@@ -110,18 +154,17 @@ export class ShieldedWalletState<TSerialized = string, _TTransaction = ledger.Fi
   }
 
   constructor(
-    state: ProtocolState.ProtocolState<CoreWallet>,
-    capabilities: ShieldedWalletCapabilities<TSerialized>,
-    services: ShieldedWalletServices,
+    protocolVersion: ProtocolVersion.ProtocolVersion,
+    state: ShieldedCoreState,
+    projections: ShieldedProjections<TSerialized>,
   ) {
-    this.protocolVersion = state.version;
-    this.state = state.state;
-    this.capabilities = capabilities;
-    this.services = services;
+    this.protocolVersion = protocolVersion;
+    this.state = state;
+    this.#projections = projections;
   }
 
   serialize(): TSerialized {
-    return this.capabilities.serialization.serialize(this.state);
+    return this.#projections.serialize();
   }
 }
 
@@ -413,9 +456,11 @@ export function CustomShieldedWallet<
     ) {
       super(runtime, scope);
       this.state = this.rawState.pipe(
-        rx.map(
-          ShieldedWalletState.mapState<TSerialized>(
+        rx.map((emission) =>
+          // One variant, so the pairing is trivial here; the forking wallet narrows on `variantTag` first.
+          ShieldedWalletState.fromVariant<CoreWallet, TSerialized>(
             CustomShieldedWalletImplementation.allVariantsRecord()[V2Tag].variant,
+            emission,
           ),
         ),
         rx.shareReplay({ refCount: true, bufferSize: 1 }),

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -21,7 +21,6 @@ import {
   type BaseV2Configuration,
   type DefaultV2Configuration,
   type RunningV2Variant,
-  V2Builder,
   V2Tag,
   type V2Variant,
   CoreWallet,

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -168,20 +168,6 @@ export class ShieldedWalletState<TSerialized = string, _TTransaction = ledger.Fi
   }
 }
 
-export type ShieldedWallet = CustomizedShieldedWallet<
-  ledger.ZswapSecretKeys,
-  ledger.FinalizedTransaction,
-  WalletSyncUpdate,
-  string
->;
-
-export type ShieldedWalletClass = CustomizedShieldedWalletClass<
-  ledger.ZswapSecretKeys,
-  ledger.FinalizedTransaction,
-  WalletSyncUpdate,
-  string
->;
-
 export type ShieldedWalletAPI<
   TStartAux = ledger.ZswapSecretKeys,
   TTransaction = ledger.FinalizedTransaction,
@@ -296,10 +282,17 @@ export interface CustomizedShieldedWalletClass<
   restore(serializedState: TSerialized): CustomizedShieldedWallet<TStartAux, TTransaction, TSyncUpdate, TSerialized>;
 }
 
-export function ShieldedWallet(configuration: DefaultShieldedConfiguration): ShieldedWalletClass {
-  return CustomShieldedWallet<DefaultShieldedConfiguration>(configuration, new V2Builder().withDefaults());
-}
-
+/**
+ * Builds a shielded wallet class over a single variant.
+ *
+ * @remarks
+ *   One variant, and therefore one ledger version: this is the composition for a wallet that is not expected to meet a
+ *   protocol boundary — a test harness, a simulator-driven wallet, an application pinned to one protocol version. The
+ *   wallet this package ships is `ShieldedWallet`, which registers a variant either side of the boundary.
+ * @param configuration What the variant is built from.
+ * @param builder The variant builder.
+ * @returns The wallet class.
+ */
 export function CustomShieldedWallet<
   TConfig extends BaseV2Configuration = DefaultV2Configuration,
   TStartAux = ledger.ZswapSecretKeys,

--- a/packages/shielded-wallet/src/index.ts
+++ b/packages/shielded-wallet/src/index.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 export * from './ShieldedWallet.js';
+export * from './ForkingShieldedWallet.js';
 export * as Restore from './Restore.js';
 export {
   type ShieldedTransactionHistoryEntry,

--- a/packages/shielded-wallet/src/test/forkHarness.ts
+++ b/packages/shielded-wallet/src/test/forkHarness.ts
@@ -12,37 +12,27 @@
 // limitations under the License.
 
 /**
- * A shielded wallet registered over _both_ variants, syncing a chain that forks under it — test scaffolding only.
+ * The shipped forking shielded wallet, driven over simulated chains, with the channels a fork proof needs to watch it.
  *
  * @remarks
- *   The shipped `ShieldedWallet` registers exactly one variant and its type is a one-element HList throughout, so it
- *   cannot express a wallet that crosses a fork. Rather than widen the public surface ahead of the API redesign this
- *   builds the two-variant wallet the way `packages/e2e-tests` builds its custom wallets: `WalletBuilder.init()` with
- *   both variant builders registered directly. Nothing here is exported from the package.
+ *   Everything here is observation and simulated infrastructure. The wallet itself is the one the package ships —
+ *   {@link CustomForkingShieldedWallet}, the same composition `ShieldedWallet(configuration)` uses — with each variant
+ *   pointed at a simulated chain instead of an indexer, and the post-fork variant's migration wrapped so both ends of
+ *   the hand-over can be recorded as plain data.
  *
  *   The two sides read different sources, which is the shape the real thing has: before the fork the pre-fork chain,
  *   after it the indexer's replayed timeline (see `forkReplay.ts`). The post-fork source does not exist when the wallet
- *   is built, so it is supplied as an effect the post-fork variant awaits at its first sync.
- *
- *   Three things it has to work around, each of which is a real question the public API will have to answer eventually:
- *
- *   - **Configuration collides.** `WalletBuilder` intersects every variant's configuration, and both variants name their
- *       simulator `simulator` — with different, incompatible ledger types. So the sync services are passed as closures
- *       that ignore configuration entirely, leaving the merged configuration as just `networkId`.
- *   - **Start-aux does not cross the boundary.** The pre-fork variant's aux is a ledger-v8 `ZswapSecretKeys`, the post-fork
- *       variant's a ledger-v9 one. A single retained value cannot serve both, so what is retained here is the _seed_,
- *       and each variant is handed keys derived from it — the same public keys either way (asserted by
- *       `forkSimulation.integration.test.ts`), just built by the ledger that variant speaks.
- *   - **The post-fork source does not exist yet** when the wallet is built, hence the effect above.
+ *   is built — the replay only happens once the fork has — so it reaches its variant as an effect awaited at the first
+ *   sync, carried in that variant's own configuration.
  */
 
 import * as v8 from '@midnight-ntwrk/ledger-v8';
 import * as v9 from '@midnightntwrk/ledger-v9';
-import { type NetworkId, type ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type NetworkId, type ProtocolState, type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type Simulator, type V8 } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
-import { WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
 import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { Deferred, Effect, FiberId, Option, Stream, pipe } from 'effect';
+import { CustomForkingShieldedWallet, type ForkingShieldedWallet } from '../ForkingShieldedWallet.js';
 import * as V1 from '../v1/index.js';
 import * as V2 from '../v2/index.js';
 
@@ -147,6 +137,12 @@ const noOpPostForkHistory: V2.TransactionHistory.TransactionHistoryService = {
   getTransactionDetails: (hash) => Effect.succeed(transactionDetails(hash)),
 };
 
+/** What the post-fork variant is configured with: a source that does not exist yet. */
+type DeferredSourceConfiguration = Readonly<{
+  networkId: NetworkId.NetworkId;
+  replayed: Effect.Effect<Simulator, never>;
+}>;
+
 /**
  * The post-fork sync source, deferred until it exists.
  *
@@ -156,12 +152,12 @@ const noOpPostForkHistory: V2.TransactionHistory.TransactionHistoryService = {
  *   error channel.
  */
 const postForkSyncService = (
-  replayed: Effect.Effect<Simulator, never>,
+  configuration: DeferredSourceConfiguration,
 ): V2.Sync.SyncService<V2.CoreWallet, v9.ZswapSecretKeys, V2.Sync.SimulatorSyncUpdate> => ({
   updates: (state, secretKeys) =>
     Stream.unwrap(
       pipe(
-        replayed,
+        configuration.replayed,
         Effect.orDie,
         Effect.map((chain) => V2.Sync.makeSimulatorSyncService({ simulator: chain }).updates(state, secretKeys)),
       ),
@@ -172,7 +168,7 @@ const postForkSyncService = (
 // The wallet
 // =============================================================================
 
-/** Everything needed to build a two-variant shielded wallet over a chain that forks. */
+/** Everything needed to point a forking shielded wallet at a chain that forks. */
 export type ForkWalletConfig = Readonly<{
   /** The pre-fork chain, available immediately. */
   preFork: V8.Simulator;
@@ -191,12 +187,17 @@ export type ForkWalletConfig = Readonly<{
   seed: Uint8Array;
 }>;
 
-/** A running two-variant shielded wallet, plus the channels a fork proof needs to observe it. */
+/** A state emission, whichever variant produced it. */
+export type ForkedState = ProtocolState.ProtocolState<V1.CoreWallet | V2.CoreWallet>;
+
+/** A running forking shielded wallet, plus the channels a fork proof needs to observe it. */
 export type ForkWallet = Readonly<{
+  /** The wallet itself, exactly as an application would hold it. */
+  shielded: ForkingShieldedWallet<V1.Sync.SimulatorSyncUpdate, V2.Sync.SimulatorSyncUpdate>;
   /** Keys of each ledger version, derived from the same seed. */
   keys: Readonly<{ preFork: v8.ZswapSecretKeys; postFork: v9.ZswapSecretKeys }>;
-  /** Starts background sync, having first registered the activation watcher that restarts it after a migration. */
-  start: Effect.Effect<void, WalletRuntimeError>;
+  /** Starts background sync through the wallet's own API, which resolves the key material each variant can use. */
+  start: Effect.Effect<void>;
   /** Resolves when the hand-over happens, with both ends of it. */
   awaitMigration: Effect.Effect<CapturedMigration>;
   /** Both ends of the migration, or `None` if none has happened yet. */
@@ -204,28 +205,20 @@ export type ForkWallet = Readonly<{
   /** The tag of the variant currently running — `V1Tag` before a migration, `V2Tag` after one. */
   activeTag: Effect.Effect<string | symbol>;
   /** The wallet's current state, whichever variant produced it. */
-  currentState: Effect.Effect<ProtocolState.ProtocolState<V1.CoreWallet | V2.CoreWallet>, WalletRuntimeError>;
+  currentState: Effect.Effect<ForkedState, WalletRuntimeError>;
   /**
    * Resolves once the wallet's state satisfies `predicate`, failing the test's timeout if it never does.
    *
    * Use monotone predicates only: the runtime's state stream keeps just the latest value, so a state that satisfies a
    * transient predicate can legitimately be skipped.
    */
-  awaitState: (
-    predicate: (state: ProtocolState.ProtocolState<V1.CoreWallet | V2.CoreWallet>) => boolean,
-  ) => Effect.Effect<ProtocolState.ProtocolState<V1.CoreWallet | V2.CoreWallet>, WalletRuntimeError>;
-  /** Runs `use` against the running post-fork variant. Fails if the wallet has not migrated. */
-  onPostForkVariant: <A, E>(
-    use: (
-      variant: V2.RunningV2Variant<string, V2.Sync.SimulatorSyncUpdate, v9.FinalizedTransaction, v9.ZswapSecretKeys>,
-    ) => Effect.Effect<A, E>,
-  ) => Effect.Effect<A, E | WalletRuntimeError>;
+  awaitState: (predicate: (state: ForkedState) => boolean) => Effect.Effect<ForkedState, WalletRuntimeError>;
   /** Tears the wallet down. */
   stop: Effect.Effect<void>;
 }>;
 
 /**
- * Builds and starts a shielded wallet registered over both variants.
+ * Builds and starts the shipped forking shielded wallet over two simulated chains.
  *
  * @param config - The two sources, the boundary version, the network and the seed.
  * @returns The running wallet and its observation channels.
@@ -240,7 +233,7 @@ export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
 
   const preForkBuilder = new V1.V1Builder()
     .withDefaultTransactionType()
-    .withSync(() => V1.Sync.makeSimulatorSyncService({ simulator: preFork }), V1.Sync.makeSimulatorSyncCapability)
+    .withSync(V1.Sync.makeSimulatorSyncService, V1.Sync.makeSimulatorSyncCapability)
     .withSerializationDefaults()
     .withTransactingDefaults()
     .withCoinsAndBalancesDefaults()
@@ -251,7 +244,7 @@ export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
 
   const postForkBuilder = new V2.V2Builder()
     .withDefaultTransactionType()
-    .withSync(() => postForkSyncService(replayed), V2.Sync.makeSimulatorSyncCapability)
+    .withSync(postForkSyncService, V2.Sync.makeSimulatorSyncCapability)
     .withSerializationDefaults()
     .withTransactingDefaults()
     .withCoinsAndBalancesDefaults()
@@ -261,31 +254,26 @@ export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
     .withCoinSelectionDefaults()
     .withMigration(() => capturingCrossLedgerMigration(captured));
 
-  const WalletClass = WalletBuilder.init()
-    .withVariant(ProtocolVersion.MinSupportedVersion, preForkBuilder)
-    .withVariant(forkVersion, postForkBuilder)
-    .build({ networkId });
+  const WalletClass = CustomForkingShieldedWallet(
+    { networkId, forkVersion },
+    { builder: preForkBuilder, configuration: { networkId, simulator: preFork } },
+    { builder: postForkBuilder, configuration: { networkId, replayed } },
+  );
 
-  const wallet = WalletClass.startFirst(WalletClass, V1.CoreWallet.initEmpty(preForkKeys, networkId));
+  const wallet = WalletClass.startWithSeed(seed);
   const runtime = wallet.runtime;
 
   const currentState = pipe(runtime.stateChanges, Stream.take(1), Stream.runHead, Effect.map(Option.getOrThrow));
 
   return {
+    shielded: wallet,
+
     keys: { preFork: preForkKeys, postFork: postForkKeys },
 
-    start: Effect.gen(function* () {
-      // Registered before the first dispatch and only once, exactly as `ShieldedWallet.start` does it: the returned
-      // effect resolves only once the subscription is live, so the migration cannot outrun the watcher.
-      yield* runtime.onVariantActivation({
-        [V1.V1Tag]: (v1) => v1.startSyncInBackground(preForkKeys),
-        [V2.V2Tag]: (v2) => v2.startSyncInBackground(postForkKeys),
-      });
-      yield* runtime.dispatch({
-        [V1.V1Tag]: (v1) => v1.startSyncInBackground(preForkKeys),
-        [V2.V2Tag]: (v2) => v2.startSyncInBackground(postForkKeys),
-      });
-    }),
+    // The keys handed over are the post-fork ledger version's, which is what the wallet's API speaks. The pre-fork
+    // variant running underneath is started from the seed the wallet retained instead — the seam a wallet crossing a
+    // boundary rests on.
+    start: Effect.promise(() => wallet.start(postForkKeys)),
 
     awaitMigration: Deferred.await(captured),
 
@@ -308,13 +296,6 @@ export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
         Stream.runHead,
         Effect.map(Option.getOrThrow),
       ),
-
-    onPostForkVariant: (use) =>
-      runtime.dispatch({
-        [V1.V1Tag]: () =>
-          Effect.die(new Error('The wallet is still running its pre-fork variant; it has not migrated')),
-        [V2.V2Tag]: use,
-      }),
 
     stop: Effect.promise(() => wallet.stop()),
   };

--- a/packages/shielded-wallet/src/test/forkSimulation.integration.test.ts
+++ b/packages/shielded-wallet/src/test/forkSimulation.integration.test.ts
@@ -60,7 +60,7 @@ import { describe, expect, it } from 'vitest';
 import { V1Tag } from '../v1/index.js';
 import { V2Tag } from '../v2/index.js';
 import { type ReplayedCoin, makeReplayChain, mintable, preForkPayment, simulatedChainRoot } from './forkReplay.js';
-import { makeForkWallet } from './forkWallet.js';
+import { makeForkWallet } from './forkHarness.js';
 import { coinIndices, coinValues, merkleRoot, totalValue, treeSize } from './forkWalletAssertions.js';
 
 const networkId = NetworkId.NetworkId.Undeployed;
@@ -219,8 +219,8 @@ describe('a shielded wallet crossing a byte-faithful hard fork', () => {
 
       // --- and it can transact against the translation ----------------------------------------------------------
       const transferred = 150n;
-      const transfer = yield* wallet.onPostForkVariant((variant) =>
-        variant.transferTransaction(wallet.keys.postFork, [
+      const transfer = yield* Effect.promise(() =>
+        wallet.shielded.transferTransaction(wallet.keys.postFork, [
           { amount: transferred, type: v9.shieldedToken().raw, receiverAddress: recipientAddress() },
         ]),
       );

--- a/packages/shielded-wallet/src/test/forkSimulation.test.ts
+++ b/packages/shielded-wallet/src/test/forkSimulation.test.ts
@@ -50,7 +50,7 @@ import { describe, expect, it } from 'vitest';
 import { V1Tag } from '../v1/index.js';
 import { V2Tag } from '../v2/index.js';
 import { type ReplayedCoin, makeReplayChain, mintable, preForkPayment } from './forkReplay.js';
-import { type ForkWallet, makeForkWallet } from './forkWallet.js';
+import { type ForkWallet, makeForkWallet } from './forkHarness.js';
 import { ascending, coinIndices, coinValues, totalValue, treeSize } from './forkWalletAssertions.js';
 
 const networkId = NetworkId.NetworkId.Undeployed;
@@ -233,8 +233,8 @@ describe('a shielded wallet crossing a hard fork', () => {
 
       // --- the re-discovered coins are spendable ----------------------------------------------------------------
       const transferred = 150n;
-      const transfer = yield* wallet.onPostForkVariant((variant) =>
-        variant.transferTransaction(wallet.keys.postFork, [
+      const transfer = yield* Effect.promise(() =>
+        wallet.shielded.transferTransaction(wallet.keys.postFork, [
           { amount: transferred, type: v9.shieldedToken().raw, receiverAddress: recipientAddress() },
         ]),
       );

--- a/packages/shielded-wallet/src/test/forkStart.test.ts
+++ b/packages/shielded-wallet/src/test/forkStart.test.ts
@@ -42,7 +42,9 @@ import {
   genesisStrictness,
   immediateBlockProducer,
 } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
-import { Cause, Effect, Option, Runtime } from 'effect';
+import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { type LedgerOps } from '@midnightntwrk/wallet-sdk-utilities';
+import { Cause, Effect, Option, Runtime, type Scope } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { PreForkTransactingUnsupportedError } from '../ForkingShieldedWallet.js';
 import { V1Tag } from '../v1/index.js';
@@ -131,17 +133,47 @@ const failureOf = (call: Promise<unknown>): Effect.Effect<Option.Option<unknown>
     ),
   );
 
-/** Every transacting call the wallet's API offers, named as the wallet names it. */
-const transactingCalls = (wallet: ForkWallet): readonly (readonly [string, () => Promise<unknown>])[] => {
+/**
+ * Every call that builds a transaction, named as the wallet names it.
+ *
+ * @remarks
+ *   `revertTransaction` is deliberately not among them: it builds nothing and needs no proving, so it is not what the
+ *   pre-fork seam is about — see the test below for what it does instead.
+ */
+const transactionBuildingCalls = (wallet: ForkWallet): readonly (readonly [string, () => Promise<unknown>])[] => {
   const transfer = { amount: 1n, type: v9.shieldedToken().raw, receiverAddress: strangerAddress() };
-  const someTransaction = v9.Transaction.fromParts(networkId);
   return [
-    ['balanceTransaction', () => wallet.shielded.balanceTransaction(wallet.keys.postFork, someTransaction)],
+    ['balanceTransaction', () => wallet.shielded.balanceTransaction(wallet.keys.postFork, someTransaction())],
     ['transferTransaction', () => wallet.shielded.transferTransaction(wallet.keys.postFork, [transfer])],
     ['initSwap', () => wallet.shielded.initSwap(wallet.keys.postFork, {}, [transfer])],
-    ['revertTransaction', () => wallet.shielded.revertTransaction(someTransaction)],
   ];
 };
+
+/** A transaction of the post-fork ledger version, which is the only kind this wallet's API accepts. */
+const someTransaction = (): v9.UnprovenTransaction => v9.Transaction.fromParts(networkId);
+
+/**
+ * A wallet on a chain that has not forked, synchronized and holding its coins.
+ *
+ * @remarks
+ *   Synchronized before anything is asked of it so that a refusal below is a refusal to transact at all, rather than a
+ *   wallet that has nothing to transact with. Scoped: the caller's scope stops it.
+ */
+const syncedPreForkWallet: Effect.Effect<ForkWallet, LedgerOps.LedgerError | WalletRuntimeError, Scope.Scope> =
+  Effect.gen(function* () {
+    const coins = chainCoins();
+    const chain = yield* chainAt(beforeFork, coins);
+    const replayed = yield* replayOf(coins, chain);
+
+    const wallet = makeForkWallet({ preFork: chain, replayed: Effect.succeed(replayed), networkId, forkVersion, seed });
+    yield* Effect.addFinalizer(() => wallet.stop);
+    yield* wallet.start;
+
+    yield* wallet.awaitState((state) => totalValue(state.state) === walletTotal);
+    expect(yield* wallet.activeTag).toBe(V1Tag);
+
+    return wallet;
+  });
 
 describe('a shielded wallet starting on a chain that has already forked', () => {
   it('hands over on the first batch, having applied nothing, and syncs on the post-fork variant', async () =>
@@ -206,30 +238,13 @@ describe('a shielded wallet starting on a chain that has not forked', () => {
       expect(yield* wallet.migration).toStrictEqual(Option.none());
     }).pipe(Effect.scoped, Effect.runPromise));
 
-  it.each(['balanceTransaction', 'transferTransaction', 'initSwap', 'revertTransaction'])(
+  it.each(['balanceTransaction', 'transferTransaction', 'initSwap'])(
     'refuses %s while it is still pre-fork, and says why',
     async (operation) =>
       Effect.gen(function* () {
-        const coins = chainCoins();
-        const chain = yield* chainAt(beforeFork, coins);
-        const replayed = yield* replayOf(coins, chain);
+        const wallet = yield* syncedPreForkWallet;
 
-        const wallet = makeForkWallet({
-          preFork: chain,
-          replayed: Effect.succeed(replayed),
-          networkId,
-          forkVersion,
-          seed,
-        });
-        yield* Effect.addFinalizer(() => wallet.stop);
-        yield* wallet.start;
-
-        // Synced first, and holding coins: what follows is a refusal to transact at all, not a wallet that has
-        // nothing to transact with.
-        yield* wallet.awaitState((state) => totalValue(state.state) === walletTotal);
-        expect(yield* wallet.activeTag).toBe(V1Tag);
-
-        const call = transactingCalls(wallet).find(([name]) => name === operation)!;
+        const call = transactionBuildingCalls(wallet).find(([name]) => name === operation)!;
         const failure = Option.getOrThrow(yield* failureOf(call[1]()));
 
         // Typed, and naming the operation: the pre-fork branch cannot produce a transaction anybody can prove, and
@@ -238,4 +253,19 @@ describe('a shielded wallet starting on a chain that has not forked', () => {
         expect(failure).toMatchObject({ operation });
       }).pipe(Effect.scoped, Effect.runPromise),
   );
+
+  it('reverts a transaction it cannot have made, by doing nothing to its state', async () =>
+    Effect.gen(function* () {
+      // Reverting releases coins a transaction booked, and no transaction of this wallet's can have booked any: it
+      // could not have built one. So this resolves, changes nothing, and is deliberately not part of the seam above —
+      // it needs no proving, so version-routed proving has nothing to unlock here. The facade reverts all three
+      // wallets together when a submission fails, and a refusal here would strand that whole path.
+      const wallet = yield* syncedPreForkWallet;
+
+      yield* Effect.promise(() => wallet.shielded.revertTransaction(someTransaction()));
+
+      const after = yield* wallet.currentState;
+      expect(totalValue(after.state)).toBe(walletTotal);
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+    }).pipe(Effect.scoped, Effect.runPromise));
 });

--- a/packages/shielded-wallet/src/test/forkStart.test.ts
+++ b/packages/shielded-wallet/src/test/forkStart.test.ts
@@ -1,0 +1,241 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Where a shielded wallet spanning a protocol boundary starts, and what it cannot do until it has crossed it.
+ *
+ * @remarks
+ *   `forkSimulation.test.ts` drives the crossing itself: a chain that forks under a running wallet. The two starts here
+ *   are the other question — a wallet meeting a chain that is already on one side or the other, which is what every
+ *   application start actually is.
+ *
+ *   A wallet always begins on the pre-fork variant, because that is the variant a wallet with no history belongs to. On a
+ *   chain that has already forked it therefore hands over immediately, having applied nothing: one migration per start,
+ *   paid on chains that are entirely past the boundary. That cost is accepted rather than hidden — removing it means
+ *   asking the chain for its version before choosing a variant, which is a separate piece of work.
+ *
+ *   Both starts assert the boundary by comparison with `forkVersion` and never by the number itself: which protocol
+ *   version a chain reports is a property of the chain, and the real fork's value is not final.
+ */
+
+import * as v8 from '@midnight-ntwrk/ledger-v8';
+import * as v9 from '@midnightntwrk/ledger-v9';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  ShieldedAddress,
+  ShieldedCoinPublicKey,
+  ShieldedEncryptionPublicKey,
+} from '@midnightntwrk/wallet-sdk-address-format';
+import {
+  type Simulator,
+  V8,
+  genesisStrictness,
+  immediateBlockProducer,
+} from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { Cause, Effect, Option, Runtime } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { PreForkTransactingUnsupportedError } from '../ForkingShieldedWallet.js';
+import { V1Tag } from '../v1/index.js';
+import { V2Tag } from '../v2/index.js';
+import { type ForkWallet, makeForkWallet } from './forkHarness.js';
+import { type ReplayedCoin, makeReplayChain, mintable, preForkPayment } from './forkReplay.js';
+import { coinValues, totalValue } from './forkWalletAssertions.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+
+/** Where the wallet registers its post-fork variant. */
+const forkVersion = ProtocolVersion.ProtocolVersion(7n);
+/** A chain that has already forked — deliberately past the boundary rather than exactly at it. */
+const afterFork = ProtocolVersion.ProtocolVersion(9n);
+/** A chain that has not — a version the pre-fork variant owns. */
+const beforeFork = ProtocolVersion.ProtocolVersion(5n);
+
+const forkBlock = 4n;
+
+const seed = Buffer.alloc(32, 42);
+const otherSeed = Buffer.alloc(32, 43);
+
+const walletValues = [100n, 200n] as const;
+const walletTotal = walletValues.reduce((sum, value) => sum + value, 0n);
+
+const walletRecipient = () => {
+  const keys = v9.ZswapSecretKeys.fromSeed(seed);
+  return { coinPublicKey: keys.coinPublicKey, encryptionPublicKey: keys.encryptionPublicKey };
+};
+
+const strangerAddress = (): ShieldedAddress => {
+  const stranger = v9.ZswapSecretKeys.fromSeed(otherSeed);
+  return new ShieldedAddress(
+    ShieldedCoinPublicKey.fromHexString(stranger.coinPublicKey),
+    ShieldedEncryptionPublicKey.fromHexString(stranger.encryptionPublicKey),
+  );
+};
+
+const chainCoins = (): readonly ReplayedCoin[] =>
+  walletValues.map((value) => mintable(v8.shieldedToken().raw, value, walletRecipient()));
+
+/** A ledger-v8 chain stamped with `version` from its genesis block, paying the wallet one coin per block. */
+const chainAt = (version: ProtocolVersion.ProtocolVersion, coins: readonly ReplayedCoin[]) =>
+  Effect.gen(function* () {
+    const chain = yield* V8.Simulator.init({
+      networkId,
+      protocolVersion: version,
+      blockProducer: V8.immediateBlockProducer(undefined, V8.genesisStrictness),
+    });
+    yield* Effect.forEach(coins, (coin) => chain.submitTransaction(preForkPayment(networkId, coin)), {
+      discard: true,
+    });
+    return chain;
+  });
+
+/** The post-fork source: the same coins, re-announced by the post-fork ledger version. */
+const replayOf = (coins: readonly ReplayedCoin[], chain: V8.Simulator) =>
+  Effect.gen(function* () {
+    const genesisTime = yield* chain.query((state) => state.currentTime);
+    return yield* makeReplayChain({
+      networkId,
+      protocolVersion: afterFork,
+      genesisBlockNumber: forkBlock,
+      genesisTime,
+      blockProducer: immediateBlockProducer(undefined, genesisStrictness),
+      coins,
+    });
+  });
+
+/**
+ * The typed failure a wallet call rejected with.
+ *
+ * @remarks
+ *   The wallet's API is promise-shaped and its failures are effect failures, so a rejection carries the cause rather than
+ *   the error itself. A call that resolves reports `None`, which fails the assertion below rather than reading a
+ *   property off nothing.
+ */
+const failureOf = (call: Promise<unknown>): Effect.Effect<Option.Option<unknown>> =>
+  Effect.promise(() =>
+    call.then(
+      () => Option.none<unknown>(),
+      (rejection: unknown) =>
+        Runtime.isFiberFailure(rejection)
+          ? Cause.failureOption(rejection[Runtime.FiberFailureCauseId])
+          : Option.some(rejection),
+    ),
+  );
+
+/** Every transacting call the wallet's API offers, named as the wallet names it. */
+const transactingCalls = (wallet: ForkWallet): readonly (readonly [string, () => Promise<unknown>])[] => {
+  const transfer = { amount: 1n, type: v9.shieldedToken().raw, receiverAddress: strangerAddress() };
+  const someTransaction = v9.Transaction.fromParts(networkId);
+  return [
+    ['balanceTransaction', () => wallet.shielded.balanceTransaction(wallet.keys.postFork, someTransaction)],
+    ['transferTransaction', () => wallet.shielded.transferTransaction(wallet.keys.postFork, [transfer])],
+    ['initSwap', () => wallet.shielded.initSwap(wallet.keys.postFork, {}, [transfer])],
+    ['revertTransaction', () => wallet.shielded.revertTransaction(someTransaction)],
+  ];
+};
+
+describe('a shielded wallet starting on a chain that has already forked', () => {
+  it('hands over on the first batch, having applied nothing, and syncs on the post-fork variant', async () =>
+    Effect.gen(function* () {
+      const coins = chainCoins();
+      const chain = yield* chainAt(afterFork, coins);
+      const replayed = yield* replayOf(coins, chain);
+
+      const wallet = makeForkWallet({
+        preFork: chain,
+        replayed: Effect.succeed(replayed),
+        networkId,
+        forkVersion,
+        seed,
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      yield* wallet.start;
+
+      const migration = yield* wallet.awaitMigration;
+
+      // The chain is past the boundary, so the pre-fork variant owns none of it: it read the version, applied no
+      // block, and handed over with a cursor that has not moved.
+      expect(migration.from.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
+      expect(migration.from.appliedIndex).toBe(0n);
+      expect(migration.to.coinCount).toBe(0);
+      // Identity crosses, which is what lets the post-fork variant decrypt anything at all.
+      expect(migration.to.coinPublicKey).toBe(v9.ZswapSecretKeys.fromSeed(seed).coinPublicKey);
+
+      // And the post-fork variant does the syncing, having been started with key material of its own ledger version.
+      const synced = yield* wallet.awaitState((state) => totalValue(state.state) === walletTotal);
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+      expect(synced.version).toBeGreaterThanOrEqual(forkVersion);
+      expect(coinValues(synced.state)).toEqual([...walletValues]);
+    }).pipe(Effect.scoped, Effect.runPromise));
+});
+
+describe('a shielded wallet starting on a chain that has not forked', () => {
+  it('syncs on the pre-fork variant and stays there', async () =>
+    Effect.gen(function* () {
+      const coins = chainCoins();
+      const chain = yield* chainAt(beforeFork, coins);
+      // The replay is never reached: a source the post-fork variant would consume if it ever ran.
+      const replayed = yield* replayOf(coins, chain);
+
+      const wallet = makeForkWallet({
+        preFork: chain,
+        replayed: Effect.succeed(replayed),
+        networkId,
+        forkVersion,
+        seed,
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      yield* wallet.start;
+
+      // Everything the chain has, read by the ledger version that produced it — from a seed, which is the only key
+      // material that answers for a variant the wallet's own API does not speak.
+      const synced = yield* wallet.awaitState((state) => totalValue(state.state) === walletTotal);
+      expect(coinValues(synced.state)).toEqual([...walletValues]);
+      expect(synced.state.protocolVersion).toBeLessThan(forkVersion);
+
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+      expect(yield* wallet.migration).toStrictEqual(Option.none());
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it.each(['balanceTransaction', 'transferTransaction', 'initSwap', 'revertTransaction'])(
+    'refuses %s while it is still pre-fork, and says why',
+    async (operation) =>
+      Effect.gen(function* () {
+        const coins = chainCoins();
+        const chain = yield* chainAt(beforeFork, coins);
+        const replayed = yield* replayOf(coins, chain);
+
+        const wallet = makeForkWallet({
+          preFork: chain,
+          replayed: Effect.succeed(replayed),
+          networkId,
+          forkVersion,
+          seed,
+        });
+        yield* Effect.addFinalizer(() => wallet.stop);
+        yield* wallet.start;
+
+        // Synced first, and holding coins: what follows is a refusal to transact at all, not a wallet that has
+        // nothing to transact with.
+        yield* wallet.awaitState((state) => totalValue(state.state) === walletTotal);
+        expect(yield* wallet.activeTag).toBe(V1Tag);
+
+        const call = transactingCalls(wallet).find(([name]) => name === operation)!;
+        const failure = Option.getOrThrow(yield* failureOf(call[1]()));
+
+        // Typed, and naming the operation: the pre-fork branch cannot produce a transaction anybody can prove, and
+        // says so instead of producing one nobody can.
+        expect(failure).toBeInstanceOf(PreForkTransactingUnsupportedError);
+        expect(failure).toMatchObject({ operation });
+      }).pipe(Effect.scoped, Effect.runPromise),
+  );
+});

--- a/packages/shielded-wallet/src/test/forkStart.test.ts
+++ b/packages/shielded-wallet/src/test/forkStart.test.ts
@@ -36,12 +36,7 @@ import {
   ShieldedCoinPublicKey,
   ShieldedEncryptionPublicKey,
 } from '@midnightntwrk/wallet-sdk-address-format';
-import {
-  type Simulator,
-  V8,
-  genesisStrictness,
-  immediateBlockProducer,
-} from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { V8, genesisStrictness, immediateBlockProducer } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type LedgerOps } from '@midnightntwrk/wallet-sdk-utilities';
 import { Cause, Effect, Option, Runtime, type Scope } from 'effect';

--- a/packages/shielded-wallet/src/test/shieldedWallet.test.ts
+++ b/packages/shielded-wallet/src/test/shieldedWallet.test.ts
@@ -15,12 +15,12 @@ import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wal
 import { Effect, Scope, Stream } from 'effect';
 import { describe, expect, it } from 'vitest';
 import {
+  CustomShieldedWallet,
   type CustomizedShieldedWallet,
   type DefaultShieldedConfiguration,
-  ShieldedWallet,
   V9_NATIVE_FORK_VERSION,
 } from '../ShieldedWallet.js';
-import { TransactionHistory, V2Tag } from '../v2/index.js';
+import { TransactionHistory, V2Builder, V2Tag } from '../v2/index.js';
 
 const configuration: DefaultShieldedConfiguration = {
   networkId: NetworkId.NetworkId.Undeployed,
@@ -56,7 +56,10 @@ const walletWith = (
 ): Effect.Effect<{ wallet: CustomizedShieldedWallet; scope: Scope.CloseableScope }> =>
   Effect.gen(function* () {
     const scope = yield* Scope.make();
-    const WalletClass = ShieldedWallet(configuration);
+    const WalletClass = CustomShieldedWallet<DefaultShieldedConfiguration>(
+      configuration,
+      new V2Builder().withDefaults(),
+    );
 
     const runningVariant = {
       __polyTag__: V2Tag,

--- a/packages/shielded-wallet/src/test/shieldedWallet.test.ts
+++ b/packages/shielded-wallet/src/test/shieldedWallet.test.ts
@@ -33,10 +33,13 @@ const configuration: DefaultShieldedConfiguration = {
  * What the wallet asked of its runtime.
  *
  * @remarks
+ *   The wallet under test is the single-variant composition, `CustomShieldedWallet` — what an application pinned to one
+ *   protocol version builds, and the only shape these claims are about. A wallet spanning a boundary resolves key
+ *   material per variant instead, and is driven end to end over real chains in `forkStart.test.ts`.
+ *
  *   The runtime is stubbed rather than driven through a real migration because the behaviour under test is entirely the
- *   wallet's: which keys it holds on to, and how many watchers it registers. Registering two variants to provoke a real
- *   activation would test the runtime — which already has its own coverage — and would need the multi-variant wallet
- *   type that is deliberately still deferred.
+ *   wallet's: which keys it holds on to, and how many watchers it registers. Provoking a real activation would test the
+ *   runtime, which already has its own coverage.
  */
 type RuntimeRecorder = {
   /** The start-aux each `dispatch` to `startSyncInBackground` was given, in order. */
@@ -106,7 +109,7 @@ const activate = (recorder: RuntimeRecorder): Effect.Effect<void> =>
 
 const keysFrom = (seed: number): ledger.ZswapSecretKeys => ledger.ZswapSecretKeys.fromSeed(Buffer.alloc(32, seed));
 
-describe('ShieldedWallet post-migration sync restart', () => {
+describe('CustomShieldedWallet post-migration sync restart', () => {
   it('registers the activation watcher exactly once, however often start is called', async () => {
     const recorder = makeRecorder();
     const first = keysFrom(1);

--- a/packages/shielded-wallet/src/v1/Sync.ts
+++ b/packages/shielded-wallet/src/v1/Sync.ts
@@ -226,42 +226,58 @@ const EventsSyncUpdatePayload = Schema.Struct({
   maxId: Schema.Number,
 });
 
+/**
+ * One event of the source's timeline, still encoded.
+ *
+ * @remarks
+ *   The event is carried as the source served it rather than as a `ledger.Event`, because whether this ledger version may
+ *   read it at all is not the source's question to answer. A batch spanning a protocol boundary carries events of the
+ *   version that follows this one, which this ledger version cannot deserialize — the serialization header names a
+ *   different version — and after a hand-over the inclusive cursor re-delivers an event of the version that preceded
+ *   it, which it equally cannot. Both are ordinary, and neither is an error: they belong to the variant either side.
+ *
+ *   So the bytes travel undecoded and only the capability, which knows the activation range, reads the ones it is about
+ *   to apply — see {@link readEvent}. Decoding here would fail the whole batch on an event nobody intended to apply.
+ */
 export const EventsSyncUpdate = Schema.TaggedStruct('EventsSyncUpdate', {
   id: Schema.Number,
   protocolVersion: Schema.Number,
   maxId: Schema.Number,
-  event: LedgerEventSchema,
+  raw: Schema.String,
 });
 
 export type EventsSyncUpdate = Schema.Schema.Type<typeof EventsSyncUpdate>;
 
-const EventsSyncUpdateFromPayload = Schema.transformOrFail(EventsSyncUpdatePayload, EventsSyncUpdate, {
-  decode: (input) =>
-    pipe(
-      Schema.decodeUnknownEither(HexedLedgerEvent)(input.raw),
-      Either.map((event) => ({
-        _tag: 'EventsSyncUpdate' as const,
-        id: input.id,
-        protocolVersion: input.protocolVersion,
-        maxId: input.maxId,
-        event,
-      })),
-      Either.mapLeft((error) => new ParseResult.Unexpected(error, 'Failed to decode ledger event payload')),
-      EitherOps.toEffect,
-    ),
-  encode: (output) =>
-    pipe(
-      Schema.encodeEither(HexedLedgerEvent)(output.event),
-      Either.map((raw) => ({
-        id: output.id,
-        raw,
-        protocolVersion: output.protocolVersion,
-        maxId: output.maxId,
-      })),
-      Either.mapLeft((error) => new ParseResult.Unexpected(error, 'Failed to encode ledger event payload')),
-      EitherOps.toEffect,
-    ),
+const EventsSyncUpdateFromPayload = Schema.transform(EventsSyncUpdatePayload, EventsSyncUpdate, {
+  strict: true,
+  decode: (input) => ({
+    _tag: 'EventsSyncUpdate' as const,
+    id: input.id,
+    protocolVersion: input.protocolVersion,
+    maxId: input.maxId,
+    raw: input.raw,
+  }),
+  encode: (update) => ({
+    id: update.id,
+    raw: update.raw,
+    protocolVersion: update.protocolVersion,
+    maxId: update.maxId,
+  }),
 });
+
+/**
+ * Reads an event this variant is going to apply.
+ *
+ * @remarks
+ *   The counterpart of {@link EventsSyncUpdate} carrying its event encoded: a capability calls this on the batch prefix it
+ *   owns, and never on what it defers. Failure here is a genuine one — an event this variant claimed and cannot read —
+ *   and is raised rather than returned, because `SyncCapability.applyUpdate` is total in its own domain and the variant
+ *   already turns a throw from it into a typed synchronization error.
+ * @param update The update to read.
+ * @returns The event it carries.
+ * @throws ParseError if the bytes are not an event this ledger version can deserialize.
+ */
+export const readEvent = (update: EventsSyncUpdate): ledger.Event => Schema.decodeSync(HexedLedgerEvent)(update.raw);
 
 export const makeEventsSyncService = (
   config: DefaultSyncConfiguration,
@@ -383,14 +399,12 @@ export const makeEventsSyncCapability = (): SyncCapability<CoreWallet, WalletSyn
         activeRange,
       );
 
+      // Read here and nowhere earlier: `applied` is exactly the slice this variant owns, so nothing outside its
+      // activation range — nor anything below its cursor — is ever handed to this ledger version's deserializer.
       const [newState, newChanges]: [CoreWallet, ledger.ZswapStateChanges[]] =
         applied.length === 0
           ? [state, []]
-          : CoreWallet.replayEventsWithChanges(
-              state,
-              wrappedUpdate.secretKeys,
-              applied.map((u) => u.event),
-            );
+          : CoreWallet.replayEventsWithChanges(state, wrappedUpdate.secretKeys, applied.map(readEvent));
 
       // `appliedIndex` stops at the last event this variant actually replayed. The next variant resumes one
       // below it on an inclusive cursor, so the deferred suffix is re-fetched rather than skipped.

--- a/packages/shielded-wallet/src/v1/test/syncCapability.test.ts
+++ b/packages/shielded-wallet/src/v1/test/syncCapability.test.ts
@@ -11,8 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnight-ntwrk/ledger-v8';
+import * as otherLedger from '@midnightntwrk/ledger-v9';
 import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
-import { V8 } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { Simulator as OtherSimulator, V8, getLastBlockEvents } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import { Effect, Option, Stream } from 'effect';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { CoreWallet } from '../CoreWallet.js';
@@ -54,22 +55,51 @@ const simulatorStateAt = (protocolVersion?: ProtocolVersion.ProtocolVersion): Pr
     return Option.getOrThrow(yield* simulator.state$.pipe(Stream.take(1), Stream.runHead));
   }).pipe(Effect.scoped, Effect.runPromise);
 
+const hex = (bytes: Uint8Array): string => Buffer.from(bytes).toString('hex');
+
 /**
- * Serialized bytes of the six real `zswapOutput` events the genesis mints emit, in chain order.
+ * Hex of the six real `zswapOutput` events the genesis mints emit, in chain order — as the indexer serves them.
  *
- * They are kept as bytes rather than as `ledger.Event` instances on purpose: `replayEventsWithChanges` consumes the
+ * They are kept encoded rather than as `ledger.Event` instances on purpose: `replayEventsWithChanges` consumes the
  * event objects it is handed (wasm-bindgen moves ownership), so a second use of the same instance throws. Every test
- * deserializes its own instances.
+ * therefore hands over what the indexer hands over, and whatever reads it makes its own instances.
  */
-let eventBytes: readonly Uint8Array[];
+let eventHex: readonly string[];
+
+/**
+ * A real event of the _other_ ledger version, as the indexer serves it.
+ *
+ * @remarks
+ *   The bytes a chain past this variant's boundary produces. This ledger version cannot deserialize them at all — the
+ *   serialization header names a different version — which is why an event reported beyond the active range must never
+ *   reach the deserializer, rather than merely never reaching the state.
+ */
+let otherLedgerEventHex: string;
 
 beforeAll(async () => {
   const state = await simulatorStateAt();
-  eventBytes = V8.getLastBlockEvents(state).map((event) => event.serialize());
-  expect(eventBytes.length).toBe(MINT_COUNT);
+  eventHex = V8.getLastBlockEvents(state).map((event) => hex(event.serialize()));
+  expect(eventHex.length).toBe(MINT_COUNT);
+
+  otherLedgerEventHex = await Effect.gen(function* () {
+    const simulator = yield* OtherSimulator.init({
+      genesisMints: [
+        {
+          type: 'shielded' as const,
+          tokenType: otherLedger.shieldedToken().raw,
+          amount: 100n,
+          recipient: otherLedger.ZswapSecretKeys.fromSeed(Buffer.alloc(32, 7)),
+        },
+      ] as never,
+    });
+    const otherState = Option.getOrThrow(yield* simulator.state$.pipe(Stream.take(1), Stream.runHead));
+    return hex(getLastBlockEvents(otherState)[0].serialize());
+  }).pipe(Effect.scoped, Effect.runPromise);
+
+  expect(() => ledger.Event.deserialize(Buffer.from(otherLedgerEventHex, 'hex'))).toThrow();
 });
 
-/** Builds a batch of sync updates, one per `(id, protocolVersion)` pair, each carrying its own fresh event instance. */
+/** Builds a batch of sync updates, one per `(id, protocolVersion)` pair, each carrying its own event, encoded. */
 const batch = (items: readonly (readonly [id: number, protocolVersion: number])[]): WalletSyncUpdate =>
   WalletSyncUpdate.create(
     items.map(([id, protocolVersion]): EventsSyncUpdate => ({
@@ -77,10 +107,19 @@ const batch = (items: readonly (readonly [id: number, protocolVersion: number])[
       id,
       protocolVersion,
       maxId: MINT_COUNT,
-      event: ledger.Event.deserialize(eventBytes[id - 1]),
+      raw: eventHex[id - 1],
     })),
     secretKeys(),
   );
+
+/** A single update carrying bytes this ledger version cannot read, reported at `protocolVersion`. */
+const unreadable = (id: number, protocolVersion: number, maxId: number): EventsSyncUpdate => ({
+  _tag: 'EventsSyncUpdate',
+  id,
+  protocolVersion,
+  maxId,
+  raw: otherLedgerEventHex,
+});
 
 const freshWallet = (): CoreWallet => CoreWallet.initEmpty(secretKeys(), networkId);
 
@@ -197,6 +236,59 @@ describe('makeEventsSyncCapability.applyUpdate boundary handling', () => {
     expect(state.state.firstFree).toBe(0n);
     expect(result.changes).toEqual([]);
     expect(state.progress.highestRelevantWalletIndex).toBe(BigInt(MINT_COUNT));
+  });
+
+  it('reads no event reported beyond the active range, not merely applying none of them', () => {
+    // The suffix is bytes of the ledger version that follows this one, which is what the source serves once the
+    // chain has forked. Deferring cannot be a decision taken after decoding: this ledger version cannot decode
+    // them at all, so the split has to keep them away from the deserializer entirely.
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      WalletSyncUpdate.create(
+        [
+          { _tag: 'EventsSyncUpdate', id: 1, protocolVersion: 3, maxId: 3, raw: eventHex[0] },
+          { _tag: 'EventsSyncUpdate', id: 2, protocolVersion: 3, maxId: 3, raw: eventHex[1] },
+          unreadable(3, 7, 3),
+        ],
+        secretKeys(),
+      ),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(2n);
+    // Seen and recorded, which is what hands the wallet over to the variant that can read it.
+    expect(state.protocolVersion).toBe(7n);
+    expect(coinIndices(state)).toEqual([0n, 1n]);
+    expect(result.changes[0].receivedCoins.length).toBe(2);
+    expect(result.protocolVersion).toBe(3);
+  });
+
+  it('reads no event at or below the applied index, which the inclusive cursor re-delivers', () => {
+    // The subscription resumes one below the applied index, so the source re-delivers the boundary event. A variant
+    // that inherited its cursor from the variant before it inherited a position in *another* ledger version's
+    // timeline, so that re-delivered event is one it cannot read — and must not try to.
+    const [applied] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 3],
+        [2, 3],
+      ]),
+      activeRange,
+    );
+    expect(applied.progress.appliedIndex).toBe(2n);
+
+    const [state, result] = capability.applyUpdate(
+      applied,
+      WalletSyncUpdate.create(
+        [unreadable(2, 3, 3), { _tag: 'EventsSyncUpdate', id: 3, protocolVersion: 3, maxId: 3, raw: eventHex[2] }],
+        secretKeys(),
+      ),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(3n);
+    expect(coinIndices(state)).toEqual([0n, 1n, 2n]);
+    expect(result.changes[0].receivedCoins.length).toBe(1);
   });
 
   it('never lowers the recorded protocol version when a later batch reports a stale lower one', () => {

--- a/packages/shielded-wallet/src/v2/Sync.ts
+++ b/packages/shielded-wallet/src/v2/Sync.ts
@@ -226,42 +226,58 @@ const EventsSyncUpdatePayload = Schema.Struct({
   maxId: Schema.Number,
 });
 
+/**
+ * One event of the source's timeline, still encoded.
+ *
+ * @remarks
+ *   The event is carried as the source served it rather than as a `ledger.Event`, because whether this ledger version may
+ *   read it at all is not the source's question to answer. A batch spanning a protocol boundary carries events of the
+ *   version that follows this one, which this ledger version cannot deserialize — the serialization header names a
+ *   different version — and after a hand-over the inclusive cursor re-delivers an event of the version that preceded
+ *   it, which it equally cannot. Both are ordinary, and neither is an error: they belong to the variant either side.
+ *
+ *   So the bytes travel undecoded and only the capability, which knows the activation range, reads the ones it is about
+ *   to apply — see {@link readEvent}. Decoding here would fail the whole batch on an event nobody intended to apply.
+ */
 export const EventsSyncUpdate = Schema.TaggedStruct('EventsSyncUpdate', {
   id: Schema.Number,
   protocolVersion: Schema.Number,
   maxId: Schema.Number,
-  event: LedgerEventSchema,
+  raw: Schema.String,
 });
 
 export type EventsSyncUpdate = Schema.Schema.Type<typeof EventsSyncUpdate>;
 
-const EventsSyncUpdateFromPayload = Schema.transformOrFail(EventsSyncUpdatePayload, EventsSyncUpdate, {
-  decode: (input) =>
-    pipe(
-      Schema.decodeUnknownEither(HexedLedgerEvent)(input.raw),
-      Either.map((event) => ({
-        _tag: 'EventsSyncUpdate' as const,
-        id: input.id,
-        protocolVersion: input.protocolVersion,
-        maxId: input.maxId,
-        event,
-      })),
-      Either.mapLeft((error) => new ParseResult.Unexpected(error, 'Failed to decode ledger event payload')),
-      EitherOps.toEffect,
-    ),
-  encode: (output) =>
-    pipe(
-      Schema.encodeEither(HexedLedgerEvent)(output.event),
-      Either.map((raw) => ({
-        id: output.id,
-        raw,
-        protocolVersion: output.protocolVersion,
-        maxId: output.maxId,
-      })),
-      Either.mapLeft((error) => new ParseResult.Unexpected(error, 'Failed to encode ledger event payload')),
-      EitherOps.toEffect,
-    ),
+const EventsSyncUpdateFromPayload = Schema.transform(EventsSyncUpdatePayload, EventsSyncUpdate, {
+  strict: true,
+  decode: (input) => ({
+    _tag: 'EventsSyncUpdate' as const,
+    id: input.id,
+    protocolVersion: input.protocolVersion,
+    maxId: input.maxId,
+    raw: input.raw,
+  }),
+  encode: (update) => ({
+    id: update.id,
+    raw: update.raw,
+    protocolVersion: update.protocolVersion,
+    maxId: update.maxId,
+  }),
 });
+
+/**
+ * Reads an event this variant is going to apply.
+ *
+ * @remarks
+ *   The counterpart of {@link EventsSyncUpdate} carrying its event encoded: a capability calls this on the batch prefix it
+ *   owns, and never on what it defers. Failure here is a genuine one — an event this variant claimed and cannot read —
+ *   and is raised rather than returned, because `SyncCapability.applyUpdate` is total in its own domain and the variant
+ *   already turns a throw from it into a typed synchronization error.
+ * @param update The update to read.
+ * @returns The event it carries.
+ * @throws ParseError if the bytes are not an event this ledger version can deserialize.
+ */
+export const readEvent = (update: EventsSyncUpdate): ledger.Event => Schema.decodeSync(HexedLedgerEvent)(update.raw);
 
 export const makeEventsSyncService = (
   config: DefaultSyncConfiguration,
@@ -383,14 +399,12 @@ export const makeEventsSyncCapability = (): SyncCapability<CoreWallet, WalletSyn
         activeRange,
       );
 
+      // Read here and nowhere earlier: `applied` is exactly the slice this variant owns, so nothing outside its
+      // activation range — nor anything below its cursor — is ever handed to this ledger version's deserializer.
       const [newState, newChanges]: [CoreWallet, ledger.ZswapStateChanges[]] =
         applied.length === 0
           ? [state, []]
-          : CoreWallet.replayEventsWithChanges(
-              state,
-              wrappedUpdate.secretKeys,
-              applied.map((u) => u.event),
-            );
+          : CoreWallet.replayEventsWithChanges(state, wrappedUpdate.secretKeys, applied.map(readEvent));
 
       // `appliedIndex` stops at the last event this variant actually replayed. The next variant resumes one
       // below it on an inclusive cursor, so the deferred suffix is re-fetched rather than skipped.

--- a/packages/shielded-wallet/src/v2/test/syncCapability.test.ts
+++ b/packages/shielded-wallet/src/v2/test/syncCapability.test.ts
@@ -11,8 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/ledger-v9';
+import * as otherLedger from '@midnight-ntwrk/ledger-v8';
 import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Simulator, type SimulatorState, getLastBlockEvents } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import {
+  Simulator,
+  type SimulatorState,
+  V8 as OtherSimulation,
+  getLastBlockEvents,
+} from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import { Effect, Option, Stream } from 'effect';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { CoreWallet } from '../CoreWallet.js';
@@ -54,22 +60,51 @@ const simulatorStateAt = (protocolVersion?: ProtocolVersion.ProtocolVersion): Pr
     return Option.getOrThrow(yield* simulator.state$.pipe(Stream.take(1), Stream.runHead));
   }).pipe(Effect.scoped, Effect.runPromise);
 
+const hex = (bytes: Uint8Array): string => Buffer.from(bytes).toString('hex');
+
 /**
- * Serialized bytes of the six real `zswapOutput` events the genesis mints emit, in chain order.
+ * Hex of the six real `zswapOutput` events the genesis mints emit, in chain order — as the indexer serves them.
  *
- * They are kept as bytes rather than as `ledger.Event` instances on purpose: `replayEventsWithChanges` consumes the
+ * They are kept encoded rather than as `ledger.Event` instances on purpose: `replayEventsWithChanges` consumes the
  * event objects it is handed (wasm-bindgen moves ownership), so a second use of the same instance throws. Every test
- * deserializes its own instances.
+ * therefore hands over what the indexer hands over, and whatever reads it makes its own instances.
  */
-let eventBytes: readonly Uint8Array[];
+let eventHex: readonly string[];
+
+/**
+ * A real event of the _other_ ledger version, as the indexer serves it.
+ *
+ * @remarks
+ *   The bytes the chain produced before this variant's boundary. This ledger version cannot deserialize them at all — the
+ *   serialization header names a different version — which is why an event outside the range this variant applies must
+ *   never reach the deserializer, rather than merely never reaching the state.
+ */
+let otherLedgerEventHex: string;
 
 beforeAll(async () => {
   const state = await simulatorStateAt();
-  eventBytes = getLastBlockEvents(state).map((event) => event.serialize());
-  expect(eventBytes.length).toBe(MINT_COUNT);
+  eventHex = getLastBlockEvents(state).map((event) => hex(event.serialize()));
+  expect(eventHex.length).toBe(MINT_COUNT);
+
+  otherLedgerEventHex = await Effect.gen(function* () {
+    const simulator = yield* OtherSimulation.Simulator.init({
+      genesisMints: [
+        {
+          type: 'shielded' as const,
+          tokenType: otherLedger.shieldedToken().raw,
+          amount: 100n,
+          recipient: otherLedger.ZswapSecretKeys.fromSeed(Buffer.alloc(32, 7)),
+        },
+      ] as never,
+    });
+    const otherState = Option.getOrThrow(yield* simulator.state$.pipe(Stream.take(1), Stream.runHead));
+    return hex(OtherSimulation.getLastBlockEvents(otherState)[0].serialize());
+  }).pipe(Effect.scoped, Effect.runPromise);
+
+  expect(() => ledger.Event.deserialize(Buffer.from(otherLedgerEventHex, 'hex'))).toThrow();
 });
 
-/** Builds a batch of sync updates, one per `(id, protocolVersion)` pair, each carrying its own fresh event instance. */
+/** Builds a batch of sync updates, one per `(id, protocolVersion)` pair, each carrying its own event, encoded. */
 const batch = (items: readonly (readonly [id: number, protocolVersion: number])[]): WalletSyncUpdate =>
   WalletSyncUpdate.create(
     items.map(([id, protocolVersion]): EventsSyncUpdate => ({
@@ -77,10 +112,19 @@ const batch = (items: readonly (readonly [id: number, protocolVersion: number])[
       id,
       protocolVersion,
       maxId: MINT_COUNT,
-      event: ledger.Event.deserialize(eventBytes[id - 1]),
+      raw: eventHex[id - 1],
     })),
     secretKeys(),
   );
+
+/** A single update carrying bytes this ledger version cannot read, reported at `protocolVersion`. */
+const unreadable = (id: number, protocolVersion: number, maxId: number): EventsSyncUpdate => ({
+  _tag: 'EventsSyncUpdate',
+  id,
+  protocolVersion,
+  maxId,
+  raw: otherLedgerEventHex,
+});
 
 const freshWallet = (): CoreWallet => CoreWallet.initEmpty(secretKeys(), networkId);
 
@@ -197,6 +241,59 @@ describe('makeEventsSyncCapability.applyUpdate boundary handling', () => {
     expect(state.state.firstFree).toBe(0n);
     expect(result.changes).toEqual([]);
     expect(state.progress.highestRelevantWalletIndex).toBe(BigInt(MINT_COUNT));
+  });
+
+  it('reads no event reported beyond the active range, not merely applying none of them', () => {
+    // The suffix is bytes of the ledger version on the other side of the boundary, which is what the source serves
+    // once the chain has moved past this variant. Deferring cannot be a decision taken after decoding: this ledger
+    // version cannot decode them at all, so the split has to keep them away from the deserializer entirely.
+    const [state, result] = capability.applyUpdate(
+      freshWallet(),
+      WalletSyncUpdate.create(
+        [
+          { _tag: 'EventsSyncUpdate', id: 1, protocolVersion: 3, maxId: 3, raw: eventHex[0] },
+          { _tag: 'EventsSyncUpdate', id: 2, protocolVersion: 3, maxId: 3, raw: eventHex[1] },
+          unreadable(3, 7, 3),
+        ],
+        secretKeys(),
+      ),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(2n);
+    // Seen and recorded, which is what hands the wallet over to the variant that can read it.
+    expect(state.protocolVersion).toBe(7n);
+    expect(coinIndices(state)).toEqual([0n, 1n]);
+    expect(result.changes[0].receivedCoins.length).toBe(2);
+    expect(result.protocolVersion).toBe(3);
+  });
+
+  it('reads no event at or below the applied index, which the inclusive cursor re-delivers', () => {
+    // The subscription resumes one below the applied index, so the source re-delivers the boundary event. This
+    // variant inherits its cursor from the one before it, which held a position in *another* ledger version's
+    // timeline — so the re-delivered event is one it cannot read, and must not try to.
+    const [applied] = capability.applyUpdate(
+      freshWallet(),
+      batch([
+        [1, 3],
+        [2, 3],
+      ]),
+      activeRange,
+    );
+    expect(applied.progress.appliedIndex).toBe(2n);
+
+    const [state, result] = capability.applyUpdate(
+      applied,
+      WalletSyncUpdate.create(
+        [unreadable(2, 3, 3), { _tag: 'EventsSyncUpdate', id: 3, protocolVersion: 3, maxId: 3, raw: eventHex[2] }],
+        secretKeys(),
+      ),
+      activeRange,
+    );
+
+    expect(state.progress.appliedIndex).toBe(3n);
+    expect(coinIndices(state)).toEqual([0n, 1n, 2n]);
+    expect(result.changes[0].receivedCoins.length).toBe(1);
   });
 
   it('never lowers the recorded protocol version when a later batch reports a stale lower one', () => {


### PR DESCRIPTION
Fourth increment of the dual-ledger public API redesign — the shielded lane's payoff: **`ShieldedWallet(config)` now registers a variant on either side of the fork**, and the fork-crossing proofs run through the shipped wallet instead of a test-only factory. Stacked on #677.

## What's here

- **`CustomForkingShieldedWallet(configuration, preFork, postFork)`** + `ForkingShieldedWalletClass`; `ShieldedWallet(config)` is now the forking wallet (v1 since `MinSupportedVersion`, v2 since `config.forkVersion`), each variant registered with its **own** configuration via the self-configured `withVariant`. `CustomShieldedWallet`/`CustomizedShieldedWallet*` are untouched and stay single-variant. The wallet-level parameter is the narrower `ForkingShieldedConfiguration` (`{networkId, forkVersion}`) — `DefaultShieldedConfiguration` satisfies it, and custom compositions no longer invent an indexer URL they don't use.
- **Unplanned but load-bearing — cross-ledger event decoding** (own commits, own changeset): measured that each ledger's `Event.deserialize` rejects the other's bytes (`expected header tag 'midnight:event[v9]:', got 'midnight:event[v14]'`), while the sync service decoded eagerly on arrival. Without a fix the flip is a paper flip: a pre-fork wallet on a v9-native chain fails its first batch and retries forever instead of observing the version and handing over. `EventsSyncUpdate` now carries raw hex and each variant decodes only the slice it actually applies — in both twins, pinned with specs feeding each variant the *other* ledger's real event bytes. Breaking for custom sync capability authors.
- **`forkWallet.ts` is deleted**, its three workarounds genuinely dissolved: config collision → per-variant self-configuration; start-aux across the boundary → retained `StartMaterial` (`startWithSeed` + `requireDerivedAuxFor`); the deferred post-fork source → an ordinary field of the post-fork variant's own configuration. The fork-simulation tests (unit + integration) were rewired with exactly two wiring edits each — import path and calling `wallet.shielded.transferTransaction(...)` through the shipped API — **zero assertion changes** (diff-verified).
- **The temporary pre-fork transacting seam**: `balanceTransaction`/`transferTransaction`/`initSwap` on the v1 branch fail with typed `PreForkTransactingUnsupportedError {operation}`, pinned against a synced coin-holding pre-fork wallet. JSDoc + changeset state loudly: TEMPORARY, closed by version-routed proving (WP-11 + Flow 2/3), must not survive to GA — mainnet is pre-fork until the fork. One deliberate exception: `revertTransaction` is a pre-fork **no-op** (pinned), because the facade reverts all three wallets together on submission failure, reverting builds nothing, and while the seam holds the pre-fork variant cannot have produced the transaction being reverted — the alternative was weakening an existing facade spec.
- **Start behavior pinned** (`forkStart.test.ts`, ≥/<-`forkVersion` semantics, no chain-version literals): a chain already past `forkVersion` → v1 boots, applies **nothing**, hands over (keys crossed, fresh state), v2 re-discovers the coins — the accepted spurious start migration. A chain below `forkVersion` → syncs on v1 with seed-derived v8 keys and stays there.

## Notes for reviewers

- **Cross-release restore**: a snapshot declaring a version below `forkVersion` now routes to the pre-fork variant; a *never-synced* snapshot from an earlier beta (declares 0) will fail to deserialize there. Within-release snapshots round-trip. Documented in its own changeset.
- **Empty-timeline chains**: a wallet on a chain that has produced no shielded events never observes a protocol version, so it stays pre-fork and refuses transaction building. This promotes WP-8b (probe chain version at start) from optimization to a likely GA requirement — tracked in the plan.
- The e2e/undeployed validation of the v9-native production path is **this PR's CI** (smoke e2e + the integration matrix run the swept suites fresh).
- Dust and unshielded have the same eager-decode shape in their sync paths — to check before their own flips.

## Tests & gate

Red-first verified with the implementation stashed (fork tests fail on the missing module; decode tests fail on the missing `raw` field). Gate: dist 17/17, typecheck 37/37, lint 58/58, unit 53/53 tasks (shielded **180 passed / 22 skipped** across 25 files), fork-simulation integration 3/3 (no --force), effect-language-service 0 findings on all 14 changed files, format + changesets green. Changesets: shielded majors (two-variant flip + decode change + the seam wording), plus the named cross-release restore case.