### PR TITLE
feat(abstractions,wallet-sdk): the transaction handle and the named ledger subpaths

### DIFF
--- a/.changeset/wallet-sdk-ledger-subpaths.md
+++ b/.changeset/wallet-sdk-ledger-subpaths.md
@@ -1,0 +1,23 @@
+---
+'@midnightntwrk/wallet-sdk': minor
+---
+
+**Both ledger versions now ship from the umbrella package, at `./ledger/v8` and `./ledger/v9`.** An application that
+authors its own transactions has always had to import a ledger package directly — depending on something this package
+does not promise, and pinning a version by hand in its own `package.json`. Now it imports the one package it already
+depends on, and the import line says which ledger version's rules the bytes follow.
+
+The subpaths are named for the **ledger** version rather than a variant ordinal, because that is what an author is
+choosing. Seal what you build with `WalletTransaction.adopt('Unproven', tx, version)` to hand it back to the wallet.
+
+**Neither is re-exported from the root barrel.** These are WebAssembly modules, and an application that only carries
+transactions should not pay for a ledger it never names; having to ask for one by name is what keeps that true.
+
+**Which one to import is a property of the chain, not of this release.** Both are shipped side by side because both are
+real: a chain is pre-fork until it forks, and mainnet is pre-fork until then. An authoring path that only ever imports
+`./ledger/v9` compiles cleanly and **fails at run time on every chain that has not yet crossed**, with a
+`ProtocolVersionMismatchError` — the wallet refuses a transaction built for a version it is not acting at. Read the
+protocol version from the wallet's state and author against the version the chain is on. The check is a run-time one by
+design: the compiler cannot know which chain an application will be pointed at.
+
+The package also gains a test runner, which is how the above is pinned rather than asserted.

--- a/.changeset/wallet-transaction-handle.md
+++ b/.changeset/wallet-transaction-handle.md
@@ -1,0 +1,33 @@
+---
+'@midnightntwrk/wallet-sdk-abstractions': minor
+---
+
+**A transaction an application carries no longer has to name a ledger version.** `WalletTransaction` is an opaque
+handle: it seals a transaction of whichever ledger version built it, and carries the protocol version that version
+serves as ordinary readable data.
+
+Additive — nothing existing changes shape. What it makes possible is the thing an SDK spanning a protocol boundary
+otherwise cannot offer: one type an application can hold across the fork. A transaction built before the boundary and
+one built after it are objects of two different runtimes with no conversion between them, so any signature naming
+either one names a ledger version, and breaks when the chain moves on.
+
+- **The carried transaction is unreachable.** It lives behind a `#private` field, so an application cannot come to
+  depend on which version produced it — which is the whole point, and why this is a class rather than a record. What is
+  readable is `protocolVersion`, `stage` and `serialize()`.
+- **The stage is a type parameter**, spelled `UnprovenTx`, `UnboundTx` and `FinalizedTx`, so a signature that needs a
+  finalized transaction still says so and a caller holding an unproven one still finds out at compile time. `AnyTx`
+  covers the operations — reverting, say — that take a transaction at whatever stage it reached.
+- **`WalletTransaction.adopt(stage, tx, version)`** seals a transaction an application built for itself, with the
+  ledger version it imported directly. The version passed is a claim, and the SDK holds the caller to it.
+- **`WalletTransaction.unwrapWithin(handle, range)`** is where that claim is enforced: a caller states the range of
+  protocol versions it can act at and is refused, with a typed `ProtocolVersionMismatchError`, when the stamp falls
+  outside it. Having the check in one place is why no caller has to invent it, and why "pre-fork bytes cannot be used
+  post-fork" is a fact about the type rather than a convention.
+- **`toWire`/`fromWire`** move a handle between processes as a JSON envelope carrying its own format version, the
+  protocol version, the stage and the bytes. Deliberately minimal: the dApp-connector contract is still open, and an
+  envelope that guessed at it would be harder to reconcile than one carrying the minimum. `fromWire` takes the decoder,
+  because choosing a ledger version is the caller's to make and hardcoding one here would be the very thing the handle
+  removes.
+
+Nothing routes through the handle yet — the wallets and the facade still name ledger types in their own signatures.
+This is the type they will be stated in terms of.

