### PR TITLE
feat(capabilities,facade): version-routed validation and one owner per transaction type

### DIFF
--- a/.changeset/facade-owns-the-transactions-it-accepts.md
+++ b/.changeset/facade-owns-the-transactions-it-accepts.md
@@ -1,0 +1,22 @@
+---
+'@midnightntwrk/wallet-sdk-facade': minor
+---
+
+The facade now exports `AnyTransaction`, the type its own public signatures already took.
+
+`calculateTransactionFee`, `estimateTransactionFee`, `revert`, `revertTransaction` and
+`BalancingRecipe.getTransactions` all name this type, but it was reachable only as
+`@midnightntwrk/wallet-sdk-dust-wallet/v2`'s `AnyTransaction` — a variant-scoped internal of a package a facade-only
+app need not depend on at all, and one with a differently-typed pre-fork twin under `/v1`. Annotating a variable, or
+writing a wrapper around any of those methods, meant importing from that subpath.
+
+Additive: `import { type AnyTransaction } from '@midnightntwrk/wallet-sdk-facade'`. Existing imports from the dust
+subpath keep working — the facade's name is an alias to that same type, deliberately so it cannot drift from what the
+methods accept.
+
+**Ownership decision.** The facade names it, rather than dust promoting it to a documented public export, because the
+facade has a single entry point and was exporting nothing for a type in five of its public signatures, while dust's
+declaration sits under `v2/types/` with a v8 twin under `v1/types/` — variant-scoped, and not a type whose identity
+survives the fork. This is transitional: `WalletTransaction` handles replace these signatures, at which point the
+protocol version a transaction was authored for travels with it instead of being lost at this boundary, and the alias
+goes away with them.

--- a/.changeset/one-owner-for-the-unbound-transaction.md
+++ b/.changeset/one-owner-for-the-unbound-transaction.md
@@ -1,0 +1,22 @@
+---
+'@midnightntwrk/wallet-sdk-shielded': patch
+'@midnightntwrk/wallet-sdk-unshielded-wallet': patch
+---
+
+`UnboundTransaction` now has one owner. `@midnightntwrk/wallet-sdk-capabilities/proving` declares it — proving is what
+produces one, and it is the package both wallets already depend on — and the two wallets re-export that declaration
+instead of writing their own.
+
+**Both public entry points still export the name**, and the type is identical to what they exported before, so no
+annotation needs to change:
+
+- `@midnightntwrk/wallet-sdk-shielded` → `UnboundTransaction` (re-export; the shielded wallet never built or consumed
+  one)
+- `@midnightntwrk/wallet-sdk-unshielded-wallet/v2` → `UnboundTransaction` (re-export)
+
+Verified identical before collapsing, and it was three of four rather than four: the pre-fork
+`@midnightntwrk/wallet-sdk-unshielded-wallet/v1` declaration names `@midnight-ntwrk/ledger-v8`'s classes, not
+`@midnightntwrk/ledger-v9`'s. It is a **different type** and deliberately keeps its own declaration — collapsing it
+would make the two ledgers interchangeable in the type system while they stay incompatible at runtime. A test pins
+both halves of that: the post-fork type is assignable to the owned one in both directions, and the pre-fork type is
+not assignable to it at all.

--- a/.changeset/validation-at-the-authored-version.md
+++ b/.changeset/validation-at-the-authored-version.md
@@ -1,0 +1,33 @@
+---
+'@midnightntwrk/wallet-sdk-capabilities': minor
+---
+
+Validate a transaction at the protocol version it was authored for, rather than assuming every transaction belongs to
+the current ledger.
+
+`@midnightntwrk/wallet-sdk-capabilities/validation` gains the same version-routing shape proving already has:
+
+- `ValidationServices` — a `ProtocolVersion.Registry` of validators, keyed by the version range each one serves.
+- `makeVersionedValidationServiceEffect(services)` / `VersionedValidationServiceEffect` — `validateTx(tx,
+protocolVersion, options)`, routing on the version the transaction was **authored** for, never on where the chain has
+  since got to. A version no validator covers fails with the typed `UnsupportedValidationVersionError`, which names it.
+- `singleVersionValidationServiceEffect(service)` — one validator answering for every version, which is what an
+  unversioned validation service was implicitly claiming. True on one side of a fork, a lie the moment it crosses, so it
+  now has to be written down.
+- `wrapVersionedValidationService(effectService)` — the promise-facing surface, rejecting with the typed error itself
+  rather than a fiber wrapper around it.
+- `makePreForkValidationServiceEffect(deps)` — a genuine pre-fork (`@midnight-ntwrk/ledger-v8`) validator that runs that
+  ledger's own `wellFormed` against its own `LedgerState`, alongside `preForkWellFormedCheck` and
+  `AnyPreForkValidatableTransaction`.
+- `makeValidationServiceEffect(check, deps)` and `WellFormedCheck` — the ledger-neutral core both validators are built
+  from.
+
+`BlockData`, `ValidateTxOptions`, `ValidationServiceDependencies`, `ValidationServiceEffect` and `ValidationService`
+gained type parameters for the ledger version they speak, each defaulting to the current ledger. Every existing
+annotation keeps naming exactly what it named before, and `makeDefaultValidationService(Effect)` is unchanged in
+signature and behaviour — this release is additive.
+
+Not yet wired: nothing registers the pre-fork validator, because the default block-data fetcher's codec registry is
+open-ended from the minimum supported version and holds only the current ledger's codec, so the block data reaching
+validation is always current-ledger parameters. Routing the block-data fetch on the version a block reports is what
+closes that.

--- a/packages/capabilities/src/validation/index.ts
+++ b/packages/capabilities/src/validation/index.ts
@@ -11,4 +11,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 export * from './blockData.js';
+export * from './preForkValidationService.js';
 export * from './validationService.js';

