### PR TITLE
feat(unshielded)!: a genuinely two-variant production unshielded wallet

### DIFF
--- a/.changeset/unshielded-two-variant-fork-flip.md
+++ b/.changeset/unshielded-two-variant-fork-flip.md
@@ -1,0 +1,71 @@
+---
+'@midnightntwrk/wallet-sdk-unshielded-wallet': major
+'@midnightntwrk/wallet-sdk-testkit': patch
+---
+
+`UnshieldedWallet(configuration)` is a two-variant, fork-crossing wallet, and `forkVersion` is required.
+
+The shipped unshielded wallet now registers one variant either side of a protocol boundary — the pre-fork ledger version
+from the minimum supported version, the post-fork one from `configuration.forkVersion` — and follows the chain across
+it. The crossing itself is unchanged and still proven by `test/forkSimulation.test.ts`, which was rewired onto the
+shipped factory with **no assertion changed**: the test-only two-variant builder it used to stand on has been dissolved
+into `test/forkHarness.ts`, which is now observation and simulated infrastructure around the real wallet.
+
+Unshielded's crossing is a **structural carry**, not a fresh state plus replay. Its UTXOs are public ledger data the
+wallet holds as plain records, so every one of them crosses field for field, along with the identity, the network and
+the parked cursor — and the wallet never passes through a state in which it has forgotten what it owns. The boundary
+transaction is applied exactly once, by the new variant: the old one records its version and refuses every part of it,
+which leaves the cursor pointing just before it for the new variant to re-fetch from.
+
+**`forkVersion` is required on `DefaultUnshieldedConfiguration`, without a default.** A wrong value does not degrade —
+it decides which ledger version reads the chain. `@midnightntwrk/wallet-sdk-shielded` publishes `V9_NATIVE_FORK_VERSION`
+(`2000000`, measured on a ledger-v9-native node line) for suites and applications pointed at such a chain; the field is
+the same name and type the shielded and dust configurations already required, so an application composing the facade's
+configuration passes it once and nothing else changes — `@midnightntwrk/wallet-sdk-facade` needed no source change at
+all.
+
+What else moved:
+
+- **`startWithPublicKey` resolves which variant can hold the identity it is given.** A ledger-v9 verifying key is a
+  `{tag, value}` record; a ledger-v8 one is bare hex, because that version had exactly one signature scheme. A
+  **schnorr** identity therefore narrows losslessly, starts on the pre-fork variant and follows the chain the whole
+  way, with the migration widening it back. An **ecdsa** identity starts on the post-fork variant and stays there: that
+  scheme did not exist pre-fork, derives a different address, and narrowing it would produce a wallet claiming an
+  identity it does not have.
+- **Nothing is retained across the boundary, and nothing needs to be.** Unshielded synchronization is watch-only — the
+  address is public and signing is supplied per call — so `start()` still takes no argument and a migration strands no
+  key material.
+- `UnshieldedWalletState` binds its projections to the variant that produced the emission
+  (`UnshieldedWalletState.fromVariant` replaces `mapState`). Everything it projects is version-agnostic plain data; the
+  version union surfaces on `state` alone. The `capabilities` and `services` members are **gone**, together with the
+  `UnshieldedWalletCapabilities` and `UnshieldedWalletServices` types — the one reading they could have exposed that is
+  genuinely version-bound, the verifying key, was never projected and still is not.
+- `restore` routes on the protocol version the snapshot declares (unshielded snapshots have always persisted it, on
+  both variants), falling back to the head variant for an envelope that declares none; a version no registered variant
+  owns raises the typed `UnsupportedSnapshotVersionError`, exported as `UnshieldedRestore.UnsupportedSnapshotVersionError`
+  so it does not collide with the other wallets' same-named classes in the umbrella barrel.
+- `CustomUnshieldedWallet` is unchanged and still single-variant.
+
+**A temporary seam, which must not survive to general availability.** While the wallet is on the pre-fork variant,
+`balanceFinalizedTransaction`, `balanceUnboundTransaction`, `balanceUnprovenTransaction`, `transferTransaction`,
+`rotateUtxos`, `initSwap`, `signUnprovenTransaction` and `signUnboundTransaction` fail with a typed
+`PreForkUnshieldedTransactingUnsupportedError`. Each of them takes or produces a transaction of the post-fork ledger
+version, which the pre-fork variant cannot even hold and which this release has no way to prove; the seam closes with
+version-routed proving. Everything else works on both sides: synchronization, the state observable and all its
+projections, balances, coins, the address, `revertTransaction`, serialization, restore, and the migration.
+`revertTransaction` is deliberately outside the seam — the pre-fork variant cannot have built the transaction being
+reverted so it has booked nothing to release, and the facade reverts all three wallets together when a submission
+fails.
+
+**One consequence, accepted and reported rather than hidden.** Every start on a chain already past the boundary pays one
+spurious migration: the wallet begins on the pre-fork variant, applies nothing, and hands over on the first message it
+sees. For unshielded that carries nothing across and leaves the cursor at the start, so the post-fork variant simply
+syncs the chain itself.
+
+BREAKING CHANGE — `DefaultUnshieldedConfiguration` requires `forkVersion`. `UnshieldedWalletState.capabilities` and
+`UnshieldedWalletState.services` are removed, along with the `UnshieldedWalletCapabilities` and
+`UnshieldedWalletServices` types and the `UnshieldedWalletState.mapState` constructor (use
+`UnshieldedWalletState.fromVariant`); read through the state's own projections instead. `UnshieldedWalletState.state`
+is a union of the two variants' core states. The `UnshieldedWallet` and `UnshieldedWalletClass` types now describe a
+two-variant wallet and are declared by `ForkingUnshieldedWallet.ts`. The testkit's environments supply `forkVersion` to
+the unshielded wallet they build.

--- a/packages/e2e-tests/src/tests/emptyWallet.universal.test.ts
+++ b/packages/e2e-tests/src/tests/emptyWallet.universal.test.ts
@@ -129,6 +129,8 @@ describe('Fresh wallet with empty state', () => {
           indexerWsUrl: fixture.getIndexerWsUri(),
         },
         txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
+        // The same boundary the shielded configuration names, taken from the one place this fixture defines it.
+        forkVersion: fixture.getWalletConfig().forkVersion,
       }).startWithPublicKey(PublicKey.fromKeyStore(wallet.unshieldedKeystore));
     } catch (error) {
       expect(error).toBeUndefined();

--- a/packages/e2e-tests/src/tests/helpers/walletInit.ts
+++ b/packages/e2e-tests/src/tests/helpers/walletInit.ts
@@ -90,6 +90,8 @@ const restoreUnshieldedWallet = async (
           indexerWsUrl: fixture.getIndexerWsUri(),
         },
         txHistoryStorage,
+        // The same boundary the shielded configuration names, taken from the one place this fixture defines it.
+        forkVersion: fixture.getWalletConfig().forkVersion,
       }).startWithPublicKey(PublicKey.fromKeyStore(keyStore));
       logger.info(`Restored unshielded wallet from ${path}`);
       return wallet;

--- a/packages/e2e-tests/src/tests/multipleWallets.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/multipleWallets.undeployed.test.ts
@@ -68,6 +68,8 @@ describe('Syncing', () => {
             indexerWsUrl: fixture.getIndexerWsUri(),
           },
           txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
+          // The same boundary the shielded configuration names, taken from the one place this fixture defines it.
+          forkVersion: fixture.getWalletConfig().forkVersion,
         }).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystores[i]));
       }
 

--- a/packages/e2e-tests/src/tests/smoke.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/smoke.undeployed.test.ts
@@ -257,6 +257,8 @@ describe('Smoke tests', () => {
           indexerWsUrl: fixture.getIndexerWsUri(),
         },
         txHistoryStorage: unshieldedTxHistoryStorage,
+        // The same boundary the shielded configuration names, taken from the one place this fixture defines it.
+        forkVersion: fixture.getWalletConfig().forkVersion,
       }).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeyStore));
       await initialWallet.start();
       logger.info(`Waiting to sync...`);
@@ -281,6 +283,8 @@ describe('Smoke tests', () => {
           indexerWsUrl: fixture.getIndexerWsUri(),
         },
         txHistoryStorage: restoredTxHistoryStorage,
+        // The same boundary the shielded configuration names, taken from the one place this fixture defines it.
+        forkVersion: fixture.getWalletConfig().forkVersion,
       }).restore(serializedState);
 
       await restoredWallet.start();