--- a/packages/abstractions/src/WalletTransaction.ts
+++ b/packages/abstractions/src/WalletTransaction.ts
@@ -1,0 +1,337 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The one transaction type an application carries, whichever ledger version produced it.
+ *
+ * @remarks
+ *   An SDK that runs one ledger version before a protocol boundary and another from it has a problem its callers should
+ *   never have to solve: a transaction built before the boundary and a transaction built after it are objects of two
+ *   different runtimes, with two different types, and no conversion between them. Naming either type in a public
+ *   signature is naming a ledger version, which is the thing that breaks when the chain moves on.
+ *
+ *   So the wallet layer hands out a handle instead. It seals the transaction away — an application cannot reach it, and
+ *   so cannot come to depend on which version made it — and carries the protocol version it was built at as ordinary
+ *   readable data. That stamp is what the SDK routes on: which prover proves it, which trait recognises it, which
+ *   variant may unwrap it at all.
+ */
+import * as Data from 'effect/Data';
+import * as Either from 'effect/Either';
+import * as Option from 'effect/Option';
+import * as ParseResult from 'effect/ParseResult';
+import * as Schema from 'effect/Schema';
+import * as ProtocolVersion from './ProtocolVersion.js';
+import * as SerializedTransaction from './SerializedTransaction.js';
+
+/**
+ * How far along the building of a transaction a handle is.
+ *
+ * @remarks
+ *   The three points at which a transaction changes hands between an application and the SDK: built but not proved,
+ *   proved but not yet bound to its own contents, and finalized — proved, signed and bound, which is the only shape the
+ *   network takes. Both ledger versions have all three, and the words mean the same thing on either side of a protocol
+ *   boundary, which is why the stage can be plain data on a version-agnostic handle.
+ */
+export type TransactionStage = 'Unproven' | 'Unbound' | 'Finalized';
+
+/** What a handle can carry: anything that can write itself out as bytes, which is every ledger's transaction. */
+type Serializable = Readonly<{ serialize: () => Uint8Array }>;
+
+/**
+ * Raised when a transaction is used at a protocol version other than the one it was built for.
+ *
+ * @remarks
+ *   The bytes of a transaction are fixed when it is built, by the ledger version that built them. A protocol boundary
+ *   does not rewrite them, so a transaction authored on one side of the boundary cannot be understood on the other —
+ *   not merged, not proved, not submitted. This is what the SDK answers with rather than handing a transaction to a
+ *   ledger version that would misread it.
+ */
+export class ProtocolVersionMismatchError extends Data.TaggedError(
+  '@midnightntwrk/wallet-sdk-abstractions/WalletTransaction/ProtocolVersionMismatchError',
+)<{
+  readonly message: string;
+  /** The protocol version the transaction was built at. */
+  readonly authoredFor: ProtocolVersion.ProtocolVersion;
+  /** The range of protocol versions the caller can act at. */
+  readonly accepted: ProtocolVersion.ProtocolVersion.Range;
+  /** How far along the building of the transaction the handle is, for the diagnostic. */
+  readonly stage: TransactionStage;
+}> {}
+
+/** Raised when a wire envelope cannot be read as a transaction of a version this SDK knows. */
+export class WireFormatError extends Data.TaggedError(
+  '@midnightntwrk/wallet-sdk-abstractions/WalletTransaction/WireFormatError',
+)<{
+  readonly message: string;
+  /** What went wrong underneath: a parse failure, or whatever the caller's decoder raised. */
+  readonly cause?: unknown;
+}> {}
+
+/**
+ * The envelope's own format version.
+ *
+ * @remarks
+ *   Deliberately separate from the protocol version it carries. A reader has to be able to tell "I do not know this
+ *   envelope" from "I do not know this ledger version", because only the second is a chain fact.
+ */
+const WIRE_FORMAT = 1;
+
+const TransactionStageSchema: Schema.Schema<TransactionStage> = Schema.Literal('Unproven', 'Unbound', 'Finalized');
+
+/**
+ * The envelope a handle crosses a process boundary in.
+ *
+ * @remarks
+ *   Everything in it is JSON-safe, because the boundary it was designed for — a dApp connector — is a JSON one: the
+ *   protocol version is a decimal string rather than a `bigint`, and the transaction is hex rather than bytes. What
+ *   travels is exactly what a reader needs to decide whether it can read the rest at all: the envelope format, the
+ *   protocol version the transaction was built at, the stage it reached, and the transaction's own serialization.
+ *
+ *   Kept deliberately small. The connector contract is an open question at the time of writing, and an envelope that
+ *   guesses at it would be harder to reconcile than one that carries the minimum.
+ */
+const WireTransactionSchema = Schema.Struct({
+  wireFormat: Schema.Literal(WIRE_FORMAT),
+  protocolVersion: ProtocolVersion.ProtocolVersionSchema,
+  stage: TransactionStageSchema,
+  transaction: Schema.Uint8ArrayFromHex,
+});
+
+/** The wire envelope as it travels: a plain JSON-safe record. See {@link WalletTransaction.toWire}. */
+export type WireTransaction = Schema.Schema.Encoded<typeof WireTransactionSchema>;
+
+const encodeWire = Schema.encodeSync(WireTransactionSchema);
+const decodeWire = Schema.decodeUnknownEither(WireTransactionSchema);
+
+/**
+ * A transaction the SDK produced or adopted, sealed together with the protocol version it was built at.
+ *
+ * @remarks
+ *   A class rather than a record, and the one place in this package where that earns its keep: a `#private` field is the
+ *   only way to carry something an application provably cannot reach, and reaching the wrapped transaction is exactly
+ *   what would re-introduce the ledger-version dependency the handle exists to remove. Nothing about it mutates — the
+ *   fields are read-only and every operation returns a new value.
+ *
+ *   The stage is a type parameter as well as a field, so a signature can ask for the shape it needs
+ *   (`WalletTransaction<'Finalized'>`, spelled {@link FinalizedTx}) and a caller who has an unproven transaction finds
+ *   out at compile time. It is covariant: a `FinalizedTx` is an {@link AnyTx}, which is what the operations that accept
+ *   a transaction at any stage — reverting one, say — are stated in terms of.
+ * @example
+ *   Sealing a transaction an application built for itself, and handing it back to the wallet:
+ *
+ *   ```typescript
+ *   import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
+ *
+ *   const intent = ledger.Intent.new(ttl);
+ *   const handle = WalletTransaction.adopt('Unproven', ledger.Transaction.fromParts(networkId, undefined, undefined, intent), version);
+ *   ```;
+ *
+ * @typeParam TStage How far along the building of this transaction the handle is.
+ */
+export class WalletTransaction<out TStage extends TransactionStage = TransactionStage> {
+  /** The protocol version this transaction was built at, and so the only one it can be used at. */
+  readonly protocolVersion: ProtocolVersion.ProtocolVersion;
+
+  /** How far along the building of this transaction the handle is. */
+  readonly stage: TStage;
+
+  /** The transaction itself, reachable only from inside this class. */
+  readonly #carried: Serializable;
+
+  private constructor(protocolVersion: ProtocolVersion.ProtocolVersion, stage: TStage, carried: Serializable) {
+    this.protocolVersion = protocolVersion;
+    this.stage = stage;
+    this.#carried = carried;
+  }
+
+  /**
+   * Seals a transaction built elsewhere into a handle.
+   *
+   * @remarks
+   *   How an application that builds its own transactions — with the ledger version it imported from
+   *   `@midnightntwrk/wallet-sdk/ledger/v8` or `/v9` — hands one to the wallet. The version passed here is a claim
+   *   about which ledger version produced the transaction, and the SDK holds the caller to it: a handle stamped for one
+   *   side of a protocol boundary is refused by a wallet acting on the other side, with a
+   *   {@link ProtocolVersionMismatchError}. Until the fork, that means a transaction built with the post-fork ledger
+   *   version is refused at run time, however well it type-checks.
+   * @param stage How far along the building of the transaction is.
+   * @param transaction The transaction, of whichever ledger version built it.
+   * @param protocolVersion The protocol version that ledger version serves.
+   * @returns The sealed handle.
+   */
+  static adopt<TStage extends TransactionStage>(
+    stage: TStage,
+    transaction: Serializable,
+    protocolVersion: ProtocolVersion.ProtocolVersion,
+  ): WalletTransaction<TStage> {
+    return new WalletTransaction(protocolVersion, stage, transaction);
+  }
+
+  /**
+   * Reads the transaction a handle carries, if it was built for a protocol version the caller can act at.
+   *
+   * @remarks
+   *   The SDK's own way in, and the enforcement point for everything an application hands back: a caller states the range
+   *   of protocol versions it speaks — a variant's activation range, or the era the chain is currently in — and gets
+   *   the transaction only when the stamp falls inside it. The result type is the caller's to name, because the handle
+   *   deliberately does not remember it; the range is the whole of the guarantee, which is why it is checked here
+   *   rather than trusted anywhere else.
+   * @param handle The handle to read.
+   * @param accepted The range of protocol versions the caller can act at.
+   * @returns The carried transaction, or a {@link ProtocolVersionMismatchError} naming what was carried and what was
+   *   asked for.
+   */
+  static unwrapWithin<T>(
+    handle: WalletTransaction,
+    accepted: ProtocolVersion.ProtocolVersion.Range,
+  ): Either.Either<T, ProtocolVersionMismatchError> {
+    if (!ProtocolVersion.withinRange(handle.protocolVersion, accepted)) {
+      const [from, to] = accepted;
+      return Either.left(
+        new ProtocolVersionMismatchError({
+          message:
+            `This transaction was built for protocol version ${handle.protocolVersion}, and can only be used at ` +
+            `that version: its bytes were fixed by the ledger version that produced them. The caller acts at ` +
+            `protocol versions ${from} up to (but not including) ${to}. Build the transaction again on the side of ` +
+            `the protocol boundary it is to be used on.`,
+          authoredFor: handle.protocolVersion,
+          accepted,
+          stage: handle.stage,
+        }),
+      );
+    }
+    // The carried type is erased when a transaction is sealed, and deliberately: remembering it would put a ledger
+    // version back into the handle's own type. The version check above is the whole of what can be guaranteed here,
+    // and it is the same guarantee the caller would have had to make for itself.
+    return Either.right(handle.#carried as T);
+  }
+
+  /**
+   * Narrows a handle to a stage, for a caller that has one of unknown stage.
+   *
+   * @param handle The handle to narrow.
+   * @param stage The stage to narrow it to.
+   * @returns The same handle, typed at that stage, or nothing when it is at another.
+   */
+  static atStage<TStage extends TransactionStage>(
+    handle: WalletTransaction,
+    stage: TStage,
+  ): Option.Option<WalletTransaction<TStage>> {
+    return handle.stage === stage
+      ? // Narrowed by the value that the type parameter names; `stage` is the only thing distinguishing the two types.
+        Option.some(handle as WalletTransaction<TStage>)
+      : Option.none();
+  }
+
+  /**
+   * Determines whether a value is a handle this SDK produced.
+   *
+   * @remarks
+   *   Answers on the sealed transaction itself, so a record that merely has the same readable fields is not mistaken for
+   *   one.
+   * @param value The value to test.
+   * @returns `true` when `value` is a {@link WalletTransaction}.
+   */
+  static is(value: unknown): value is WalletTransaction {
+    return typeof value === 'object' && value !== null && #carried in value;
+  }
+
+  /**
+   * Writes a handle out as an envelope that can cross a process boundary.
+   *
+   * @param handle The handle to write out.
+   * @returns The envelope. See {@link WireTransaction}.
+   */
+  static toWire(handle: WalletTransaction): WireTransaction {
+    return encodeWire({
+      wireFormat: WIRE_FORMAT,
+      protocolVersion: handle.protocolVersion,
+      stage: handle.stage,
+      transaction: handle.serialize(),
+    });
+  }
+
+  /**
+   * Reads an envelope back into a handle, decoding its bytes with whichever ledger version the envelope names.
+   *
+   * @remarks
+   *   The decoder is the caller's because the choice of ledger version is: this package has none, and picking one here
+   *   would be the hardcoded version the handle exists to avoid. It is handed the version and stage the envelope
+   *   declares so it can route on them, and it may raise — a deserializer meeting bytes of another ledger version does
+   *   — which is reported as a {@link WireFormatError} rather than escaping.
+   * @param value The envelope, as received.
+   * @param decode Produces the transaction from the envelope's bytes, at the version and stage it names.
+   * @returns The handle, or a {@link WireFormatError} describing what could not be read.
+   */
+  static fromWire(
+    value: unknown,
+    decode: (
+      bytes: Uint8Array,
+      protocolVersion: ProtocolVersion.ProtocolVersion,
+      stage: TransactionStage,
+    ) => Serializable,
+  ): Either.Either<WalletTransaction, WireFormatError> {
+    return decodeWire(value).pipe(
+      Either.mapLeft(
+        (error) =>
+          new WireFormatError({
+            message: `This is not a transaction envelope this SDK can read: ${ParseResult.TreeFormatter.formatErrorSync(error)}`,
+            cause: error,
+          }),
+      ),
+      Either.flatMap((envelope) =>
+        Either.try({
+          try: () => decode(envelope.transaction, envelope.protocolVersion, envelope.stage),
+          catch: (cause) =>
+            new WireFormatError({
+              message:
+                `The envelope declares protocol version ${envelope.protocolVersion}, but its bytes could not be ` +
+                `read as a ${envelope.stage.toLowerCase()} transaction of that version.`,
+              cause,
+            }),
+        }).pipe(
+          Either.map((transaction) => WalletTransaction.adopt(envelope.stage, transaction, envelope.protocolVersion)),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * Writes the carried transaction out as bytes.
+   *
+   * @remarks
+   *   The one thing every ledger version's transaction can do identically, and so the one thing a handle can offer
+   *   without knowing which produced it. What the bytes mean still depends on {@link protocolVersion}.
+   * @returns The transaction's own serialization.
+   */
+  serialize(): SerializedTransaction.SerializedTransaction {
+    return SerializedTransaction.from(this.#carried);
+  }
+}
+
+export declare namespace WalletTransaction {
+  /** How far along the building of a transaction a handle is. See {@link TransactionStage}. */
+  type Stage = TransactionStage;
+}
+
+/** A transaction that has been built but not proved. */
+export type UnprovenTx = WalletTransaction<'Unproven'>;
+
+/** A transaction that has been proved but not yet bound to its own contents. */
+export type UnboundTx = WalletTransaction<'Unbound'>;
+
+/** A transaction that is proved, signed and bound: the only shape the network takes. */
+export type FinalizedTx = WalletTransaction<'Finalized'>;
+
+/** A transaction at whichever stage it happens to have reached. */
+export type AnyTx = WalletTransaction<TransactionStage>;

--- a/packages/abstractions/src/index.ts
+++ b/packages/abstractions/src/index.ts
@@ -17,6 +17,7 @@ export * as ProtocolState from './ProtocolState.js';
 export * as ProtocolVersion from './ProtocolVersion.js';
 export * as NetworkId from './NetworkId.js';
 export * as SyncProgress from './SyncProgress.js';
+export * from './WalletTransaction.js';
 export * from './InMemoryTransactionHistoryStorage.js';
 export * from './NoOpTransactionHistoryStorage.js';
 export * as TransactionHistoryStorage from './TransactionHistoryStorage.js';

--- a/packages/abstractions/src/test/walletTransaction.test.ts
+++ b/packages/abstractions/src/test/walletTransaction.test.ts
@@ -1,0 +1,220 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { Either, Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import * as ProtocolVersion from '../ProtocolVersion.js';
+import { ProtocolVersionMismatchError, WalletTransaction, WireFormatError } from '../WalletTransaction.js';
+
+const version = (value: bigint): ProtocolVersion.ProtocolVersion => ProtocolVersion.ProtocolVersion(value);
+
+const range = (start: bigint, end: bigint): ProtocolVersion.ProtocolVersion.Range =>
+  ProtocolVersion.makeRange(version(start), version(end));
+
+/** Where the two ledger versions hand over, in the numbers a v9-native chain actually reports. */
+const preFork = version(1_000_000n);
+const postFork = version(2_000_000n);
+const preForkEra = range(0n, 2_000_000n);
+const postForkEra = range(2_000_000n, 3_000_000n);
+
+/**
+ * A stand-in for what either ledger version's transaction objects have in common: they serialize themselves, and
+ * nothing about their type tells the wallet layer which version produced them.
+ */
+type LedgerLikeTransaction = Readonly<{ kind: string; serialize: () => Uint8Array }>;
+
+const ledgerLikeTransaction = (kind: string, bytes: readonly number[]): LedgerLikeTransaction => ({
+  kind,
+  serialize: () => Uint8Array.from(bytes),
+});
+
+const someBytes = [0xde, 0xad, 0xbe, 0xef] as const;
+const someTransaction = (): LedgerLikeTransaction => ledgerLikeTransaction('v9-finalized', someBytes);
+
+describe('WalletTransaction', () => {
+  describe('adopt', () => {
+    it('seals a transaction with the stage and the protocol version it was built at', () => {
+      const handle = WalletTransaction.adopt('Finalized', someTransaction(), postFork);
+
+      expect(handle.stage).toBe('Finalized');
+      expect(handle.protocolVersion).toBe(postFork);
+    });
+
+    it('does not expose the transaction it carries', () => {
+      const transaction = someTransaction();
+      const handle = WalletTransaction.adopt('Finalized', transaction, postFork);
+
+      expect(Object.keys(handle)).toStrictEqual(['protocolVersion', 'stage']);
+      expect(Object.values(handle)).not.toContain(transaction);
+      // @ts-expect-error the carried transaction is unreachable through the handle, which is the point of it
+      expect(handle.transaction).toBeUndefined();
+    });
+
+    it('serializes as the transaction it carries does', () => {
+      const handle = WalletTransaction.adopt('Unproven', someTransaction(), preFork);
+
+      expect(handle.serialize()).toStrictEqual(Uint8Array.from(someBytes));
+    });
+  });
+
+  describe('unwrapWithin', () => {
+    it('hands the transaction over when the stamp lies in the range the caller acts at', () => {
+      const transaction = someTransaction();
+      const handle = WalletTransaction.adopt('Finalized', transaction, postFork);
+
+      expect(WalletTransaction.unwrapWithin<LedgerLikeTransaction>(handle, postForkEra)).toStrictEqual(
+        Either.right(transaction),
+      );
+    });
+
+    it('refuses a pre-fork transaction handed to a post-fork caller, naming both', () => {
+      const handle = WalletTransaction.adopt('Finalized', someTransaction(), preFork);
+
+      const error = WalletTransaction.unwrapWithin(handle, postForkEra).pipe(Either.flip, Either.getOrThrow);
+
+      expect(error).toBeInstanceOf(ProtocolVersionMismatchError);
+      expect(error._tag).toBe('@midnightntwrk/wallet-sdk-abstractions/WalletTransaction/ProtocolVersionMismatchError');
+      expect(error.authoredFor).toBe(preFork);
+      expect(error.accepted).toStrictEqual(postForkEra);
+      expect(error.stage).toBe('Finalized');
+    });
+
+    it('refuses a post-fork transaction handed to a pre-fork caller, naming both', () => {
+      const handle = WalletTransaction.adopt('Unproven', someTransaction(), postFork);
+
+      const error = WalletTransaction.unwrapWithin(handle, preForkEra).pipe(Either.flip, Either.getOrThrow);
+
+      expect(error.authoredFor).toBe(postFork);
+      expect(error.accepted).toStrictEqual(preForkEra);
+      expect(error.stage).toBe('Unproven');
+    });
+  });
+
+  describe('atStage', () => {
+    it('narrows a handle to the stage it is at', () => {
+      const handle = WalletTransaction.adopt('Unbound', someTransaction(), postFork);
+
+      expect(WalletTransaction.atStage(handle, 'Unbound')).toStrictEqual(Option.some(handle));
+    });
+
+    it('answers nothing for a stage the handle is not at', () => {
+      const handle = WalletTransaction.adopt('Unbound', someTransaction(), postFork);
+
+      expect(WalletTransaction.atStage(handle, 'Finalized')).toStrictEqual(Option.none());
+    });
+  });
+
+  describe('is', () => {
+    it('recognises a handle', () => {
+      expect(WalletTransaction.is(WalletTransaction.adopt('Finalized', someTransaction(), postFork))).toBe(true);
+    });
+
+    it('rejects an object that merely looks like one', () => {
+      const lookalike = { protocolVersion: postFork, stage: 'Finalized', serialize: () => Uint8Array.from(someBytes) };
+
+      expect(WalletTransaction.is(lookalike)).toBe(false);
+    });
+
+    it('rejects values that are not objects at all', () => {
+      expect(WalletTransaction.is(undefined)).toBe(false);
+      expect(WalletTransaction.is('Finalized')).toBe(false);
+    });
+  });
+
+  describe('toWire', () => {
+    it('writes an envelope naming its own format, the protocol version, the stage and the bytes', () => {
+      const handle = WalletTransaction.adopt('Finalized', someTransaction(), postFork);
+
+      expect(WalletTransaction.toWire(handle)).toStrictEqual({
+        wireFormat: 1,
+        protocolVersion: '2000000',
+        stage: 'Finalized',
+        transaction: 'deadbeef',
+      });
+    });
+  });
+
+  describe('fromWire', () => {
+    /** A decoder that reports back, in the transaction it produces, exactly what the envelope handed it. */
+    const decodeEchoing = (
+      bytes: Uint8Array,
+      protocolVersion: ProtocolVersion.ProtocolVersion,
+      stage: WalletTransaction.Stage,
+    ): LedgerLikeTransaction => ledgerLikeTransaction(`${stage}@${protocolVersion}`, Array.from(bytes));
+
+    it('reads the envelope back into a handle, decoding at the version the envelope names', () => {
+      const wire = WalletTransaction.toWire(WalletTransaction.adopt('Finalized', someTransaction(), postFork));
+
+      const handle = WalletTransaction.fromWire(wire, decodeEchoing).pipe(Either.getOrThrow);
+
+      expect(handle.protocolVersion).toBe(postFork);
+      expect(handle.stage).toBe('Finalized');
+      expect(WalletTransaction.unwrapWithin<LedgerLikeTransaction>(handle, postForkEra)).toStrictEqual(
+        Either.right(ledgerLikeTransaction('Finalized@2000000', someBytes)),
+      );
+    });
+
+    it('round-trips the bytes the handle carried', () => {
+      const wire = WalletTransaction.toWire(WalletTransaction.adopt('Unproven', someTransaction(), preFork));
+
+      const handle = WalletTransaction.fromWire(wire, decodeEchoing).pipe(Either.getOrThrow);
+
+      expect(handle.serialize()).toStrictEqual(Uint8Array.from(someBytes));
+    });
+
+    it('refuses an envelope of a wire format it does not know', () => {
+      const wire = { ...WalletTransaction.toWire(WalletTransaction.adopt('Unproven', someTransaction(), preFork)) };
+
+      const error = WalletTransaction.fromWire({ ...wire, wireFormat: 2 }, decodeEchoing).pipe(
+        Either.flip,
+        Either.getOrThrow,
+      );
+
+      expect(error).toBeInstanceOf(WireFormatError);
+      expect(error._tag).toBe('@midnightntwrk/wallet-sdk-abstractions/WalletTransaction/WireFormatError');
+    });
+
+    it('refuses an envelope that is missing a field', () => {
+      const error = WalletTransaction.fromWire(
+        { wireFormat: 1, protocolVersion: '2000000', stage: 'Finalized' },
+        decodeEchoing,
+      ).pipe(Either.flip, Either.getOrThrow);
+
+      expect(error).toBeInstanceOf(WireFormatError);
+    });
+
+    it('refuses an envelope naming a stage that is not one', () => {
+      const error = WalletTransaction.fromWire(
+        { wireFormat: 1, protocolVersion: '2000000', stage: 'Proven', transaction: 'deadbeef' },
+        decodeEchoing,
+      ).pipe(Either.flip, Either.getOrThrow);
+
+      expect(error).toBeInstanceOf(WireFormatError);
+    });
+
+    it('refuses anything that is not an envelope at all', () => {
+      expect(Either.isLeft(WalletTransaction.fromWire('deadbeef', decodeEchoing))).toBe(true);
+    });
+
+    it('carries out a decoder that throws as a wire failure rather than letting it escape', () => {
+      const wire = WalletTransaction.toWire(WalletTransaction.adopt('Finalized', someTransaction(), postFork));
+      const cause = new Error('these bytes are not of this ledger version');
+
+      const error = WalletTransaction.fromWire(wire, () => {
+        throw cause;
+      }).pipe(Either.flip, Either.getOrThrow);
+
+      expect(error).toBeInstanceOf(WireFormatError);
+      expect(error.cause).toBe(cause);
+    });
+  });
+});

--- a/packages/abstractions/src/test/walletTransaction.test.ts
+++ b/packages/abstractions/src/test/walletTransaction.test.ts
@@ -158,9 +158,11 @@ describe('WalletTransaction', () => {
 
       expect(handle.protocolVersion).toBe(postFork);
       expect(handle.stage).toBe('Finalized');
-      expect(WalletTransaction.unwrapWithin<LedgerLikeTransaction>(handle, postForkEra)).toStrictEqual(
-        Either.right(ledgerLikeTransaction('Finalized@2000000', someBytes)),
+      const decoded = WalletTransaction.unwrapWithin<LedgerLikeTransaction>(handle, postForkEra).pipe(
+        Either.getOrThrow,
       );
+      expect(decoded.kind).toBe('Finalized@2000000');
+      expect(decoded.serialize()).toStrictEqual(Uint8Array.from(someBytes));
     });
 
     it('round-trips the bytes the handle carried', () => {

--- a/packages/wallet-sdk/README.md
+++ b/packages/wallet-sdk/README.md
@@ -32,6 +32,8 @@ re-exports the core wallet types, while dedicated sub-path exports give access t
 | `@midnightntwrk/wallet-sdk/hd`                               | `@midnightntwrk/wallet-sdk-hd`                                                                                                                                                                                                                    |
 | `@midnightntwrk/wallet-sdk/indexer-client`                   | `@midnightntwrk/wallet-sdk-indexer-client`                                                                                                                                                                                                        |
 | `@midnightntwrk/wallet-sdk/indexer-client/effect`            | `@midnightntwrk/wallet-sdk-indexer-client/effect`                                                                                                                                                                                                 |
+| `@midnightntwrk/wallet-sdk/ledger/v8`                        | `@midnight-ntwrk/ledger-v8` (pre-fork ledger version, for authors — see [Authoring transactions](#authoring-transactions))                                                                                                                        |
+| `@midnightntwrk/wallet-sdk/ledger/v9`                        | `@midnightntwrk/ledger-v9` (post-fork ledger version, for authors — see [Authoring transactions](#authoring-transactions))                                                                                                                        |
 | `@midnightntwrk/wallet-sdk/node-client`                      | `@midnightntwrk/wallet-sdk-node-client`                                                                                                                                                                                                           |
 | `@midnightntwrk/wallet-sdk/node-client/effect`               | `@midnightntwrk/wallet-sdk-node-client/effect`                                                                                                                                                                                                    |
 | `@midnightntwrk/wallet-sdk/node-client/testing`              | `@midnightntwrk/wallet-sdk-node-client/testing`                                                                                                                                                                                                   |
@@ -148,6 +150,34 @@ const registrationRecipe = await facade.registerNightUtxosForDustGeneration(
 // Estimate registration costs
 const { fee, dustGenerationEstimations } = await facade.estimateRegistration(nightUtxos);
 ```
+
+### Authoring transactions
+
+Most applications never build a transaction themselves: they ask the wallet for a transfer or a swap and carry what
+comes back. An application that _does_ build one — reaching for `Intent.new` or `Transaction.fromParts` — has to choose
+which ledger version's rules the bytes follow, and both are shipped here so that choice is made in the import line
+rather than by reaching past this package for a ledger of your own:
+
+```typescript
+import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
+import { WalletTransaction } from '@midnightntwrk/wallet-sdk';
+
+const authored = ledger.Transaction.fromParts(networkId, undefined, undefined, intent);
+const handle = WalletTransaction.adopt('Unproven', authored, state.activeProtocolVersion);
+```
+
+`adopt` seals what you built into the same handle the wallet's own methods return, stamped with the protocol version you
+claim it was built for. The SDK holds you to that claim: a transaction stamped for one side of the protocol boundary is
+refused by a wallet acting on the other, with a typed `ProtocolVersionMismatchError`.
+
+**Which subpath to import is a property of the chain, not of this release.** A chain is pre-fork until it forks, and
+mainnet is pre-fork until then — so an authoring path that only ever imports `./ledger/v9` compiles cleanly and **fails
+at run time on every chain that has not yet crossed**. Read `state.activeProtocolVersion` and author against the version
+the chain is actually on; the check is a run-time one by design, because the compiler cannot know which chain the
+application will be pointed at.
+
+Neither subpath is re-exported from the package root. They are WebAssembly modules, and an application that only carries
+transactions should not pay for a ledger it never names.
 
 ## Types
 

--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -163,6 +163,8 @@
     }
   },
   "dependencies": {
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
+    "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
     "@midnightntwrk/wallet-sdk-abstractions": "3.0.0-beta.0",
     "@midnightntwrk/wallet-sdk-address-format": "4.0.0-beta.2",
     "@midnightntwrk/wallet-sdk-capabilities": "4.0.0-beta.2",
@@ -179,6 +181,9 @@
   },
   "scripts": {
     "typecheck": "tsc -b ./tsconfig.json --noEmit --force",
+    "test": "vitest run",
+    "test:unit": "vitest run --project unit --passWithNoTests",
+    "test:integration": "vitest run --project integration --passWithNoTests",
     "lint": "eslint --max-warnings 0",
     "format": "prettier --write \"**/*.{ts,js,json,yaml,yml,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,yaml,yml,md}\"",

--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -77,6 +77,14 @@
       "types": "./dist/hd.d.ts",
       "import": "./dist/hd.js"
     },
+    "./ledger/v8": {
+      "types": "./dist/ledger/v8.d.ts",
+      "import": "./dist/ledger/v8.js"
+    },
+    "./ledger/v9": {
+      "types": "./dist/ledger/v9.d.ts",
+      "import": "./dist/ledger/v9.js"
+    },
     "./indexer-client": {
       "types": "./dist/indexer-client/index.d.ts",
       "import": "./dist/indexer-client/index.js"

--- a/packages/wallet-sdk/src/ledger/v8.ts
+++ b/packages/wallet-sdk/src/ledger/v8.ts
@@ -1,0 +1,38 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The pre-fork ledger version, for an application that builds its own transactions.
+ *
+ * @remarks
+ *   The version every chain is on until it crosses the protocol boundary — mainnet included, until the fork happens. An
+ *   application authoring transactions for a chain that has not yet forked imports this one, and seals what it built
+ *   with `WalletTransaction.adopt('Unproven', tx, version)` at a version below the fork.
+ *
+ *   Named for the ledger version rather than for a variant ordinal, so the import line says which rules the bytes follow.
+ *   See {@link ../ledger/v9} for the post-fork version and for what authoring costs an application in general; the
+ *   choice between the two is a property of the chain, and an application that spans the boundary reads the protocol
+ *   version from the wallet's state and authors accordingly.
+ *
+ *   Deliberately not part of the root barrel: this is WebAssembly, and an application that only carries transactions
+ *   should not pay for a ledger it never names.
+ * @example
+ *   ```typescript
+ *   import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v8';
+ *   import { WalletTransaction } from '@midnightntwrk/wallet-sdk';
+ *
+ *   const authored = ledger.Transaction.fromParts(networkId, undefined, undefined, intent);
+ *   const handle = WalletTransaction.adopt('Unproven', authored, state.activeProtocolVersion);
+ *   ```;
+ */
+export * from '@midnight-ntwrk/ledger-v8';

--- a/packages/wallet-sdk/src/ledger/v9.ts
+++ b/packages/wallet-sdk/src/ledger/v9.ts
@@ -1,0 +1,45 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The post-fork ledger version, for an application that builds its own transactions.
+ *
+ * @remarks
+ *   Most applications never need this. They ask the wallet for a transfer or a swap, carry what comes back as a
+ *   `WalletTransaction`, and hand it straight to the next call — and because the handle never names a ledger version,
+ *   nothing they wrote has to change when the chain crosses the protocol boundary.
+ *
+ *   An application that reaches for `Intent.new` or `Transaction.fromParts` is doing something different: it is
+ *   authoring, and authoring means choosing which ledger version's rules the bytes follow. That choice cannot be hidden
+ *   behind a version-free API, so this subpath makes it explicit and importable from the one package the application
+ *   already depends on. Seal the result with `WalletTransaction.adopt('Unproven', tx, version)` to hand it back.
+ *
+ *   **Which one to import is a property of the chain, not of this release.** Both are shipped, side by side, because both
+ *   are real: a chain is pre-fork until it forks, and mainnet is pre-fork until then. An authoring path that only ever
+ *   imports `./ledger/v9` type-checks perfectly and fails at run time, with a `ProtocolVersionMismatchError`, on every
+ *   chain that has not yet crossed — the wallet refuses a transaction built for a version it is not acting at. An
+ *   application that must work either side of the boundary reads the protocol version from the wallet's state and
+ *   authors accordingly.
+ *
+ *   Deliberately not part of the root barrel: this is WebAssembly, and an application that only carries transactions
+ *   should not pay for a ledger it never names.
+ * @example
+ *   ```typescript
+ *   import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
+ *   import { WalletTransaction } from '@midnightntwrk/wallet-sdk';
+ *
+ *   const authored = ledger.Transaction.fromParts(networkId, undefined, undefined, intent);
+ *   const handle = WalletTransaction.adopt('Unproven', authored, state.activeProtocolVersion);
+ *   ```;
+ */
+export * from '@midnightntwrk/ledger-v9';

--- a/packages/wallet-sdk/src/test/ledgerSubpaths.test.ts
+++ b/packages/wallet-sdk/src/test/ledgerSubpaths.test.ts
@@ -1,0 +1,94 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ledgerV8 from '@midnight-ntwrk/ledger-v8';
+import * as ledgerV9 from '@midnightntwrk/ledger-v9';
+import {
+  NetworkId,
+  ProtocolVersion,
+  ProtocolVersionMismatchError,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
+import { Either } from 'effect';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import * as sdk from '../index.js';
+import * as v8 from '../ledger/v8.js';
+import * as v9 from '../ledger/v9.js';
+
+const packageJson: { readonly exports: Readonly<Record<string, unknown>> } = JSON.parse(
+  readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'),
+);
+
+/**
+ * Names only a ledger package defines. None of them may reach an application through the umbrella package's root: an
+ * application that never names a ledger version is one the fork cannot break.
+ */
+const ledgerOnlyNames = [
+  'Transaction',
+  'Intent',
+  'ZswapSecretKeys',
+  'DustSecretKey',
+  'LedgerParameters',
+  'sampleSigningKey',
+  'signatureVerifyingKey',
+  'nativeToken',
+] as const;
+
+describe('the ledger subpaths an author builds transactions with', () => {
+  it('offers the pre-fork ledger version at ./ledger/v8', () => {
+    expect(v8.Transaction).toBe(ledgerV8.Transaction);
+    expect(v8.Intent).toBe(ledgerV8.Intent);
+  });
+
+  it('offers the post-fork ledger version at ./ledger/v9', () => {
+    expect(v9.Transaction).toBe(ledgerV9.Transaction);
+    expect(v9.Intent).toBe(ledgerV9.Intent);
+  });
+
+  it('keeps the two apart, so an author knows which one they imported', () => {
+    expect(v8.Transaction).not.toBe(v9.Transaction);
+  });
+
+  it('declares both subpaths in the package exports, so they resolve by name', () => {
+    expect(Object.keys(packageJson.exports)).toEqual(expect.arrayContaining(['./ledger/v8', './ledger/v9']));
+  });
+
+  it('never lets a ledger version out through the root, whatever the subpaths offer', () => {
+    expect(Object.keys(sdk).filter((name) => (ledgerOnlyNames as readonly string[]).includes(name))).toStrictEqual([]);
+  });
+});
+
+describe('a transaction an author built for itself', () => {
+  const version = ProtocolVersion.ProtocolVersion(2_000_000n);
+
+  it('can be sealed into a handle, whichever ledger version built it', () => {
+    const preFork = v8.Transaction.fromParts(NetworkId.NetworkId.Undeployed);
+    const postFork = v9.Transaction.fromParts(NetworkId.NetworkId.Undeployed);
+
+    expect(WalletTransaction.adopt('Unproven', preFork, ProtocolVersion.MinSupportedVersion).serialize()).toStrictEqual(
+      preFork.serialize(),
+    );
+    expect(WalletTransaction.adopt('Unproven', postFork, version).serialize()).toStrictEqual(postFork.serialize());
+  });
+
+  it('is refused by a caller acting on the other side of the boundary', () => {
+    const postFork = v9.Transaction.fromParts(NetworkId.NetworkId.Undeployed);
+    const handle = WalletTransaction.adopt('Unproven', postFork, version);
+    const preForkEra = ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, version);
+
+    const error = WalletTransaction.unwrapWithin(handle, preForkEra).pipe(Either.flip, Either.getOrThrow);
+
+    expect(error).toBeInstanceOf(ProtocolVersionMismatchError);
+    expect(error.authoredFor).toBe(version);
+  });
+});

--- a/packages/wallet-sdk/src/test/ledgerSubpaths.test.ts
+++ b/packages/wallet-sdk/src/test/ledgerSubpaths.test.ts
@@ -18,16 +18,19 @@ import {
   ProtocolVersionMismatchError,
   WalletTransaction,
 } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Either } from 'effect';
+import { Either, Schema } from 'effect';
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import * as sdk from '../index.js';
 import * as v8 from '../ledger/v8.js';
 import * as v9 from '../ledger/v9.js';
 
-const packageJson: { readonly exports: Readonly<Record<string, unknown>> } = JSON.parse(
-  readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'),
-);
+const PackageManifest = Schema.Struct({ exports: Schema.Record({ key: Schema.String, value: Schema.Unknown }) });
+
+const declaredExports = Schema.decodeUnknownSync(PackageManifest)(
+  // `JSON.parse` is typed `any`; widening to `unknown` is what leaves the schema as the only thing that types this.
+  JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf-8')) as unknown,
+).exports;
 
 /**
  * Names only a ledger package defines. None of them may reach an application through the umbrella package's root: an
@@ -60,7 +63,7 @@ describe('the ledger subpaths an author builds transactions with', () => {
   });
 
   it('declares both subpaths in the package exports, so they resolve by name', () => {
-    expect(Object.keys(packageJson.exports)).toEqual(expect.arrayContaining(['./ledger/v8', './ledger/v9']));
+    expect(Object.keys(declaredExports)).toEqual(expect.arrayContaining(['./ledger/v8', './ledger/v9']));
   });
 
   it('never lets a ledger version out through the root, whatever the subpaths offer', () => {

--- a/packages/wallet-sdk/tsconfig.json
+++ b/packages/wallet-sdk/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
   "files": [],
-  "references": [{ "path": "./tsconfig.build.json" }]
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/wallet-sdk/tsconfig.test.json
+++ b/packages/wallet-sdk/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/test/**/*.ts", "test/**/*.ts", "src/**/*.ts"]
+}

--- a/packages/wallet-sdk/vitest.config.ts
+++ b/packages/wallet-sdk/vitest.config.ts
@@ -1,0 +1,54 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/// <reference types="vitest" />
+/// <reference types="vitest/globals" />
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, '**/dist/**'],
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      enabled: true,
+      clean: true,
+      include: ['src/**/*.ts'],
+      exclude: ['**/test/**'],
+      reporter: ['clover', 'json', 'json-summary', 'lcov', 'text'],
+      reportsDirectory: './coverage',
+    },
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'unit',
+          include: ['**/*.test.ts'],
+          exclude: [...configDefaults.exclude, '**/dist/**', '**/*.integration.test.ts'],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'integration',
+          include: ['**/*.integration.test.ts'],
+        },
+      },
+    ],
+    reporters: [
+      'default',
+      ['junit', { outputFile: `reports/report/test-report.xml` }],
+      ['html', { outputFile: `reports/report/test-report.html` }],
+    ],
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2806,6 +2806,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnightntwrk/wallet-sdk@workspace:packages/wallet-sdk"
   dependencies:
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
+    "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.3"
     "@midnightntwrk/wallet-sdk-abstractions": "npm:3.0.0-beta.0"
     "@midnightntwrk/wallet-sdk-address-format": "npm:4.0.0-beta.2"
     "@midnightntwrk/wallet-sdk-capabilities": "npm:4.0.0-beta.2"


### PR DESCRIPTION
Eighth increment of the dual-ledger public API redesign — the Flow 2/3 primitives. Stacked on #681. This PR deliberately stops at the primitives boundary: its survey found the downstream cascade (the `secretKeys` drop, the three seam closures, the facade rewiring) is strictly ordered with no gate-green intermediate, and three prep refactors belong ahead of it (see "What comes next").

## What's here

- **`WalletTransaction<Stage>`** (`abstractions` — ledger-free, reaches the umbrella root): the opaque carrier handle. A class with a private `#carried` field and private constructor — nominal in TS, payload unreachable; `adopt(stage, tx, version)` seals author output in; `unwrapWithin(handle, range)` is the ONE unwrap primitive, taking a `ProtocolVersion.Range` rather than a version, because enforcement means "same side of the boundary", not stamp equality (a pre-fork chain reports many versions; exact-stamp stays expressible as a one-wide range). `ProtocolVersionMismatchError {authoredFor, accepted, stage}` and `WireFormatError` are typed.
- **Stages are three, not four**: `'Unproven' | 'Unbound' | 'Finalized'` — `ProvenTransaction` appears nowhere in the repo; `UnboundTransaction` *is* the proven-not-bound stage. Consumer aliases: `UnprovenTx`, `UnboundTx`, `FinalizedTx`, `AnyTx` (covariant stage).
- **Wire envelope**, minimal and versioned: `{ wireFormat: 1, protocolVersion, stage, transaction: hex }` — `wireFormat` is separate from `protocolVersion` so a reader can distinguish "unknown envelope" from "unknown ledger version"; `fromWire` takes the decoder from the caller (this package holds no ledger) and converts throws into typed errors. Deliberately conservative — connector coordination is an open external ask.
- **`wallet-sdk/ledger/v8` and `wallet-sdk/ledger/v9`** author subpaths (real dist targets, publint-clean), with root-barrel ledger-freedom verified two ways: zero ledger imports in the barrel source, and a test asserting no ledger symbol appears in the root's runtime exports. The v9-only-authoring-throws-until-the-fork consequence is documented in both subpath headers, the changeset, and a new README "Authoring transactions" section. The package gained its first test runner.
- The handle is pinned against **real WASM objects of both ledgers** (`v8/v9.Transaction.fromParts`), which is what validates its structural constraint against the actual classes.

## What comes next (the survey's findings, ahead of the seam closures)

1. `ValidationService.validateTx` is a closed v9 union with no type parameter — the only subsystem with no version story; every balance path calls it.
2. `UnboundTransaction` is defined identically in four places (three exported publicly) and must collapse to one owner.
3. `AnyTransaction` is a dust-internal v9 union re-exported through facade public signatures and needs an owner.

Also corrected from the plan: `FacadeState.pending` does have a consumer (`dust-sponsorship.ts` reads `pending.all.length`), and the carrier blast radius is 47 consumer files, not ~33.

## Tests & gate

26 new tests (handle 19, subpaths 7), red-first (one disclosed test-defect fix after green: a fixture-closure identity comparison replaced with strictly more precise value assertions). Gate: dist 17/17, typecheck 37/37, lint 58/58, unit 54/54 tasks (the new wallet-sdk runner joins), shielded fork-simulation integration 3/3, effect-language-service clean on all changed files, format + changesets green, publint clean. Per-wallet totals unchanged (shielded 180/dust 184/unshielded 211) — this PR touches none of them; all three temporary seams remain in place for the closure increment.