--- a/packages/capabilities/src/validation/preForkValidationService.ts
+++ b/packages/capabilities/src/validation/preForkValidationService.ts
@@ -1,0 +1,71 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import {
+  makeValidationServiceEffect,
+  type ValidationServiceDependencies,
+  type ValidationServiceEffect,
+  type WellFormedCheck,
+  type WellFormedStrictnessFlags,
+} from './validationService.js';
+
+/** A pre-fork transaction that has been proven but not yet bound. */
+export type PreForkUnboundTransaction = ledger.Transaction<ledger.SignatureEnabled, ledger.Proof, ledger.PreBinding>;
+
+/**
+ * Every pre-fork transaction shape well-formedness can be asked about — the pre-fork counterpart of
+ * `AnyValidatableTransaction`, and a genuinely different type from it: these are the other ledger version's classes,
+ * and neither ledger can read the other's.
+ */
+export type AnyPreForkValidatableTransaction =
+  ledger.FinalizedTransaction | PreForkUnboundTransaction | ledger.UnprovenTransaction;
+
+const buildStrictness = (flags: WellFormedStrictnessFlags): ledger.WellFormedStrictness => {
+  const strictness = new ledger.WellFormedStrictness();
+  strictness.enforceBalancing = flags.enforceBalancing;
+  strictness.verifySignatures = flags.verifySignatures;
+  strictness.enforceLimits = flags.enforceLimits;
+  return strictness;
+};
+
+const buildBlankLedgerState = (networkId: string, parameters: ledger.LedgerParameters): ledger.LedgerState => {
+  const state = ledger.LedgerState.blank(networkId);
+  state.parameters = parameters;
+  return state;
+};
+
+/**
+ * The pre-fork ledger version's well-formedness check.
+ *
+ * @remarks
+ *   Structurally the same three steps as the current ledger's, against a different ledger version's classes. It is the
+ *   classes, not the steps, that make this a separate check: a pre-fork transaction cannot be handed to the current
+ *   ledger's `wellFormed`, nor current-ledger parameters to this one.
+ */
+export const preForkWellFormedCheck: WellFormedCheck<AnyPreForkValidatableTransaction, ledger.LedgerParameters> = (
+  tx,
+  { networkId, ledgerParameters, flags, now },
+) => {
+  tx.wellFormed(buildBlankLedgerState(networkId, ledgerParameters), buildStrictness(flags), now);
+};
+
+/**
+ * Builds the validator for pre-fork transactions.
+ *
+ * @param deps The network, clock, and a block-data fetcher whose parameters are decoded at the pre-fork ledger version.
+ * @returns A validator to register in a `ValidationServices` registry for the version range before the fork.
+ */
+export const makePreForkValidationServiceEffect = (
+  deps: ValidationServiceDependencies<ledger.LedgerParameters>,
+): ValidationServiceEffect<AnyPreForkValidatableTransaction, ledger.LedgerParameters> =>
+  makeValidationServiceEffect(preForkWellFormedCheck, deps);

--- a/packages/capabilities/src/validation/preForkValidationService.ts
+++ b/packages/capabilities/src/validation/preForkValidationService.ts
@@ -62,6 +62,13 @@ export const preForkWellFormedCheck: WellFormedCheck<AnyPreForkValidatableTransa
 /**
  * Builds the validator for pre-fork transactions.
  *
+ * @remarks
+ *   Nothing in the SDK registers this yet, and that is a wiring gap rather than a missing capability. The default
+ *   block-data fetcher decodes with `defaultLedgerParametersCodecs`, which is open-ended from the minimum supported
+ *   version and holds only the current ledger's codec — so the block data reaching validation today is always
+ *   current-ledger parameters, which this validator cannot use. Registering a pre-fork codec and routing the fetch on
+ *   the block's reported version is what closes it; until then the pre-fork range stays empty and a pre-fork
+ *   transaction is refused by name rather than checked against the wrong ledger.
  * @param deps The network, clock, and a block-data fetcher whose parameters are decoded at the pre-fork ledger version.
  * @returns A validator to register in a `ValidationServices` registry for the version range before the fork.
  */