--- a/packages/unshielded-wallet/README.md
+++ b/packages/unshielded-wallet/README.md
@@ -25,6 +25,7 @@ Unlike shielded transactions, unshielded operations do not use zero-knowledge pr
 
 ```typescript
 import { UnshieldedWallet, createKeystore, PublicKey } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
+import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
 import { randomBytes } from 'node:crypto';
 
@@ -36,6 +37,9 @@ const configuration = {
     indexerHttpUrl: 'http://localhost:8088/api/v4/graphql',
   },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+  // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
+  // the final mainnet fork constant is not yet fixed, so it is supplied per environment.
+  forkVersion: V9_NATIVE_FORK_VERSION,
 };
 
 // Create a keystore from a random unshielded seed

--- a/packages/unshielded-wallet/src/ForkingUnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/ForkingUnshieldedWallet.ts
@@ -1,0 +1,551 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * An unshielded wallet that registers a variant either side of a protocol boundary and follows the chain across it.
+ *
+ * @remarks
+ *   One wallet, two ledger versions. Before the boundary the pre-fork variant reads the chain with the ledger version
+ *   that produced it; from the boundary the post-fork variant does, having been handed everything the pre-fork one held
+ *   — which for unshielded is everything, because its UTXOs are public ledger data the wallet keeps as plain records.
+ *   Nothing is re-earned from a replay, so the wallet never passes through a state in which it has forgotten what it
+ *   owns; `test/forkSimulation.test.ts` proves that, and proves the boundary transaction is applied exactly once, by
+ *   the new variant. Which variant is running is the runtime's business, not the application's: the wallet's public API
+ *   speaks the post-fork ledger version throughout.
+ *
+ *   This wallet retains nothing, and that is the honest difference from the shielded and dust wallets. Unshielded
+ *   synchronization is watch-only — the address is public and signing is supplied per call by the caller — so
+ *   `startSyncInBackground` takes no argument on either variant and there is no key material for a migration to strand.
+ *   The one place the two ledger versions genuinely disagree is the _shape_ of a verifying key, and that is resolved
+ *   once, at start, by {@link asPreForkPublicKey}.
+ */
+import type * as ledger from '@midnightntwrk/ledger-v9';
+import { type NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type UnshieldedAddress } from '@midnightntwrk/wallet-sdk-address-format';
+import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
+import { type Variant, type VariantBuilder, type WalletLike } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { HList } from '@midnightntwrk/wallet-sdk-utilities';
+import { Data, Effect, Either, Option, Ref, type Scope } from 'effect';
+import * as rx from 'rxjs';
+import { type PublicKey } from './KeyStore.js';
+import { variantForSnapshot } from './Restore.js';
+import {
+  type DefaultUnshieldedConfiguration,
+  type UnshieldedWalletAPI,
+  UnshieldedWalletState,
+} from './UnshieldedWallet.js';
+import { CoreWallet as PreForkCoreWallet, V1Builder, V1Tag, type V1Variant } from './v1/index.js';
+import { type PublicKey as PreForkPublicKey } from './v1/KeyStore.js';
+import { type WalletSyncUpdate as PreForkSyncUpdate } from './v1/SyncSchema.js';
+import { CoreWallet, Migration, V2Builder, V2Tag, type V2Variant } from './v2/index.js';
+import { type SignSegment } from './v2/Signing.js';
+import { type WalletSyncUpdate as PostForkSyncUpdate } from './v2/SyncSchema.js';
+import {
+  type FinalizedTransactionBalanceResult,
+  type TokenTransfer,
+  type UnboundTransactionBalanceResult,
+  type UnprovenTransactionBalanceResult,
+} from './v2/Transacting.js';
+import { type UnboundTransaction } from './v2/TransactionOps.js';
+import { type UtxoWithMeta } from './v2/UnshieldedState.js';
+import { type WalletError } from './v2/WalletError.js';
+
+/**
+ * Raised when a transaction is asked for while the wallet is still on the pre-fork protocol version.
+ *
+ * @remarks
+ *   **This seam is temporary and must not survive to general availability.** Mainnet is pre-fork until the fork happens,
+ *   so a wallet that cannot move Night pre-fork cannot be the wallet that ships. It closes with the proving-routing
+ *   increment (WP-11 together with the carrier and author flows), which routes a recipe to the prover that speaks the
+ *   protocol version it was built at; until then the only proving path this SDK has speaks the post-fork ledger
+ *   version, and there is nothing honest for the pre-fork branch to return — every operation gated below either takes
+ *   or produces a transaction of the post-fork ledger version, which the pre-fork variant cannot even hold.
+ *
+ *   Everything else works on both sides of the boundary: synchronization, the state observable and everything it
+ *   projects, balances, coins, the address, serialization, restoring a snapshot, reverting, and the migration itself.
+ */
+export class PreForkUnshieldedTransactingUnsupportedError extends Data.TaggedError(
+  '@midnightntwrk/wallet-sdk-unshielded-wallet/ForkingUnshieldedWallet/PreForkUnshieldedTransactingUnsupportedError',
+)<{
+  readonly message: string;
+  /** The wallet operation that was asked for. */
+  readonly operation: string;
+}> {}
+
+/** What a transacting call can fail with: the post-fork variant's own errors, or the pre-fork variant's refusal. */
+type TransactingError = WalletError | PreForkUnshieldedTransactingUnsupportedError;
+
+const preForkTransactingUnsupported = (
+  operation: string,
+): Effect.Effect<never, PreForkUnshieldedTransactingUnsupportedError> =>
+  Effect.fail(
+    new PreForkUnshieldedTransactingUnsupportedError({
+      operation,
+      message:
+        `${operation} is not available while this wallet is on the pre-fork protocol version: it takes or produces a ` +
+        `transaction of the previous ledger version, which this release has no way to prove. Pre-fork transacting ` +
+        `arrives with version-routed proving; until then the post-fork path is the one that works. Synchronization, ` +
+        `balances, coins, the address, state and serialization are unaffected on either side of the boundary.`,
+    }),
+  );
+
+/** The pre-fork variant a forking unshielded wallet registers: the one that reads the chain before the boundary. */
+export type PreForkUnshieldedVariant<TSyncUpdate> = V1Variant<string, TSyncUpdate>;
+
+/** The post-fork variant a forking unshielded wallet registers: the one the pre-fork wallet is migrated into. */
+export type PostForkUnshieldedVariant<TSyncUpdate> = V2Variant<string, TSyncUpdate, Migration.PreviousLedgerWallet>;
+
+/** The two variants a forking unshielded wallet runs, in registration order. */
+export type ForkingUnshieldedVariants<TPreForkSyncUpdate, TPostForkSyncUpdate> = [
+  Variant.VersionedVariant<PreForkUnshieldedVariant<TPreForkSyncUpdate>>,
+  Variant.VersionedVariant<PostForkUnshieldedVariant<TPostForkSyncUpdate>>,
+];
+
+/**
+ * A variant builder registered together with the configuration it alone is built from.
+ *
+ * @remarks
+ *   Per-variant rather than shared, because two variants either side of a protocol boundary can mean different and
+ *   mutually unassignable things by the same configuration key — a simulator or a transaction-history service belonging
+ *   to one ledger version or the other. A wallet-wide intersection of those is a configuration no single variant can
+ *   consume.
+ */
+export type SelfConfiguredUnshieldedVariant<
+  TVariant extends Variant.AnyVariant,
+  TConfiguration extends object,
+> = Readonly<{
+  builder: VariantBuilder.VariantBuilder<TVariant, TConfiguration>;
+  configuration: TConfiguration;
+}>;
+
+/** What a forking unshielded wallet needs to know about itself, whatever its variants are built from. */
+export type ForkingUnshieldedConfiguration = {
+  networkId: NetworkId.NetworkId;
+  /** The protocol version at which the chain hands over from the pre-fork ledger version to the post-fork one. */
+  forkVersion: ProtocolVersion.ProtocolVersion;
+};
+
+/** A running unshielded wallet that spans a protocol boundary. */
+export type ForkingUnshieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate> = UnshieldedWalletAPI<string> &
+  WalletLike.WalletLike<ForkingUnshieldedVariants<TPreForkSyncUpdate, TPostForkSyncUpdate>>;
+
+/** The class a forking unshielded wallet is started from. */
+export interface ForkingUnshieldedWalletClass<
+  TPreForkSyncUpdate,
+  TPostForkSyncUpdate,
+  TConfiguration extends ForkingUnshieldedConfiguration = ForkingUnshieldedConfiguration,
+> extends WalletLike.BaseWalletClass<
+  ForkingUnshieldedVariants<TPreForkSyncUpdate, TPostForkSyncUpdate>,
+  TConfiguration
+> {
+  /**
+   * Builds a wallet that watches the chain for an identity.
+   *
+   * @remarks
+   *   There is no secret here and none is wanted: an unshielded wallet reads public UTXO data addressed to an address
+   *   anybody could compute, and signing is supplied per call by the caller. What the wallet does have to settle is
+   *   which variant can _hold_ the identity, and that turns on the signature scheme — see {@link asPreForkPublicKey}. A
+   *   schnorr identity begins on the pre-fork variant and follows the chain the whole way; an ecdsa one begins on the
+   *   post-fork variant, because the pre-fork ledger version has no way to express it.
+   * @param publicKey The identity to watch, in the post-fork ledger version's shape, which is the one this wallet's
+   *   public API speaks.
+   * @returns A started wallet.
+   */
+  startWithPublicKey(publicKey: PublicKey): ForkingUnshieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+  /**
+   * Restores a wallet from a snapshot, into whichever registered variant wrote it.
+   *
+   * @param serializedState The serialized wallet state.
+   * @returns A wallet started from that state, on the variant that owns its protocol version.
+   * @throws UnsupportedSnapshotVersionError if the snapshot declares a version no registered variant reads.
+   */
+  restore(serializedState: string): ForkingUnshieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+}
+
+/**
+ * The same identity, as the pre-fork ledger version has it.
+ *
+ * @remarks
+ *   Unshielded's one genuine version break, and the whole of it. A ledger-v9 verifying key is a `{tag, value}` record
+ *   naming a signature scheme; a ledger-v8 one is the bare hex, with no room to name anything, because that ledger
+ *   version had exactly one scheme. So a schnorr identity narrows losslessly — dropping a tag whose value was never in
+ *   doubt — and the cross-ledger migration widens it back on the way over, which is where its `schnorr` default comes
+ *   from.
+ *
+ *   An ecdsa identity does not narrow at all, and `None` says so rather than dropping the tag and producing a pre-fork
+ *   wallet claiming an identity it does not have: an ecdsa key derives a _different_ address, and the migration back
+ *   would relabel it `schnorr`, so the round trip is not merely lossy but wrong. The address itself is a scheme-less
+ *   hash and is carried, not re-derived, which is why the schnorr narrowing needs no ledger call at all.
+ * @param publicKey The identity in the post-fork ledger version's shape.
+ * @returns The same identity as the pre-fork ledger version has it, or `None` when that version cannot express it.
+ */
+export const asPreForkPublicKey = (publicKey: PublicKey): Option.Option<PreForkPublicKey> =>
+  publicKey.publicKey.tag === 'schnorr'
+    ? Option.some({
+        publicKey: publicKey.publicKey.value,
+        addressHex: publicKey.addressHex,
+        address: publicKey.address,
+      })
+    : Option.none();
+
+/**
+ * Builds an unshielded wallet class over a variant either side of a protocol boundary.
+ *
+ * @remarks
+ *   The boundary is `configuration.forkVersion` and nothing else: the pre-fork variant is registered from the minimum
+ *   supported version and the post-fork one from the fork version, so the version at which the runtime hands over and
+ *   the version at which each variant stops applying are the same number, taken from one place.
+ *
+ *   Each variant is built from its own configuration — see {@link SelfConfiguredUnshieldedVariant}.
+ * @example
+ *   ```typescript
+ *   const Wallet = CustomForkingUnshieldedWallet(
+ *     { networkId, forkVersion },
+ *     { builder: new V1Builder().withDefaults(), configuration: preForkConfiguration },
+ *     { builder: new V2Builder().withDefaults().withMigration(...), configuration: postForkConfiguration },
+ *   );
+ *   const wallet = Wallet.startWithPublicKey(publicKey);
+ *   ```;
+ *
+ * @param configuration What the wallet layer needs: the network, and where the boundary lies.
+ * @param preFork The variant that reads the chain below the boundary, with the configuration it is built from.
+ * @param postFork The variant that reads it from the boundary, with the configuration it is built from.
+ * @returns The wallet class.
+ */
+export function CustomForkingUnshieldedWallet<
+  TPreForkSyncUpdate,
+  TPostForkSyncUpdate,
+  TPreForkConfig extends object,
+  TPostForkConfig extends object,
+  TConfiguration extends ForkingUnshieldedConfiguration = ForkingUnshieldedConfiguration,
+>(
+  configuration: TConfiguration,
+  preFork: SelfConfiguredUnshieldedVariant<PreForkUnshieldedVariant<TPreForkSyncUpdate>, TPreForkConfig>,
+  postFork: SelfConfiguredUnshieldedVariant<PostForkUnshieldedVariant<TPostForkSyncUpdate>, TPostForkConfig>,
+): ForkingUnshieldedWalletClass<TPreForkSyncUpdate, TPostForkSyncUpdate, TConfiguration> {
+  type Variants = ForkingUnshieldedVariants<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+
+  // Registered through the shape the builder states rather than through the one this function was handed. The two are
+  // the same builder; what is dropped is the configuration *type*, which the parameter types have already paired with
+  // its builder — and which, left generic, keeps `build`'s "nothing further is owed" argument list unresolvable.
+  const preForkBuilder: VariantBuilder.VariantBuilder<
+    PreForkUnshieldedVariant<TPreForkSyncUpdate>,
+    object
+  > = preFork.builder;
+  const postForkBuilder: VariantBuilder.VariantBuilder<
+    PostForkUnshieldedVariant<TPostForkSyncUpdate>,
+    object
+  > = postFork.builder;
+
+  const BaseWallet: WalletLike.BaseWalletClass<Variants> = WalletBuilder.init()
+    .withVariant(ProtocolVersion.MinSupportedVersion, preForkBuilder, preFork.configuration)
+    .withVariant(configuration.forkVersion, postForkBuilder, postFork.configuration)
+    .build();
+
+  const variants = BaseWallet.allVariantsRecord();
+
+  return class ForkingUnshieldedWalletImplementation
+    extends BaseWallet
+    implements ForkingUnshieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>
+  {
+    static readonly configuration: TConfiguration = configuration;
+
+    static startWithPublicKey(publicKey: PublicKey): ForkingUnshieldedWalletImplementation {
+      return Option.match(asPreForkPublicKey(publicKey), {
+        // The identity both ledger versions can express: begin where a wallet with no history belongs, below the
+        // boundary, and let the runtime hand over when the chain says so.
+        onSome: (preForkPublicKey) =>
+          ForkingUnshieldedWalletImplementation.startFirst(
+            ForkingUnshieldedWalletImplementation,
+            PreForkCoreWallet.init(preForkPublicKey, configuration.networkId),
+          ),
+        // An identity only the post-fork ledger version can express, so it starts on that variant and stays there.
+        // Stamped with the boundary version rather than left at the minimum: a variant that starts from a state
+        // outside its own activation range reports that on sight, which is how a stranded snapshot heals — and here
+        // there is no variant above this one to hand over to. The state does belong to this variant, so it says so.
+        onNone: () =>
+          ForkingUnshieldedWalletImplementation.startAtVariant(
+            ForkingUnshieldedWalletImplementation,
+            variants[V2Tag],
+            CoreWallet.withProtocolVersion(
+              CoreWallet.init(publicKey, configuration.networkId),
+              configuration.forkVersion,
+            ),
+          ),
+      });
+    }
+
+    static restore(serializedState: string): ForkingUnshieldedWalletImplementation {
+      const headVariant = HList.head(ForkingUnshieldedWalletImplementation.allVariants());
+      const variant = variantForSnapshot(
+        serializedState,
+        (version) => ForkingUnshieldedWalletImplementation.variantFor(version),
+        headVariant,
+      ).pipe(Either.getOrThrow);
+      // Stated with its result type because the resolved variant is either of the two, so its deserializer is either
+      // of theirs: what comes back is a state of whichever one wrote the snapshot, which is what `startAtVariant`
+      // takes.
+      const deserialized = Either.getOrThrow<PreForkCoreWallet | CoreWallet, unknown>(
+        variant.variant.deserializeState(serializedState),
+      );
+
+      return ForkingUnshieldedWalletImplementation.startAtVariant(
+        ForkingUnshieldedWalletImplementation,
+        variant,
+        deserialized,
+      );
+    }
+
+    readonly state: rx.Observable<UnshieldedWalletState<string>>;
+
+    /**
+     * Whether the activation watcher has been registered.
+     *
+     * @remarks
+     *   Registration is per wallet, not per `start`: watchers accumulate, so registering on every call would restart sync
+     *   once per historical `start` on the next activation. Flipped with `getAndSet` so concurrent `start` calls cannot
+     *   both observe it unset.
+     */
+    readonly #watcherRegistered = Ref.unsafeMake(false);
+
+    /**
+     * Whether the wallet is currently started.
+     *
+     * @remarks
+     *   The unshielded counterpart of the retained start material the shielded and dust wallets hold. This wallet is
+     *   watch-only — sync needs nothing secret, and signing is supplied per call by the caller — so there is no key to
+     *   keep and the restart needs no argument. All the watcher has to know is whether a stopped wallet should be left
+     *   stopped, which is what this records; `stop` clears it so a stopped wallet cannot be resurrected by a late
+     *   activation.
+     */
+    readonly #started = Ref.unsafeMake(false);
+
+    constructor(runtime: Runtime.Runtime<Variants>, scope: Scope.CloseableScope) {
+      super(runtime, scope);
+      this.state = this.rawState.pipe(
+        rx.map((emission) =>
+          // The capabilities that understand a state and the state itself are chosen together, in the branch where
+          // the producing variant is known. The two variants' capability types are structurally identical, so a
+          // capability of one would type-check against a state of the other and be wrong at runtime.
+          emission.variantTag === V2Tag
+            ? UnshieldedWalletState.fromVariant(variants[V2Tag].variant, emission)
+            : UnshieldedWalletState.fromVariant(variants[V1Tag].variant, emission),
+        ),
+        rx.shareReplay({ refCount: true, bufferSize: 1 }),
+      );
+    }
+
+    /**
+     * Starts background synchronization on whichever variant is current.
+     *
+     * @remarks
+     *   Takes no argument, on either side of the boundary, and that is the shape of the whole wallet: an unshielded
+     *   wallet watches an address, and an address is public. A migration therefore strands nothing — the new variant is
+     *   simply told to start, exactly as the old one was.
+     */
+    start(): Promise<void> {
+      return Effect.gen(this, function* () {
+        yield* Ref.set(this.#started, true);
+
+        // Registered before the first dispatch, and only once: `onVariantActivation` resolves only after its
+        // subscription is live, so an activation racing this call is queued rather than missed.
+        const alreadyRegistered = yield* Ref.getAndSet(this.#watcherRegistered, true);
+        if (!alreadyRegistered) {
+          yield* this.runtime.onVariantActivation({
+            [V1Tag]: (v1) => this.#resumeSyncOn(v1),
+            [V2Tag]: (v2) => this.#resumeSyncOn(v2),
+          });
+        }
+
+        yield* this.runtime.dispatch({
+          [V1Tag]: (v1) => v1.startSyncInBackground(),
+          [V2Tag]: (v2) => v2.startSyncInBackground(),
+        });
+      }).pipe(Effect.runPromise);
+    }
+
+    /** Starts synchronization on a variant that has just become current, unless the wallet has been stopped. */
+    #resumeSyncOn(running: { startSyncInBackground: () => Effect.Effect<void> }): Effect.Effect<void> {
+      return Ref.get(this.#started).pipe(
+        // Stopped, or never started: there is nothing to resume.
+        Effect.flatMap((started) => (started ? running.startSyncInBackground() : Effect.void)),
+      );
+    }
+
+    override async stop(): Promise<void> {
+      // Cleared before the runtime is torn down, so a stopped wallet cannot be resurrected by an in-flight activation.
+      Ref.set(this.#started, false).pipe(Effect.runSync);
+      await super.stop();
+    }
+
+    balanceFinalizedTransaction(tx: ledger.FinalizedTransaction): Promise<FinalizedTransactionBalanceResult> {
+      return this.runtime
+        .dispatch<FinalizedTransactionBalanceResult, TransactingError>({
+          [V1Tag]: () => preForkTransactingUnsupported('balanceFinalizedTransaction'),
+          [V2Tag]: (v2) => v2.balanceFinalizedTransaction(tx),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    balanceUnboundTransaction(tx: UnboundTransaction): Promise<UnboundTransactionBalanceResult> {
+      return this.runtime
+        .dispatch<UnboundTransactionBalanceResult, TransactingError>({
+          [V1Tag]: () => preForkTransactingUnsupported('balanceUnboundTransaction'),
+          [V2Tag]: (v2) => v2.balanceUnboundTransaction(tx),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    balanceUnprovenTransaction(tx: ledger.UnprovenTransaction): Promise<UnprovenTransactionBalanceResult> {
+      return this.runtime
+        .dispatch<UnprovenTransactionBalanceResult, TransactingError>({
+          [V1Tag]: () => preForkTransactingUnsupported('balanceUnprovenTransaction'),
+          [V2Tag]: (v2) => v2.balanceUnprovenTransaction(tx),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    transferTransaction(outputs: readonly TokenTransfer[], ttl: Date): Promise<ledger.UnprovenTransaction> {
+      return this.runtime
+        .dispatch<ledger.UnprovenTransaction, TransactingError>({
+          [V1Tag]: () => preForkTransactingUnsupported('transferTransaction'),
+          [V2Tag]: (v2) => v2.transferTransaction(outputs, ttl),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    rotateUtxos(
+      guaranteedUtxos: readonly UtxoWithMeta[],
+      fallibleUtxos: readonly UtxoWithMeta[],
+      nightVerifyingKey: ledger.SignatureVerifyingKey,
+      ttl: Date,
+    ): Promise<ledger.UnprovenTransaction> {
+      return this.runtime
+        .dispatch<ledger.UnprovenTransaction, TransactingError>({
+          [V1Tag]: () => preForkTransactingUnsupported('rotateUtxos'),
+          [V2Tag]: (v2) => v2.rotateUtxos(guaranteedUtxos, fallibleUtxos, nightVerifyingKey, ttl),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    initSwap(
+      desiredInputs: Record<ledger.RawTokenType, bigint>,
+      desiredOutputs: readonly TokenTransfer[],
+      ttl: Date,
+    ): Promise<ledger.UnprovenTransaction> {
+      return this.runtime
+        .dispatch<ledger.UnprovenTransaction, TransactingError>({
+          [V1Tag]: () => preForkTransactingUnsupported('initSwap'),
+          [V2Tag]: (v2) => v2.initSwap(desiredInputs, desiredOutputs, ttl),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    signUnprovenTransaction(
+      transaction: ledger.UnprovenTransaction,
+      signSegment: SignSegment,
+    ): Promise<ledger.UnprovenTransaction> {
+      return this.runtime
+        .dispatch<ledger.UnprovenTransaction, TransactingError>({
+          [V1Tag]: () => preForkTransactingUnsupported('signUnprovenTransaction'),
+          [V2Tag]: (v2) => v2.signUnprovenTransaction(transaction, signSegment),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    signUnboundTransaction(transaction: UnboundTransaction, signSegment: SignSegment): Promise<UnboundTransaction> {
+      return this.runtime
+        .dispatch<UnboundTransaction, TransactingError>({
+          [V1Tag]: () => preForkTransactingUnsupported('signUnboundTransaction'),
+          [V2Tag]: (v2) => v2.signUnboundTransaction(transaction, signSegment),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    /**
+     * Un-books the UTxOs a transaction of this wallet's had reserved, returning them to the available set.
+     *
+     * @remarks
+     *   Nothing to do on the pre-fork variant, and that is a fact about the wallet rather than a convenience: while
+     *   pre-fork transacting is unavailable that variant cannot have built the transaction being reverted, so it has
+     *   booked nothing of it to release. The parameter's type says the same thing. Unlike the operations that build
+     *   transactions, this needs no proving, so there is nothing here for version-routed proving to unlock later — and
+     *   the facade reverts all three wallets together when a submission fails, so a refusal here would strand that
+     *   whole path.
+     * @param transaction The transaction to un-book.
+     */
+    revertTransaction(
+      transaction: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>,
+    ): Promise<void> {
+      return this.runtime
+        .dispatch<void, WalletError>({
+          [V1Tag]: () => Effect.void,
+          [V2Tag]: (v2) => v2.revertTransaction(transaction),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    waitForSyncedState(allowedGap: bigint = 0n): Promise<UnshieldedWalletState<string>> {
+      return rx.firstValueFrom(
+        this.state.pipe(rx.filter((state) => state.state.progress.isCompleteWithin(allowedGap))),
+      );
+    }
+
+    /**
+     * Serializes the most recent state. It's preferable to use [[UnshieldedWalletState.serialize]] instead, to know
+     * exactly which state is serialized.
+     */
+    serializeState(): Promise<string> {
+      return rx.firstValueFrom(this.state).then((state) => state.serialize());
+    }
+
+    getAddress(): Promise<UnshieldedAddress> {
+      return rx.firstValueFrom(this.state).then((state) => state.address);
+    }
+  };
+}
+
+/** An unshielded wallet built the way this package ships it: one variant either side of the protocol boundary. */
+export type UnshieldedWallet = ForkingUnshieldedWallet<PreForkSyncUpdate, PostForkSyncUpdate>;
+
+/** The class {@link UnshieldedWallet} builds. */
+export type UnshieldedWalletClass = ForkingUnshieldedWalletClass<
+  PreForkSyncUpdate,
+  PostForkSyncUpdate,
+  DefaultUnshieldedConfiguration
+>;
+
+/**
+ * Builds the unshielded wallet this package ships: the default variant either side of `configuration.forkVersion`.
+ *
+ * @remarks
+ *   Both variants read the chain through the indexer's unshielded-transaction subscription and record transaction history
+ *   in the same storage, and both are built from the same application configuration, because what they ask for is
+ *   identical — unshielded sync carries no ledger object in either direction, only public UTXO records as JSON.
+ *
+ *   **Transacting is available only once the wallet is on the post-fork variant** — see
+ *   {@link PreForkUnshieldedTransactingUnsupportedError}, a temporary seam that closes with version-routed proving.
+ *   Synchronization, balances, coins, addresses, serialization, restore and reverting work on both sides.
+ * @param configuration What the wallet and both its variants are built from, including where the boundary lies.
+ * @returns The wallet class.
+ */
+export function UnshieldedWallet(configuration: DefaultUnshieldedConfiguration): UnshieldedWalletClass {
+  return CustomForkingUnshieldedWallet(
+    configuration,
+    { builder: new V1Builder().withDefaults(), configuration },
+    {
+      builder: new V2Builder().withDefaults().withMigration(() => Migration.makeCrossLedgerMigration()),
+      configuration,
+    },
+  );
+}

--- a/packages/unshielded-wallet/src/Restore.ts
+++ b/packages/unshielded-wallet/src/Restore.ts
@@ -1,0 +1,84 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Data, Either, Option, Schema } from 'effect';
+
+/**
+ * Raised when a snapshot declares a protocol version that no registered variant is able to read.
+ *
+ * @remarks
+ *   A wallet built for one range of protocol versions cannot invent a reader for a snapshot written outside it, and
+ *   guessing — handing the bytes to whichever variant happens to be registered — would decode them with the wrong
+ *   ledger. The version is carried on the error so an application can say which one it was.
+ */
+export class UnsupportedSnapshotVersionError extends Data.TaggedError(
+  '@midnightntwrk/wallet-sdk-unshielded-wallet/Restore/UnsupportedSnapshotVersionError',
+)<{
+  readonly message: string;
+  readonly protocolVersion: ProtocolVersion.ProtocolVersion;
+}> {}
+
+/**
+ * The envelope the peek reads.
+ *
+ * @remarks
+ *   Deliberately the smallest possible description of a snapshot: one optional field, every other ignored. It has to read
+ *   snapshots written by _any_ variant, including ones whose full schema this build does not have, so it must not
+ *   assert anything it does not need. Everything it cannot make sense of is reported as "no version declared", leaving
+ *   the real diagnosis to the deserializer that eventually reads the whole thing.
+ */
+const EnvelopeSchema = Schema.Struct({
+  protocolVersion: Schema.optional(ProtocolVersion.ProtocolVersionSchema),
+});
+
+/**
+ * Reads the protocol version a serialized unshielded wallet snapshot declares.
+ *
+ * @param serialized The serialized wallet state.
+ * @returns The declared version, or `Option.none()` when the snapshot declares none or cannot be read at all.
+ */
+export const peekProtocolVersion = (serialized: string): Option.Option<ProtocolVersion.ProtocolVersion> =>
+  Schema.decodeUnknownOption(Schema.parseJson(EnvelopeSchema))(serialized).pipe(
+    Option.flatMap((envelope) => Option.fromNullable(envelope.protocolVersion)),
+  );
+
+/**
+ * Chooses the variant that should read a serialized unshielded wallet snapshot.
+ *
+ * @remarks
+ *   A snapshot that declares no version predates snapshots declaring one, and can only have been written by the variant
+ *   that shipped before the question arose — the head variant. The same fallback covers an envelope this function
+ *   cannot read at all: refusing it here would replace the deserializer's precise error with a vaguer one.
+ * @param serialized The serialized wallet state.
+ * @param variantFor Resolves the variant registered for a protocol version.
+ * @param headVariant The variant a snapshot with no declared version is restored into.
+ * @returns The variant to restore with, or {@link UnsupportedSnapshotVersionError} when the declared version is one no
+ *   registered variant owns.
+ */
+export const variantForSnapshot = <TVariant>(
+  serialized: string,
+  variantFor: (version: ProtocolVersion.ProtocolVersion) => Option.Option<TVariant>,
+  headVariant: TVariant,
+): Either.Either<TVariant, UnsupportedSnapshotVersionError> =>
+  Option.match(peekProtocolVersion(serialized), {
+    onNone: () => Either.right(headVariant),
+    onSome: (protocolVersion) =>
+      Either.fromOption(
+        variantFor(protocolVersion),
+        () =>
+          new UnsupportedSnapshotVersionError({
+            message: `No registered variant reads unshielded wallet snapshots of protocol version ${protocolVersion}.`,
+            protocolVersion,
+          }),
+      ),
+  });

--- a/packages/unshielded-wallet/src/UnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/UnshieldedWallet.ts
@@ -14,17 +14,17 @@ import { type NetworkId, type ProtocolState, ProtocolVersion } from '@midnightnt
 import {
   type BaseV2Configuration,
   type DefaultV2Configuration,
-  V2Builder,
   V2Tag,
   type V2Variant,
   CoreWallet,
   type UnboundTransaction,
 } from './v2/index.js';
+import { type CoreWallet as PreForkCoreWallet } from './v1/CoreWallet.js';
 import type * as ledger from '@midnightntwrk/ledger-v9';
 import { Effect, Either, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
 import { type SerializationCapability } from './v2/Serialization.js';
-import { type TransactionHistoryService, type UnshieldedHistoryStorage } from './v2/TransactionHistory.js';
+import { type UnshieldedHistoryStorage } from './v2/TransactionHistory.js';
 import { type IndexerClientConnection } from './v2/Sync.js';
 import { type CoinsAndBalancesCapability } from './v2/CoinsAndBalances.js';
 import { type KeysCapability } from './v2/Keys.js';
@@ -44,48 +44,92 @@ import { type PublicKey } from './KeyStore.js';
 import { type SyncProgress } from './v2/SyncProgress.js';
 import { type UnshieldedAddress } from '@midnightntwrk/wallet-sdk-address-format';
 
-export type UnshieldedWalletCapabilities<TSerialized = string> = {
-  serialization: SerializationCapability<CoreWallet, TSerialized>;
-  coinsAndBalances: CoinsAndBalancesCapability<CoreWallet>;
-  keys: KeysCapability<CoreWallet>;
-};
+/** The core state of whichever unshielded variant produced an emission. */
+export type UnshieldedCoreState = PreForkCoreWallet | CoreWallet;
 
-export type UnshieldedWalletServices = {
-  transactionHistory: TransactionHistoryService;
-};
+/**
+ * Everything a state emission projects, already bound to the variant that produced it.
+ *
+ * @remarks
+ *   Binding is the point. The capabilities that understand a state and the state itself must be chosen together, in the
+ *   branch where the producing variant is known; the two variants' capability types are structurally identical, so a
+ *   capability of one would type-check against a state of the other and be wrong at runtime. Once bound there is
+ *   nothing left to mis-pair, and everything below is version-agnostic plain data — balances are `bigint` under string
+ *   token types, a UTXO is a plain record of value, owner, type, intent hash and output number, and the address is the
+ *   SDK's own type. The one genuinely version-bound reading a variant offers, the verifying key, is deliberately not
+ *   projected here: it is a bare hex string on one side and a `{tag, value}` record on the other.
+ */
+type UnshieldedProjections<TSerialized> = Readonly<{
+  balances: () => Record<ledger.RawTokenType, bigint>;
+  totalCoins: () => readonly UtxoWithMeta[];
+  availableCoins: () => readonly UtxoWithMeta[];
+  pendingCoins: () => readonly UtxoWithMeta[];
+  address: () => UnshieldedAddress;
+  serialize: () => TSerialized;
+}>;
+
+/**
+ * What a variant has to offer for its own state to be projected — exactly that, and nothing more.
+ *
+ * @remarks
+ *   Narrowed to the projected methods rather than naming the three capability types whole, because one of their members
+ *   is the version break itself: `KeysCapability.getPublicKey` answers with a bare hex string on the pre-fork ledger
+ *   version and a `{tag, value}` record on the post-fork one, so a type demanding it could only ever be satisfied by
+ *   one of the two variants. Asking for what is projected keeps a wallet spanning the boundary buildable and keeps the
+ *   unprojectable reading out of reach, in one stroke.
+ */
+type UnshieldedStateCapabilities<TState, TSerialized> = Readonly<{
+  serialization: Pick<SerializationCapability<TState, TSerialized>, 'serialize'>;
+  coinsAndBalances: Pick<
+    CoinsAndBalancesCapability<TState>,
+    'getAvailableBalances' | 'getTotalCoins' | 'getAvailableCoins' | 'getPendingCoins'
+  >;
+  keys: Pick<KeysCapability<TState>, 'getAddress'>;
+}>;
 
 export class UnshieldedWalletState<TSerialized = string> {
-  static readonly mapState =
-    <TSerialized = string>(variant: UnshieldedWalletCapabilities<TSerialized> & UnshieldedWalletServices) =>
-    (state: ProtocolState.ProtocolState<CoreWallet>): UnshieldedWalletState<TSerialized> => {
-      const { serialization, coinsAndBalances, keys } = variant;
-      const { transactionHistory } = variant;
-      return new UnshieldedWalletState(state, { serialization, coinsAndBalances, keys }, { transactionHistory });
-    };
+  /**
+   * Wraps a state emission with the capabilities of the variant that produced it.
+   *
+   * @remarks
+   *   Call this inside a branch that has narrowed on the emission's `variantTag`, so `variant` and `state` are known to
+   *   belong together. It is generic over the state type precisely so that pairing is checked.
+   */
+  static readonly fromVariant = <TState extends UnshieldedCoreState, TSerialized = string>(
+    variant: UnshieldedStateCapabilities<TState, TSerialized>,
+    state: ProtocolState.ProtocolState<TState>,
+  ): UnshieldedWalletState<TSerialized> =>
+    new UnshieldedWalletState<TSerialized>(state.version, state.state, {
+      balances: () => variant.coinsAndBalances.getAvailableBalances(state.state),
+      totalCoins: () => variant.coinsAndBalances.getTotalCoins(state.state),
+      availableCoins: () => variant.coinsAndBalances.getAvailableCoins(state.state),
+      pendingCoins: () => variant.coinsAndBalances.getPendingCoins(state.state),
+      address: () => variant.keys.getAddress(state.state),
+      serialize: () => variant.serialization.serialize(state.state),
+    });
 
   readonly protocolVersion: ProtocolVersion.ProtocolVersion;
-  readonly state: CoreWallet;
-  readonly capabilities: UnshieldedWalletCapabilities<TSerialized>;
-  readonly services: UnshieldedWalletServices;
+  readonly state: UnshieldedCoreState;
+  readonly #projections: UnshieldedProjections<TSerialized>;
 
   get balances(): Record<ledger.RawTokenType, bigint> {
-    return this.capabilities.coinsAndBalances.getAvailableBalances(this.state);
+    return this.#projections.balances();
   }
 
   get totalCoins(): readonly UtxoWithMeta[] {
-    return this.capabilities.coinsAndBalances.getTotalCoins(this.state);
+    return this.#projections.totalCoins();
   }
 
   get availableCoins(): readonly UtxoWithMeta[] {
-    return this.capabilities.coinsAndBalances.getAvailableCoins(this.state);
+    return this.#projections.availableCoins();
   }
 
   get pendingCoins(): readonly UtxoWithMeta[] {
-    return this.capabilities.coinsAndBalances.getPendingCoins(this.state);
+    return this.#projections.pendingCoins();
   }
 
   get address(): UnshieldedAddress {
-    return this.capabilities.keys.getAddress(this.state);
+    return this.#projections.address();
   }
 
   get progress(): SyncProgress {
@@ -93,22 +137,19 @@ export class UnshieldedWalletState<TSerialized = string> {
   }
 
   constructor(
-    state: ProtocolState.ProtocolState<CoreWallet>,
-    capabilities: UnshieldedWalletCapabilities<TSerialized>,
-    services: UnshieldedWalletServices,
+    protocolVersion: ProtocolVersion.ProtocolVersion,
+    state: UnshieldedCoreState,
+    projections: UnshieldedProjections<TSerialized>,
   ) {
-    this.protocolVersion = state.version;
-    this.state = state.state;
-    this.capabilities = capabilities;
-    this.services = services;
+    this.protocolVersion = protocolVersion;
+    this.state = state;
+    this.#projections = projections;
   }
 
   serialize(): TSerialized {
-    return this.capabilities.serialization.serialize(this.state);
+    return this.#projections.serialize();
   }
 }
-
-export type UnshieldedWallet = CustomizedUnshieldedWallet<WalletSyncUpdate, string>;
 
 /**
  * The configuration a default {@link UnshieldedWallet} is built from.
@@ -126,13 +167,22 @@ export type DefaultUnshieldedConfiguration = {
   networkId: NetworkId.NetworkId;
   indexerClientConnection: IndexerClientConnection;
   txHistoryStorage: UnshieldedHistoryStorage;
+  /**
+   * The protocol version at which this chain hands over from the pre-fork ledger to the post-fork one.
+   *
+   * @remarks
+   *   Required, and deliberately without a default: the wallet registers one variant either side of it, so a wrong value
+   *   does not degrade — it decides which ledger version reads the chain. Below this version the pre-fork variant is
+   *   active; from it, the post-fork one. The SDK cannot guess it, because it is a property of the chain the
+   *   application points at, not of the SDK.
+   *
+   *   A node reporting a 2.x runtime version reports protocol version `2000000`, which is therefore the value for a
+   *   ledger-v9-native chain — the shielded package publishes it as `V9_NATIVE_FORK_VERSION`. The final mainnet fork
+   *   constant is not yet fixed; a `ProtocolVersion.Forks.*` default will ship once it is, and this field keeps working
+   *   unchanged.
+   */
+  forkVersion: ProtocolVersion.ProtocolVersion;
 };
-
-export type UnshieldedWalletClass = CustomizedUnshieldedWalletClass<
-  WalletSyncUpdate,
-  string,
-  DefaultUnshieldedConfiguration
->;
 
 export type UnshieldedWalletAPI<TSerialized = string> = {
   readonly state: rx.Observable<UnshieldedWalletState<TSerialized>>;
@@ -202,10 +252,6 @@ export interface CustomizedUnshieldedWalletClass<
   restore(serializedState: TSerialized): CustomizedUnshieldedWallet<TSyncUpdate, TSerialized>;
 }
 
-export function UnshieldedWallet(configuration: DefaultUnshieldedConfiguration): UnshieldedWalletClass {
-  return CustomUnshieldedWallet(configuration, new V2Builder().withDefaults());
-}
-
 export function CustomUnshieldedWallet<
   TConfig extends BaseV2Configuration = DefaultV2Configuration,
   TSyncUpdate = WalletSyncUpdate,
@@ -254,9 +300,11 @@ export function CustomUnshieldedWallet<
     ) {
       super(runtime, scope);
       this.state = this.rawState.pipe(
-        rx.map(
-          UnshieldedWalletState.mapState<TSerialized>(
+        rx.map((emission) =>
+          // One variant, so the pairing is trivial here; the forking wallet narrows on `variantTag` first.
+          UnshieldedWalletState.fromVariant<CoreWallet, TSerialized>(
             CustomUnshieldedWalletImplementation.allVariantsRecord()[V2Tag].variant,
+            emission,
           ),
         ),
         rx.shareReplay({ refCount: true, bufferSize: 1 }),

--- a/packages/unshielded-wallet/src/index.ts
+++ b/packages/unshielded-wallet/src/index.ts
@@ -11,6 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 export * from './UnshieldedWallet.js';
+export * from './ForkingUnshieldedWallet.js';
+// Exported under a wallet-qualified name rather than unqualified. The umbrella package re-exports all three wallets
+// into one barrel, and each declares its own `UnsupportedSnapshotVersionError` — three classes of the same name with
+// three different deterministic tags, one per wallet whose snapshot could not be read. Namespacing the third one keeps
+// that barrel unambiguous without renaming the two that shipped before it.
+export * as UnshieldedRestore from './Restore.js';
 export {
   type UnshieldedTransactionHistoryEntry,
   UnshieldedSectionSchema,

--- a/packages/unshielded-wallet/src/test/configuration.test.ts
+++ b/packages/unshielded-wallet/src/test/configuration.test.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type NetworkId, type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type CanAssign, type Equal, type Expect } from '@midnightntwrk/wallet-sdk-utilities/types';
 import { describe, it } from 'vitest';
 import { type DefaultUnshieldedConfiguration } from '../UnshieldedWallet.js';
@@ -30,15 +30,24 @@ describe('DefaultUnshieldedConfiguration', () => {
           networkId: NetworkId.NetworkId;
           indexerClientConnection: V2Sync.IndexerClientConnection;
           txHistoryStorage: V2TransactionHistory.UnshieldedHistoryStorage;
+          forkVersion: ProtocolVersion.ProtocolVersion;
         }
       >
     >;
   });
 
-  it('stays interchangeable with what either variant is built from', () => {
+  it('builds either variant, being a superset of what each is built from', () => {
+    // One direction only, and deliberately so. The wallet's configuration now says something no single variant does —
+    // where the boundary between them lies — so it is strictly larger than either variant's. What must keep holding is
+    // that it can still build both: a variant asking for something this type does not carry would be a wallet that
+    // cannot be built for one of its own variants.
     type _1 = Expect<CanAssign<DefaultUnshieldedConfiguration, DefaultV2Configuration>>;
-    type _2 = Expect<CanAssign<DefaultV2Configuration, DefaultUnshieldedConfiguration>>;
-    type _3 = Expect<CanAssign<DefaultUnshieldedConfiguration, DefaultV1Configuration>>;
-    type _4 = Expect<CanAssign<DefaultV1Configuration, DefaultUnshieldedConfiguration>>;
+    // The two variants ask for exactly the same things, which is what lets one configuration serve both — asserted
+    // here so a divergence shows up as a compile error rather than as a wallet that cannot be built for one of them.
+    type _2 = Expect<CanAssign<DefaultUnshieldedConfiguration, DefaultV1Configuration>>;
+
+    // `forkVersion` is the wallet layer's alone: neither variant knows there is another one.
+    type _3 = Expect<Equal<'forkVersion' extends keyof DefaultV1Configuration ? true : false, false>>;
+    type _4 = Expect<Equal<'forkVersion' extends keyof DefaultV2Configuration ? true : false, false>>;
   });
 });

--- a/packages/unshielded-wallet/src/test/forkHarness.ts
+++ b/packages/unshielded-wallet/src/test/forkHarness.ts
@@ -10,33 +10,46 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// A test-only unshielded wallet registered over BOTH variants, so a crossing can actually be driven.
-//
-// The shipped `UnshieldedWallet` registers exactly one variant and is typed as a one-element HList throughout, so it
-// cannot express a fork-crossing wallet. Rather than widen the public surface ahead of the API redesign, this builds the
-// two-variant wallet the way `packages/e2e-tests` builds its custom wallets: `WalletBuilder.init()` with both variant
-// builders registered directly. Nothing here is exported from the package.
-//
-// This factory is markedly simpler than the shielded and dust equivalents, and the reason is the point of the whole
-// unshielded increment: there is no key to retain. Unshielded sync is watch-only — the address is public and signing is
-// supplied per call by the caller — so `startSyncInBackground` takes no argument, the activation watcher re-dispatches
-// with nothing, and none of the start-aux workarounds those factories document apply here.
-import { NetworkId, ProtocolVersion, type ProtocolState } from '@midnightntwrk/wallet-sdk-abstractions';
+
+/**
+ * The shipped forking unshielded wallet, driven over an in-memory timeline, with the channels a fork proof needs.
+ *
+ * @remarks
+ *   Everything here is observation and simulated infrastructure. The wallet itself is the one the package ships —
+ *   {@link CustomForkingUnshieldedWallet}, the same composition `UnshieldedWallet(configuration)` uses — with each
+ *   variant's sync _service_ replaced by a numbered, version-tagged timeline instead of a WebSocket to an indexer, and
+ *   the post-fork variant's migration wrapped so both ends of the hand-over can be recorded as plain data. The
+ *   capability that folds a message into the wallet, boundary rule and all, is the real one.
+ *
+ *   This harness is markedly simpler than the shielded and dust equivalents, and the reason is the point of the whole
+ *   unshielded increment: there is no key to retain. Unshielded synchronization is watch-only — the address is public
+ *   and signing is supplied per call by the caller — so `startSyncInBackground` takes no argument on either variant,
+ *   the activation watcher re-dispatches with nothing, and none of the start-aux machinery those wallets need applies
+ *   here. What the wallet is started with is an identity, and the harness hands it the one an application holds: the
+ *   post-fork ledger version's {@link PublicKey}.
+ */
+import { NetworkId, type ProtocolState, type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
-import { WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
 import { Deferred, Effect, FiberId, HashMap, Option, Stream, pipe } from 'effect';
-import { V1Builder, V1Tag, type CoreWallet as PreForkWallet } from '../v1/index.js';
-import * as PreForkSync from '../v1/Sync.js';
+import { CustomForkingUnshieldedWallet, type ForkingUnshieldedWallet } from '../ForkingUnshieldedWallet.js';
+import { type PublicKey } from '../KeyStore.js';
+import { type CoreWallet as PreForkWallet } from '../v1/CoreWallet.js';
 import * as PreForkMigration from '../v1/Migration.js';
-import { V2Builder, V2Tag, type CoreWallet as PostForkWallet } from '../v2/index.js';
-import * as PostForkSync from '../v2/Sync.js';
-import * as PostForkMigration from '../v2/Migration.js';
-import { type TransactionHistoryService as PreForkHistory } from '../v1/TransactionHistory.js';
-import { type TransactionHistoryService as PostForkHistory } from '../v2/TransactionHistory.js';
+import * as PreForkSync from '../v1/Sync.js';
 import { type WalletSyncUpdate as PreForkUpdate } from '../v1/SyncSchema.js';
+import { type TransactionHistoryService as PreForkHistory } from '../v1/TransactionHistory.js';
+import { V1Builder } from '../v1/V1Builder.js';
+import { type CoreWallet as PostForkWallet } from '../v2/CoreWallet.js';
+import * as PostForkMigration from '../v2/Migration.js';
+import * as PostForkSync from '../v2/Sync.js';
 import { type WalletSyncUpdate as PostForkUpdate } from '../v2/SyncSchema.js';
+import { type TransactionHistoryService as PostForkHistory } from '../v2/TransactionHistory.js';
+import { V2Builder } from '../v2/V2Builder.js';
 import { type TimelineItem } from './forkTimeline.js';
+
+// =============================================================================
+// Observation channels
+// =============================================================================
 
 /**
  * A migration captured as plain data.
@@ -128,8 +141,27 @@ const capturingCrossLedgerMigration = (
   };
 };
 
+// =============================================================================
+// Stand-ins for services the proof does not exercise
+// =============================================================================
+
+/**
+ * Transaction history reduced to nothing.
+ *
+ * @remarks
+ *   The real service needs an indexer connection and a storage instance, neither of which says anything about crossing a
+ *   fork. Written out once per variant because the two `TransactionHistoryService` types name their own ledger
+ *   version's update.
+ */
 const noOpPreForkHistory: PreForkHistory = { put: () => Effect.void };
 const noOpPostForkHistory: PostForkHistory = { put: () => Effect.void };
+
+/** What each variant is configured with, on top of what its builder already asks for. */
+type SourceConfiguration = Readonly<{
+  networkId: NetworkId.NetworkId;
+  /** The single timeline both variants read, each decoding it as its own ledger version's update. */
+  timeline: readonly TimelineItem[];
+}>;
 
 /**
  * A sync service over an in-memory timeline, honouring the wallet's cursor.
@@ -148,43 +180,72 @@ const timelineSyncService = <TUpdate>(
     Stream.fromIterable(timeline.filter((item) => BigInt(item.id) > state.progress.appliedId).map(toUpdate)),
 });
 
+// =============================================================================
+// The wallet
+// =============================================================================
+
+/** Everything needed to point the shipped forking unshielded wallet at a timeline that forks. */
 export type ForkWalletConfig = {
   /** The single timeline both variants read, each decoding it as its own ledger version's update. */
   readonly timeline: readonly TimelineItem[];
-  /** The protocol version at which the second variant takes over. */
+  /**
+   * The version at which the post-fork variant is registered.
+   *
+   * The single source of truth for the boundary: the pre-fork variant's activation range ends here, and so does the
+   * point at which its sync stops applying. Deliberately not a production constant — the real fork version is not
+   * final.
+   */
   readonly forkVersion: ProtocolVersion.ProtocolVersion;
-  /** The wallet's starting state, built on the pre-fork ledger version. */
-  readonly initialState: PreForkWallet;
+  /** The identity the wallet is started with, in the shape an application holds it: the post-fork ledger version's. */
+  readonly publicKey: PublicKey;
   readonly networkId?: NetworkId.NetworkId;
 };
 
+/** A state emission, whichever variant produced it. */
+export type ForkedState = ProtocolState.ProtocolState<PreForkWallet | PostForkWallet>;
+
+/** A running forking unshielded wallet, plus the channels a fork proof needs to observe it. */
 export type ForkWallet = {
-  readonly start: Effect.Effect<void, WalletRuntimeError>;
+  /** The wallet itself, exactly as an application would hold it. */
+  readonly unshielded: ForkingUnshieldedWallet<PreForkUpdate, PostForkUpdate>;
+  /** Starts background synchronization through the wallet's own API. */
+  readonly start: Effect.Effect<void>;
+  /** Resolves when the hand-over happens, with both ends of it. */
   readonly awaitMigration: Effect.Effect<CapturedMigration>;
+  /** Both ends of the migration, or `None` if none has happened yet. */
   readonly migration: Effect.Effect<Option.Option<CapturedMigration>>;
+  /** The tag of the variant currently running — `V1Tag` before a migration, `V2Tag` after one. */
   readonly activeTag: Effect.Effect<string | symbol>;
-  readonly currentState: Effect.Effect<ProtocolState.ProtocolState<PreForkWallet | PostForkWallet>, WalletRuntimeError>;
-  readonly awaitState: (
-    predicate: (state: ProtocolState.ProtocolState<PreForkWallet | PostForkWallet>) => boolean,
-  ) => Effect.Effect<ProtocolState.ProtocolState<PreForkWallet | PostForkWallet>, WalletRuntimeError>;
+  /** The wallet's current state, whichever variant produced it. */
+  readonly currentState: Effect.Effect<ForkedState, WalletRuntimeError>;
+  /**
+   * Resolves once the wallet's state satisfies `predicate`, failing the test's timeout if it never does.
+   *
+   * Use monotone predicates only: the runtime's state stream keeps just the latest value, so a state that satisfies a
+   * transient predicate can legitimately be skipped.
+   */
+  readonly awaitState: (predicate: (state: ForkedState) => boolean) => Effect.Effect<ForkedState, WalletRuntimeError>;
+  /** Tears the wallet down. */
   readonly stop: Effect.Effect<void>;
 };
 
 /**
- * Builds and starts an unshielded wallet registered over both variants.
+ * Builds and starts the shipped forking unshielded wallet over an in-memory timeline that forks.
  *
- * @param config The timeline, the boundary version and the starting state.
+ * @param config The timeline, the boundary version and the identity to start with.
  * @returns The running wallet and its observation channels.
  */
 export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
   const networkId = config.networkId ?? NetworkId.NetworkId.Undeployed;
   const captured = Deferred.unsafeMake<CapturedMigration>(FiberId.none);
+  const variantConfiguration: SourceConfiguration = { networkId, timeline: config.timeline };
 
   const preForkBuilder = new V1Builder()
     .withSync(
-      () => timelineSyncService<PreForkUpdate>(config.timeline, (item) => item.update as PreForkUpdate),
+      (configuration: SourceConfiguration) =>
+        timelineSyncService<PreForkUpdate>(configuration.timeline, (item) => item.update as PreForkUpdate),
       // The REAL capability, boundary rule and all — only the service that would open a WebSocket is substituted.
-      (_c: object, getContext: () => { transactionHistoryService: PreForkHistory }) =>
+      (_configuration: SourceConfiguration, getContext: () => { transactionHistoryService: PreForkHistory }) =>
         PreForkSync.makeDefaultSyncCapability({ indexerClientConnection: { indexerHttpUrl: 'http://unused' } }, () =>
           getContext(),
         ),
@@ -196,12 +257,15 @@ export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
     .withTransactionHistory(() => noOpPreForkHistory)
     .withKeysDefaults()
     .withCoinSelectionDefaults()
-    .withMigration(() => PreForkMigration.makeEmptyWalletMigration({ networkId }));
+    .withMigration((configuration: SourceConfiguration) =>
+      PreForkMigration.makeEmptyWalletMigration({ networkId: configuration.networkId }),
+    );
 
   const postForkBuilder = new V2Builder()
     .withSync(
-      () => timelineSyncService<PostForkUpdate>(config.timeline, (item) => item.update as PostForkUpdate),
-      (_c: object, getContext: () => { transactionHistoryService: PostForkHistory }) =>
+      (configuration: SourceConfiguration) =>
+        timelineSyncService<PostForkUpdate>(configuration.timeline, (item) => item.update as PostForkUpdate),
+      (_configuration: SourceConfiguration, getContext: () => { transactionHistoryService: PostForkHistory }) =>
         PostForkSync.makeDefaultSyncCapability({ indexerClientConnection: { indexerHttpUrl: 'http://unused' } }, () =>
           getContext(),
         ),
@@ -215,27 +279,19 @@ export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
     .withCoinSelectionDefaults()
     .withMigration(() => capturingCrossLedgerMigration(captured));
 
-  const WalletClass = WalletBuilder.init()
-    .withVariant(ProtocolVersion.MinSupportedVersion, preForkBuilder)
-    .withVariant(config.forkVersion, postForkBuilder)
-    .build({ networkId });
+  const WalletClass = CustomForkingUnshieldedWallet(
+    { networkId, forkVersion: config.forkVersion },
+    { builder: preForkBuilder, configuration: variantConfiguration },
+    { builder: postForkBuilder, configuration: variantConfiguration },
+  );
 
-  const wallet = WalletClass.startFirst(WalletClass, config.initialState);
+  const wallet = WalletClass.startWithPublicKey(config.publicKey);
   const runtime = wallet.runtime;
 
   return {
-    start: Effect.gen(function* () {
-      // Registered before the first dispatch and only once, exactly as `UnshieldedWallet.start` does it — and with no
-      // argument, which is the point: nothing secret has to survive the crossing.
-      yield* runtime.onVariantActivation({
-        [V1Tag]: (v1) => v1.startSyncInBackground(),
-        [V2Tag]: (v2) => v2.startSyncInBackground(),
-      });
-      yield* runtime.dispatch({
-        [V1Tag]: (v1) => v1.startSyncInBackground(),
-        [V2Tag]: (v2) => v2.startSyncInBackground(),
-      });
-    }),
+    unshielded: wallet,
+
+    start: Effect.promise(() => wallet.start()),
 
     awaitMigration: Deferred.await(captured),
 

--- a/packages/unshielded-wallet/src/test/forkSimulation.test.ts
+++ b/packages/unshielded-wallet/src/test/forkSimulation.test.ts
@@ -30,12 +30,10 @@
 import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Effect, identity, Option } from 'effect';
 import { describe, expect, it } from 'vitest';
-import { CoreWallet as PreForkWallet } from '../v1/CoreWallet.js';
-import { UnshieldedState as PreForkState } from '../v1/UnshieldedState.js';
 import { V1Tag } from '../v1/index.js';
 import { V2Tag } from '../v2/index.js';
 import { forkSeed, postForkIdentity, preForkIdentity, timelineTransaction } from './forkTimeline.js';
-import { makeForkWallet, utxosOf, type CarriedUtxo } from './forkWallet.js';
+import { makeForkWallet, utxosOf, type CarriedUtxo } from './forkHarness.js';
 
 const networkId = NetworkId.NetworkId.Undeployed;
 /** The pre-fork variant owns everything below this; the post-fork variant takes over at it. */
@@ -62,20 +60,11 @@ const timeline = [
   timelineTransaction({ id: 6, protocolVersion: Number(forkVersion), owner: preFork.addressHex, value: 600n }),
 ];
 
-const emptyPreForkWallet = () =>
-  PreForkWallet.restore(
-    PreForkState.empty(),
-    preFork,
-    { appliedId: 0n, highestTransactionId: 0n },
-    ProtocolVersion.MinSupportedVersion,
-    networkId,
-  );
-
 const valuesOf = (utxos: readonly CarriedUtxo[]): readonly bigint[] => utxos.map((u) => u.value);
 
 describe('unshielded hard-fork crossing', () => {
   it('carries every UTXO across and applies the boundary transaction exactly once, in the new variant', async () => {
-    const wallet = makeForkWallet({ timeline, forkVersion, initialState: emptyPreForkWallet() });
+    const wallet = makeForkWallet({ timeline, forkVersion, publicKey: postFork });
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
@@ -126,7 +115,7 @@ describe('unshielded hard-fork crossing', () => {
   });
 
   it('carries the pre-fork UTXOs field for field, not merely by count', async () => {
-    const wallet = makeForkWallet({ timeline, forkVersion, initialState: emptyPreForkWallet() });
+    const wallet = makeForkWallet({ timeline, forkVersion, publicKey: postFork });
 
     const { before, after } = await Effect.runPromise(
       Effect.gen(function* () {
@@ -162,7 +151,7 @@ describe('unshielded hard-fork crossing', () => {
       // 5 is still below the boundary of 7, so this must be applied, not deferred.
       timelineTransaction({ id: 2, protocolVersion: 5, owner: preFork.addressHex, value: 200n }),
     ];
-    const wallet = makeForkWallet({ timeline: withinRange, forkVersion, initialState: emptyPreForkWallet() });
+    const wallet = makeForkWallet({ timeline: withinRange, forkVersion, publicKey: postFork });
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
@@ -187,7 +176,7 @@ describe('unshielded hard-fork crossing', () => {
   it('reaches the same end state from a wallet whose first sync already contains the fork', async () => {
     // Scenario 2: a fresh wallet syncing a timeline that already straddles the boundary. It still syncs the pre-fork
     // prefix with the old variant, hands over, and consumes the rest — double work by design, correct by construction.
-    const wallet = makeForkWallet({ timeline, forkVersion, initialState: emptyPreForkWallet() });
+    const wallet = makeForkWallet({ timeline, forkVersion, publicKey: postFork });
 
     const final = await Effect.runPromise(
       Effect.gen(function* () {

--- a/packages/unshielded-wallet/src/test/forkStart.test.ts
+++ b/packages/unshielded-wallet/src/test/forkStart.test.ts
@@ -38,6 +38,7 @@ import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractio
 import { Cause, Effect, Fiber, Option, Runtime, type Scope } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { PreForkUnshieldedTransactingUnsupportedError } from '../ForkingUnshieldedWallet.js';
+import { peekProtocolVersion } from '../Restore.js';
 import { V1Tag } from '../v1/RunningV1Variant.js';
 import { type SignSegment } from '../v2/Signing.js';
 import { type UnboundTransaction } from '../v2/TransactionOps.js';
@@ -133,10 +134,7 @@ const gatedCalls = (wallet: ForkWallet): readonly (readonly [string, () => Promi
   const ttl = new Date(Date.now() + 3_600_000);
   const verifyingKey = v9.signatureVerifyingKey(v9.sampleSigningKey());
   return [
-    [
-      'balanceFinalizedTransaction',
-      () => wallet.unshielded.balanceFinalizedTransaction(someFinalizedTransaction()),
-    ],
+    ['balanceFinalizedTransaction', () => wallet.unshielded.balanceFinalizedTransaction(someFinalizedTransaction())],
     ['balanceUnboundTransaction', () => wallet.unshielded.balanceUnboundTransaction(someUnboundTransaction())],
     ['balanceUnprovenTransaction', () => wallet.unshielded.balanceUnprovenTransaction(someTransaction())],
     ['transferTransaction', () => wallet.unshielded.transferTransaction([], ttl)],
@@ -253,7 +251,10 @@ describe('an unshielded wallet starting on a chain that has not forked', () => {
       const snapshot = yield* Effect.promise(() => wallet.unshielded.serializeState());
 
       expect(address.hexString).toBe(postFork.addressHex);
-      expect(JSON.parse(snapshot).protocolVersion).toBe(String(beforeFork));
+      // Read back through the very function `restore` routes on, so the snapshot is pinned as the router sees it.
+      expect(peekProtocolVersion(snapshot)).toStrictEqual(
+        Option.some(ProtocolVersion.ProtocolVersion(BigInt(beforeFork))),
+      );
     }).pipe(Effect.scoped, Effect.runPromise));
 });
 

--- a/packages/unshielded-wallet/src/test/forkStart.test.ts
+++ b/packages/unshielded-wallet/src/test/forkStart.test.ts
@@ -1,0 +1,281 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Where an unshielded wallet spanning a protocol boundary starts, and what it cannot do until it has crossed it.
+ *
+ * @remarks
+ *   `forkSimulation.test.ts` drives the crossing itself: a timeline that forks under a running wallet. The two starts
+ *   here are the other question — a wallet meeting a chain that is already on one side or the other, which is what
+ *   every application start actually is.
+ *
+ *   A wallet always begins on the pre-fork variant, because that is the variant a wallet with no history belongs to. On a
+ *   chain that has already forked it therefore hands over immediately, having applied nothing: one migration per start,
+ *   paid on chains that are entirely past the boundary. That cost is accepted rather than hidden — removing it means
+ *   asking the chain for its version before choosing a variant, which is a separate piece of work.
+ *
+ *   Unshielded's hand-over is a **structural carry** rather than a fresh state plus replay, so the "applied nothing"
+ *   start is asserted for what a carry of nothing actually looks like: an empty carry, a cursor still at the start, and
+ *   a post-fork variant that then syncs the whole history itself. Nothing is re-earned from a replay here, because
+ *   there is nothing shielded to re-derive.
+ *
+ *   Both starts assert the boundary by comparison with `forkVersion` and never by the number itself: which protocol
+ *   version a chain reports is a property of the chain, and the real fork's value is not final.
+ */
+
+import * as v9 from '@midnightntwrk/ledger-v9';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Cause, Effect, Fiber, Option, Runtime, type Scope } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { PreForkUnshieldedTransactingUnsupportedError } from '../ForkingUnshieldedWallet.js';
+import { V1Tag } from '../v1/RunningV1Variant.js';
+import { type SignSegment } from '../v2/Signing.js';
+import { type UnboundTransaction } from '../v2/TransactionOps.js';
+import { V2Tag } from '../v2/RunningV2Variant.js';
+import { type CarriedUtxo, type ForkWallet, makeForkWallet, utxosOf } from './forkHarness.js';
+import { ecdsaIdentity, postForkIdentity, preForkIdentity, timelineTransaction } from './forkTimeline.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+
+/** Where the wallet registers its post-fork variant. */
+const forkVersion = ProtocolVersion.ProtocolVersion(7n);
+/** A chain that has already forked — deliberately past the boundary rather than exactly at it. */
+const afterFork = 9;
+/** A chain that has not — a version the pre-fork variant owns. */
+const beforeFork = 5;
+
+const postFork = postForkIdentity(networkId);
+const preFork = preForkIdentity(networkId);
+
+/** The whole history of a chain sitting on one side of the boundary: every message reported at the same version. */
+const chainAt = (protocolVersion: number) => [
+  timelineTransaction({ id: 1, protocolVersion, owner: postFork.addressHex, value: 100n }),
+  timelineTransaction({ id: 2, protocolVersion, owner: postFork.addressHex, value: 200n }),
+];
+
+const valuesOf = (utxos: readonly CarriedUtxo[]): readonly bigint[] => utxos.map((u) => u.value);
+
+/** A started wallet that has consumed the whole of `timeline`, torn down when the surrounding scope closes. */
+const walletOnChainAt = (
+  protocolVersion: number,
+  publicKey = postFork,
+): Effect.Effect<ForkWallet, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const wallet = makeForkWallet({ timeline: chainAt(protocolVersion), forkVersion, publicKey });
+    yield* Effect.addFinalizer(() => wallet.stop);
+    yield* wallet.start;
+    return wallet;
+  });
+
+/** A wallet on a chain that has not forked, synchronized and holding its UTXOs. */
+const syncedPreForkWallet: Effect.Effect<ForkWallet, never, Scope.Scope> = Effect.gen(function* () {
+  const wallet = yield* walletOnChainAt(beforeFork);
+  yield* wallet.awaitState((state) => state.state.progress.appliedId === 2n).pipe(Effect.orDie);
+  expect(yield* wallet.activeTag).toBe(V1Tag);
+  return wallet;
+});
+
+/**
+ * The typed failure a wallet call rejected with.
+ *
+ * @remarks
+ *   The wallet's API is promise-shaped and its failures are effect failures, so a rejection carries the cause rather than
+ *   the error itself. A call that resolves reports `None`, which fails the assertion below rather than reading a
+ *   property off nothing.
+ */
+const failureOf = (call: Promise<unknown>): Effect.Effect<Option.Option<unknown>> =>
+  Effect.promise(() =>
+    call.then(
+      () => Option.none<unknown>(),
+      (rejection: unknown) =>
+        Runtime.isFiberFailure(rejection)
+          ? Cause.failureOption(rejection[Runtime.FiberFailureCauseId])
+          : Option.some(rejection),
+    ),
+  );
+
+/** A transaction of the post-fork ledger version, which is the only kind this wallet's API accepts. */
+const someTransaction = (): v9.UnprovenTransaction => v9.Transaction.fromParts(networkId);
+
+/** The same transaction, proven and bound. */
+const someFinalizedTransaction = (): v9.FinalizedTransaction => someTransaction().mockProve();
+
+/**
+ * The same transaction at the unbound stage.
+ *
+ * @remarks
+ *   Only a prover produces one — `mockProve` binds as it proves — and a unit-tier proof has no prover.
+ */
+// Type cast required because: the unbound stage is reachable only through a real proving provider, which this tier
+// deliberately does not have, and `Binding`/`PreBinding` are nominal. The gated branch refuses before touching the
+// argument, so what is load-bearing here is the static type of the parameter and never the value.
+const someUnboundTransaction = (): UnboundTransaction => someTransaction() as unknown as UnboundTransaction;
+
+const signSegment: SignSegment = (data) => Promise.resolve(v9.signData(v9.sampleSigningKey(), data));
+
+/**
+ * Every call that builds, balances or signs a transaction, named as the wallet names it.
+ *
+ * @remarks
+ *   `revertTransaction` is deliberately not among them — see the test below for what it does instead.
+ */
+const gatedCalls = (wallet: ForkWallet): readonly (readonly [string, () => Promise<unknown>])[] => {
+  const ttl = new Date(Date.now() + 3_600_000);
+  const verifyingKey = v9.signatureVerifyingKey(v9.sampleSigningKey());
+  return [
+    [
+      'balanceFinalizedTransaction',
+      () => wallet.unshielded.balanceFinalizedTransaction(someFinalizedTransaction()),
+    ],
+    ['balanceUnboundTransaction', () => wallet.unshielded.balanceUnboundTransaction(someUnboundTransaction())],
+    ['balanceUnprovenTransaction', () => wallet.unshielded.balanceUnprovenTransaction(someTransaction())],
+    ['transferTransaction', () => wallet.unshielded.transferTransaction([], ttl)],
+    ['rotateUtxos', () => wallet.unshielded.rotateUtxos([], [], verifyingKey, ttl)],
+    ['initSwap', () => wallet.unshielded.initSwap({}, [], ttl)],
+    ['signUnprovenTransaction', () => wallet.unshielded.signUnprovenTransaction(someTransaction(), signSegment)],
+    ['signUnboundTransaction', () => wallet.unshielded.signUnboundTransaction(someUnboundTransaction(), signSegment)],
+  ];
+};
+
+describe('an unshielded wallet starting on a chain that has already forked', () => {
+  it('hands over having applied nothing, carrying nothing, and syncs the whole chain on the post-fork variant', async () =>
+    Effect.gen(function* () {
+      const wallet = makeForkWallet({ timeline: chainAt(afterFork), forkVersion, publicKey: postFork });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      // Subscribed BEFORE starting: `stateChanges` does not replay, so a settled state reached while nobody was
+      // listening would be missed and the wait would hang rather than fail.
+      const settled = yield* Effect.fork(
+        wallet.awaitState((state) => state.state.progress.appliedId === 2n).pipe(Effect.orDie),
+      );
+      yield* wallet.start;
+
+      const migration = yield* wallet.awaitMigration;
+
+      // The chain is past the boundary, so the pre-fork variant owns none of it: it read the version off the first
+      // message, applied nothing, and handed over with a cursor that has not moved.
+      expect(migration.from.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
+      expect(migration.from.appliedId).toBe(0n);
+      expect(migration.from.utxos).toEqual([]);
+
+      // Unshielded's hand-over is a structural carry, so a start that applied nothing carries nothing — and this is
+      // where it differs from shielded and dust, which start empty by design and wait for a replay. There is no replay
+      // here: the cursor is still at the beginning, so the post-fork variant simply syncs the chain itself.
+      expect(migration.to.utxos).toEqual([]);
+      expect(migration.to.appliedId).toBe(migration.from.appliedId);
+      expect(migration.to.appliedId).toBe(0n);
+      // Identity crosses, which is what lets the post-fork variant read anything addressed to this wallet at all.
+      expect(migration.to.address).toBe(postFork.address);
+      expect(migration.to.networkId).toBe(networkId);
+
+      const final = yield* Fiber.join(settled);
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+      expect(valuesOf(utxosOf(final.state))).toEqual([100n, 200n]);
+      expect(final.state.progress.appliedId).toBe(2n);
+      expect(final.state.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
+    }).pipe(Effect.scoped, Effect.runPromise));
+});
+
+describe('an unshielded wallet starting on a chain that has not forked', () => {
+  it('syncs on the pre-fork variant and stays there, holding a pre-fork verifying key', async () =>
+    Effect.gen(function* () {
+      const wallet = yield* syncedPreForkWallet;
+
+      const settled = yield* wallet.currentState;
+      expect(valuesOf(utxosOf(settled.state))).toEqual([100n, 200n]);
+      expect(settled.state.protocolVersion).toBeLessThan(forkVersion);
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+      expect(yield* wallet.migration).toStrictEqual(Option.none());
+
+      // The v8 signer world, intact: the identity the application handed over is a `{tag, value}` record, and what the
+      // pre-fork variant holds is the bare hex the ledger version that owns it understands. The address is the same on
+      // both sides, which is the whole reason the narrowing is lossless.
+      expect(settled.state.publicKey.publicKey).toStrictEqual(preFork.publicKey);
+      expect(typeof settled.state.publicKey.publicKey).toBe('string');
+      expect(settled.state.publicKey.address).toBe(postFork.address);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it.each([
+    'balanceFinalizedTransaction',
+    'balanceUnboundTransaction',
+    'balanceUnprovenTransaction',
+    'transferTransaction',
+    'rotateUtxos',
+    'initSwap',
+    'signUnprovenTransaction',
+    'signUnboundTransaction',
+  ])('refuses %s while it is still pre-fork, and says why', async (operation) =>
+    Effect.gen(function* () {
+      const wallet = yield* syncedPreForkWallet;
+
+      const call = gatedCalls(wallet).find(([name]) => name === operation)!;
+      const failure = Option.getOrThrow(yield* failureOf(call[1]()));
+
+      // Typed, and naming the operation: the pre-fork branch cannot hold a transaction of the post-fork ledger
+      // version, let alone produce one anybody can prove, and says so instead of producing one nobody can.
+      expect(failure).toBeInstanceOf(PreForkUnshieldedTransactingUnsupportedError);
+      expect(failure).toMatchObject({ operation });
+    }).pipe(Effect.scoped, Effect.runPromise),
+  );
+
+  it('reverts a transaction it cannot have made, by doing nothing to its state', async () =>
+    Effect.gen(function* () {
+      // Reverting releases UTXOs a transaction booked, and no transaction of this wallet's can have booked any: it
+      // could not have built one. So this resolves, changes nothing, and is deliberately not part of the seam above —
+      // it needs no proving. The facade reverts all three wallets together when a submission fails, and a refusal here
+      // would strand that whole path.
+      const wallet = yield* syncedPreForkWallet;
+
+      yield* Effect.promise(() => wallet.unshielded.revertTransaction(someFinalizedTransaction()));
+
+      const after = yield* wallet.currentState;
+      expect(valuesOf(utxosOf(after.state))).toEqual([100n, 200n]);
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('still reads its address and writes a snapshot naming the version it is on', async () =>
+    Effect.gen(function* () {
+      // Observation and serialization are version-agnostic on both sides of the boundary: an address is a scheme-less
+      // hash and a snapshot is JSON. The declared version is what `restore` later routes on, so a pre-fork wallet must
+      // write the pre-fork version rather than the one its API speaks.
+      const wallet = yield* syncedPreForkWallet;
+
+      const address = yield* Effect.promise(() => wallet.unshielded.getAddress());
+      const snapshot = yield* Effect.promise(() => wallet.unshielded.serializeState());
+
+      expect(address.hexString).toBe(postFork.addressHex);
+      expect(JSON.parse(snapshot).protocolVersion).toBe(String(beforeFork));
+    }).pipe(Effect.scoped, Effect.runPromise));
+});
+
+describe('an unshielded wallet whose identity the pre-fork ledger version cannot hold', () => {
+  it('starts an ecdsa identity on the post-fork variant, and stays there on a chain that has not forked', async () =>
+    Effect.gen(function* () {
+      // The honest consequence of a scheme that did not exist pre-fork. Ledger-v8 keys are bare hex with no room to
+      // name a scheme, and an ecdsa key derives a different address, so narrowing one to the pre-fork shape would
+      // produce a wallet claiming an identity it does not have — and the migration back would relabel it `schnorr`.
+      // Such a wallet therefore starts on the variant its key belongs to and stays there, exactly as a dust wallet
+      // built from a post-fork secret key does.
+      const ecdsa = ecdsaIdentity(networkId);
+      expect(ecdsa.addressHex).not.toBe(postFork.addressHex);
+
+      const wallet = yield* walletOnChainAt(beforeFork, ecdsa);
+
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+      const state = yield* wallet.currentState;
+      expect(state.state.publicKey.publicKey).toStrictEqual(ecdsa.publicKey);
+      // Stamped with the boundary version rather than left at the minimum, so a variant that would otherwise find
+      // itself outside its own activation range does not report that on sight and migrate away from itself.
+      expect(state.state.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
+      expect(yield* wallet.migration).toStrictEqual(Option.none());
+    }).pipe(Effect.scoped, Effect.runPromise));
+});

--- a/packages/unshielded-wallet/src/test/forkTimeline.ts
+++ b/packages/unshielded-wallet/src/test/forkTimeline.ts
@@ -46,6 +46,17 @@ export const preForkIdentity = (networkId: NetworkId.NetworkId = NetworkId.Netwo
 export const postForkIdentity = (networkId: NetworkId.NetworkId = NetworkId.NetworkId.Undeployed): PostForkPublicKey =>
   PostForkPublicKey.fromKeyStore(createPostForkKeystore({ kind: 'schnorr', secret: forkSeed() }, networkId));
 
+/**
+ * The same secret read under the other signature scheme, which only the post-fork ledger version has.
+ *
+ * @remarks
+ *   Ledger-v8 has exactly one scheme, and its keys are bare hex with no room to name one — so an ecdsa identity is not
+ *   merely inconvenient to represent pre-fork, it is unrepresentable. It derives a different address, too, which is why
+ *   nothing about it can be narrowed to the pre-fork shape and back.
+ */
+export const ecdsaIdentity = (networkId: NetworkId.NetworkId = NetworkId.NetworkId.Undeployed): PostForkPublicKey =>
+  PostForkPublicKey.fromKeyStore(createPostForkKeystore({ kind: 'ecdsa', secret: forkSeed() }, networkId));
+
 /** A UTXO as it appears on the wire, in the shape both variants decode it to. */
 export type TimelineUtxo = {
   readonly utxo: {

--- a/packages/unshielded-wallet/src/test/restore.test.ts
+++ b/packages/unshielded-wallet/src/test/restore.test.ts
@@ -1,0 +1,103 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Either, Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { peekProtocolVersion, UnsupportedSnapshotVersionError, variantForSnapshot } from '../Restore.js';
+
+/** A snapshot envelope carrying a declared protocol version, plus the fields the peek must ignore. */
+const envelope = (protocolVersion: string): string =>
+  JSON.stringify({
+    publicKey: { publicKey: { tag: 'schnorr', value: 'aa' }, addressHex: 'bb', address: 'mn_addr1...' },
+    state: { availableUtxos: [], pendingUtxos: [] },
+    protocolVersion,
+    appliedId: '3',
+    networkId: 'undeployed',
+  });
+
+/**
+ * The same envelope as written before snapshots declared a version at all.
+ *
+ * @remarks
+ *   Unshielded snapshots have carried `protocolVersion` for as long as they have existed, so this is a defensive case
+ *   rather than an observed one — but the routing must not depend on that being true of every snapshot an application
+ *   still holds, and the fallback is what keeps it from depending on it.
+ */
+const legacyEnvelope = JSON.stringify({
+  publicKey: { publicKey: 'aa', addressHex: 'bb', address: 'mn_addr1...' },
+  state: { availableUtxos: [], pendingUtxos: [] },
+  networkId: 'undeployed',
+});
+
+const preFork = { name: 'pre-fork variant' };
+const postFork = { name: 'post-fork variant' };
+
+/** Stands in for `BaseWalletClass.variantFor`: pre-fork below 100, post-fork from 100, nothing above 1000. */
+const registered = (version: ProtocolVersion.ProtocolVersion): Option.Option<typeof preFork> =>
+  version >= 1000n ? Option.none() : Option.some(version >= 100n ? postFork : preFork);
+
+const neverResolves = (): Option.Option<typeof preFork> => {
+  throw new Error('A snapshot that declares no version must not be routed by version');
+};
+
+describe('peekProtocolVersion', () => {
+  it('reads the version a snapshot declares, ignoring every other field', () => {
+    expect(peekProtocolVersion(envelope('100'))).toStrictEqual(Option.some(ProtocolVersion.ProtocolVersion(100n)));
+  });
+
+  it('reads a version from an envelope carrying nothing else', () => {
+    expect(peekProtocolVersion(JSON.stringify({ protocolVersion: '7' }))).toStrictEqual(
+      Option.some(ProtocolVersion.ProtocolVersion(7n)),
+    );
+  });
+
+  it('finds nothing in a snapshot written before snapshots declared a version', () => {
+    expect(peekProtocolVersion(legacyEnvelope)).toStrictEqual(Option.none());
+  });
+
+  it('finds nothing, rather than throwing, in something that is not a snapshot envelope at all', () => {
+    expect(peekProtocolVersion('not json at all')).toStrictEqual(Option.none());
+    expect(peekProtocolVersion('[]')).toStrictEqual(Option.none());
+    expect(peekProtocolVersion('"a string"')).toStrictEqual(Option.none());
+    expect(peekProtocolVersion('')).toStrictEqual(Option.none());
+  });
+
+  it('finds nothing when the declared version is not a version', () => {
+    expect(peekProtocolVersion(JSON.stringify({ protocolVersion: 'tomorrow' }))).toStrictEqual(Option.none());
+    expect(peekProtocolVersion(JSON.stringify({ protocolVersion: null }))).toStrictEqual(Option.none());
+  });
+});
+
+describe('variantForSnapshot', () => {
+  it('routes a snapshot to the variant that owns the version it declares', () => {
+    expect(variantForSnapshot(envelope('100'), registered, preFork)).toStrictEqual(Either.right(postFork));
+    expect(variantForSnapshot(envelope('99'), registered, preFork)).toStrictEqual(Either.right(preFork));
+  });
+
+  it('falls back to the head variant for a snapshot that declares no version', () => {
+    expect(variantForSnapshot(legacyEnvelope, neverResolves, preFork)).toStrictEqual(Either.right(preFork));
+  });
+
+  it('falls back to the head variant for an envelope it cannot read, leaving the real error to deserialization', () => {
+    expect(variantForSnapshot('not json at all', neverResolves, preFork)).toStrictEqual(Either.right(preFork));
+  });
+
+  it('reports a version no registered variant owns, naming it', () => {
+    const routed = variantForSnapshot(envelope('4000'), registered, preFork);
+
+    const error = routed.pipe(Either.flip, Either.getOrThrow);
+    expect(error).toBeInstanceOf(UnsupportedSnapshotVersionError);
+    expect(error._tag).toBe('@midnightntwrk/wallet-sdk-unshielded-wallet/Restore/UnsupportedSnapshotVersionError');
+    expect(error.protocolVersion).toBe(ProtocolVersion.ProtocolVersion(4000n));
+  });
+});

--- a/packages/unshielded-wallet/test/testUtils.ts
+++ b/packages/unshielded-wallet/test/testUtils.ts
@@ -21,12 +21,14 @@ import {
 } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Schema } from 'effect';
 import { UnshieldedSectionSchema } from '../src/v2/TransactionHistory.js';
-import { type DefaultV2Configuration } from '../src/v2/index.js';
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type DefaultUnshieldedConfiguration } from '../src/UnshieldedWallet.js';
 
 const UnshieldedEntrySchema = TransactionHistoryStorage.extendEntrySchema({
   unshielded: Schema.optional(UnshieldedSectionSchema),
 });
-import { type UnshieldedWallet, type UnshieldedWalletState } from '../src/UnshieldedWallet.js';
+import { type UnshieldedWalletState } from '../src/UnshieldedWallet.js';
+import { type UnshieldedWallet } from '../src/ForkingUnshieldedWallet.js';
 
 /** TODO: place in separate package with more additional mock functions */
 export const generateMockTransaction = (
@@ -110,19 +112,23 @@ export const getUnshieldedSeed = (seed: string): Uint8Array => {
  *
  * @param indexerPort - The port number for the indexer service
  * @param overrides - Optional partial configuration to override defaults
- * @returns A complete DefaultV2Configuration object
+ * @returns A complete DefaultUnshieldedConfiguration object
  */
 export const createWalletConfig = (
   indexerPort: number,
-  overrides?: Partial<DefaultV2Configuration>,
-): DefaultV2Configuration => {
-  const defaultConfig: DefaultV2Configuration = {
+  overrides?: Partial<DefaultUnshieldedConfiguration>,
+): DefaultUnshieldedConfiguration => {
+  const defaultConfig: DefaultUnshieldedConfiguration = {
     indexerClientConnection: {
       indexerWsUrl: `ws://localhost:${indexerPort}/api/v4/graphql/ws`,
       indexerHttpUrl: `http://localhost:${indexerPort}/api/v4/graphql`,
     },
     networkId: NetworkId.NetworkId.Undeployed,
     txHistoryStorage: new InMemoryTransactionHistoryStorage(UnshieldedEntrySchema),