--- a/packages/capabilities/src/validation/test/preForkValidationService.test.ts
+++ b/packages/capabilities/src/validation/test/preForkValidationService.test.ts
@@ -1,0 +1,106 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Cause, Effect, Exit, Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import {
+  makePreForkValidationServiceEffect,
+  type AnyPreForkValidatableTransaction,
+} from '../preForkValidationService.js';
+import { ValidationFetchError, WellFormedError, type BlockData } from '../validationService.js';
+
+const NETWORK_ID = NetworkId.NetworkId.Undeployed;
+const NOW = new Date(1_752_487_200_000);
+
+const FULL_STRICTNESS = { enforceBalancing: true, verifySignatures: true, enforceLimits: true } as const;
+const NO_STRICTNESS = { enforceBalancing: false, verifySignatures: false, enforceLimits: false } as const;
+
+const preForkBlockData = (): BlockData<ledger.LedgerParameters> => ({
+  hash: '00'.repeat(32),
+  height: 7,
+  protocolVersion: 0,
+  ledgerParameters: ledger.LedgerParameters.initialParameters(),
+  timestamp: NOW,
+});
+
+const deps = (fetchBlockData: () => Promise<BlockData<ledger.LedgerParameters>>) => ({
+  fetchBlockData,
+  networkId: NETWORK_ID,
+  clock: { now: () => NOW },
+});
+
+const fetching = () => makePreForkValidationServiceEffect(deps(() => Promise.resolve(preForkBlockData())));
+
+const failureOf = async <A, E>(effect: Effect.Effect<A, E>): Promise<E> => {
+  const exit = await Effect.runPromiseExit(effect);
+  if (Exit.isSuccess(exit)) throw new Error('expected the effect to fail');
+  return Option.getOrThrow(Cause.failureOption(exit.cause));
+};
+
+// A pre-fork transaction built for a different network violates the non-configurable network-ID structural check.
+const wrongNetworkTx = (): AnyPreForkValidatableTransaction =>
+  ledger.Transaction.fromParts(NetworkId.NetworkId.MainNet);
+
+// A pre-fork finalized transaction whose TTL is already past fails the non-configurable TTL structural check.
+const expiredTx = (): AnyPreForkValidatableTransaction =>
+  ledger.Transaction.fromParts(NETWORK_ID, undefined, undefined, ledger.Intent.new(new Date(0))).mockProve();
+
+describe('Checking a pre-fork transaction against the pre-fork ledger', () => {
+  it('passes a well-formed pre-fork transaction', async () => {
+    const validator = fetching();
+
+    await expect(
+      Effect.runPromise(validator.validateTx(ledger.Transaction.fromParts(NETWORK_ID), { flags: NO_STRICTNESS })),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects a pre-fork transaction built for the wrong network', async () => {
+    const error = await failureOf(fetching().validateTx(wrongNetworkTx(), { flags: FULL_STRICTNESS }));
+
+    expect(error).toBeInstanceOf(WellFormedError);
+  });
+
+  it('rejects a pre-fork transaction whose TTL has already passed', async () => {
+    const error = await failureOf(fetching().validateTx(expiredTx(), { flags: FULL_STRICTNESS }));
+
+    expect(error).toBeInstanceOf(WellFormedError);
+  });
+
+  it('checks against the pre-fork parameters it is handed, without fetching', async () => {
+    // The fetch is the only I/O in the path; a validator handed block data must not perform it. A fetcher that can
+    // only fail is how that is observable — reaching it at all turns a pass into a `ValidationFetchError`.
+    const validator = makePreForkValidationServiceEffect(
+      deps(() => Promise.reject(new Error('the fetcher must not be reached'))),
+    );
+
+    await expect(
+      Effect.runPromise(
+        validator.validateTx(ledger.Transaction.fromParts(NETWORK_ID), {
+          flags: NO_STRICTNESS,
+          blockData: preForkBlockData(),
+        }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('reports a failed block-data fetch as a fetch failure, not a malformed transaction', async () => {
+    const validator = makePreForkValidationServiceEffect(deps(() => Promise.reject(new Error('indexer unreachable'))));
+
+    const error = await failureOf(
+      validator.validateTx(ledger.Transaction.fromParts(NETWORK_ID), { flags: NO_STRICTNESS }),
+    );
+
+    expect(error).toBeInstanceOf(ValidationFetchError);
+  });
+});

--- a/packages/capabilities/src/validation/test/versionedValidationService.test.ts
+++ b/packages/capabilities/src/validation/test/versionedValidationService.test.ts
@@ -1,0 +1,105 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Cause, Effect, Either, Exit, Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import {
+  makeVersionedValidationServiceEffect,
+  singleVersionValidationServiceEffect,
+  UnsupportedValidationVersionError,
+  WellFormedError,
+  wrapVersionedValidationService,
+  type ValidationServiceEffect,
+} from '../validationService.js';
+
+const version = (value: bigint): ProtocolVersion.ProtocolVersion => ProtocolVersion.ProtocolVersion(value);
+const FORK = version(2_000_000n);
+
+const NO_STRICTNESS = { enforceBalancing: false, verifySignatures: false, enforceLimits: false } as const;
+
+/**
+ * A validator that reports which one answered, through the failure channel, so routing is observable without a ledger.
+ * Failing is how a validator speaks at all — a pass returns nothing — so this is the only pure way to see the choice.
+ */
+const labelled = (label: string): ValidationServiceEffect<string, string> => ({
+  validateTx: (transaction) => Effect.fail(new WellFormedError({ cause: `${label}:${transaction}` })),
+});
+
+const registryOf = (
+  ...activations: readonly {
+    sinceVersion: ProtocolVersion.ProtocolVersion;
+    value: ValidationServiceEffect<string, string>;
+  }[]
+) => Either.getOrThrow(ProtocolVersion.makeRegistryFromActivations(activations));
+
+const failureOf = async <A, E>(effect: Effect.Effect<A, E>): Promise<E> => {
+  const exit = await Effect.runPromiseExit(effect);
+  if (Exit.isSuccess(exit)) throw new Error('expected the effect to fail');
+  return Option.getOrThrow(Cause.failureOption(exit.cause));
+};
+
+describe('Routing a transaction to the validator for the version it was authored for', () => {
+  const router = makeVersionedValidationServiceEffect(
+    registryOf(
+      { sinceVersion: ProtocolVersion.MinSupportedVersion, value: labelled('pre-fork') },
+      { sinceVersion: FORK, value: labelled('post-fork') },
+    ),
+  );
+
+  it('validates with the validator registered for the version the transaction was authored for', async () => {
+    const preFork = await failureOf(router.validateTx('tx', version(17n), { flags: NO_STRICTNESS }));
+    const postFork = await failureOf(router.validateTx('tx', FORK, { flags: NO_STRICTNESS }));
+
+    expect((preFork as WellFormedError).cause).toBe('pre-fork:tx');
+    expect((postFork as WellFormedError).cause).toBe('post-fork:tx');
+  });
+
+  it('routes on the stamp the author gave, not on where the chain has since got to', async () => {
+    // A transaction's bytes were fixed at the version it was authored for. Well-formedness asks whether *that* ledger
+    // would accept them, so a fork landing between authoring and validation cannot change which validator answers.
+    const error = await failureOf(router.validateTx('authored-before', version(1n), { flags: NO_STRICTNESS }));
+
+    expect((error as WellFormedError).cause).toBe('pre-fork:authored-before');
+  });
+
+  it('refuses a version no validator is registered for, naming that version', async () => {
+    const postForkOnly = makeVersionedValidationServiceEffect(
+      registryOf({ sinceVersion: FORK, value: labelled('post-fork') }),
+    );
+
+    const error = await failureOf(postForkOnly.validateTx('tx', version(1n), { flags: NO_STRICTNESS }));
+
+    expect(error).toBeInstanceOf(UnsupportedValidationVersionError);
+    expect((error as UnsupportedValidationVersionError).protocolVersion).toStrictEqual(version(1n));
+  });
+
+  it('lets a single-version validator answer for every version, explicitly', async () => {
+    const anywhere = singleVersionValidationServiceEffect(labelled('only'));
+
+    const atZero = await failureOf(anywhere.validateTx('tx', version(0n), { flags: NO_STRICTNESS }));
+    const atFork = await failureOf(anywhere.validateTx('tx', FORK, { flags: NO_STRICTNESS }));
+
+    expect((atZero as WellFormedError).cause).toBe('only:tx');
+    expect((atFork as WellFormedError).cause).toBe('only:tx');
+  });
+
+  it('rejects the promise with the typed error itself, not a wrapper around it', async () => {
+    const promising = wrapVersionedValidationService(
+      makeVersionedValidationServiceEffect(registryOf({ sinceVersion: FORK, value: labelled('post-fork') })),
+    );
+
+    await expect(promising.validateTx('tx', version(1n), { flags: NO_STRICTNESS })).rejects.toBeInstanceOf(
+      UnsupportedValidationVersionError,
+    );
+  });
+});

--- a/packages/capabilities/src/validation/validationService.ts
+++ b/packages/capabilities/src/validation/validationService.ts
@@ -278,8 +278,12 @@ export const currentLedgerWellFormedCheck: WellFormedCheck<AnyValidatableTransac
 /**
  * Rejects a promise with the typed failure itself rather than the fiber wrapper around it, so a caller can `catch` the
  * error class the signature names.
+ *
+ * @remarks
+ *   `E extends Error` is what makes that rejection legitimate rather than a thrown bare value, and every failure on this
+ *   surface is a `Data.TaggedError`, which is one.
  */
-const runPromiseThrowingFailure = async <A, E>(effect: Effect.Effect<A, E>): Promise<A> => {
+const runPromiseThrowingFailure = async <A, E extends Error>(effect: Effect.Effect<A, E>): Promise<A> => {
   const exit = await Effect.runPromiseExit(effect);
   if (Exit.isSuccess(exit)) return exit.value;
   const failure = Cause.failureOption(exit.cause);

--- a/packages/capabilities/src/validation/validationService.ts
+++ b/packages/capabilities/src/validation/validationService.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/ledger-v9';
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import type { Clock } from '@midnightntwrk/wallet-sdk-utilities';
 import { Cause, Data, Effect, Exit, Option, pipe } from 'effect';
 import type { UnboundTransaction } from '../proving/provingService.js';
@@ -19,13 +20,16 @@ import type { UnboundTransaction } from '../proving/provingService.js';
  * Snapshot of chain state required for transaction validation. Structurally identical to the dust-wallet's `BlockData`
  * — a separate declaration here keeps the validation service decoupled from dust-wallet. The two can be passed
  * interchangeably via structural typing.
+ *
+ * @typeParam TParameters The `LedgerParameters` type of the ledger version the parameters were decoded at. Defaults to
+ *   the current ledger's, so `BlockData` unqualified still names exactly what it always did.
  */
-export interface BlockData {
+export interface BlockData<TParameters = ledger.LedgerParameters> {
   hash: string;
   height: number;
   /** The protocol version the indexer reported this block under, and so the ledger version its parameters are in. */
   protocolVersion: number;
-  ledgerParameters: ledger.LedgerParameters;
+  ledgerParameters: TParameters;
   timestamp: Date;
 }
 
@@ -39,9 +43,13 @@ export type WellFormedStrictnessFlags = Pick<
   'enforceBalancing' | 'verifySignatures' | 'enforceLimits'
 >;
 
-export type ValidateTxOptions = {
+/**
+ * @typeParam TParameters The `LedgerParameters` type of the ledger version `blockData` was decoded at — necessarily the
+ *   version the validator being called speaks, since well-formedness is checked against a state built from them.
+ */
+export type ValidateTxOptions<TParameters = ledger.LedgerParameters> = {
   flags: WellFormedStrictnessFlags;
-  blockData?: BlockData | undefined;
+  blockData?: BlockData<TParameters> | undefined;
 };
 
 /** Thrown when a transaction fails the structural well-formedness check. */
@@ -60,26 +68,190 @@ export class ValidationFetchError extends Data.TaggedError(
 
 export type AnyValidatableTransaction = ledger.FinalizedTransaction | UnboundTransaction | ledger.UnprovenTransaction;
 
-export interface ValidationServiceEffect {
+/**
+ * Checks a transaction for well-formedness.
+ *
+ * @typeParam TTransaction The transactions this validator accepts. Defaults to the current ledger's, because a
+ *   validator is only ever written against one ledger version — which is exactly why choosing between validators is
+ *   {@link VersionedValidationServiceEffect}'s job and not this interface's.
+ * @typeParam TParameters The `LedgerParameters` type of that same ledger version.
+ */
+export interface ValidationServiceEffect<
+  TTransaction = AnyValidatableTransaction,
+  TParameters = ledger.LedgerParameters,
+> {
   validateTx(
-    tx: AnyValidatableTransaction,
-    options: ValidateTxOptions,
+    tx: TTransaction,
+    options: ValidateTxOptions<TParameters>,
   ): Effect.Effect<void, WellFormedError | ValidationFetchError>;
 }
 
-export interface ValidationService {
-  validateTx(tx: AnyValidatableTransaction, options: ValidateTxOptions): Promise<void>;
+export interface ValidationService<TTransaction = AnyValidatableTransaction, TParameters = ledger.LedgerParameters> {
+  validateTx(tx: TTransaction, options: ValidateTxOptions<TParameters>): Promise<void>;
 }
+
+/** Raised when no validator is registered for the protocol version a transaction was authored for. */
+export class UnsupportedValidationVersionError extends Data.TaggedError(
+  '@midnightntwrk/wallet-sdk-capabilities/validation/validationService/UnsupportedValidationVersionError',
+)<{
+  readonly message: string;
+  /** The version the transaction was authored for, which no registered validator serves. */
+  readonly protocolVersion: ProtocolVersion.ProtocolVersion;
+}> {}
+
+/**
+ * Checks a transaction with the validator registered for the protocol version it was authored for.
+ *
+ * @remarks
+ *   The version is the transaction's own stamp, taken when it was authored, and never the version the chain has reached
+ *   by the time it is validated. Well-formedness asks whether the ledger that produced these bytes would accept them; a
+ *   fork landing between authoring and validation does not rewrite the bytes, so it cannot change the answer or who
+ *   gives it.
+ */
+export interface VersionedValidationServiceEffect<
+  TTransaction = AnyValidatableTransaction,
+  TParameters = ledger.LedgerParameters,
+> {
+  validateTx(
+    tx: TTransaction,
+    protocolVersion: ProtocolVersion.ProtocolVersion,
+    options: ValidateTxOptions<TParameters>,
+  ): Effect.Effect<void, WellFormedError | ValidationFetchError | UnsupportedValidationVersionError>;
+}
+
+export interface VersionedValidationService<
+  TTransaction = AnyValidatableTransaction,
+  TParameters = ledger.LedgerParameters,
+> {
+  validateTx(
+    tx: TTransaction,
+    protocolVersion: ProtocolVersion.ProtocolVersion,
+    options: ValidateTxOptions<TParameters>,
+  ): Promise<void>;
+}
+
+/**
+ * The validators a caller is willing to check with, keyed by the protocol version range each one serves.
+ *
+ * @remarks
+ *   Registration is per caller, not global, and a caller registers only the ledger versions its own types are written
+ *   against — the same rule the ledger-parameters codecs follow, and for the same reason: a `LedgerState` belongs to
+ *   one ledger version, so a validator that speaks two would have nothing to build. A version outside every registered
+ *   range therefore means "this transaction belongs to a different variant", and the router says so with
+ *   {@link UnsupportedValidationVersionError} instead of handing the bytes to a checker that could only reject them.
+ */
+export type ValidationServices<
+  TTransaction = AnyValidatableTransaction,
+  TParameters = ledger.LedgerParameters,
+> = ProtocolVersion.Registry<ValidationServiceEffect<TTransaction, TParameters>>;
+
+/**
+ * Builds a validation service that routes on the version a transaction was authored for.
+ *
+ * @param services The validators and the version ranges they serve.
+ * @returns A validation service that fails with {@link UnsupportedValidationVersionError} for a version nothing serves.
+ */
+export const makeVersionedValidationServiceEffect = <TTransaction, TParameters>(
+  services: ValidationServices<TTransaction, TParameters>,
+): VersionedValidationServiceEffect<TTransaction, TParameters> => ({
+  validateTx: (tx, protocolVersion, options) =>
+    Option.match(ProtocolVersion.select(services, protocolVersion), {
+      onNone: () =>
+        Effect.fail(
+          new UnsupportedValidationVersionError({
+            message: `No validator is registered for protocol version ${protocolVersion}.`,
+            protocolVersion,
+          }),
+        ),
+      onSome: (service) => service.validateTx(tx, options),
+    }),
+});
+
+/**
+ * Lets one validator answer for every protocol version.
+ *
+ * @remarks
+ *   Says out loud what an unversioned validation service was implicitly claiming: that it can judge anything, whatever
+ *   version authored it. True for a wallet on one side of a fork, and a lie the moment it crosses — so it has to be
+ *   written down rather than assumed.
+ * @param service The validator to use for every version.
+ * @returns The same validator, addressed by version.
+ */
+export const singleVersionValidationServiceEffect = <TTransaction, TParameters>(
+  service: ValidationServiceEffect<TTransaction, TParameters>,
+): VersionedValidationServiceEffect<TTransaction, TParameters> => ({
+  validateTx: (tx, _protocolVersion, options) => service.validateTx(tx, options),
+});
 
 export type DefaultValidationConfiguration = {
   networkId: string;
 };
 
-export type ValidationServiceDependencies = {
-  fetchBlockData: () => Promise<BlockData>;
+/**
+ * @typeParam TParameters The `LedgerParameters` type of the ledger version this validator speaks, and so the version
+ *   its `fetchBlockData` must decode at.
+ */
+export type ValidationServiceDependencies<TParameters = ledger.LedgerParameters> = {
+  fetchBlockData: () => Promise<BlockData<TParameters>>;
   networkId: string;
   clock: Clock.Clock;
 };
+
+/**
+ * The one thing a ledger version has to supply for its transactions to be checked: run its own well-formedness check
+ * against a blank state carrying the block's parameters, throwing whatever that ledger throws.
+ *
+ * @remarks
+ *   Deliberately allowed to throw, exactly like a {@link LedgerParametersCodec}: it wraps a WASM call whose failure mode
+ *   is an exception. {@link makeValidationServiceEffect} is the only way to reach one, and it turns that into a typed
+ *   {@link WellFormedError}.
+ */
+export type WellFormedCheck<TTransaction, TParameters> = (
+  transaction: TTransaction,
+  context: Readonly<{
+    networkId: string;
+    ledgerParameters: TParameters;
+    flags: WellFormedStrictnessFlags;
+    now: Date;
+  }>,
+) => void;
+
+/**
+ * Builds a validation service for one ledger version from that version's well-formedness check.
+ *
+ * @param check The ledger version's well-formedness check.
+ * @param deps The network, clock, and the block-data fetcher that decodes at the same ledger version.
+ * @returns A validator for that ledger version, ready to register in {@link ValidationServices}.
+ */
+export const makeValidationServiceEffect = <TTransaction, TParameters>(
+  check: WellFormedCheck<TTransaction, TParameters>,
+  deps: ValidationServiceDependencies<TParameters>,
+): ValidationServiceEffect<TTransaction, TParameters> => ({
+  validateTx(tx, options) {
+    const fetchOrUse: Effect.Effect<BlockData<TParameters>, ValidationFetchError> = options.blockData
+      ? Effect.succeed(options.blockData)
+      : Effect.tryPromise({
+          try: () => deps.fetchBlockData(),
+          catch: (cause) => new ValidationFetchError({ cause }),
+        });
+
+    return pipe(
+      fetchOrUse,
+      Effect.flatMap((blockData) =>
+        Effect.try({
+          try: () =>
+            check(tx, {
+              networkId: deps.networkId,
+              ledgerParameters: blockData.ledgerParameters,
+              flags: options.flags,
+              now: deps.clock.now(),
+            }),
+          catch: (cause) => new WellFormedError({ cause }),
+        }),
+      ),
+    );
+  },
+});
 
 const buildStrictness = (flags: WellFormedStrictnessFlags): ledger.WellFormedStrictness => {
   const strictness = new ledger.WellFormedStrictness();
@@ -95,40 +267,40 @@ const buildBlankLedgerState = (networkId: string, parameters: ledger.LedgerParam
   return state;
 };
 
-export const makeDefaultValidationServiceEffect = (deps: ValidationServiceDependencies): ValidationServiceEffect => ({
-  validateTx(tx, options) {
-    const fetchOrUse: Effect.Effect<BlockData, ValidationFetchError> = options.blockData
-      ? Effect.succeed(options.blockData)
-      : Effect.tryPromise({
-          try: () => deps.fetchBlockData(),
-          catch: (cause) => new ValidationFetchError({ cause }),
-        });
+/** The current ledger version's well-formedness check. */
+export const currentLedgerWellFormedCheck: WellFormedCheck<AnyValidatableTransaction, ledger.LedgerParameters> = (
+  tx,
+  { networkId, ledgerParameters, flags, now },
+) => {
+  tx.wellFormed(buildBlankLedgerState(networkId, ledgerParameters), buildStrictness(flags), now);
+};
 
-    return pipe(
-      fetchOrUse,
-      Effect.flatMap((blockData) =>
-        Effect.try({
-          try: () => {
-            const ledgerState = buildBlankLedgerState(deps.networkId, blockData.ledgerParameters);
-            const strictness = buildStrictness(options.flags);
-            tx.wellFormed(ledgerState, strictness, deps.clock.now());
-          },
-          catch: (cause) => new WellFormedError({ cause }),
-        }),
-      ),
-    );
-  },
-});
+/**
+ * Rejects a promise with the typed failure itself rather than the fiber wrapper around it, so a caller can `catch` the
+ * error class the signature names.
+ */
+const runPromiseThrowingFailure = async <A, E>(effect: Effect.Effect<A, E>): Promise<A> => {
+  const exit = await Effect.runPromiseExit(effect);
+  if (Exit.isSuccess(exit)) return exit.value;
+  const failure = Cause.failureOption(exit.cause);
+  if (Option.isSome(failure)) throw failure.value;
+  throw new Error(Cause.pretty(exit.cause));
+};
+
+export const makeDefaultValidationServiceEffect = (deps: ValidationServiceDependencies): ValidationServiceEffect =>
+  makeValidationServiceEffect(currentLedgerWellFormedCheck, deps);
 
 export const makeDefaultValidationService = (deps: ValidationServiceDependencies): ValidationService => {
   const effectService = makeDefaultValidationServiceEffect(deps);
   return {
-    validateTx: async (tx, options) => {
-      const exit = await Effect.runPromiseExit(effectService.validateTx(tx, options));
-      if (Exit.isSuccess(exit)) return;
-      const failure = Cause.failureOption(exit.cause);
-      if (Option.isSome(failure)) throw failure.value;
-      throw new Error(Cause.pretty(exit.cause));
-    },
+    validateTx: (tx, options) => runPromiseThrowingFailure(effectService.validateTx(tx, options)),
   };
 };
+
+/** Adapts a version-routed validation service to the promise-facing surface the facade exposes. */
+export const wrapVersionedValidationService = <TTransaction, TParameters>(
+  effectService: VersionedValidationServiceEffect<TTransaction, TParameters>,
+): VersionedValidationService<TTransaction, TParameters> => ({
+  validateTx: (tx, protocolVersion, options) =>
+    runPromiseThrowingFailure(effectService.validateTx(tx, protocolVersion, options)),
+});

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -28,7 +28,7 @@ import {
   type DustWalletState,
 } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import {
-  type AnyTransaction,
+  type AnyTransaction as DustAnyTransaction,
   type CoinsAndBalances as DustCoinsAndBalances,
 } from '@midnightntwrk/wallet-sdk-dust-wallet/v2';
 import {
@@ -173,6 +173,22 @@ export function mergeWalletEntries(existing: WalletEntry, incoming: WalletEntry)
     ...(dust !== undefined ? { dust } : {}),
   };
 }
+
+/**
+ * Every transaction shape the facade will take from a caller: unproven, proven-but-unbound, finalized, or proof-erased.
+ *
+ * @remarks
+ *   Named here because the facade's own signatures take it. It was previously reachable only as
+ *   `@midnightntwrk/wallet-sdk-dust-wallet/v2`'s `AnyTransaction` — a variant-scoped internal of a package a
+ *   facade-only app need not depend on at all, and one with a differently-typed pre-fork twin under `/v1`. The facade
+ *   owning the name is what keeps that an implementation detail.
+ *
+ *   Transitional, and deliberately an alias rather than a fresh declaration so it cannot drift from what these methods
+ *   actually accept. `WalletTransaction` handles are what replace these signatures — at which point the version a
+ *   transaction was authored for travels with it instead of being lost at this boundary, and this alias goes with
+ *   them.
+ */
+export type AnyTransaction = DustAnyTransaction;
 
 /**
  * Storage key for a tx we're about to submit (record as pending). The hash comes from {@link txHistoryHash}, which the

--- a/packages/facade/test/transactionTypes.test.ts
+++ b/packages/facade/test/transactionTypes.test.ts
@@ -1,0 +1,50 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { describe, expect, it } from 'vitest';
+import type { AnyTransaction, WalletFacade } from '../src/index.js';
+
+const NETWORK_ID = NetworkId.NetworkId.Undeployed;
+
+/** Compiles only when `A` is assignable to `B`. */
+type AssertAssignable<A extends B, B> = [A, B];
+
+// The name the facade exports is the very type its own public signatures take, in both directions — not a lookalike
+// declared beside them that could drift. A caller who annotates with it can always call these methods.
+export type AliasIsTheFeeParameter = AssertAssignable<
+  AnyTransaction,
+  Parameters<WalletFacade['calculateTransactionFee']>[0]
+>;
+export type FeeParameterIsTheAlias = AssertAssignable<
+  Parameters<WalletFacade['calculateTransactionFee']>[0],
+  AnyTransaction
+>;
+export type AliasIsTheRevertParameter = AssertAssignable<
+  AnyTransaction,
+  Parameters<WalletFacade['revertTransaction']>[0]
+>;
+
+describe('Naming the transactions the facade accepts, from the facade alone', () => {
+  it('names every transaction shape its fee and revert methods take, without reaching into another package', () => {
+    // Each binding is annotated with the facade's own exported name. That the annotations compile is the assertion:
+    // before, a caller had to import the type from a dust-wallet variant subpath to write any of these lines.
+    const unproven: AnyTransaction = ledger.Transaction.fromParts(NETWORK_ID);
+    const finalized: AnyTransaction = ledger.Transaction.fromParts(NETWORK_ID).mockProve();
+    const proofErased: AnyTransaction = ledger.Transaction.fromParts(NETWORK_ID).eraseProofs();
+
+    expect(unproven).toBeInstanceOf(ledger.Transaction);
+    expect(finalized).toBeInstanceOf(ledger.Transaction);
+    expect(proofErased).toBeInstanceOf(ledger.Transaction);
+  });
+});

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -48,6 +48,7 @@ import {
   type WalletLike,
 } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
+import type { UnboundTransaction } from '@midnightntwrk/wallet-sdk-capabilities/proving';
 import { EitherOps, HList, Poly } from '@midnightntwrk/wallet-sdk-utilities';
 import { variantForSnapshot } from './Restore.js';
 
@@ -61,7 +62,14 @@ export type ShieldedWalletServices = {
   transactionHistory: TransactionHistoryService;
 };
 
-export type UnboundTransaction = ledger.Transaction<ledger.SignatureEnabled, ledger.Proof, ledger.PreBinding>;
+/**
+ * A transaction that has been proven but not yet bound.
+ *
+ * @remarks
+ *   Owned by the proving capability, which is what produces one, and re-exported here so the name stays where callers
+ *   already reach for it. The shielded wallet neither builds nor consumes one itself.
+ */
+export type { UnboundTransaction };
 
 /** The core state of whichever shielded variant produced an emission. */
 export type ShieldedCoreState = V1CoreWallet | CoreWallet;

--- a/packages/unshielded-wallet/src/test/unboundTransaction.test.ts
+++ b/packages/unshielded-wallet/src/test/unboundTransaction.test.ts
@@ -1,0 +1,45 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
+import * as postForkLedger from '@midnightntwrk/ledger-v9';
+import type { UnboundTransaction as OwnedUnboundTransaction } from '@midnightntwrk/wallet-sdk-capabilities/proving';
+import { describe, expect, it } from 'vitest';
+import type { UnboundTransaction as PreForkUnboundTransaction } from '../v1/TransactionOps.js';
+import type { UnboundTransaction as PostForkUnboundTransaction } from '../v2/TransactionOps.js';
+
+/** Compiles only when `A` is assignable to `B`. */
+type AssertAssignable<A extends B, B> = [A, B];
+
+// The post-fork wallet's unbound transaction and the one the proving capability owns are one type, in both directions.
+// This is what makes the wallet's declaration a re-export rather than a second opinion.
+export type PostForkIsOwned = AssertAssignable<PostForkUnboundTransaction, OwnedUnboundTransaction>;
+export type OwnedIsPostFork = AssertAssignable<OwnedUnboundTransaction, PostForkUnboundTransaction>;
+
+// The pre-fork one is NOT the same type, and must never be collapsed into it: it names the other ledger version's
+// classes. Were this assignment to start compiling, the two ledgers would have become interchangeable in the type
+// system while staying incompatible at runtime — which is the whole failure the fork work exists to prevent.
+// @ts-expect-error - a pre-fork unbound transaction is not a post-fork one.
+export type PreForkIsNotOwned = AssertAssignable<PreForkUnboundTransaction, OwnedUnboundTransaction>;
+
+describe('The unbound transaction each side of the fork names', () => {
+  it('is a different class on each side, so no single declaration can stand for both', () => {
+    // The type-level assertions above are erased at build time; this is the same fact standing at runtime. Two distinct
+    // WASM modules are loaded, and a transaction built by one is not an instance of the other's class.
+    expect(preForkLedger.Transaction).not.toBe(postForkLedger.Transaction);
+
+    const postForkTransaction = postForkLedger.Transaction.fromParts('undeployed');
+
+    expect(postForkTransaction).toBeInstanceOf(postForkLedger.Transaction);
+    expect(postForkTransaction).not.toBeInstanceOf(preForkLedger.Transaction);
+  });
+});

--- a/packages/unshielded-wallet/src/v1/TransactionOps.ts
+++ b/packages/unshielded-wallet/src/v1/TransactionOps.ts
@@ -16,7 +16,14 @@ import type * as ledger from '@midnight-ntwrk/ledger-v8';
 import { addressFromKey } from '@midnight-ntwrk/ledger-v8';
 import { TransactingError, type WalletError } from './WalletError.js';
 
-/** Unbound transaction type. This is a transaction that has no signatures and is not bound yet. */
+/**
+ * Unbound transaction type. This is a transaction that has no signatures and is not bound yet.
+ *
+ * @remarks
+ *   Declared here rather than re-exported from the proving capability, unlike its post-fork twin: this one names the
+ *   pre-fork ledger's classes, so it is a different type and not a duplicate of one. Collapsing the two would make the
+ *   two ledgers interchangeable in the type system while they stay incompatible at runtime.
+ */
 export type UnboundTransaction = ledger.Transaction<ledger.SignatureEnabled, ledger.Proof, ledger.PreBinding>;
 
 /** Utility type to extract the Intent type from a Transaction type. Maps Transaction<S, P, B> to Intent<S, P, B>. */

--- a/packages/unshielded-wallet/src/v2/TransactionOps.ts
+++ b/packages/unshielded-wallet/src/v2/TransactionOps.ts
@@ -12,13 +12,21 @@
 // limitations under the License.
 import { Either, type Option, pipe, Array as Arr, Iterable as IterableOps } from 'effect';
 import { Imbalances } from '@midnightntwrk/wallet-sdk-capabilities';
+import type { UnboundTransaction } from '@midnightntwrk/wallet-sdk-capabilities/proving';
 import type * as ledger from '@midnightntwrk/ledger-v9';
 import { addressFromKey, SignatureEnabled } from '@midnightntwrk/ledger-v9';
 import { assertSignatureMatchesKey } from '../SchemeConsistency.js';
 import { TransactingError, type WalletError } from './WalletError.js';
 
-/** Unbound transaction type. This is a transaction that has no signatures and is not bound yet. */
-export type UnboundTransaction = ledger.Transaction<ledger.SignatureEnabled, ledger.Proof, ledger.PreBinding>;
+/**
+ * Unbound transaction type. This is a transaction that has no signatures and is not bound yet.
+ *
+ * @remarks
+ *   Owned by the proving capability, which is what produces one, and re-exported here so the name stays where callers
+ *   already reach for it. The pre-fork twin in `../v1/TransactionOps.ts` keeps its own declaration on purpose: it names
+ *   the other ledger version's classes and is a genuinely different type.
+ */
+export type { UnboundTransaction };
 
 /** Utility type to extract the Intent type from a Transaction type. Maps Transaction<S, P, B> to Intent<S, P, B>. */
 export type IntentOf<T> = T extends ledger.Transaction<infer S, infer P, infer B> ? ledger.Intent<S, P, B> : never;


### PR DESCRIPTION
Ninth increment of the dual-ledger public API redesign — the three plumbing refactors the #682 survey put ahead of the seam-closure cascade. Stacked on #682. All three are green intermediates; the seams themselves remain untouched.

## What's here

- **Version-routed `ValidationService`** — mirrored on the proving shape: `ValidationServices` = a `ProtocolVersion.Registry` of per-version validators, `makeVersionedValidationServiceEffect` selecting on the version a transaction was **authored** for (stamp, not chain), typed `UnsupportedValidationVersionError` miss, `singleVersionValidationServiceEffect` compat wrapper. Existing types gained parameters **defaulting to the current ledger**, so zero call sites changed — the changeset is additive/minor. (Survey correction along the way: `validateTx` has exactly ONE caller — the facade's `validateTransaction`; no balance path calls it.)
- **A genuine ledger-v8 validator, shipped, not deferred**: `makePreForkValidationServiceEffect` really calls v8's `LedgerState.blank`/`wellFormed` and is pinned against real v8 transactions (pass, wrong network, expired TTL, fetch given/failed). This corrects a plan asymmetry: "no v8 proving path exists" is true for proving, but v8 *validation* is fully constructible today. **The one remaining gap is wiring, stop-and-reported for the closure increment**: nothing registers the v8 validator yet because `defaultLedgerParametersCodecs` holds a single open-ended v9 entry — closure task #1 is a v8 codec entry + routing the block-data fetch on the block's reported version.
- **`UnboundTransaction` collapsed — it was three, not four**: the shielded and unshielded-v2 duplicates re-export capabilities/proving's declaration (the dependency-graph owner; shielded's was a dead alias); unshielded-v1's is `@midnight-ntwrk/ledger-v8`-typed — a genuinely DIFFERENT type, kept with a comment, and pinned non-assignable via a compiler-enforced `@ts-expect-error`. Public entry points keep exporting the same names (verified in emitted `.d.ts`).
- **`AnyTransaction` gets an owner**: the facade was using a dust-*variant-internal* type in five public signatures while exporting nothing — a facade-only app had to import from `dust-wallet/v2`. The facade now exports its own `AnyTransaction` (deliberately an alias, so it cannot drift from what the methods accept), with the closure-increment pointer on the declaration.

## Tests & gate

12 new tests across 4 files — the two validation suites red-first behavioural (routing, stamp-not-chain, typed miss, real v8 `wellFormed` semantics), the two type pins compiler-enforced and honestly disclosed as such (structurally-identical duplicates cannot produce a runtime red). Zero type casts added. Gate: dist 17/17, typecheck 37/37, lint 58/58, unit 54/54 tasks, shielded fork-simulation integration passing, effect-language-service 0 findings on all 11 changed files, format + changesets green. Changesets: capabilities minor (additive routing + the v8 validator), facade minor (additive `AnyTransaction`), shielded/unshielded patches (same names, one declaration).