+    // The ledger-v9-native node line these suites run against reports this protocol version, so the wallet reaches its
+    // post-fork variant. Spelled out rather than imported: it is published as `V9_NATIVE_FORK_VERSION` by the shielded
+    // package, which this one does not depend on.
+    forkVersion: ProtocolVersion.ProtocolVersion(2_000_000n),
   };
 
   return { ...defaultConfig, ...overrides };

--- a/packages/wallet-integration-tests/test/serializationAndRestoration.integration.test.ts
+++ b/packages/wallet-integration-tests/test/serializationAndRestoration.integration.test.ts
@@ -20,7 +20,7 @@ import {
 import { UnshieldedWallet, createKeystore, PublicKey } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import * as ledger from '@midnightntwrk/ledger-v9';
 
-import { type DefaultV2Configuration as UnshieldedV2Configuration } from '@midnightntwrk/wallet-sdk-unshielded-wallet/v2';
+import { type DefaultUnshieldedConfiguration } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnightntwrk/wallet-sdk-utilities/testing';
@@ -50,7 +50,7 @@ const environment = new DockerComposeEnvironment(getComposeDirectory(), 'docker-
 describe('Wallet serialization and restoration', () => {
   let startedEnvironment: StartedDockerComposeEnvironment;
   let shieldedConfiguration: DefaultShieldedConfiguration;
-  let unshieldedConfiguration: UnshieldedV2Configuration;
+  let unshieldedConfiguration: DefaultUnshieldedConfiguration;
   let indexerPort: number;
 
   beforeAll(async () => {
@@ -67,6 +67,9 @@ describe('Wallet serialization and restoration', () => {
     };
 
     unshieldedConfiguration = {
+      // The same boundary the shielded configuration names, for the same reason: this stack runs the
+      // ledger-v9-native node line, so the unshielded wallet reaches its post-fork variant too.
+      forkVersion: V9_NATIVE_FORK_VERSION,
       indexerClientConnection: {
         indexerWsUrl: `ws://localhost:${indexerPort}/api/v4/graphql/ws`,
         indexerHttpUrl: `http://localhost:${indexerPort}/api/v4/graphql`,

--- a/packages/wallet-sdk-testkit/src/wallet.ts
+++ b/packages/wallet-sdk-testkit/src/wallet.ts
@@ -103,6 +103,8 @@ const restoreUnshieldedWallet = async (
           indexerWsUrl: env.endpoints.indexerWsUrl,
         },
         txHistoryStorage,
+        // The same boundary the shielded configuration names, taken from the one place this environment defines it.
+        forkVersion: env.getWalletConfig().forkVersion,
       }).startWithPublicKey(PublicKey.fromKeyStore(keyStore));
       logger.info(`Restored unshielded wallet from ${path}`);
       return wallet;


### PR DESCRIPTION
Seventh increment of the dual-ledger public API redesign — the unshielded flip, completing the set: **all three wallets now register a variant on either side of the fork.** Stacked on #680.

## What's here

- **The flip**: `CustomForkingUnshieldedWallet(configuration, preFork, postFork)`; `UnshieldedWallet(config)` registers v1 since `MinSupportedVersion` and v2 since required `config.forkVersion`, each variant self-configured; `CustomUnshieldedWallet` unchanged. The fork-crossing proof rewired with **zero assertion changes** (wiring only — the proof previously named a pre-built pre-fork *state*; it now drives the production `startWithPublicKey` identity path, which is why the diff is a few lines rather than dust's one).
- **The honest survey result**: unshielded retains no key material at all (sync reads the state's own public address), so `StartMaterial` deliberately does NOT apply — no machinery was forced where nothing derives. What IS version-bound is the start identity: `startWithPublicKey` takes the v9 `{tag, value}` key while v8 keys are bare hex. Resolution, pinned by tests: a **schnorr** key narrows losslessly and starts on v1 (migration re-widens it); an **ecdsa** key starts directly at the post-fork variant via `startAtVariant`, stamped with `forkVersion` — narrowing it would create a v8 wallet claiming an identity it does not have (ecdsa derives a different address), corrupting restore and signing. This is the first production use of the restore-routing `startAtVariant` primitive outside `restore()`.
- **State encapsulation**: the same `capabilities`/`services` public leak dust had (here with zero external readers) is removed; projections are bound per emission in the `variantTag`-narrowed branch. One load-bearing departure from the dust template: the capability requirement is narrowed with `Pick<>` to exactly the projected methods, because the whole `KeysCapability` cannot be satisfied two-variant (`getPublicKey` returns `string` on v1 vs `SignatureVerifyingKey` on v9) — the narrowing keeps the wallet buildable while keeping the unprojectable member out of reach.
- **Temporary pre-fork seam** (`PreForkUnshieldedTransactingUnsupportedError`, same TEMPORARY/MUST-NOT-SURVIVE-GA wording): the eight v9-typed balance/transfer/swap/sign/rotate methods are gated on the v1 branch; `revertTransaction` is deliberately a pre-fork no-op (consistent with shielded and dust — the facade reverts all three wallets together, and the pre-fork variant booked nothing). Sync, state, balances, serialize/restore, and migration work fully on both branches.
- **Start pins** (13 tests, ≥/<-`forkVersion` semantics): v9-native start = boot v1, apply nothing, migrate via **empty structural carry** (`appliedId === 0n` both sides — unshielded carries UTXOs with an unchanged cursor, unlike shielded/dust's fresh-state replay), v2 syncs the whole chain; pre-fork start = stays v1 in the bare-hex v8 signer world with the shared address. Plus 9 restore-routing tests mirroring shielded's.
- **Eager decode confirmed absent** (the #679 survey held: no ledger import in either twin's wire schemas) — checked, not inherited.

## Sweep

Facade churn: **zero** (diff-verified empty against facade/apps/docs-snippets — the `DefaultConfiguration` intersection collapsed onto the `forkVersion` field shielded and dust already require). Touched: testkit's `restoreUnshieldedWallet`, five e2e fixtures (all reading `forkVersion` from their environment's one definition), the wallet-integration-tests config, unshielded's own test utils and README. One barrel collision resolved: unshielded's restore module exports as `UnshieldedRestore` (dust already claimed the unqualified names in the umbrella).

## Tests & gate

22 new tests + the rewired proof; one disclosed post-red edit (a snapshot-peek assertion re-routed through the `peekProtocolVersion` production function — equivalent-or-tighter, lint-driven). Gate: dist 17/17, typecheck 37/37, lint 58/58, unit 53/53 tasks (unshielded **211 tests / 22 files**), shielded fork-simulation integration passing (cache + direct vitest run), effect-language-service 0 findings on all 17 changed files, format + changesets green. Changesets: unshielded-wallet major, testkit patch-level touch.