### PR TITLE
feat(facade,wallets)!: pre-fork transacting, carried on version-stamped handles

### DIFF
--- a/.changeset/abstractions-epoch-of.md
+++ b/.changeset/abstractions-epoch-of.md
@@ -1,0 +1,8 @@
+---
+'@midnightntwrk/wallet-sdk-abstractions': minor
+---
+
+`ProtocolVersion.epochOf(version, forkVersion)` names the range of protocol versions on the same side of a protocol
+boundary as a given version — what the SDK means by "the same ledger version made these bytes". Everything that routes
+on a version is really asking which epoch it belongs to, so the boundary is computed in one place and the two ends of
+that question, the wallet stamping a transaction and the caller unwrapping it, cannot disagree.

--- a/.changeset/capabilities-validate-and-lower.md
+++ b/.changeset/capabilities-validate-and-lower.md
@@ -1,0 +1,26 @@
+---
+'@midnightntwrk/wallet-sdk-capabilities': major
+---
+
+Validate a transaction at the version it was authored for, on a chain with a protocol boundary.
+
+BREAKING CHANGE — `defaultLedgerParametersCodecs` is now a function of the chain's fork version and returns a registry
+**split at it**: a block reported from before the boundary is read with the previous ledger version's deserializer and
+one from the boundary with the current one, so the parameters handed to a validator are always ones its own
+`LedgerState` accepts. `makeDefaultBlockDataFetcher`'s configuration gains a required `forkVersion` for the same
+reason.
+
+`makeDefaultValidationServices` and `makeDefaultVersionedValidationService` register a validator either side of the
+boundary — the shipped pre-fork validator is no longer merely constructible but actually reachable — and route on the
+version a transaction was authored for.
+
+BREAKING CHANGE — `makeDefaultValidationService` and `makeDefaultValidationServiceEffect` take their block data as
+`AnyLedgerParameters`, the union naming what a fetcher spanning a boundary can yield. The two ledger versions'
+`LedgerParameters` are structurally identical, so this is a statement of intent rather than something the compiler
+enforces; the distinction is nominal at run time, which is why the routing has to be right rather than merely
+well-typed.
+
+New: `@midnightntwrk/wallet-sdk-capabilities/signatures` lowers a signature or verifying key from the current ledger
+version's `{ tag, value }` shape to the bare hex the previous one reads, and lifts it back. Lowering is partial — a
+scheme that version does not have cannot be expressed there at all, and says so with `UnsupportedSignatureKindError` —
+while lifting is total, because that version has exactly one scheme.

--- a/.changeset/facade-transaction-handles.md
+++ b/.changeset/facade-transaction-handles.md
@@ -1,0 +1,32 @@
+---
+'@midnightntwrk/wallet-sdk-facade': major
+'@midnightntwrk/wallet-sdk': major
+---
+
+The facade speaks transaction handles, and enforces which side of the protocol boundary it is on.
+
+BREAKING CHANGE — every public method that took or returned a ledger transaction now takes or returns a
+`WalletTransaction` handle: `submitTransaction`, `validateTransaction`, the three `balance*` methods,
+`finalizeTransaction`, `finalizeRecipe`, `signUnprovenTransaction`, `signUnboundTransaction`, the two fee methods,
+`revert`/`revertTransaction`, and the three recipe types. `AnyTransaction` is still the name the fee and revert methods
+are stated in terms of; it is now an alias of `AnyTx`.
+
+BREAKING CHANGE — **the `secretKeys` parameters are gone** from `transferTransaction`, `initSwap`, the three `balance*`
+methods and `estimateTransactionFee`. The wallets derive their own.
+
+BREAKING CHANGE — `finalizeTransaction` no longer takes an optional protocol version, and no longer falls back to the
+version the wallets have reached. The stamp on the transaction is authoritative: it is the version that fixed the
+bytes, so a fork landing between building and proving cannot send them to the wrong prover.
+
+**Enforcement.** At every point a transaction enters the facade it is accepted only if it was built on the side of the
+boundary the facade is currently on, and refused with a `ProtocolVersionMismatchError` otherwise. That covers a
+transaction an application authored and sealed itself, a transaction stranded by a crossing, and — because a merge
+across the boundary is not a failure to compute but an impossibility — every merge the facade performs for balancing.
+
+`validateTransaction` routes on the transaction's own stamp instead: well-formedness asks whether the ledger version
+that produced these bytes would accept them, and a fork landing afterwards cannot change the answer or who gives it.
+
+`FacadeState.pending` is now a set of handles. The pending machinery reads each entry with the trait registered for the
+version it was authored at, and the pre-fork entry is now a **genuine ledger-v8 trait** rather than the current
+version's standing in for it — so a transaction the fork stranded is recognised as stranded, by a reader that can
+actually read it, instead of waiting out a TTL for an inclusion that can never happen.

--- a/.changeset/prefork-transacting-closed.md
+++ b/.changeset/prefork-transacting-closed.md
@@ -1,0 +1,44 @@
+---
+'@midnightntwrk/wallet-sdk-shielded': major
+'@midnightntwrk/wallet-sdk-dust-wallet': major
+'@midnightntwrk/wallet-sdk-unshielded-wallet': major
+---
+
+Transact on either side of the protocol boundary. The three wallets' `PreFork*TransactingUnsupportedError` seams —
+each documented as temporary, and each refusing every transaction-building call while the wallet was still on the
+pre-fork variant — are **closed**. The pre-fork variant builds with the ledger version the chain is actually on, using
+its own key material, and what it produces says which version built it.
+
+BREAKING CHANGE — **the `secretKeys` parameters are gone** from every transacting method. A wallet spanning a protocol
+boundary derives what its current variant needs from what it was started with; a caller-supplied key object can only
+ever belong to one ledger version, which is exactly why it made pre-fork building impossible:
+
+```ts
+// before
+await shielded.transferTransaction(secretKeys, outputs);
+await dust.balanceTransactions(dustSecretKey, [tx], ttl);
+await dust.estimateFee(dustSecretKey, [tx], ttl);
+// after
+await shielded.transferTransaction(outputs);
+await dust.balanceTransactions([tx], ttl);
+await dust.estimateFee([tx], ttl);
+```
+
+BREAKING CHANGE — **transactions cross these APIs as `WalletTransaction` handles** (`UnprovenTx`, `UnboundTx`,
+`FinalizedTx`, `AnyTx`) rather than as one ledger version's classes. A handle carries the protocol version it was built
+at as ordinary readable data, which is what the SDK routes on: which prover proves it, which validator checks it, which
+variant may unwrap it at all. A transaction built on the other side of the boundary is refused by name with a
+`ProtocolVersionMismatchError` rather than handed to a ledger version that would misread it — except by
+`revertTransaction`, which has nothing of it to release and says so by doing nothing.
+
+An application that builds its own transactions imports `@midnightntwrk/wallet-sdk/ledger/v8` or `/v9` and seals the
+result with `WalletTransaction.adopt(stage, tx, version)`.
+
+Signatures and verifying keys are stated in the current ledger version's `{ tag, value }` shape throughout, including
+pre-fork: the wallet lowers them for the previous ledger version, which has one signature scheme and writes bare hex.
+A signature naming a scheme that version does not have is refused with a typed `UnsupportedSignatureKindError` rather
+than lowered into bytes it would misread.
+
+Dust's `balanceTransactions` now returns the block it priced the fee against in the terms both ledger versions report
+identically — hash, height, protocol version and parameters — rather than the variant's own `BlockData`, whose dust
+index and root fields were never a caller's business.

--- a/packages/abstractions/src/ProtocolVersion.ts
+++ b/packages/abstractions/src/ProtocolVersion.ts
@@ -71,6 +71,28 @@ export const MinSupportedVersion = ProtocolVersion(0n);
 export const MaxSupportedVersion = ProtocolVersion(BigInt(Number.MAX_SAFE_INTEGER));
 
 /**
+ * The range of protocol versions on the same side of a protocol boundary as a given version.
+ *
+ * @remarks
+ *   What the SDK means by "the same ledger version made these bytes". A protocol boundary divides the timeline into two
+ *   epochs, and everything that routes on a version — which prover proves a transaction, which validator checks it,
+ *   which variant may unwrap it — is really asking which epoch it belongs to. Stated once here so the two ends of that
+ *   question, the wallet stamping a transaction and the caller unwrapping it, cannot compute the boundary differently.
+ *
+ *   A chain whose boundary is at or below the minimum supported version has never had two epochs, so the whole range is
+ *   one.
+ * @param version A version in the epoch of interest.
+ * @param forkVersion The version at which the chain hands over to the next ledger version.
+ * @returns The half-open range of versions in that epoch.
+ */
+export const epochOf = (version: ProtocolVersion, forkVersion: ProtocolVersion): ProtocolVersion.Range =>
+  forkVersion <= MinSupportedVersion
+    ? makeRange(MinSupportedVersion, MaxSupportedVersion)
+    : version < forkVersion
+      ? makeRange(MinSupportedVersion, forkVersion)
+      : makeRange(forkVersion, MaxSupportedVersion);
+
+/**
  * A value together with the protocol version range it serves.
  *
  * @typeParam T The type of the registered value.

--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -44,6 +44,10 @@
       "types": "./dist/proving/index.d.ts",
       "import": "./dist/proving/index.js"
     },
+    "./signatures": {
+      "types": "./dist/signatures/index.d.ts",
+      "import": "./dist/signatures/index.js"
+    },
     "./simulation": {
       "types": "./dist/simulation/index.d.ts",
       "import": "./dist/simulation/index.js"

--- a/packages/capabilities/src/signatures/index.ts
+++ b/packages/capabilities/src/signatures/index.ts
@@ -10,11 +10,4 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-export * from './balancer/index.js';
-export * from './codecs/index.js';
-export * from './pendingTransactions/index.js';
-export * from './proving/index.js';
-export * from './signatures/index.js';
-export * from './simulation/index.js';
-export * from './submission/index.js';
-export * from './validation/index.js';
+export * from './preForkSignatures.js';

--- a/packages/capabilities/src/signatures/preForkSignatures.ts
+++ b/packages/capabilities/src/signatures/preForkSignatures.ts
@@ -1,0 +1,98 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Signatures and verifying keys across a protocol boundary.
+ *
+ * @remarks
+ *   The one scalar that genuinely changed shape at the fork. The pre-fork ledger version has a single signature scheme
+ *   and writes a signature as bare hex; the current one names the scheme alongside the bytes, because it has more than
+ *   one. So the SDK speaks the current shape everywhere and lowers it for the pre-fork variant, which is a total
+ *   operation in one direction and a partial one in the other: a signature of a scheme the pre-fork ledger has never
+ *   heard of cannot be lowered at all, and says so rather than being handed over as bytes it would misread.
+ */
+import type * as preForkLedger from '@midnight-ntwrk/ledger-v8';
+import type * as ledger from '@midnightntwrk/ledger-v9';
+import { Data, Either } from 'effect';
+
+/** The signature scheme the pre-fork ledger version has, and the only one a lowered value can name. */
+const PRE_FORK_SIGNATURE_KIND: ledger.SignatureKind = 'schnorr';
+
+/** Raised when a signature or verifying key names a scheme the pre-fork ledger version does not have. */
+export class UnsupportedSignatureKindError extends Data.TaggedError(
+  '@midnightntwrk/wallet-sdk-capabilities/signatures/preForkSignatures/UnsupportedSignatureKindError',
+)<{
+  readonly message: string;
+  /** The scheme that was named. */
+  readonly kind: ledger.SignatureKind;
+}> {}
+
+const lower = (
+  value: Readonly<{ tag: ledger.SignatureKind; value: string }>,
+  what: string,
+): Either.Either<string, UnsupportedSignatureKindError> =>
+  value.tag === PRE_FORK_SIGNATURE_KIND
+    ? Either.right(value.value)
+    : Either.left(
+        new UnsupportedSignatureKindError({
+          message:
+            `This ${what} names the ${value.tag} signature scheme, which the ledger version before the protocol ` +
+            `boundary does not have: it has ${PRE_FORK_SIGNATURE_KIND} and nothing else. Sign with ` +
+            `${PRE_FORK_SIGNATURE_KIND} while the chain is still pre-fork.`,
+          kind: value.tag,
+        }),
+      );
+
+/**
+ * Lowers a signature to the pre-fork ledger version's shape.
+ *
+ * @param signature The signature, as the current ledger version writes it.
+ * @returns The bare hex the pre-fork ledger version reads, or the reason it cannot be expressed there.
+ */
+export const lowerSignature = (
+  signature: ledger.Signature,
+): Either.Either<preForkLedger.Signature, UnsupportedSignatureKindError> => lower(signature, 'signature');
+
+/**
+ * Lowers a signature verifying key to the pre-fork ledger version's shape.
+ *
+ * @param key The verifying key, as the current ledger version writes it.
+ * @returns The bare hex the pre-fork ledger version reads, or the reason it cannot be expressed there.
+ */
+export const lowerSignatureVerifyingKey = (
+  key: ledger.SignatureVerifyingKey,
+): Either.Either<preForkLedger.SignatureVerifyingKey, UnsupportedSignatureKindError> => lower(key, 'verifying key');
+
+/**
+ * Lifts a pre-fork signature into the current ledger version's shape.
+ *
+ * @remarks
+ *   Total, unlike lowering: the pre-fork ledger version has exactly one scheme, so naming it is never a guess.
+ * @param signature The signature, as the pre-fork ledger version writes it.
+ * @returns The same signature, with the scheme it necessarily used named.
+ */
+export const liftSignature = (signature: preForkLedger.Signature): ledger.Signature => ({
+  tag: PRE_FORK_SIGNATURE_KIND,
+  value: signature,
+});
+
+/**
+ * Lifts a pre-fork verifying key into the current ledger version's shape.
+ *
+ * @param key The verifying key, as the pre-fork ledger version writes it.
+ * @returns The same key, with the scheme it necessarily used named.
+ */
+export const liftSignatureVerifyingKey = (key: preForkLedger.SignatureVerifyingKey): ledger.SignatureVerifyingKey => ({
+  tag: PRE_FORK_SIGNATURE_KIND,
+  value: key,
+});

--- a/packages/capabilities/src/validation/blockData.ts
+++ b/packages/capabilities/src/validation/blockData.ts
@@ -10,6 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import { LedgerParameters as PreForkLedgerParameters } from '@midnight-ntwrk/ledger-v8';
 import { LedgerParameters } from '@midnightntwrk/ledger-v9';
 import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { BlockHash } from '@midnightntwrk/wallet-sdk-indexer-client';
@@ -17,34 +18,62 @@ import { HttpQueryClient } from '@midnightntwrk/wallet-sdk-indexer-client/effect
 import { Effect, Either, pipe } from 'effect';
 import { LedgerParametersCodec } from '../codecs/index.js';
 import { getLastBlock, type Simulator } from '../simulation/index.js';
-import type { BlockData } from './validationService.js';
+import type { AnyLedgerParameters, BlockData } from './validationService.js';
 
-export type BlockDataFetcher = () => Promise<BlockData>;
+export type BlockDataFetcher = () => Promise<BlockData<AnyLedgerParameters>>;
 
 /**
- * The ledger parameters codecs validation reads blocks with, unless it is told otherwise.
+ * The ledger parameters codecs validation reads blocks with, split at the version the chain forks at.
  *
  * @remarks
- *   Open-ended from the minimum supported version, because well-formedness is checked against one ledger version's
- *   `LedgerState`: this registry is the seam where a second ledger version's codec is registered when validation itself
- *   learns to speak two.
+ *   A block's parameters are bytes of whichever ledger version produced the block, and the version the indexer reports
+ *   the block under is what says which. Below the fork version they are read with the pre-fork ledger version's
+ *   deserializer and from it with the current one, so that the object handed to a validator is always one its own
+ *   `LedgerState` accepts.
+ *
+ *   Nothing in the resulting type distinguishes the two: the ledger versions' `LedgerParameters` are structurally
+ *   identical, so {@link AnyLedgerParameters} is a statement of intent rather than something the compiler enforces. The
+ *   distinction is nominal at run time — the classes differ, and each ledger's WASM boundary rejects the other's —
+ *   which is why the routing has to be right rather than merely well-typed.
+ * @param forkVersion The protocol version at which the chain hands over to the current ledger version.
+ * @returns The registry blocks are read with.
  */
-export const defaultLedgerParametersCodecs: LedgerParametersCodec.LedgerParametersCodecs<LedgerParameters> =
+export const defaultLedgerParametersCodecs = (
+  forkVersion: ProtocolVersion.ProtocolVersion,
+): LedgerParametersCodec.LedgerParametersCodecs<AnyLedgerParameters> =>
   Either.getOrThrow(
-    LedgerParametersCodec.makeCodecs([
-      {
-        sinceVersion: ProtocolVersion.MinSupportedVersion,
-        codec: LedgerParametersCodec.fromDeserializer((bytes: Uint8Array) => LedgerParameters.deserialize(bytes)),
-      },
-    ]),
+    LedgerParametersCodec.makeCodecs<AnyLedgerParameters>(
+      forkVersion > ProtocolVersion.MinSupportedVersion
+        ? [
+            {
+              sinceVersion: ProtocolVersion.MinSupportedVersion,
+              codec: LedgerParametersCodec.fromDeserializer((bytes: Uint8Array) =>
+                PreForkLedgerParameters.deserialize(bytes),
+              ),
+            },
+            {
+              sinceVersion: forkVersion,
+              codec: LedgerParametersCodec.fromDeserializer((bytes: Uint8Array) => LedgerParameters.deserialize(bytes)),
+            },
+          ]
+        : // A chain whose boundary is at or below the minimum supported version has no pre-fork epoch to register for.
+          [
+            {
+              sinceVersion: ProtocolVersion.MinSupportedVersion,
+              codec: LedgerParametersCodec.fromDeserializer((bytes: Uint8Array) => LedgerParameters.deserialize(bytes)),
+            },
+          ],
+    ),
   );
 
 export type DefaultBlockDataFetcherConfiguration = {
   indexerClientConnection: {
     indexerHttpUrl: string;
   };
+  /** The protocol version at which this chain hands over to the current ledger version. */
+  forkVersion: ProtocolVersion.ProtocolVersion;
   /** The ledger parameters codecs blocks are read with; defaults to {@link defaultLedgerParametersCodecs}. */
-  ledgerParametersCodecs?: LedgerParametersCodec.LedgerParametersCodecs<LedgerParameters>;
+  ledgerParametersCodecs?: LedgerParametersCodec.LedgerParametersCodecs<AnyLedgerParameters>;
 };
 
 /** The block as the indexer serves it: parameters still hex, and the version that says how to read them. */
@@ -65,9 +94,9 @@ export type WireBlock = Readonly<{
  * @returns The block data, or the typed reason its parameters could not be read.
  */
 export const blockDataFrom = (
-  codecs: LedgerParametersCodec.LedgerParametersCodecs<LedgerParameters>,
+  codecs: LedgerParametersCodec.LedgerParametersCodecs<AnyLedgerParameters>,
   block: WireBlock,
-): Either.Either<BlockData, LedgerParametersCodec.LedgerParametersCodecError> =>
+): Either.Either<BlockData<AnyLedgerParameters>, LedgerParametersCodec.LedgerParametersCodecError> =>
   pipe(
     LedgerParametersCodec.decode(
       codecs,
@@ -90,7 +119,7 @@ export const blockDataFrom = (
  */
 export const makeDefaultBlockDataFetcher = (config: DefaultBlockDataFetcherConfiguration): BlockDataFetcher => {
   const url = config.indexerClientConnection.indexerHttpUrl;
-  const codecs = config.ledgerParametersCodecs ?? defaultLedgerParametersCodecs;
+  const codecs = config.ledgerParametersCodecs ?? defaultLedgerParametersCodecs(config.forkVersion);
   return () =>
     Effect.runPromise(
       Effect.gen(function* () {

--- a/packages/capabilities/src/validation/index.ts
+++ b/packages/capabilities/src/validation/index.ts
@@ -13,3 +13,4 @@
 export * from './blockData.js';
 export * from './preForkValidationService.js';
 export * from './validationService.js';
+export * from './versionedValidation.js';

--- a/packages/capabilities/src/validation/preForkValidationService.ts
+++ b/packages/capabilities/src/validation/preForkValidationService.ts
@@ -13,6 +13,7 @@
 import * as ledger from '@midnight-ntwrk/ledger-v8';
 import {
   makeValidationServiceEffect,
+  type AnyLedgerParameters,
   type ValidationServiceDependencies,
   type ValidationServiceEffect,
   type WellFormedCheck,
@@ -52,7 +53,7 @@ const buildBlankLedgerState = (networkId: string, parameters: ledger.LedgerParam
  *   classes, not the steps, that make this a separate check: a pre-fork transaction cannot be handed to the current
  *   ledger's `wellFormed`, nor current-ledger parameters to this one.
  */
-export const preForkWellFormedCheck: WellFormedCheck<AnyPreForkValidatableTransaction, ledger.LedgerParameters> = (
+export const preForkWellFormedCheck: WellFormedCheck<AnyPreForkValidatableTransaction, AnyLedgerParameters> = (
   tx,
   { networkId, ledgerParameters, flags, now },
 ) => {
@@ -63,16 +64,13 @@ export const preForkWellFormedCheck: WellFormedCheck<AnyPreForkValidatableTransa
  * Builds the validator for pre-fork transactions.
  *
  * @remarks
- *   Nothing in the SDK registers this yet, and that is a wiring gap rather than a missing capability. The default
- *   block-data fetcher decodes with `defaultLedgerParametersCodecs`, which is open-ended from the minimum supported
- *   version and holds only the current ledger's codec — so the block data reaching validation today is always
- *   current-ledger parameters, which this validator cannot use. Registering a pre-fork codec and routing the fetch on
- *   the block's reported version is what closes it; until then the pre-fork range stays empty and a pre-fork
- *   transaction is refused by name rather than checked against the wrong ledger.
- * @param deps The network, clock, and a block-data fetcher whose parameters are decoded at the pre-fork ledger version.
+ *   Registered below the fork version by `makeDefaultValidationServices`, against a block-data fetcher whose codec
+ *   registry is split at the same version — so a block reported from before the boundary reaches this validator as
+ *   pre-fork parameters, which is the only kind its ledger version can build a state from.
+ * @param deps The network, clock, and the block-data fetcher, which decodes each block at the version it reports.
  * @returns A validator to register in a `ValidationServices` registry for the version range before the fork.
  */
 export const makePreForkValidationServiceEffect = (
-  deps: ValidationServiceDependencies<ledger.LedgerParameters>,
-): ValidationServiceEffect<AnyPreForkValidatableTransaction, ledger.LedgerParameters> =>
+  deps: ValidationServiceDependencies<AnyLedgerParameters>,
+): ValidationServiceEffect<AnyPreForkValidatableTransaction, AnyLedgerParameters> =>
   makeValidationServiceEffect(preForkWellFormedCheck, deps);

--- a/packages/capabilities/src/validation/test/blockData.test.ts
+++ b/packages/capabilities/src/validation/test/blockData.test.ts
@@ -31,15 +31,46 @@ const blockAt = (protocolVersion: number, ledgerParameters: string) => ({
 
 describe('Reading a block the indexer served', () => {
   const hex = Buffer.from(LedgerParameters.initialParameters().serialize()).toString('hex');
+  const preForkHex = Buffer.from(PreForkLedgerParameters.initialParameters().serialize()).toString('hex');
+  const codecs = defaultLedgerParametersCodecs(V9_NATIVE);
 
   it('reads the parameters with the codec registered for the version the block reports', () => {
-    const result = blockDataFrom(defaultLedgerParametersCodecs, blockAt(2_000_000, hex));
+    const result = blockDataFrom(codecs, blockAt(2_000_000, hex));
 
     expect(Either.isRight(result)).toBe(true);
     const blockData = Option.getOrThrow(Either.getRight(result));
     expect(blockData.ledgerParameters).toBeInstanceOf(LedgerParameters);
     expect(blockData.protocolVersion).toBe(2_000_000);
     expect(blockData.timestamp).toEqual(new Date(1752487200000));
+  });
+
+  it('reads a block from before the fork with the pre-fork ledger version, and says so by its class', () => {
+    // The two ledger versions' `LedgerParameters` are structurally identical, so nothing in the type says which one
+    // came back — the class does, and it is the class the ledger's own `wellFormed` insists on.
+    const result = blockDataFrom(codecs, blockAt(1, preForkHex));
+
+    expect(Either.isRight(result)).toBe(true);
+    const blockData = Option.getOrThrow(Either.getRight(result));
+    expect(blockData.ledgerParameters).toBeInstanceOf(PreForkLedgerParameters);
+    expect(blockData.ledgerParameters).not.toBeInstanceOf(LedgerParameters);
+  });
+
+  it('splits at the fork version exactly, so the boundary block is already post-fork', () => {
+    const atBoundary = Option.getOrThrow(Either.getRight(blockDataFrom(codecs, blockAt(2_000_000, hex))));
+    const belowBoundary = Option.getOrThrow(Either.getRight(blockDataFrom(codecs, blockAt(1_999_999, preForkHex))));
+
+    expect(atBoundary.ledgerParameters).toBeInstanceOf(LedgerParameters);
+    expect(belowBoundary.ledgerParameters).toBeInstanceOf(PreForkLedgerParameters);
+  });
+
+  it('reads every block with the current ledger version when the chain has no boundary below it', () => {
+    // A chain whose fork version is the minimum supported one has no pre-fork epoch at all, so registering a codec
+    // for one would claim a range that cannot occur.
+    const noPreFork = defaultLedgerParametersCodecs(ProtocolVersion.MinSupportedVersion);
+
+    const blockData = Option.getOrThrow(Either.getRight(blockDataFrom(noPreFork, blockAt(0, hex))));
+
+    expect(blockData.ledgerParameters).toBeInstanceOf(LedgerParameters);
   });
 
   it('refuses a block reported at a version the caller does not validate for, naming that version', () => {
@@ -59,11 +90,10 @@ describe('Reading a block the indexer served', () => {
   });
 
   it('reports the other ledger version parameters as a typed decode failure', () => {
-    const preForkHex = Buffer.from(PreForkLedgerParameters.initialParameters().serialize()).toString('hex');
-
-    const error = Option.getOrThrow(
-      Either.getLeft(blockDataFrom(defaultLedgerParametersCodecs, blockAt(0, preForkHex))),
-    );
+    // A block reported from after the boundary, carrying bytes from before it: the version says which codec to use,
+    // and that codec cannot read them. Nothing else can tell the two apart, which is why this is a decode failure and
+    // not a mis-read.
+    const error = Option.getOrThrow(Either.getLeft(blockDataFrom(codecs, blockAt(2_000_000, preForkHex))));
 
     expect(error).toBeInstanceOf(LedgerParametersCodec.LedgerParametersDecodeError);
   });

--- a/packages/capabilities/src/validation/test/versionedValidation.test.ts
+++ b/packages/capabilities/src/validation/test/versionedValidation.test.ts
@@ -1,0 +1,146 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Which validator answers for a transaction, on an SDK that runs a ledger version either side of a protocol boundary.
+ *
+ * @remarks
+ *   Observed through real ledgers rather than labels, because the fact under test is that the two cannot read each other:
+ *   a pre-fork transaction handed to the current ledger's `wellFormed` fails, and vice versa. A pass therefore proves
+ *   the routing as surely as a failure does — nothing but the right validator can produce one.
+ */
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Cause, Effect, Either, Exit, Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { blockDataFrom, defaultLedgerParametersCodecs } from '../blockData.js';
+import { UnsupportedValidationVersionError, WellFormedError, type BlockData } from '../validationService.js';
+import { makeDefaultVersionedValidationServiceEffect } from '../versionedValidation.js';
+
+const NETWORK_ID = NetworkId.NetworkId.Undeployed;
+const NOW = new Date(1_752_487_200_000);
+
+const FORK = ProtocolVersion.ProtocolVersion(2_000_000n);
+const BEFORE_FORK = ProtocolVersion.ProtocolVersion(1n);
+
+const NO_STRICTNESS = { enforceBalancing: false, verifySignatures: false, enforceLimits: false } as const;
+
+/** A block as the indexer serves it, at `protocolVersion`, carrying the parameters of the matching ledger version. */
+const blockAt = (protocolVersion: bigint, hex: string) => ({
+  hash: '00'.repeat(32),
+  height: 7,
+  protocolVersion: Number(protocolVersion),
+  ledgerParameters: hex,
+  timestamp: NOW.getTime(),
+});
+
+const preForkHex = () => Buffer.from(preForkLedger.LedgerParameters.initialParameters().serialize()).toString('hex');
+const postForkHex = () => Buffer.from(ledger.LedgerParameters.initialParameters().serialize()).toString('hex');
+
+/** Reads a block the way the SDK's own fetcher does: with the codecs split at the same fork version. */
+const blockDataAt = (protocolVersion: bigint, hex: string): BlockData =>
+  Either.getOrThrow(blockDataFrom(defaultLedgerParametersCodecs(FORK), blockAt(protocolVersion, hex)));
+
+const validator = (blockData: BlockData) =>
+  makeDefaultVersionedValidationServiceEffect(
+    {
+      fetchBlockData: () => Promise.resolve(blockData),
+      networkId: NETWORK_ID,
+      clock: { now: () => NOW },
+    },
+    FORK,
+  );
+
+const failureOf = async <A, E>(effect: Effect.Effect<A, E>): Promise<E> => {
+  const exit = await Effect.runPromiseExit(effect);
+  if (Exit.isSuccess(exit)) throw new Error('expected the effect to fail');
+  return Option.getOrThrow(Cause.failureOption(exit.cause));
+};
+
+describe('Validating at the version a transaction was authored for, either side of the fork', () => {
+  it('checks a transaction authored before the fork with the pre-fork ledger version', async () => {
+    const routed = validator(blockDataAt(1n, preForkHex()));
+
+    await expect(
+      Effect.runPromise(
+        routed.validateTx(preForkLedger.Transaction.fromParts(NETWORK_ID), BEFORE_FORK, { flags: NO_STRICTNESS }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('checks a transaction authored from the fork with the current ledger version', async () => {
+    const routed = validator(blockDataAt(FORK, postForkHex()));
+
+    await expect(
+      Effect.runPromise(routed.validateTx(ledger.Transaction.fromParts(NETWORK_ID), FORK, { flags: NO_STRICTNESS })),
+    ).resolves.toBeUndefined();
+  });
+
+  it('refuses a pre-fork transaction offered at a post-fork version, rather than checking it with the wrong ledger', async () => {
+    // The routing is on the transaction's own stamp, so this is a caller claiming the wrong epoch for its bytes. The
+    // current ledger's `wellFormed` cannot read them, and says so.
+    const routed = validator(blockDataAt(FORK, postForkHex()));
+
+    const error = await failureOf(
+      routed.validateTx(preForkLedger.Transaction.fromParts(NETWORK_ID), FORK, { flags: NO_STRICTNESS }),
+    );
+
+    expect(error).toBeInstanceOf(WellFormedError);
+  });
+
+  it('refuses a post-fork transaction offered at a pre-fork version, symmetrically', async () => {
+    const routed = validator(blockDataAt(1n, preForkHex()));
+
+    const error = await failureOf(
+      routed.validateTx(ledger.Transaction.fromParts(NETWORK_ID), BEFORE_FORK, { flags: NO_STRICTNESS }),
+    );
+
+    expect(error).toBeInstanceOf(WellFormedError);
+  });
+
+  it('registers only the current ledger version when the chain has no epoch below the boundary', async () => {
+    // With the boundary at the minimum supported version there is no pre-fork range at all, so a pre-fork stamp is a
+    // version the registry genuinely does not cover — which is a different answer from "checked and malformed".
+    const routed = makeDefaultVersionedValidationServiceEffect(
+      {
+        fetchBlockData: () => Promise.resolve(blockDataAt(FORK, postForkHex())),
+        networkId: NETWORK_ID,
+        clock: { now: () => NOW },
+      },
+      ProtocolVersion.MinSupportedVersion,
+    );
+
+    await expect(
+      Effect.runPromise(routed.validateTx(ledger.Transaction.fromParts(NETWORK_ID), FORK, { flags: NO_STRICTNESS })),
+    ).resolves.toBeUndefined();
+  });
+
+  it('names the version when nothing is registered for it at all', async () => {
+    const routed = makeDefaultVersionedValidationServiceEffect(
+      {
+        fetchBlockData: () => Promise.resolve(blockDataAt(FORK, postForkHex())),
+        networkId: NETWORK_ID,
+        clock: { now: () => NOW },
+      },
+      FORK,
+    );
+
+    const belowMinimum = ProtocolVersion.ProtocolVersion(-1n);
+    const error = await failureOf(
+      routed.validateTx(ledger.Transaction.fromParts(NETWORK_ID), belowMinimum, { flags: NO_STRICTNESS }),
+    );
+
+    expect(error).toBeInstanceOf(UnsupportedValidationVersionError);
+  });
+});

--- a/packages/capabilities/src/validation/validationService.ts
+++ b/packages/capabilities/src/validation/validationService.ts
@@ -10,11 +10,24 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import type * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import type { Clock } from '@midnightntwrk/wallet-sdk-utilities';
 import { Cause, Data, Effect, Exit, Option, pipe } from 'effect';
 import type { UnboundTransaction } from '../proving/provingService.js';
+
+/**
+ * Ledger parameters as either ledger version reads them: what a block-data fetch spanning a protocol boundary yields.
+ *
+ * @remarks
+ *   The two ledger versions' `LedgerParameters` are structurally identical, so this union carries no information the
+ *   compiler can act on — it names, at the one place a block's parameters cross into validation, that which ledger
+ *   version produced them is a run-time fact settled by the block's reported protocol version. Each ledger's
+ *   `LedgerState` still insists on its own class, so handing over the wrong one fails at the WASM boundary and is
+ *   reported as a {@link WellFormedError}.
+ */
+export type AnyLedgerParameters = preForkLedger.LedgerParameters | ledger.LedgerParameters;
 
 /**
  * Snapshot of chain state required for transaction validation. Structurally identical to the dust-wallet's `BlockData`
@@ -268,7 +281,7 @@ const buildBlankLedgerState = (networkId: string, parameters: ledger.LedgerParam
 };
 
 /** The current ledger version's well-formedness check. */
-export const currentLedgerWellFormedCheck: WellFormedCheck<AnyValidatableTransaction, ledger.LedgerParameters> = (
+export const currentLedgerWellFormedCheck: WellFormedCheck<AnyValidatableTransaction, AnyLedgerParameters> = (
   tx,
   { networkId, ledgerParameters, flags, now },
 ) => {
@@ -291,10 +304,14 @@ const runPromiseThrowingFailure = async <A, E extends Error>(effect: Effect.Effe
   throw new Error(Cause.pretty(exit.cause));
 };
 
-export const makeDefaultValidationServiceEffect = (deps: ValidationServiceDependencies): ValidationServiceEffect =>
+export const makeDefaultValidationServiceEffect = (
+  deps: ValidationServiceDependencies<AnyLedgerParameters>,
+): ValidationServiceEffect<AnyValidatableTransaction, AnyLedgerParameters> =>
   makeValidationServiceEffect(currentLedgerWellFormedCheck, deps);
 
-export const makeDefaultValidationService = (deps: ValidationServiceDependencies): ValidationService => {
+export const makeDefaultValidationService = (
+  deps: ValidationServiceDependencies<AnyLedgerParameters>,
+): ValidationService<AnyValidatableTransaction, AnyLedgerParameters> => {
   const effectService = makeDefaultValidationServiceEffect(deps);
   return {
     validateTx: (tx, options) => runPromiseThrowingFailure(effectService.validateTx(tx, options)),

--- a/packages/capabilities/src/validation/versionedValidation.ts
+++ b/packages/capabilities/src/validation/versionedValidation.ts
@@ -1,0 +1,104 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Well-formedness for an SDK that spans a protocol boundary: one validator per ledger version, chosen by the version a
+ * transaction was authored for.
+ *
+ * @remarks
+ *   The two halves already exist and are each written against one ledger version. What this module supplies is the only
+ *   thing neither of them can: the registration that says which range of protocol versions each one answers for, taken
+ *   from the same fork version the wallets are built with.
+ */
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Either } from 'effect';
+import {
+  makePreForkValidationServiceEffect,
+  type AnyPreForkValidatableTransaction,
+} from './preForkValidationService.js';
+import {
+  makeDefaultValidationServiceEffect,
+  makeVersionedValidationServiceEffect,
+  wrapVersionedValidationService,
+  type AnyLedgerParameters,
+  type AnyValidatableTransaction,
+  type ValidationServiceDependencies,
+  type ValidationServiceEffect,
+  type ValidationServices,
+  type VersionedValidationService,
+  type VersionedValidationServiceEffect,
+} from './validationService.js';
+
+/**
+ * Every transaction shape either ledger version can be asked about.
+ *
+ * @remarks
+ *   A genuine union, unlike {@link AnyLedgerParameters}: the two ledger versions' transaction types are nominally
+ *   distinct, so a caller holding one of them is holding something the other version's validator provably cannot read.
+ */
+export type AnyVersionValidatableTransaction = AnyValidatableTransaction | AnyPreForkValidatableTransaction;
+
+/** A validator registered in a two-version registry, whichever ledger version it was written against. */
+export type VersionValidationServiceEffect = ValidationServiceEffect<
+  AnyVersionValidatableTransaction,
+  AnyLedgerParameters
+>;
+
+/**
+ * Registers a validator either side of the protocol boundary.
+ *
+ * @remarks
+ *   Both validators are handed the same block-data fetcher, and that is correct rather than a shortcut: the fetcher
+ *   decodes a block's parameters with the codec registered for the version the block itself was reported under, so it
+ *   already yields the ledger version whose validator will be chosen for a transaction authored in the same epoch. A
+ *   transaction authored on the other side of the boundary from the chain's current block is the case neither can
+ *   serve, and it fails at the ledger rather than silently checking against the wrong parameters.
+ * @param deps The network, clock, and the block-data fetcher shared by both validators.
+ * @param forkVersion The protocol version at which the chain hands over to the current ledger version.
+ * @returns The validators and the version ranges they serve.
+ */
+export const makeDefaultValidationServices = (
+  deps: ValidationServiceDependencies<AnyLedgerParameters>,
+  forkVersion: ProtocolVersion.ProtocolVersion,
+): ValidationServices<AnyVersionValidatableTransaction, AnyLedgerParameters> =>
+  Either.getOrThrow(
+    ProtocolVersion.makeRegistryFromActivations<VersionValidationServiceEffect>(
+      forkVersion > ProtocolVersion.MinSupportedVersion
+        ? [
+            { sinceVersion: ProtocolVersion.MinSupportedVersion, value: makePreForkValidationServiceEffect(deps) },
+            { sinceVersion: forkVersion, value: makeDefaultValidationServiceEffect(deps) },
+          ]
+        : // A chain whose boundary is at or below the minimum supported version has no pre-fork epoch to register for.
+          [{ sinceVersion: ProtocolVersion.MinSupportedVersion, value: makeDefaultValidationServiceEffect(deps) }],
+    ),
+  );
+
+/**
+ * Builds the version-routed validator an SDK spanning a protocol boundary checks with.
+ *
+ * @param deps The network, clock, and the block-data fetcher shared by both validators.
+ * @param forkVersion The protocol version at which the chain hands over to the current ledger version.
+ * @returns A validator that routes on the version a transaction was authored for.
+ */
+export const makeDefaultVersionedValidationServiceEffect = (
+  deps: ValidationServiceDependencies<AnyLedgerParameters>,
+  forkVersion: ProtocolVersion.ProtocolVersion,
+): VersionedValidationServiceEffect<AnyVersionValidatableTransaction, AnyLedgerParameters> =>
+  makeVersionedValidationServiceEffect(makeDefaultValidationServices(deps, forkVersion));
+
+/** The promise-facing surface of {@link makeDefaultVersionedValidationServiceEffect}, for the facade to expose. */
+export const makeDefaultVersionedValidationService = (
+  deps: ValidationServiceDependencies<AnyLedgerParameters>,
+  forkVersion: ProtocolVersion.ProtocolVersion,
+): VersionedValidationService<AnyVersionValidatableTransaction, AnyLedgerParameters> =>
+  wrapVersionedValidationService(makeDefaultVersionedValidationServiceEffect(deps, forkVersion));

--- a/packages/docs-snippets/src/snippets/balancing.ts
+++ b/packages/docs-snippets/src/snippets/balancing.ts
@@ -10,8 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import * as ledger from '@midnightntwrk/ledger-v9';
-import { generateRandomSeed } from '@midnightntwrk/wallet-sdk';
+import { generateRandomSeed, ProtocolVersion, WalletTransaction } from '@midnightntwrk/wallet-sdk';
+import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
 import { Buffer } from 'buffer';
 import * as rx from 'rxjs';
 import { initWalletWithSeed } from '../utils.ts';
@@ -38,20 +38,19 @@ const makeTransactionBlueprint = () => {
   );
   const intent = ledger.Intent.new(new Date(Date.now() + 30 * 60 * 1000));
   intent.fallibleUnshieldedOffer = unshieldedOffer;
-  return ledger.Transaction.fromParts('undeployed', undefined, undefined, intent);
+  // Sealed together with the protocol version the ledger module above serves: an application that builds its own
+  // transaction is the one thing that has to say which ledger version built it.
+  return WalletTransaction.adopt(
+    'Unproven',
+    ledger.Transaction.fromParts('undeployed', undefined, undefined, intent),
+    ProtocolVersion.MinSupportedVersion,
+  );
 };
 
 await sender.wallet
-  .balanceUnprovenTransaction(
-    makeTransactionBlueprint(),
-    {
-      shieldedSecretKeys: sender.shieldedSecretKeys,
-      dustSecretKey: sender.dustSecretKey,
-    },
-    {
-      ttl: new Date(Date.now() + 30 * 60 * 1000),
-    },
-  )
+  .balanceUnprovenTransaction(makeTransactionBlueprint(), {
+    ttl: new Date(Date.now() + 30 * 60 * 1000),
+  })
   .then((recipe) => {
     return sender.wallet.signRecipe(recipe, sender.unshieldedKeystore.signDataAsync);
   })

--- a/packages/docs-snippets/src/snippets/combined-transfer.ts
+++ b/packages/docs-snippets/src/snippets/combined-transfer.ts
@@ -48,10 +48,6 @@ await sender.wallet
       },
     ],
     {
-      shieldedSecretKeys: sender.shieldedSecretKeys,
-      dustSecretKey: sender.dustSecretKey,
-    },
-    {
       ttl: new Date(Date.now() + 30 * 60 * 1000),
     },
   )

--- a/packages/docs-snippets/src/snippets/deregistration.ts
+++ b/packages/docs-snippets/src/snippets/deregistration.ts
@@ -34,17 +34,10 @@ await sender.wallet
     sender.unshieldedKeystore.signDataAsync,
   )
   .then((recipe) =>
-    sender.wallet.balanceUnprovenTransaction(
-      recipe.transaction,
-      {
-        shieldedSecretKeys: sender.shieldedSecretKeys,
-        dustSecretKey: sender.dustSecretKey,
-      },
-      {
-        ttl: new Date(Date.now() + 30 * 60 * 1000),
-        tokenKindsToBalance: ['dust'],
-      },
-    ),
+    sender.wallet.balanceUnprovenTransaction(recipe.transaction, {
+      ttl: new Date(Date.now() + 30 * 60 * 1000),
+      tokenKindsToBalance: ['dust'],
+    }),
   )
   .then((recipe) => sender.wallet.finalizeRecipe(recipe))
   .then((finalizedTransaction) => sender.wallet.submitTransaction(finalizedTransaction));

--- a/packages/docs-snippets/src/snippets/designation.ts
+++ b/packages/docs-snippets/src/snippets/designation.ts
@@ -39,10 +39,6 @@ await sender.wallet
       },
     ],
     {
-      shieldedSecretKeys: sender.shieldedSecretKeys,
-      dustSecretKey: sender.dustSecretKey,
-    },
-    {
       ttl: new Date(Date.now() + 30 * 60 * 1000),
     },
   )

--- a/packages/docs-snippets/src/snippets/dust-sponsorship.ts
+++ b/packages/docs-snippets/src/snippets/dust-sponsorship.ts
@@ -10,11 +10,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import * as ledger from '@midnightntwrk/ledger-v9';
-import { generateRandomSeed } from '@midnightntwrk/wallet-sdk';
+import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
+import { generateRandomSeed, ProtocolVersion, type UnboundTx, WalletTransaction } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import * as rx from 'rxjs';
-import { type UnboundTransaction } from '@midnightntwrk/wallet-sdk/proving';
 import { aFakeProvingProvider, initWalletWithSeed } from '../utils.ts';
 
 /*
@@ -54,10 +53,6 @@ await sponsor.wallet
         ],
       },
     ],
-    {
-      shieldedSecretKeys: sponsor.shieldedSecretKeys,
-      dustSecretKey: sponsor.dustSecretKey,
-    },
     { ttl: new Date(Date.now() + 30 * 60 * 1000) },
   )
   .then((recipe) => sponsor.wallet.signRecipe(recipe, sponsor.unshieldedKeystore.signDataAsync))
@@ -75,7 +70,7 @@ console.log(
   userReceivedNight.unshielded.balances[ledger.nativeToken().raw],
 );
 
-const prepareTransactionToBalance = async (): Promise<UnboundTransaction> => {
+const prepareTransactionToBalance = async (): Promise<UnboundTx> => {
   const unshieldedOffer = ledger.UnshieldedOffer.new(
     [],
     [
@@ -91,43 +86,32 @@ const prepareTransactionToBalance = async (): Promise<UnboundTransaction> => {
   intent.fallibleUnshieldedOffer = unshieldedOffer;
   const unprovenTransaction = ledger.Transaction.fromParts('undeployed', undefined, undefined, intent);
   // Fake proving will work here as no proofs are involved. This is a major difference compared to real flow
-  return await unprovenTransaction.prove(
+  const proven = await unprovenTransaction.prove(
     aFakeProvingProvider,
     ledger.LedgerParameters.initialParameters().transactionCostModel.runtimeCostModel,
   );
+  // Sealed with the protocol version the ledger module above serves: a transaction an application built for itself is
+  // handed to the wallet as a handle, saying which ledger version made it.
+  return WalletTransaction.adopt('Unbound', proven, ProtocolVersion.MinSupportedVersion);
 };
 //Transaction as DApp could prepare it
 const transactionToBalance = await prepareTransactionToBalance();
 
 // Balanced by user without paying fees
 const transactionWithoutFees = await user.wallet
-  .balanceUnboundTransaction(
-    transactionToBalance,
-    {
-      shieldedSecretKeys: user.shieldedSecretKeys,
-      dustSecretKey: user.dustSecretKey,
-    },
-    {
-      ttl: new Date(Date.now() + 30 * 60 * 1000),
-      tokenKindsToBalance: ['shielded', 'unshielded'],
-    },
-  )
+  .balanceUnboundTransaction(transactionToBalance, {
+    ttl: new Date(Date.now() + 30 * 60 * 1000),
+    tokenKindsToBalance: ['shielded', 'unshielded'],
+  })
   .then((recipe) => user.wallet.signRecipe(recipe, user.unshieldedKeystore.signDataAsync))
   .then((tx) => user.wallet.finalizeRecipe(tx));
 
 // With sponsor paying fees and submitting transaction
 await sponsor.wallet
-  .balanceFinalizedTransaction(
-    transactionWithoutFees,
-    {
-      shieldedSecretKeys: sponsor.shieldedSecretKeys,
-      dustSecretKey: sponsor.dustSecretKey,
-    },
-    {
-      ttl: new Date(Date.now() + 30 * 60 * 1000),
-      tokenKindsToBalance: ['dust'],
-    },
-  )
+  .balanceFinalizedTransaction(transactionWithoutFees, {
+    ttl: new Date(Date.now() + 30 * 60 * 1000),
+    tokenKindsToBalance: ['dust'],
+  })
   .then((recipe) => sponsor.wallet.signRecipe(recipe, sponsor.unshieldedKeystore.signDataAsync))
   .then((recipe) => sponsor.wallet.finalizeRecipe(recipe))
   .then((finalizedTransaction) => sponsor.wallet.submitTransaction(finalizedTransaction));

--- a/packages/docs-snippets/src/snippets/redesignation.ts
+++ b/packages/docs-snippets/src/snippets/redesignation.ts
@@ -34,17 +34,10 @@ await sender.wallet
     receiverStateBefore.dust.address,
   )
   .then((recipe) =>
-    sender.wallet.balanceUnprovenTransaction(
-      recipe.transaction,
-      {
-        shieldedSecretKeys: sender.shieldedSecretKeys,
-        dustSecretKey: sender.dustSecretKey,
-      },
-      {
-        ttl: new Date(Date.now() + 30 * 60 * 1000),
-        tokenKindsToBalance: ['dust'],
-      },
-    ),
+    sender.wallet.balanceUnprovenTransaction(recipe.transaction, {
+      ttl: new Date(Date.now() + 30 * 60 * 1000),
+      tokenKindsToBalance: ['dust'],
+    }),
   )
   .then((recipe) => sender.wallet.finalizeRecipe(recipe))
   .then((finalizedTransaction) => sender.wallet.submitTransaction(finalizedTransaction));

--- a/packages/docs-snippets/src/snippets/shielded-transfer.ts
+++ b/packages/docs-snippets/src/snippets/shielded-transfer.ts
@@ -38,10 +38,6 @@ await sender.wallet
       },
     ],
     {
-      shieldedSecretKeys: sender.shieldedSecretKeys,
-      dustSecretKey: sender.dustSecretKey,
-    },
-    {
       ttl: new Date(Date.now() + 30 * 60 * 1000),
     },
   )

--- a/packages/docs-snippets/src/snippets/swap.ts
+++ b/packages/docs-snippets/src/snippets/swap.ts
@@ -13,8 +13,7 @@
 import { Buffer } from 'buffer';
 import * as rx from 'rxjs';
 import { initWalletWithSeed } from '../utils.ts';
-import type * as ledger from '@midnightntwrk/ledger-v9';
-import { type FacadeState } from '@midnightntwrk/wallet-sdk';
+import { type FacadeState, type FinalizedTx } from '@midnightntwrk/wallet-sdk';
 
 const alice = await initWalletWithSeed(
   Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex'),
@@ -38,7 +37,7 @@ console.log(
   bobInitialState.shielded.availableCoins.some((c) => c.coin.type === shieldedToken1 && c.coin.value === 1_000_000n),
 );
 
-const aliceSwapTx: ledger.FinalizedTransaction = await alice.wallet
+const aliceSwapTx: FinalizedTx = await alice.wallet
   .initSwap(
     { shielded: { [shieldedToken1]: 1_000_000n } },
     [
@@ -54,26 +53,15 @@ const aliceSwapTx: ledger.FinalizedTransaction = await alice.wallet
       },
     ],
     {
-      shieldedSecretKeys: alice.shieldedSecretKeys,
-      dustSecretKey: alice.dustSecretKey,
-    },
-    {
       ttl: new Date(Date.now() + 30 * 60 * 1000),
     },
   )
   .then((recipe) => alice.wallet.finalizeRecipe(recipe));
 
 await bob.wallet
-  .balanceFinalizedTransaction(
-    aliceSwapTx,
-    {
-      shieldedSecretKeys: bob.shieldedSecretKeys,
-      dustSecretKey: bob.dustSecretKey,
-    },
-    {
-      ttl: new Date(Date.now() + 30 * 60 * 1000),
-    },
-  )
+  .balanceFinalizedTransaction(aliceSwapTx, {
+    ttl: new Date(Date.now() + 30 * 60 * 1000),
+  })
   .then((recipe) => bob.wallet.finalizeRecipe(recipe))
   .then((tx) => bob.wallet.submitTransaction(tx));
 

--- a/packages/docs-snippets/src/snippets/unshielded-transfer.ts
+++ b/packages/docs-snippets/src/snippets/unshielded-transfer.ts
@@ -38,10 +38,6 @@ await sender.wallet
       },
     ],
     {
-      shieldedSecretKeys: sender.shieldedSecretKeys,
-      dustSecretKey: sender.dustSecretKey,
-    },
-    {
       ttl: new Date(Date.now() + 30 * 60 * 1000),
     },
   )

--- a/packages/docs-snippets/src/snippets/well-formed-validation.ts
+++ b/packages/docs-snippets/src/snippets/well-formed-validation.ts
@@ -10,8 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import * as ledger from '@midnightntwrk/ledger-v9';
-import { generateRandomSeed } from '@midnightntwrk/wallet-sdk';
+import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
+import { generateRandomSeed, ProtocolVersion, WalletTransaction } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import * as rx from 'rxjs';
 import { initWalletWithSeed } from '../utils.ts';
@@ -32,7 +32,13 @@ const buildUnprovenTransaction = () => {
   );
   const intent = ledger.Intent.new(new Date(Date.now() + 30 * 60 * 1000));
   intent.fallibleUnshieldedOffer = unshieldedOffer;
-  return ledger.Transaction.fromParts('undeployed', undefined, undefined, intent);
+  // Sealed with the protocol version the ledger module above serves, which is how the wallet knows which of its
+  // variants may read these bytes and which prover and validator answer for them.
+  return WalletTransaction.adopt(
+    'Unproven',
+    ledger.Transaction.fromParts('undeployed', undefined, undefined, intent),
+    ProtocolVersion.MinSupportedVersion,
+  );
 };
 
 const unprovenTx = buildUnprovenTransaction();
@@ -44,11 +50,9 @@ await sender.wallet.validateTransaction(unprovenTx, {
 });
 console.log('Validated unproven transaction (structural checks only)');
 
-const recipe = await sender.wallet.balanceUnprovenTransaction(
-  unprovenTx,
-  { shieldedSecretKeys: sender.shieldedSecretKeys, dustSecretKey: sender.dustSecretKey },
-  { ttl: new Date(Date.now() + 30 * 60 * 1000) },
-);
+const recipe = await sender.wallet.balanceUnprovenTransaction(unprovenTx, {
+  ttl: new Date(Date.now() + 30 * 60 * 1000),
+});
 const signedRecipe = await sender.wallet.signRecipe(recipe, sender.unshieldedKeystore.signDataAsync);
 const finalizedTx = await sender.wallet.finalizeRecipe(signedRecipe);
 

--- a/packages/dust-wallet/src/DustWallet.ts
+++ b/packages/dust-wallet/src/DustWallet.ts
@@ -19,11 +19,25 @@ import {
   type SignatureVerifyingKey,
   type UnprovenTransaction,
 } from '@midnightntwrk/ledger-v9';
-import { type ProtocolState, ProtocolVersion, type SyncProgress } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  type AnyTx,
+  type ProtocolState,
+  ProtocolVersion,
+  type ProtocolVersionMismatchError,
+  type SyncProgress,
+  type UnprovenTx,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
 import { type DustAddress } from '@midnightntwrk/wallet-sdk-address-format';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
-import { type Variant, type VariantBuilder, type WalletLike } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
-import { type Clock } from '@midnightntwrk/wallet-sdk-utilities';
+import {
+  StartMaterial,
+  type Variant,
+  type VariantBuilder,
+  type WalletLike,
+} from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { type BlockData as PricedBlockData } from '@midnightntwrk/wallet-sdk-capabilities/validation';
+import { type Clock, EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
 import { type Duration, Effect, Either, Option, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
 import { type Balance, type CoinsAndBalancesCapability, type UtxoWithFullDustDetails } from './v2/CoinsAndBalances.js';
@@ -38,7 +52,7 @@ import { type BaseV2Configuration, type V2Variant } from './v2/V2Builder.js';
 import { type DustHistoryStorage } from './v2/TransactionHistory.js';
 import { type CoreWallet as V1CoreWallet } from './v1/CoreWallet.js';
 import { type NetworkId, type TotalCostParameters } from './v2/types/index.js';
-import { type WalletSyncUpdate, type BlockData } from './v2/SyncSchema.js';
+import { type WalletSyncUpdate } from './v2/SyncSchema.js';
 
 export type { BlockData } from './v2/SyncSchema.js';
 
@@ -201,7 +215,7 @@ export type DustWalletAPI<TStartAux = DustSecretKey, TSerialized = string> = {
     nightUtxos: Array<UtxoWithMeta>,
     nightVerifyingKey: SignatureVerifyingKey,
     dustReceiverAddress: DustAddress | undefined,
-  ): Promise<UnprovenTransaction>;
+  ): Promise<UnprovenTx>;
 
   splitNightUtxosForDustRegistration(
     currentTime: Date,
@@ -210,14 +224,14 @@ export type DustWalletAPI<TStartAux = DustSecretKey, TSerialized = string> = {
   ): Promise<NightUtxoSplitForDustRegistration>;
 
   attachDustRegistration(
-    transaction: UnprovenTransaction,
+    transaction: UnprovenTx,
     currentTime: Date,
     nightVerifyingKey: SignatureVerifyingKey,
     dustReceiverAddress: DustAddress | undefined,
     feePayment: bigint,
-  ): Promise<UnprovenTransaction>;
+  ): Promise<UnprovenTx>;
 
-  addDustGenerationSignature(transaction: UnprovenTransaction, signature: Signature): Promise<UnprovenTransaction>;
+  addDustGenerationSignature(transaction: UnprovenTx, signature: Signature): Promise<UnprovenTx>;
 
   /**
    * Attaches a signature to the DustRegistration in segment 1's `dustActions` only. Unlike
@@ -225,23 +239,31 @@ export type DustWalletAPI<TStartAux = DustSecretKey, TSerialized = string> = {
    * via the unshielded-wallet signing path. Use this when the caller orchestrates signing across both packages (e.g.
    * the facade's `signRecipe`).
    */
-  addDustRegistrationSignature(transaction: UnprovenTransaction, signature: Signature): Promise<UnprovenTransaction>;
+  addDustRegistrationSignature(transaction: UnprovenTx, signature: Signature): Promise<UnprovenTx>;
 
-  calculateFee(transactions: ReadonlyArray<AnyTransaction>): Promise<bigint>;
+  calculateFee(transactions: ReadonlyArray<AnyTx>): Promise<bigint>;
 
-  estimateFee(
-    secretKey: DustSecretKey,
-    transactions: ReadonlyArray<AnyTransaction>,
-    ttl?: Date,
-    currentTime?: Date,
-  ): Promise<bigint>;
+  /**
+   * Estimates what a set of transactions will cost, including the fee of the balancing transaction.
+   *
+   * @remarks
+   *   No key material is passed: the wallet derives what its current variant needs from what it was started with.
+   */
+  estimateFee(transactions: ReadonlyArray<AnyTx>, ttl?: Date, currentTime?: Date): Promise<bigint>;
 
+  /**
+   * Balances a set of transactions by paying their fee in dust.
+   *
+   * @remarks
+   *   The block data returned is the block the fee was priced against, stated in the terms every ledger version reports
+   *   identically — the parameters, the height, and the version they were read at. Each variant's own `BlockData`
+   *   carries dust index and root fields besides, which are the variant's business and not a caller's.
+   */
   balanceTransactions(
-    secretKey: DustSecretKey,
-    transactions: ReadonlyArray<AnyTransaction>,
+    transactions: ReadonlyArray<AnyTx>,
     ttl: Date,
     currentTime?: Date,
-  ): Promise<{ transaction: UnprovenTransaction; blockData: BlockData }>;
+  ): Promise<{ transaction: UnprovenTx; blockData: PricedBlockData }>;
 
   serializeState(): Promise<TSerialized>;
 
@@ -274,7 +296,7 @@ export type DustWalletAPI<TStartAux = DustSecretKey, TSerialized = string> = {
     opts?: { timeoutMs?: number },
   ): Promise<void>;
 
-  revertTransaction(transaction: AnyTransaction): Promise<void>;
+  revertTransaction(transaction: AnyTx): Promise<void>;
 
   getAddress(): Promise<DustAddress>;
 
@@ -348,7 +370,7 @@ export interface CustomizedDustWalletClass<
 
 export function CustomDustWallet<
   TConfig extends BaseV2Configuration = DefaultDustConfiguration,
-  TStartAux = DustSecretKey,
+  TStartAux extends DustSecretKey = DustSecretKey,
   TTransaction = FinalizedTransaction,
   TSyncUpdate = WalletSyncUpdate,
   TSerialized = string,
@@ -369,6 +391,20 @@ export function CustomDustWallet<
     [Variant.VersionedVariant<V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>>],
     TConfig
   >;
+
+  /** The whole of the protocol timeline: one variant answers for every version this wallet will ever see. */
+  const wholeTimeline = ProtocolVersion.epochOf(
+    ProtocolVersion.MinSupportedVersion,
+    ProtocolVersion.MinSupportedVersion,
+  );
+
+  /** Seals a transaction this wallet built, at the version its one variant answers from. */
+  const seal = (transaction: UnprovenTransaction): UnprovenTx =>
+    WalletTransaction.adopt('Unproven', transaction, ProtocolVersion.MinSupportedVersion);
+
+  /** Reads a transaction a caller handed in, which a single-variant wallet accepts at any version. */
+  const carried = <T>(handle: AnyTx): Effect.Effect<T, ProtocolVersionMismatchError> =>
+    EitherOps.toEffect(WalletTransaction.unwrapWithin<T>(handle, wholeTimeline));
 
   return class CustomDustWalletImplementation
     extends BaseWallet
@@ -477,17 +513,44 @@ export function CustomDustWallet<
       return this.runtime.dispatch({ [V2Tag]: (v2) => v2.sync(secretKey) }).pipe(Effect.runPromise);
     }
 
+    /**
+     * The key material this wallet's one variant uses, from what it was started with.
+     *
+     * @remarks
+     *   Fee payment selects dust the wallet owns, so it needs the same secret synchronization does.
+     */
+    #requireAux(): Effect.Effect<TStartAux, StartMaterial.MissingStartAuxError> {
+      return Ref.get(this.#retainedAux).pipe(
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new StartMaterial.MissingStartAuxError({
+                  message:
+                    `This wallet holds no key material: it has not been started, or it has been stopped. Start it ` +
+                    `before asking it to pay a fee.`,
+                  variantTag: V2Tag,
+                }),
+              ),
+            onSome: (aux: TStartAux) => Effect.succeed(aux),
+          }),
+        ),
+      );
+    }
+
     async createDustGenerationTransaction(
       currentTime: Date | undefined,
       ttl: Date,
       nightUtxos: Array<UtxoWithMeta>,
       nightVerifyingKey: SignatureVerifyingKey,
       dustReceiverAddress: DustAddress | undefined,
-    ): Promise<UnprovenTransaction> {
+    ): Promise<UnprovenTx> {
       return this.runtime
         .dispatch({
           [V2Tag]: (v2) =>
-            v2.createDustGenerationTransaction(currentTime, ttl, nightUtxos, nightVerifyingKey, dustReceiverAddress),
+            v2
+              .createDustGenerationTransaction(currentTime, ttl, nightUtxos, nightVerifyingKey, dustReceiverAddress)
+              .pipe(Effect.map(seal)),
         })
         .pipe(Effect.runPromise);
     }
@@ -505,75 +568,94 @@ export function CustomDustWallet<
     }
 
     async attachDustRegistration(
-      transaction: UnprovenTransaction,
+      transaction: UnprovenTx,
       currentTime: Date,
       nightVerifyingKey: SignatureVerifyingKey,
       dustReceiverAddress: DustAddress | undefined,
       feePayment: bigint,
-    ): Promise<UnprovenTransaction> {
+    ): Promise<UnprovenTx> {
       return this.runtime
         .dispatch({
           [V2Tag]: (v2) =>
-            v2.attachDustRegistration(transaction, currentTime, nightVerifyingKey, dustReceiverAddress, feePayment),
+            carried<UnprovenTransaction>(transaction).pipe(
+              Effect.flatMap((tx) =>
+                v2.attachDustRegistration(tx, currentTime, nightVerifyingKey, dustReceiverAddress, feePayment),
+              ),
+              Effect.map(seal),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    addDustGenerationSignature(transaction: UnprovenTransaction, signature: Signature): Promise<UnprovenTransaction> {
+    addDustGenerationSignature(transaction: UnprovenTx, signature: Signature): Promise<UnprovenTx> {
       return this.runtime
         .dispatch({
-          [V2Tag]: (v2) => v2.addDustGenerationSignature(transaction, signature),
+          [V2Tag]: (v2) =>
+            carried<UnprovenTransaction>(transaction).pipe(
+              Effect.flatMap((tx) => v2.addDustGenerationSignature(tx, signature)),
+              Effect.map(seal),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    addDustRegistrationSignature(transaction: UnprovenTransaction, signature: Signature): Promise<UnprovenTransaction> {
+    addDustRegistrationSignature(transaction: UnprovenTx, signature: Signature): Promise<UnprovenTx> {
       return this.runtime
         .dispatch({
-          [V2Tag]: (v2) => v2.addDustRegistrationSignature(transaction, signature),
+          [V2Tag]: (v2) =>
+            carried<UnprovenTransaction>(transaction).pipe(
+              Effect.flatMap((tx) => v2.addDustRegistrationSignature(tx, signature)),
+              Effect.map(seal),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    calculateFee(transactions: ReadonlyArray<AnyTransaction>): Promise<bigint> {
+    calculateFee(transactions: ReadonlyArray<AnyTx>): Promise<bigint> {
       return this.runtime
         .dispatch({
-          [V2Tag]: (v2) => v2.calculateFee(transactions),
+          [V2Tag]: (v2) =>
+            Effect.forEach(transactions, carried<AnyTransaction>).pipe(Effect.flatMap((txs) => v2.calculateFee(txs))),
         })
         .pipe(Effect.runPromise);
     }
 
-    estimateFee(
-      secretKey: DustSecretKey,
-      transactions: ReadonlyArray<AnyTransaction>,
-      ttl?: Date,
-      currentTime?: Date,
-    ): Promise<bigint> {
+    estimateFee(transactions: ReadonlyArray<AnyTx>, ttl?: Date, currentTime?: Date): Promise<bigint> {
       const effectiveTtl = ttl ?? new Date(Date.now() + 60 * 60 * 1000);
       return this.runtime
         .dispatch({
-          [V2Tag]: (v2) => v2.estimateFee(secretKey, transactions, effectiveTtl, currentTime),
+          [V2Tag]: (v2) =>
+            Effect.all([this.#requireAux(), Effect.forEach(transactions, carried<AnyTransaction>)]).pipe(
+              Effect.flatMap(([key, txs]) => v2.estimateFee(key, txs, effectiveTtl, currentTime)),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
     balanceTransactions(
-      secretKey: DustSecretKey,
-      transactions: ReadonlyArray<AnyTransaction>,
+      transactions: ReadonlyArray<AnyTx>,
       ttl: Date,
       currentTime?: Date,
-    ): Promise<{ transaction: UnprovenTransaction; blockData: BlockData }> {
+    ): Promise<{ transaction: UnprovenTx; blockData: PricedBlockData }> {
       return this.runtime
         .dispatch({
-          [V2Tag]: (v2) => v2.balanceTransactions(secretKey, transactions, ttl, currentTime),
+          [V2Tag]: (v2) =>
+            Effect.all([this.#requireAux(), Effect.forEach(transactions, carried<AnyTransaction>)]).pipe(
+              Effect.flatMap(([key, txs]) => v2.balanceTransactions(key, txs, ttl, currentTime)),
+              Effect.map(({ transaction, blockData }) => ({ transaction: seal(transaction), blockData })),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    revertTransaction(transaction: AnyTransaction): Promise<void> {
+    revertTransaction(transaction: AnyTx): Promise<void> {
       return this.runtime
         .dispatch({
-          [V2Tag]: (v2) => v2.revertTransaction(transaction),
+          [V2Tag]: (v2) =>
+            Either.match(WalletTransaction.unwrapWithin<AnyTransaction>(transaction, wholeTimeline), {
+              onLeft: () => Effect.void,
+              onRight: (tx) => v2.revertTransaction(tx),
+            }),
         })
         .pipe(Effect.runPromise);
     }

--- a/packages/dust-wallet/src/ForkingDustWallet.ts
+++ b/packages/dust-wallet/src/ForkingDustWallet.ts
@@ -783,8 +783,8 @@ export type DustWalletClass = ForkingDustWalletClass<PreForkSyncUpdate, PostFork
  *   needs four `DustLocalState` APIs that no published pre-fork ledger has. That is a permanent property of the
  *   pre-fork variant, not a gap to be closed.
  *
- *   **Fee-paying operations are available only once the wallet is on the post-fork variant** — see
- *   {@link PreForkDustTransactingUnsupportedError}, a temporary seam that closes with version-routed proving.
+ *   **Fee-paying operations work on either side of the boundary**: the active variant answers with its own ledger's
+ *   objects, and every result travels as a handle stamped with the epoch that built it.
  * @param configuration What the wallet and both its variants are built from, including where the boundary lies.
  * @returns The wallet class.
  */

--- a/packages/dust-wallet/src/ForkingDustWallet.ts
+++ b/packages/dust-wallet/src/ForkingDustWallet.ts
@@ -24,8 +24,16 @@
  */
 import * as v8 from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { ProtocolVersion, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  type AnyTx,
+  ProtocolVersion,
+  type ProtocolVersionMismatchError,
+  type UnprovenTx,
+  WalletSeed,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
 import { type DustAddress } from '@midnightntwrk/wallet-sdk-address-format';
+import * as PreForkSignatures from '@midnightntwrk/wallet-sdk-capabilities/signatures';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
 import {
   StartMaterial,
@@ -34,10 +42,11 @@ import {
   type WalletLike,
 } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type Clock, EitherOps, HList } from '@midnightntwrk/wallet-sdk-utilities';
-import { Data, Effect, Either, Option, Ref, type Scope } from 'effect';
+import { Effect, Either, Option, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
 import { variantForSnapshot } from './Restore.js';
-import { type DefaultDustConfiguration, type DustWalletAPI, DustWalletState, type BlockData } from './DustWallet.js';
+import { type DefaultDustConfiguration, type DustWalletAPI, DustWalletState } from './DustWallet.js';
+import { type BlockData as PricedBlockData } from '@midnightntwrk/wallet-sdk-capabilities/validation';
 import { CoreWallet as PreForkCoreWallet, V1Builder, V1Tag, type V1Variant } from './v1/index.js';
 import { type WalletSyncUpdate as PreForkSyncUpdate } from './v1/Sync.js';
 import { CoreWallet, Migration, V2Builder, V2Tag, type V2Variant } from './v2/index.js';
@@ -45,48 +54,23 @@ import { type WalletSyncUpdate as PostForkSyncUpdate } from './v2/SyncSchema.js'
 import { type NightUtxoSplitForDustRegistration } from './v2/Transacting.js';
 import { type UtxoWithMeta } from './v2/types/Dust.js';
 import { type NetworkId } from './v2/types/index.js';
+import { type AnyTransaction as PreForkAnyTransaction } from './v1/types/ledger.js';
 import { type AnyTransaction } from './v2/types/ledger.js';
 import { type WalletError } from './v2/WalletError.js';
 
 /**
- * Raised when a transaction is asked for while the wallet is still on the pre-fork protocol version.
+ * What a transacting call can fail with.
  *
  * @remarks
- *   **This seam is temporary and must not survive to general availability.** Mainnet is pre-fork until the fork happens,
- *   so a wallet that cannot pay a fee pre-fork cannot be the wallet that ships. It closes with the proving-routing
- *   increment (WP-11 together with the carrier and author flows), which routes a recipe to the prover that speaks the
- *   protocol version it was built at; until then the only proving path this SDK has speaks the post-fork ledger
- *   version, and there is nothing honest for the pre-fork branch to return — every operation gated below either takes
- *   or produces a transaction of the post-fork ledger version, which the pre-fork variant cannot even hold.
- *
- *   Everything else works on both sides of the boundary: synchronization, the state observable and everything it
- *   projects, `balance(date)`, dust generation estimates, the Night-UTxO split, addresses, serialization, restoring a
- *   snapshot, and the migration itself.
+ *   Three failures beyond the variant's own: the wallet may hold no key material the current variant can use, a
+ *   transaction handed in may have been built on the other side of the boundary, and a signature or verifying key may
+ *   name a signature scheme the pre-fork ledger version does not have.
  */
-export class PreForkDustTransactingUnsupportedError extends Data.TaggedError(
-  '@midnightntwrk/wallet-sdk-dust-wallet/ForkingDustWallet/PreForkDustTransactingUnsupportedError',
-)<{
-  readonly message: string;
-  /** The wallet operation that was asked for. */
-  readonly operation: string;
-}> {}
-
-/** What a transacting call can fail with: the post-fork variant's own errors, or the pre-fork variant's refusal. */
-type TransactingError = WalletError | PreForkDustTransactingUnsupportedError;
-
-const preForkTransactingUnsupported = (
-  operation: string,
-): Effect.Effect<never, PreForkDustTransactingUnsupportedError> =>
-  Effect.fail(
-    new PreForkDustTransactingUnsupportedError({
-      operation,
-      message:
-        `${operation} is not available while this wallet is on the pre-fork protocol version: it takes or produces a ` +
-        `transaction of the previous ledger version, which this release has no way to prove. Pre-fork transacting ` +
-        `arrives with version-routed proving; until then the post-fork path is the one that works. Synchronization, ` +
-        `balances, dust generation estimates, state and serialization are unaffected on either side of the boundary.`,
-    }),
-  );
+type TransactingError =
+  | WalletError
+  | StartMaterial.MissingStartAuxError
+  | ProtocolVersionMismatchError
+  | PreForkSignatures.UnsupportedSignatureKindError;
 
 /** The pre-fork variant a forking dust wallet registers: the one that reads the chain before the boundary. */
 export type PreForkDustVariant<TSyncUpdate> = V1Variant<string, TSyncUpdate, v8.FinalizedTransaction, v8.DustSecretKey>;
@@ -271,6 +255,26 @@ export function CustomForkingDustWallet<
     retained: RetainedStartMaterial,
   ): Either.Either<ledger.DustSecretKey, StartMaterial.MissingStartAuxError> =>
     StartMaterial.requireAuxFor(retained, V2Tag, (seed) => variants[V2Tag].variant.startAux.fromSeed(seed));
+
+  /**
+   * The protocol versions each variant owns, and the version a transaction it builds is stamped with.
+   *
+   * @remarks
+   *   The stamp is the floor of the variant's epoch: every decision it is later read for asks which side of the boundary
+   *   the bytes belong to, and the floor answers that the same way as any other version in the same epoch.
+   */
+  const preForkEpoch = ProtocolVersion.epochOf(ProtocolVersion.MinSupportedVersion, configuration.forkVersion);
+  const postForkEpoch = ProtocolVersion.epochOf(configuration.forkVersion, configuration.forkVersion);
+  const [preForkStamp] = preForkEpoch;
+  const [postForkStamp] = postForkEpoch;
+
+  /** Reads a transaction built before the boundary, refusing one built after it. */
+  const preForkTx = <T>(handle: AnyTx): Effect.Effect<T, ProtocolVersionMismatchError> =>
+    EitherOps.toEffect(WalletTransaction.unwrapWithin<T>(handle, preForkEpoch));
+
+  /** Reads a transaction built from the boundary, refusing one built before it. */
+  const postForkTx = <T>(handle: AnyTx): Effect.Effect<T, ProtocolVersionMismatchError> =>
+    EitherOps.toEffect(WalletTransaction.unwrapWithin<T>(handle, postForkEpoch));
 
   return class ForkingDustWalletImplementation
     extends BaseWallet
@@ -477,18 +481,56 @@ export function CustomForkingDustWallet<
         .pipe(Effect.runPromise);
     }
 
+    /**
+     * The key material the variant that is current can use, from what this wallet retained.
+     *
+     * @remarks
+     *   Fee payment selects dust the wallet owns, so it needs the same secret synchronization does. A wallet that was
+     *   never started, or one holding a key object of the other ledger version, has none the current variant can use
+     *   and says so by name.
+     */
+    #requireAux<TAux>(
+      auxFor: (retained: RetainedStartMaterial) => Either.Either<TAux, StartMaterial.MissingStartAuxError>,
+      variantTag: symbol,
+    ): Effect.Effect<TAux, StartMaterial.MissingStartAuxError> {
+      return Ref.get(this.#retainedStartMaterial).pipe(
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new StartMaterial.MissingStartAuxError({
+                  message:
+                    `This wallet holds no key material: it has not been started, or it has been stopped. Start it ` +
+                    `before asking it to pay a fee.`,
+                  variantTag,
+                }),
+              ),
+            onSome: (retained: RetainedStartMaterial) => EitherOps.toEffect(auxFor(retained)),
+          }),
+        ),
+      );
+    }
+
     createDustGenerationTransaction(
       currentTime: Date | undefined,
       ttl: Date,
       nightUtxos: Array<UtxoWithMeta>,
       nightVerifyingKey: ledger.SignatureVerifyingKey,
       dustReceiverAddress: DustAddress | undefined,
-    ): Promise<ledger.UnprovenTransaction> {
+    ): Promise<UnprovenTx> {
       return this.runtime
-        .dispatch<ledger.UnprovenTransaction, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('createDustGenerationTransaction'),
+        .dispatch<UnprovenTx, TransactingError>({
+          [V1Tag]: (v1) =>
+            EitherOps.toEffect(PreForkSignatures.lowerSignatureVerifyingKey(nightVerifyingKey)).pipe(
+              Effect.flatMap((key) =>
+                v1.createDustGenerationTransaction(currentTime, ttl, nightUtxos, key, dustReceiverAddress),
+              ),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, preForkStamp)),
+            ),
           [V2Tag]: (v2) =>
-            v2.createDustGenerationTransaction(currentTime, ttl, nightUtxos, nightVerifyingKey, dustReceiverAddress),
+            v2
+              .createDustGenerationTransaction(currentTime, ttl, nightUtxos, nightVerifyingKey, dustReceiverAddress)
+              .pipe(Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, postForkStamp))),
         })
         .pipe(Effect.runPromise);
     }
@@ -515,79 +557,137 @@ export function CustomForkingDustWallet<
     }
 
     attachDustRegistration(
-      transaction: ledger.UnprovenTransaction,
+      transaction: UnprovenTx,
       currentTime: Date,
       nightVerifyingKey: ledger.SignatureVerifyingKey,
       dustReceiverAddress: DustAddress | undefined,
       feePayment: bigint,
-    ): Promise<ledger.UnprovenTransaction> {
+    ): Promise<UnprovenTx> {
       return this.runtime
-        .dispatch<ledger.UnprovenTransaction, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('attachDustRegistration'),
+        .dispatch<UnprovenTx, TransactingError>({
+          [V1Tag]: (v1) =>
+            Effect.all([
+              preForkTx<v8.UnprovenTransaction>(transaction),
+              EitherOps.toEffect(PreForkSignatures.lowerSignatureVerifyingKey(nightVerifyingKey)),
+            ]).pipe(
+              Effect.flatMap(([tx, key]) =>
+                v1.attachDustRegistration(tx, currentTime, key, dustReceiverAddress, feePayment),
+              ),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, preForkStamp)),
+            ),
           [V2Tag]: (v2) =>
-            v2.attachDustRegistration(transaction, currentTime, nightVerifyingKey, dustReceiverAddress, feePayment),
+            postForkTx<ledger.UnprovenTransaction>(transaction).pipe(
+              Effect.flatMap((tx) =>
+                v2.attachDustRegistration(tx, currentTime, nightVerifyingKey, dustReceiverAddress, feePayment),
+              ),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, postForkStamp)),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    addDustGenerationSignature(
-      transaction: ledger.UnprovenTransaction,
-      signature: ledger.Signature,
-    ): Promise<ledger.UnprovenTransaction> {
+    addDustGenerationSignature(transaction: UnprovenTx, signature: ledger.Signature): Promise<UnprovenTx> {
       return this.runtime
-        .dispatch<ledger.UnprovenTransaction, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('addDustGenerationSignature'),
-          [V2Tag]: (v2) => v2.addDustGenerationSignature(transaction, signature),
+        .dispatch<UnprovenTx, TransactingError>({
+          [V1Tag]: (v1) =>
+            Effect.all([
+              preForkTx<v8.UnprovenTransaction>(transaction),
+              EitherOps.toEffect(PreForkSignatures.lowerSignature(signature)),
+            ]).pipe(
+              Effect.flatMap(([tx, lowered]) => v1.addDustGenerationSignature(tx, lowered)),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, preForkStamp)),
+            ),
+          [V2Tag]: (v2) =>
+            postForkTx<ledger.UnprovenTransaction>(transaction).pipe(
+              Effect.flatMap((tx) => v2.addDustGenerationSignature(tx, signature)),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, postForkStamp)),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    addDustRegistrationSignature(
-      transaction: ledger.UnprovenTransaction,
-      signature: ledger.Signature,
-    ): Promise<ledger.UnprovenTransaction> {
+    addDustRegistrationSignature(transaction: UnprovenTx, signature: ledger.Signature): Promise<UnprovenTx> {
       return this.runtime
-        .dispatch<ledger.UnprovenTransaction, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('addDustRegistrationSignature'),
-          [V2Tag]: (v2) => v2.addDustRegistrationSignature(transaction, signature),
+        .dispatch<UnprovenTx, TransactingError>({
+          [V1Tag]: (v1) =>
+            Effect.all([
+              preForkTx<v8.UnprovenTransaction>(transaction),
+              EitherOps.toEffect(PreForkSignatures.lowerSignature(signature)),
+            ]).pipe(
+              Effect.flatMap(([tx, lowered]) => v1.addDustRegistrationSignature(tx, lowered)),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, preForkStamp)),
+            ),
+          [V2Tag]: (v2) =>
+            postForkTx<ledger.UnprovenTransaction>(transaction).pipe(
+              Effect.flatMap((tx) => v2.addDustRegistrationSignature(tx, signature)),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, postForkStamp)),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    calculateFee(transactions: ReadonlyArray<AnyTransaction>): Promise<bigint> {
+    calculateFee(transactions: ReadonlyArray<AnyTx>): Promise<bigint> {
       return this.runtime
         .dispatch<bigint, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('calculateFee'),
-          [V2Tag]: (v2) => v2.calculateFee(transactions),
+          [V1Tag]: (v1) =>
+            Effect.forEach(transactions, preForkTx<PreForkAnyTransaction>).pipe(
+              Effect.flatMap((txs) => v1.calculateFee(txs)),
+            ),
+          [V2Tag]: (v2) =>
+            Effect.forEach(transactions, postForkTx<AnyTransaction>).pipe(
+              Effect.flatMap((txs) => v2.calculateFee(txs)),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    estimateFee(
-      secretKey: ledger.DustSecretKey,
-      transactions: ReadonlyArray<AnyTransaction>,
-      ttl?: Date,
-      currentTime?: Date,
-    ): Promise<bigint> {
+    estimateFee(transactions: ReadonlyArray<AnyTx>, ttl?: Date, currentTime?: Date): Promise<bigint> {
       const effectiveTtl = ttl ?? new Date(Date.now() + 60 * 60 * 1000);
       return this.runtime
         .dispatch<bigint, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('estimateFee'),
-          [V2Tag]: (v2) => v2.estimateFee(secretKey, transactions, effectiveTtl, currentTime),
+          [V1Tag]: (v1) =>
+            Effect.all([
+              this.#requireAux(preForkAux, V1Tag),
+              Effect.forEach(transactions, preForkTx<PreForkAnyTransaction>),
+            ]).pipe(Effect.flatMap(([key, txs]) => v1.estimateFee(key, txs, effectiveTtl, currentTime))),
+          [V2Tag]: (v2) =>
+            Effect.all([
+              this.#requireAux(postForkAux, V2Tag),
+              Effect.forEach(transactions, postForkTx<AnyTransaction>),
+            ]).pipe(Effect.flatMap(([key, txs]) => v2.estimateFee(key, txs, effectiveTtl, currentTime))),
         })
         .pipe(Effect.runPromise);
     }
 
     balanceTransactions(
-      secretKey: ledger.DustSecretKey,
-      transactions: ReadonlyArray<AnyTransaction>,
+      transactions: ReadonlyArray<AnyTx>,
       ttl: Date,
       currentTime?: Date,
-    ): Promise<{ transaction: ledger.UnprovenTransaction; blockData: BlockData }> {
+    ): Promise<{ transaction: UnprovenTx; blockData: PricedBlockData }> {
       return this.runtime
-        .dispatch<{ transaction: ledger.UnprovenTransaction; blockData: BlockData }, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('balanceTransactions'),
-          [V2Tag]: (v2) => v2.balanceTransactions(secretKey, transactions, ttl, currentTime),
+        .dispatch<{ transaction: UnprovenTx; blockData: PricedBlockData }, TransactingError>({
+          [V1Tag]: (v1) =>
+            Effect.all([
+              this.#requireAux(preForkAux, V1Tag),
+              Effect.forEach(transactions, preForkTx<PreForkAnyTransaction>),
+            ]).pipe(
+              Effect.flatMap(([key, txs]) => v1.balanceTransactions(key, txs, ttl, currentTime)),
+              Effect.map(({ transaction, blockData }) => ({
+                transaction: WalletTransaction.adopt('Unproven', transaction, preForkStamp),
+                blockData,
+              })),
+            ),
+          [V2Tag]: (v2) =>
+            Effect.all([
+              this.#requireAux(postForkAux, V2Tag),
+              Effect.forEach(transactions, postForkTx<AnyTransaction>),
+            ]).pipe(
+              Effect.flatMap(([key, txs]) => v2.balanceTransactions(key, txs, ttl, currentTime)),
+              Effect.map(({ transaction, blockData }) => ({
+                transaction: WalletTransaction.adopt('Unproven', transaction, postForkStamp),
+                blockData,
+              })),
+            ),
         })
         .pipe(Effect.runPromise);
     }
@@ -596,19 +696,25 @@ export function CustomForkingDustWallet<
      * Un-records a transaction this wallet paid the fee for, releasing the dust it had booked.
      *
      * @remarks
-     *   Nothing to do on the pre-fork variant, and that is a fact about the wallet rather than a convenience: while
-     *   pre-fork transacting is unavailable that variant cannot have paid for the transaction being reverted, so it
-     *   holds no dust of it to release. The parameter's type says the same thing. Unlike the operations that build
-     *   transactions, this needs no proving, so there is nothing here for version-routed proving to unlock later — and
-     *   the facade reverts all three wallets together when a submission fails, so a refusal here would strand that
-     *   whole path.
+     *   A transaction built on the other side of the boundary cannot have had its fee paid by the current variant, so
+     *   there is no dust of it to release and this resolves having done nothing. That is the one place a version
+     *   mismatch is not an error: the facade reverts all three wallets together when a submission fails, and a refusal
+     *   here would strand that whole path over a transaction this wallet was never holding anything for.
      * @param transaction The transaction to un-record.
      */
-    revertTransaction(transaction: AnyTransaction): Promise<void> {
+    revertTransaction(transaction: AnyTx): Promise<void> {
       return this.runtime
         .dispatch<void, TransactingError>({
-          [V1Tag]: () => Effect.void,
-          [V2Tag]: (v2) => v2.revertTransaction(transaction),
+          [V1Tag]: (v1) =>
+            Either.match(WalletTransaction.unwrapWithin<PreForkAnyTransaction>(transaction, preForkEpoch), {
+              onLeft: () => Effect.void,
+              onRight: (tx) => v1.revertTransaction(tx),
+            }),
+          [V2Tag]: (v2) =>
+            Either.match(WalletTransaction.unwrapWithin<AnyTransaction>(transaction, postForkEpoch), {
+              onLeft: () => Effect.void,
+              onRight: (tx) => v2.revertTransaction(tx),
+            }),
         })
         .pipe(Effect.runPromise);
     }

--- a/packages/dust-wallet/src/test/forkStart.test.ts
+++ b/packages/dust-wallet/src/test/forkStart.test.ts
@@ -28,13 +28,20 @@
  *   version a chain reports is a property of the chain, and the real fork's value is not final.
  */
 
+import * as v8 from '@midnight-ntwrk/ledger-v8';
 import { LedgerParameters as PreForkLedgerParameters } from '@midnight-ntwrk/ledger-v8';
 import * as v9 from '@midnightntwrk/ledger-v9';
-import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  type AnyTx,
+  NetworkId,
+  ProtocolVersion,
+  ProtocolVersionMismatchError,
+  type UnprovenTx,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
 import { Cause, Deferred, Effect, Option, Queue, Runtime, type Scope, Stream } from 'effect';
 import { describe, expect, it, vi } from 'vitest';
 import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
-import { PreForkDustTransactingUnsupportedError } from '../ForkingDustWallet.js';
 import { V1Tag } from '../v1/RunningV1Variant.js';
 import * as PreForkSync from '../v1/Sync.js';
 import { DUST_EVENT_COUNT, type DustChain, buildDustChain, dustSeed } from '../v1/test/dustEvents.js';
@@ -119,10 +126,46 @@ const failureOf = (call: Promise<unknown>): Effect.Effect<Option.Option<unknown>
     ),
   );
 
-/** A transaction of the post-fork ledger version, which is the only kind this wallet's API accepts. */
-const someTransaction = (): v9.UnprovenTransaction => v9.Transaction.fromParts(networkId);
+/** A transaction of the pre-fork ledger version, sealed as an application would seal one it built for itself. */
+const preForkTransaction = (): UnprovenTx =>
+  WalletTransaction.adopt('Unproven', v8.Transaction.fromParts(networkId), ProtocolVersion.MinSupportedVersion);
+
+/** A transaction of the post-fork ledger version, sealed at the version the post-fork variant answers for. */
+const postForkTransaction = (): AnyTx =>
+  WalletTransaction.adopt('Unproven', v9.Transaction.fromParts(networkId), forkVersion);
 
 const signingKey = (): v9.SigningKey => v9.sampleSigningKey();
+
+/** A Night UTxO the verifying key owns, as plain data — the shape both ledger versions read identically. */
+const nightUtxo = (verifyingKey: v9.SignatureVerifyingKey) => ({
+  value: 1_000_000n,
+  type: v9.nativeToken().raw,
+  owner: v9.addressFromKey(verifyingKey),
+  intentHash: '00'.repeat(32),
+  outputNo: 0,
+  ctime: new Date(0),
+  registeredForDustGeneration: false,
+});
+
+/**
+ * A dust generation transaction the wallet built for itself: the shape the registration operations act on.
+ *
+ * @param withRegistration Whether the base already carries a registration — `attachDustRegistration` needs one that
+ *   does not, and the signing operations need one that does.
+ */
+const registrationTransaction = async (
+  wallet: ForkWallet,
+  ttl: Date,
+  verifyingKey: v9.SignatureVerifyingKey,
+  withRegistration: boolean,
+): Promise<UnprovenTx> =>
+  wallet.dust.createDustGenerationTransaction(
+    undefined,
+    ttl,
+    [nightUtxo(verifyingKey)],
+    verifyingKey,
+    withRegistration ? await wallet.dust.getAddress() : undefined,
+  );
 
 /**
  * Every call that builds, signs or prices a transaction, named as the wallet names it.
@@ -130,8 +173,12 @@ const signingKey = (): v9.SigningKey => v9.sampleSigningKey();
  * @remarks
  *   `revertTransaction` and `splitNightUtxosForDustRegistration` are deliberately not among them — see the tests below
  *   for what they do instead.
+ *
+ *   Every argument is stated in the wallet's own terms: a handle, and a verifying key or signature in the shape the SDK
+ *   speaks. What the pre-fork variant is handed underneath — bare hex, and the previous ledger version's transaction —
+ *   is the wallet's business, and that it manages the translation is exactly what these assert.
  */
-const gatedCalls = (wallet: ForkWallet): readonly (readonly [string, () => Promise<unknown>])[] => {
+const transactionBuildingCalls = (wallet: ForkWallet): readonly (readonly [string, () => Promise<unknown>])[] => {
   const ttl = new Date(Date.now() + 3_600_000);
   const verifyingKey = v9.signatureVerifyingKey(signingKey());
   const signature = v9.signData(signingKey(), new Uint8Array([1, 2, 3]));
@@ -141,14 +188,22 @@ const gatedCalls = (wallet: ForkWallet): readonly (readonly [string, () => Promi
       () => wallet.dust.createDustGenerationTransaction(undefined, ttl, [], verifyingKey, undefined),
     ],
     [
-      'attachDustRegistration',
-      () => wallet.dust.attachDustRegistration(someTransaction(), new Date(), verifyingKey, undefined, 0n),
+      'addDustGenerationSignature',
+      async () => {
+        const base = await registrationTransaction(wallet, ttl, verifyingKey, true);
+        return wallet.dust.addDustGenerationSignature(base, signature);
+      },
     ],
-    ['addDustGenerationSignature', () => wallet.dust.addDustGenerationSignature(someTransaction(), signature)],
-    ['addDustRegistrationSignature', () => wallet.dust.addDustRegistrationSignature(someTransaction(), signature)],
-    ['calculateFee', () => wallet.dust.calculateFee([someTransaction()])],
-    ['estimateFee', () => wallet.dust.estimateFee(wallet.keys.postFork, [someTransaction()])],
-    ['balanceTransactions', () => wallet.dust.balanceTransactions(wallet.keys.postFork, [someTransaction()], ttl)],
+    [
+      'addDustRegistrationSignature',
+      async () => {
+        const base = await registrationTransaction(wallet, ttl, verifyingKey, true);
+        return wallet.dust.addDustRegistrationSignature(base, signature);
+      },
+    ],
+    ['calculateFee', () => wallet.dust.calculateFee([preForkTransaction()])],
+    ['estimateFee', () => wallet.dust.estimateFee([preForkTransaction()])],
+    ['balanceTransactions', () => wallet.dust.balanceTransactions([preForkTransaction()], ttl)],
   ];
 };
 
@@ -205,35 +260,97 @@ describe('a dust wallet starting on a chain that has not forked', () => {
 
   it.each([
     'createDustGenerationTransaction',
-    'attachDustRegistration',
     'addDustGenerationSignature',
     'addDustRegistrationSignature',
     'calculateFee',
     'estimateFee',
     'balanceTransactions',
-  ])('refuses %s while it is still pre-fork, and says why', async (operation) =>
+  ])('answers %s while it is still pre-fork, with the ledger version the chain is on', async (operation) =>
     Effect.gen(function* () {
       const wallet = yield* syncedPreForkWallet;
 
-      const call = gatedCalls(wallet).find(([name]) => name === operation)!;
-      const failure = Option.getOrThrow(yield* failureOf(call[1]()));
+      const call = transactionBuildingCalls(wallet).find(([name]) => name === operation)!;
+      const answer = yield* Effect.promise(call[1]);
 
-      // Typed, and naming the operation: the pre-fork branch cannot produce a transaction anybody can prove, and says
-      // so instead of producing one nobody can.
-      expect(failure).toBeInstanceOf(PreForkDustTransactingUnsupportedError);
-      expect(failure).toMatchObject({ operation });
+      // It answered rather than refusing. Where the answer is a transaction it is stamped with the version that built
+      // it — a pre-fork one — so everything that routes on the version afterwards has what it needs; where it is a
+      // number (a fee), the answer is the number the pre-fork ledger's own cost model gives.
+      if (WalletTransaction.is(answer)) {
+        expect(answer.protocolVersion).toBeLessThan(forkVersion);
+      } else {
+        expect(answer).toBeDefined();
+      }
+      expect(yield* wallet.activeTag).toBe(V1Tag);
     }).pipe(Effect.scoped, Effect.runPromise),
   );
 
-  it('reverts a transaction it cannot have made, by doing nothing to its state', async () =>
+  it('attaches a registration on the pre-fork variant, which is what raises when there is nowhere to attach it', async () =>
     Effect.gen(function* () {
-      // Reverting releases dust a transaction booked, and no transaction of this wallet's can have booked any: it
-      // could not have built one. So this resolves, changes nothing, and is deliberately not part of the seam above —
-      // it needs no proving. The facade reverts all three wallets together when a submission fails, and a refusal here
-      // would strand that whole path.
+      // The only intent `attachDustRegistration` can act on is one the *unshielded* wallet built, which this suite has
+      // no way to produce — so what is asserted here is the thing the refusal it replaced hid: the call reaches the
+      // pre-fork variant's own transacting and is answered by it. The error is that capability's own, about the state
+      // of the intent, and is neither a refusal to transact pre-fork nor a version mismatch.
+      const wallet = yield* syncedPreForkWallet;
+      const ttl = new Date(Date.now() + 3_600_000);
+      const verifyingKey = v9.signatureVerifyingKey(signingKey());
+      const base = yield* Effect.promise(() => registrationTransaction(wallet, ttl, verifyingKey, true));
+
+      const failure = Option.getOrThrow(
+        yield* failureOf(wallet.dust.attachDustRegistration(base, new Date(), verifyingKey, undefined, 0n)),
+      );
+
+      expect(failure).not.toBeInstanceOf(ProtocolVersionMismatchError);
+      expect(String(failure)).toContain('already has a dust registration attached');
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('pays a fee out of the dust it actually holds', async () =>
+    Effect.gen(function* () {
+      // The refusal these replaced could be satisfied by any wallet at all; this cannot. Balancing selects dust the
+      // pre-fork variant synchronized, with the pre-fork variant's own key, and prices it against a pre-fork block.
       const wallet = yield* syncedPreForkWallet;
 
-      yield* Effect.promise(() => wallet.dust.revertTransaction(someTransaction()));
+      const { transaction, blockData } = yield* Effect.promise(() =>
+        wallet.dust.balanceTransactions([preForkTransaction()], new Date(Date.now() + 3_600_000)),
+      );
+
+      expect(transaction.protocolVersion).toBeLessThan(forkVersion);
+      expect(blockData.ledgerParameters).toBeInstanceOf(PreForkLedgerParameters);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('refuses a transaction built on the other side of the boundary, naming both versions', async () =>
+    Effect.gen(function* () {
+      const wallet = yield* syncedPreForkWallet;
+
+      const failure = Option.getOrThrow(yield* failureOf(wallet.dust.calculateFee([postForkTransaction()])));
+
+      expect(failure).toBeInstanceOf(ProtocolVersionMismatchError);
+      expect(failure).toMatchObject({ authoredFor: forkVersion });
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('refuses a signature of a scheme the pre-fork ledger version does not have', async () =>
+    Effect.gen(function* () {
+      // The one scalar that genuinely changed shape at the fork. An ecdsa signature has no pre-fork encoding at all,
+      // so it is refused by name rather than lowered into bytes that ledger version would misread.
+      const wallet = yield* syncedPreForkWallet;
+
+      const failure = Option.getOrThrow(
+        yield* failureOf(
+          wallet.dust.addDustRegistrationSignature(preForkTransaction(), { tag: 'ecdsa', value: '00'.repeat(64) }),
+        ),
+      );
+
+      expect(failure).toMatchObject({ kind: 'ecdsa' });
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('reverts a transaction of the other epoch by doing nothing to its state', async () =>
+    Effect.gen(function* () {
+      // Reverting releases dust a transaction booked, and a transaction of the other ledger version cannot have
+      // booked any of this variant's. So this resolves, changes nothing, and is deliberately not a version mismatch:
+      // the facade reverts all three wallets together when a submission fails, and a refusal here would strand that
+      // whole path.
+      const wallet = yield* syncedPreForkWallet;
+
+      yield* Effect.promise(() => wallet.dust.revertTransaction(postForkTransaction()));
 
       const after = yield* wallet.currentState;
       expect(dustCount(after.state)).toBe(DUST_EVENT_COUNT);

--- a/packages/e2e-tests/src/tests/balancing.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/balancing.undeployed.test.ts
@@ -17,6 +17,7 @@ import { logger } from './logger.js';
 import { randomBytes } from 'node:crypto';
 import { type CombinedTokenTransfer } from '@midnightntwrk/wallet-sdk-facade';
 import { inspect } from 'node:util';
+import { Buffer } from 'buffer';
 
 /** Tests checking transaction balancing */
 
@@ -93,16 +94,9 @@ describe('Transaction balancing examples', () => {
       },
     ];
     await utils.waitForBlockAdvancement(fixture.getIndexerUri());
-    const txRecipe = await funded.wallet.transferTransaction(
-      outputsToCreate,
-      {
-        shieldedSecretKeys: funded.shieldedSecretKeys,
-        dustSecretKey: funded.dustSecretKey,
-      },
-      {
-        ttl: getTtl(),
-      },
-    );
+    const txRecipe = await funded.wallet.transferTransaction(outputsToCreate, {
+      ttl: getTtl(),
+    });
     const signedTxRecipe = await funded.wallet.signRecipe(txRecipe, funded.unshieldedKeystore.signDataAsync);
     const finalizedTx = await funded.wallet.finalizeRecipe(signedTxRecipe);
     const id = await funded.wallet.submitTransaction(finalizedTx);
@@ -126,9 +120,9 @@ describe('Transaction balancing examples', () => {
       sender.unshieldedKeystore.signDataAsync,
     );
     logger.info('Dust registration recipe:');
-    logger.info(dustRegistrationRecipe.transaction.toString());
+    logger.info(Buffer.from(dustRegistrationRecipe.transaction.serialize()).toString('hex'));
     const finalizedDustTx = await sender.wallet.finalizeRecipe(dustRegistrationRecipe);
-    logger.info(finalizedDustTx.toString());
+    logger.info(Buffer.from(finalizedDustTx.serialize()).toString('hex'));
     logger.info('Submitting dust registration transaction');
     const dustRegistrationTxid = await sender.wallet.submitTransaction(finalizedDustTx);
     logger.info(`Dust registration tx id: ${dustRegistrationTxid}`);
@@ -175,16 +169,9 @@ describe('Transaction balancing examples', () => {
           ],
         },
       ];
-      const txRecipe = await sender.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: sender.shieldedSecretKeys,
-          dustSecretKey: sender.dustSecretKey,
-        },
-        {
-          ttl: getTtl(),
-        },
-      );
+      const txRecipe = await sender.wallet.transferTransaction(outputsToCreate, {
+        ttl: getTtl(),
+      });
       const finalizedTx = await sender.wallet.finalizeRecipe(txRecipe);
       const txId = await sender.wallet.submitTransaction(finalizedTx);
       logger.info('Transaction id: ' + txId);
@@ -249,16 +236,9 @@ describe('Transaction balancing examples', () => {
           ],
         },
       ];
-      const txRecipe = await sender.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: sender.shieldedSecretKeys,
-          dustSecretKey: sender.dustSecretKey,
-        },
-        {
-          ttl: getTtl(),
-        },
-      );
+      const txRecipe = await sender.wallet.transferTransaction(outputsToCreate, {
+        ttl: getTtl(),
+      });
       const finalizedTx = await sender.wallet.finalizeRecipe(txRecipe);
       const txId = await sender.wallet.submitTransaction(finalizedTx);
       logger.info('Transaction id: ' + txId);
@@ -346,16 +326,9 @@ describe('Transaction balancing examples', () => {
           ],
         },
       ];
-      const txRecipe = await sender.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: sender.shieldedSecretKeys,
-          dustSecretKey: sender.dustSecretKey,
-        },
-        {
-          ttl: getTtl(),
-        },
-      );
+      const txRecipe = await sender.wallet.transferTransaction(outputsToCreate, {
+        ttl: getTtl(),
+      });
       const finalizedTx = await sender.wallet.finalizeRecipe(txRecipe);
       const txId = await sender.wallet.submitTransaction(finalizedTx);
       logger.info('Transaction id: ' + txId);
@@ -426,16 +399,9 @@ describe('Transaction balancing examples', () => {
         },
       ];
       await expect(
-        receiver1.wallet.transferTransaction(
-          outputsToCreate,
-          {
-            shieldedSecretKeys: funded.shieldedSecretKeys,
-            dustSecretKey: funded.dustSecretKey,
-          },
-          {
-            ttl: getTtl(),
-          },
-        ),
+        receiver1.wallet.transferTransaction(outputsToCreate, {
+          ttl: getTtl(),
+        }),
       ).rejects.toThrow('Insufficient funds');
       await receiver1.wallet.stop();
     },

--- a/packages/e2e-tests/src/tests/dust.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dust.undeployed.test.ts
@@ -87,14 +87,7 @@ describe('Dust tests', () => {
     ];
     await utils.waitForBlockAdvancement(fixture.getIndexerUri());
     const ttl = new Date(Date.now() + 30 * 60 * 1000);
-    const txRecipe = await funded.wallet.transferTransaction(
-      outputsToCreate,
-      {
-        shieldedSecretKeys: funded.shieldedSecretKeys,
-        dustSecretKey: funded.dustSecretKey,
-      },
-      { ttl },
-    );
+    const txRecipe = await funded.wallet.transferTransaction(outputsToCreate, { ttl });
     const signedTxRecipe = await funded.wallet.signRecipe(txRecipe, funded.unshieldedKeystore.signDataAsync);
     const finalizedTx = await funded.wallet.finalizeRecipe(signedTxRecipe);
     const txId = await funded.wallet.submitTransaction(finalizedTx);
@@ -220,10 +213,6 @@ describe('Dust tests', () => {
 
       const balancedTransactionRecipe = await receiver.wallet.balanceUnprovenTransaction(
         dustDeregistrationRecipe.transaction,
-        {
-          shieldedSecretKeys: receiver.shieldedSecretKeys,
-          dustSecretKey: receiver.dustSecretKey,
-        },
         { ttl: new Date(Date.now() + 30 * 60 * 1000) },
       );
 
@@ -322,14 +311,7 @@ describe('Dust tests', () => {
         },
       ];
       const ttl = new Date(Date.now() + 30 * 60 * 1000);
-      const txRecipe = await receiver.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: receiver.shieldedSecretKeys,
-          dustSecretKey: receiver.dustSecretKey,
-        },
-        { ttl },
-      );
+      const txRecipe = await receiver.wallet.transferTransaction(outputsToCreate, { ttl });
       const finalizedTx = await receiver.wallet.finalizeRecipe(txRecipe);
       const txId = await receiver.wallet.submitTransaction(finalizedTx);
       expect(txId).toBeDefined();
@@ -404,14 +386,7 @@ describe('Dust tests', () => {
         },
       ];
       const ttl = new Date(Date.now() + 30 * 60 * 1000);
-      const txRecipe = await receiver.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: receiver.shieldedSecretKeys,
-          dustSecretKey: receiver.dustSecretKey,
-        },
-        { ttl },
-      );
+      const txRecipe = await receiver.wallet.transferTransaction(outputsToCreate, { ttl });
       const signedTxRecipe = await receiver.wallet.signRecipe(txRecipe, receiver.unshieldedKeystore.signDataAsync);
       const finalizedTx = await receiver.wallet.finalizeRecipe(signedTxRecipe);
       const txId = await receiver.wallet.submitTransaction(finalizedTx);

--- a/packages/e2e-tests/src/tests/dustDeregistration.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dustDeregistration.undeployed.test.ts
@@ -30,6 +30,7 @@ import {
 import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { makeDefaultSubmissionService } from '@midnightntwrk/wallet-sdk-capabilities';
+import { carried } from './helpers/transactions.js';
 
 vi.setConfig({ testTimeout: 200_000, hookTimeout: 120_000 });
 
@@ -140,16 +141,9 @@ describe('Dust Deregistration', () => {
       unshieldedWalletKeystore.signDataAsync,
     );
 
-    const balancingRecipe = await walletFacade.balanceUnprovenTransaction(
-      dustDeregistrationTx.transaction,
-      {
-        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedWalletSeed),
-        dustSecretKey: ledger.DustSecretKey.fromSeed(dustWalletSeed),
-      },
-      {
-        ttl: new Date(Date.now() + 30 * 60 * 1000),
-      },
-    );
+    const balancingRecipe = await walletFacade.balanceUnprovenTransaction(dustDeregistrationTx.transaction, {
+      ttl: new Date(Date.now() + 30 * 60 * 1000),
+    });
 
     const finalizedDustDeregistrationTx = await walletFacade.finalizeRecipe(balancingRecipe);
 
@@ -160,7 +154,9 @@ describe('Dust Deregistration', () => {
     const walletStateAfterDeregistration = await rx.firstValueFrom(
       walletFacade.state().pipe(
         rx.mergeMap(async (state) => {
-          const txInHistory = await walletFacade.queryTxHistoryByHash(finalizedDustDeregistrationTx.transactionHash());
+          const txInHistory = await walletFacade.queryTxHistoryByHash(
+            carried<ledger.FinalizedTransaction>(finalizedDustDeregistrationTx).transactionHash(),
+          );
 
           return {
             state,

--- a/packages/e2e-tests/src/tests/dustRegistration.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dustRegistration.undeployed.test.ts
@@ -40,6 +40,7 @@ import {
 import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { ArrayOps, DateOps } from '@midnightntwrk/wallet-sdk-utilities';
+import { carried } from './helpers/transactions.js';
 
 vi.setConfig({ testTimeout: 200_000, hookTimeout: 200_000 });
 
@@ -172,16 +173,9 @@ describe('Dust Registration', () => {
     ];
 
     const ttl = new Date(Date.now() + 30 * 60 * 1000);
-    const transferTxRecipe = await senderFacade.transferTransaction(
-      tokenTransfer,
-      {
-        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSenderSeed),
-        dustSecretKey: ledger.DustSecretKey.fromSeed(dustSenderSeed),
-      },
-      {
-        ttl,
-      },
-    );
+    const transferTxRecipe = await senderFacade.transferTransaction(tokenTransfer, {
+      ttl,
+    });
 
     const signedTransferTxRecipe = await senderFacade.signRecipe(
       transferTxRecipe,
@@ -231,7 +225,9 @@ describe('Dust Registration', () => {
     const receiverStateAfterRegistration = await rx.firstValueFrom(
       receiverFacade.state().pipe(
         rx.mergeMap(async (state) => {
-          const txInHistory = await receiverFacade.queryTxHistoryByHash(provenDustRegistrationTx.transactionHash());
+          const txInHistory = await receiverFacade.queryTxHistoryByHash(
+            carried<ledger.FinalizedTransaction>(provenDustRegistrationTx).transactionHash(),
+          );
 
           return {
             state,
@@ -270,10 +266,6 @@ describe('Dust Registration', () => {
           ],
         },
       ],
-      {
-        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSenderSeed),
-        dustSecretKey: ledger.DustSecretKey.fromSeed(dustSenderSeed),
-      },
       { ttl: new Date(Date.now() + 30 * 60 * 1000) },
     );
     const signedTransfer = await senderFacade.signRecipe(transferTxRecipe, unshieldedSenderKeystore.signDataAsync);
@@ -355,16 +347,9 @@ describe('Dust Registration', () => {
     };
 
     await senderFacade
-      .transferTransaction(
-        [transfersToMake],
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSenderSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSenderSeed),
-        },
-        {
-          ttl: DateOps.addSeconds(new Date(), 1800),
-        },
-      )
+      .transferTransaction([transfersToMake], {
+        ttl: DateOps.addSeconds(new Date(), 1800),
+      })
       .then((recipe) => senderFacade.signRecipe(recipe, unshieldedSenderKeystore.signDataAsync))
       .then((signedTxRecipe) => senderFacade.finalizeRecipe(signedTxRecipe))
       .then((tx) => senderFacade.submitTransaction(tx));

--- a/packages/e2e-tests/src/tests/ecdsaSpend.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/ecdsaSpend.undeployed.test.ts
@@ -79,11 +79,9 @@ describe('ECDSA unshielded spend (undeployed)', () => {
       },
     ];
     await utils.waitForBlockAdvancement(fixture.getIndexerUri());
-    const fundingRecipe = await funded.wallet.transferTransaction(
-      outputs,
-      { shieldedSecretKeys: funded.shieldedSecretKeys, dustSecretKey: funded.dustSecretKey },
-      { ttl: new Date(Date.now() + 30 * 60 * 1000) },
-    );
+    const fundingRecipe = await funded.wallet.transferTransaction(outputs, {
+      ttl: new Date(Date.now() + 30 * 60 * 1000),
+    });
     const signedFunding = await funded.wallet.signRecipe(fundingRecipe, funded.unshieldedKeystore.signDataAsync);
     await funded.wallet.submitTransaction(await funded.wallet.finalizeRecipe(signedFunding));
 
@@ -139,7 +137,6 @@ describe('ECDSA unshielded spend (undeployed)', () => {
             ],
           },
         ],
-        { shieldedSecretKeys: ecdsa.shieldedSecretKeys, dustSecretKey: ecdsa.dustSecretKey },
         { ttl: new Date(Date.now() + 30 * 60 * 1000) },
       );
       const signed = await ecdsa.wallet.signRecipe(spendRecipe, ecdsa.unshieldedKeystore.signDataAsync);
@@ -187,7 +184,6 @@ describe('ECDSA unshielded spend (undeployed)', () => {
             ],
           },
         ],
-        { shieldedSecretKeys: ecdsa.shieldedSecretKeys, dustSecretKey: ecdsa.dustSecretKey },
         { ttl: new Date(Date.now() + 30 * 60 * 1000) },
       );
 

--- a/packages/e2e-tests/src/tests/facadeTransfer.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/facadeTransfer.undeployed.test.ts
@@ -32,6 +32,7 @@ import {
 } from '@midnightntwrk/wallet-sdk-facade';
 import { getDustSeed, getShieldedSeed, getUnshieldedSeed, tokenValue } from './utils.js';
 import { makeWasmProvingService } from '@midnightntwrk/wallet-sdk-capabilities';
+import { carried, sealed } from './helpers/transactions.js';
 
 vi.setConfig({ testTimeout: 800_000, hookTimeout: 800_000 });
 
@@ -164,16 +165,12 @@ describe('Wallet Facade Transfer', () => {
         },
       ],
       {
-        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSenderSeed),
-        dustSecretKey: ledger.DustSecretKey.fromSeed(dustSenderSeed),
-      },
-      {
         ttl,
       },
     );
 
     const finalizedTx = await senderFacade.finalizeRecipe(unprovenTxRecipe);
-    const finalizedTxHash = finalizedTx.transactionHash().toString();
+    const finalizedTxHash = carried<ledger.FinalizedTransaction>(finalizedTx).transactionHash().toString();
     const submittedTxIdentifier = await senderFacade.submitTransaction(finalizedTx);
 
     expect(submittedTxIdentifier).toBeTypeOf('string');
@@ -217,21 +214,14 @@ describe('Wallet Facade Transfer', () => {
     ];
 
     const ttl = new Date(Date.now() + 30 * 60 * 1000);
-    const transactionRecipe = await senderFacade.transferTransaction(
-      tokenTransfer,
-      {
-        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSenderSeed),
-        dustSecretKey: ledger.DustSecretKey.fromSeed(dustSenderSeed),
-      },
-      {
-        ttl,
-      },
-    );
+    const transactionRecipe = await senderFacade.transferTransaction(tokenTransfer, {
+      ttl,
+    });
 
     const signedTxRecipe = await senderFacade.signRecipe(transactionRecipe, unshieldedSenderKeystore.signDataAsync);
 
     const finalizedTx = await senderFacade.finalizeRecipe(signedTxRecipe);
-    const finalizedTxHash = finalizedTx.transactionHash().toString();
+    const finalizedTxHash = carried<ledger.FinalizedTransaction>(finalizedTx).transactionHash().toString();
 
     const submittedTxHash = await senderFacade.submitTransaction(finalizedTx);
 
@@ -285,16 +275,9 @@ describe('Wallet Facade Transfer', () => {
 
     const arbitraryTx = ledger.Transaction.fromParts(configuration.networkId, outputOffer);
 
-    const balancingTxRecipe = await senderFacade.balanceUnprovenTransaction(
-      arbitraryTx,
-      {
-        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSenderSeed),
-        dustSecretKey: ledger.DustSecretKey.fromSeed(dustSenderSeed),
-      },
-      {
-        ttl: new Date(Date.now() + 30 * 60 * 1000),
-      },
-    );
+    const balancingTxRecipe = await senderFacade.balanceUnprovenTransaction(sealed('Unproven', arbitraryTx), {
+      ttl: new Date(Date.now() + 30 * 60 * 1000),
+    });
 
     const finalizedArbitraryTx = await senderFacade.finalizeRecipe(balancingTxRecipe);
 
@@ -332,16 +315,9 @@ describe('Wallet Facade Transfer', () => {
 
     const arbitraryTx = ledger.Transaction.fromParts(NetworkId.NetworkId.Undeployed, undefined, undefined, intent);
 
-    const balancingTxRecipe = await senderFacade.balanceUnprovenTransaction(
-      arbitraryTx,
-      {
-        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSenderSeed),
-        dustSecretKey: ledger.DustSecretKey.fromSeed(dustSenderSeed),
-      },
-      {
-        ttl: new Date(Date.now() + 30 * 60 * 1000),
-      },
-    );
+    const balancingTxRecipe = await senderFacade.balanceUnprovenTransaction(sealed('Unproven', arbitraryTx), {
+      ttl: new Date(Date.now() + 30 * 60 * 1000),
+    });
 
     // Sign the balancing transaction before finalizing
     const signedBalancingTxRecipe = await senderFacade.signRecipe(
@@ -430,18 +406,11 @@ describe('Wallet Facade Transfer', () => {
       },
     ];
 
-    const transactionRecipe = await senderFacade.transferTransaction(
-      tokenTransfer,
-      {
-        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSenderSeed),
-        dustSecretKey: ledger.DustSecretKey.fromSeed(dustSenderSeed),
-      },
-      { ttl },
-    );
+    const transactionRecipe = await senderFacade.transferTransaction(tokenTransfer, { ttl });
 
     const signedTxRecipe = await senderFacade.signRecipe(transactionRecipe, unshieldedSenderKeystore.signDataAsync);
     const finalizedTx = await senderFacade.finalizeRecipe(signedTxRecipe);
-    const finalizedTxHash = finalizedTx.transactionHash().toString();
+    const finalizedTxHash = carried<ledger.FinalizedTransaction>(finalizedTx).transactionHash().toString();
     const submittedTxIdentifier = await senderFacade.submitTransaction(finalizedTx);
 
     // Wait for the tx to land in sender history as a SUCCESS with all three sections present.

--- a/packages/e2e-tests/src/tests/fundTestWallets.remote.test.ts
+++ b/packages/e2e-tests/src/tests/fundTestWallets.remote.test.ts
@@ -19,6 +19,7 @@ import { exit } from 'node:process';
 import { logger } from './logger.js';
 import { type CombinedTokenTransfer } from '@midnightntwrk/wallet-sdk-facade';
 import { inspect } from 'node:util';
+import { Buffer } from 'buffer';
 
 /** Tests performing a token transfer */
 
@@ -112,16 +113,9 @@ describe('Set up test wallet', () => {
         },
       ];
 
-      const txRecipe = await sender.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: sender.shieldedSecretKeys,
-          dustSecretKey: sender.dustSecretKey,
-        },
-        {
-          ttl: new Date(Date.now() + 30 * 60 * 1000),
-        },
-      );
+      const txRecipe = await sender.wallet.transferTransaction(outputsToCreate, {
+        ttl: new Date(Date.now() + 30 * 60 * 1000),
+      });
       logger.info('Signing tx...');
       logger.info(txRecipe);
       const signedTxRecipe = await sender.wallet.signRecipe(txRecipe, sender.unshieldedKeystore.signDataAsync);
@@ -129,7 +123,7 @@ describe('Set up test wallet', () => {
       logger.info(signedTxRecipe.type.toString());
       const finalizedTx = await sender.wallet.finalizeRecipe(signedTxRecipe);
       logger.info('Submitting transaction...');
-      logger.info(finalizedTx.toString());
+      logger.info(Buffer.from(finalizedTx.serialize()).toString('hex'));
       const txId = await sender.wallet.submitTransaction(finalizedTx);
       logger.info('txProcessing');
       logger.info('Transaction id: ' + txId);
@@ -199,16 +193,9 @@ describe('Set up test wallet', () => {
         },
       ];
 
-      const txRecipe = await sender.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: sender.shieldedSecretKeys,
-          dustSecretKey: sender.dustSecretKey,
-        },
-        {
-          ttl: new Date(Date.now() + 30 * 60 * 1000),
-        },
-      );
+      const txRecipe = await sender.wallet.transferTransaction(outputsToCreate, {
+        ttl: new Date(Date.now() + 30 * 60 * 1000),
+      });
       logger.info('Signing tx...');
       logger.info(txRecipe);
       const signedTxRecipe = await sender.wallet.signRecipe(txRecipe, sender.unshieldedKeystore.signDataAsync);
@@ -216,7 +203,7 @@ describe('Set up test wallet', () => {
       logger.info(signedTxRecipe);
       const finalizedTx = await sender.wallet.finalizeRecipe(signedTxRecipe);
       logger.info('Submitting transaction...');
-      logger.info(finalizedTx.toString());
+      logger.info(Buffer.from(finalizedTx.serialize()).toString('hex'));
       const txId = await sender.wallet.submitTransaction(finalizedTx);
       logger.info('txProcessing');
       logger.info('Transaction id: ' + txId);

--- a/packages/e2e-tests/src/tests/helpers/stateWaiters.ts
+++ b/packages/e2e-tests/src/tests/helpers/stateWaiters.ts
@@ -23,6 +23,8 @@ import {
   isFinalizedWalletEntry,
 } from '@midnightntwrk/wallet-sdk-facade';
 import { logger } from '../logger.js';
+import { carried } from './transactions.js';
+import { type FinalizedTx } from '@midnightntwrk/wallet-sdk';
 
 export const waitForSyncUnshielded = (wallet: UnshieldedWallet) =>
   rx.firstValueFrom(
@@ -107,11 +109,13 @@ export const waitForUnshieldedCoinUpdate = (wallet: WalletFacade, initialNumAvai
     ),
   );
 
-export const waitForStateAfterDustRegistration = (wallet: WalletFacade, finalizedTx: ledger.FinalizedTransaction) =>
+export const waitForStateAfterDustRegistration = (wallet: WalletFacade, finalizedTx: FinalizedTx) =>
   rx.firstValueFrom(
     wallet.state().pipe(
       rx.mergeMap(async (state) => {
-        const txInHistory = await wallet.queryTxHistoryByHash(finalizedTx.transactionHash());
+        const txInHistory = await wallet.queryTxHistoryByHash(
+          carried<ledger.FinalizedTransaction>(finalizedTx).transactionHash(),
+        );
 
         return {
           state,
@@ -126,13 +130,15 @@ export const waitForStateAfterDustRegistration = (wallet: WalletFacade, finalize
 /** Waits for a dust deregistration transaction to settle and the consolidated Night output to re-sync. */
 export const waitForStateAfterDustDeregistration = (
   wallet: WalletFacade,
-  finalizedTx: ledger.FinalizedTransaction,
+  finalizedTx: FinalizedTx,
   unshieldedTokenRaw: ledger.RawTokenType,
 ) =>
   rx.firstValueFrom(
     wallet.state().pipe(
       rx.mergeMap(async (state) => {
-        const txInHistory = await wallet.queryTxHistoryByHash(finalizedTx.transactionHash());
+        const txInHistory = await wallet.queryTxHistoryByHash(
+          carried<ledger.FinalizedTransaction>(finalizedTx).transactionHash(),
+        );
 
         return {
           state,

--- a/packages/e2e-tests/src/tests/helpers/transactions.ts
+++ b/packages/e2e-tests/src/tests/helpers/transactions.ts
@@ -1,0 +1,54 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Sealing a transaction a test built, and opening one the wallet handed back.
+ *
+ * @remarks
+ *   These suites are both authors and inspectors: they hand-build transactions to see what the wallet does with them, and
+ *   then read identifiers and imbalances off what it returns. Neither is what an ordinary application does, which is
+ *   why the two directions are named here rather than scattered — an application carries a handle and never opens it.
+ */
+import { ProtocolVersion, WalletTransaction, type AnyTx } from '@midnightntwrk/wallet-sdk';
+import { Either } from 'effect';
+
+/**
+ * The protocol version these suites author at.
+ *
+ * @remarks
+ *   The minimum supported version, which is the epoch a wallet with no history is in and the one an undeployed chain
+ *   reports. A transaction sealed at any other version is refused by the facade until the wallets have crossed to it.
+ */
+export const AUTHORED_AT = ProtocolVersion.MinSupportedVersion;
+
+/** Seals a transaction a test built for itself, saying which ledger version built it. */
+export const sealed = <TStage extends WalletTransaction.Stage>(
+  stage: TStage,
+  transaction: { serialize: () => Uint8Array },
+): WalletTransaction<TStage> => WalletTransaction.adopt(stage, transaction, AUTHORED_AT);
+
+/**
+ * Reads the transaction a handle carries, at exactly the version it says it was built at.
+ *
+ * @remarks
+ *   A one-wide range: a test that opens a handle is asking for the transaction it is holding and no other, so the version
+ *   it names is the handle's own. The result type is the caller's to name — which is the choice the stamp has already
+ *   settled, so naming the wrong ledger version fails on the very next line.
+ */
+export const carried = <T>(handle: AnyTx): T =>
+  Either.getOrThrow(
+    WalletTransaction.unwrapWithin<T>(
+      handle,
+      ProtocolVersion.makeRange(handle.protocolVersion, ProtocolVersion.ProtocolVersion(handle.protocolVersion + 1n)),
+    ),
+  );

--- a/packages/e2e-tests/src/tests/nativeTokenTransfer.remote.test.ts
+++ b/packages/e2e-tests/src/tests/nativeTokenTransfer.remote.test.ts
@@ -17,6 +17,8 @@ import * as utils from './utils.js';
 import { logger } from './logger.js';
 import { exit } from 'node:process';
 import { type CombinedTokenTransfer } from '@midnightntwrk/wallet-sdk-facade';
+import { carried } from './helpers/transactions.js';
+import { Buffer } from 'buffer';
 
 /** Tests performing a token transfer */
 
@@ -121,22 +123,15 @@ describe('Token transfer', () => {
         },
       ];
 
-      const txRecipe = await sender.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: sender.shieldedSecretKeys,
-          dustSecretKey: sender.dustSecretKey,
-        },
-        {
-          ttl: new Date(Date.now() + 30 * 60 * 1000),
-        },
-      );
+      const txRecipe = await sender.wallet.transferTransaction(outputsToCreate, {
+        ttl: new Date(Date.now() + 30 * 60 * 1000),
+      });
       logger.info(txRecipe);
       const finalizedTx = await sender.wallet.finalizeRecipe(txRecipe);
-      logger.info(finalizedTx.toString());
+      logger.info(Buffer.from(finalizedTx.serialize()).toString('hex'));
       logger.info('Submitting tx:');
       const txId = await sender.wallet.submitTransaction(finalizedTx);
-      const txHash = finalizedTx.transactionHash();
+      const txHash = carried<ledger.FinalizedTransaction>(finalizedTx).transactionHash();
       logger.info('txProcessing');
       logger.info('Transaction id: ' + txId);
       logger.info('Transaction hash: ' + txHash);
@@ -213,16 +208,9 @@ describe('Token transfer', () => {
           ],
         },
       ];
-      const txRecipe = await sender.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: sender.shieldedSecretKeys,
-          dustSecretKey: sender.dustSecretKey,
-        },
-        {
-          ttl: new Date(Date.now() + 30 * 60 * 1000),
-        },
-      );
+      const txRecipe = await sender.wallet.transferTransaction(outputsToCreate, {
+        ttl: new Date(Date.now() + 30 * 60 * 1000),
+      });
       const finalizedTx = await sender.wallet.finalizeRecipe(txRecipe);
       const txId = await sender.wallet.submitTransaction(finalizedTx);
       logger.info('Transaction id: ' + txId);

--- a/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
@@ -29,6 +29,7 @@ import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wal
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { makeWasmProvingService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { pipe } from 'effect';
+import { carried, sealed } from './helpers/transactions.js';
 
 vi.setConfig({ testTimeout: 200_000, hookTimeout: 200_000 });
 
@@ -163,16 +164,12 @@ describe('Optional Balancing', () => {
       await facade.waitForSyncedState();
 
       const arbitraryTx = createArbitraryTx(configuration.networkId);
-      const recipe = await facade.balanceUnprovenTransaction(
-        arbitraryTx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl, tokenKindsToBalance: ['shielded'] },
-      );
+      const recipe = await facade.balanceUnprovenTransaction(sealed('Unproven', arbitraryTx), {
+        ttl,
+        tokenKindsToBalance: ['shielded'],
+      });
 
-      const imbalances = getImbalances(recipe.transaction, 0);
+      const imbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.transaction), 0);
 
       // Verify shielded IS balanced (imbalance = 0n)
       expect(imbalances.shielded).toEqual(0n);
@@ -190,14 +187,10 @@ describe('Optional Balancing', () => {
       const tx = pipe(createArbitraryShieldedOffer(), (offer) =>
         ledger.Transaction.fromParts(configuration.networkId, offer),
       );
-      const recipe = await facade.balanceUnprovenTransaction(
-        tx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl, tokenKindsToBalance: ['shielded'] },
-      );
+      const recipe = await facade.balanceUnprovenTransaction(sealed('Unproven', tx), {
+        ttl,
+        tokenKindsToBalance: ['shielded'],
+      });
 
       const signed = await facade.signRecipe(recipe, () => {
         throw new Error('Should not be called');
@@ -211,16 +204,12 @@ describe('Optional Balancing', () => {
 
       const arbitraryTx = createArbitraryTx(configuration.networkId);
 
-      const recipe = await facade.balanceUnprovenTransaction(
-        arbitraryTx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl, tokenKindsToBalance: ['unshielded'] },
-      );
+      const recipe = await facade.balanceUnprovenTransaction(sealed('Unproven', arbitraryTx), {
+        ttl,
+        tokenKindsToBalance: ['unshielded'],
+      });
 
-      const imbalances = getImbalances(recipe.transaction, 0);
+      const imbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.transaction), 0);
 
       // Verify unshielded IS balanced (imbalance = 0n)
       expect(imbalances.unshielded).toBe(0n);
@@ -237,16 +226,12 @@ describe('Optional Balancing', () => {
 
       const arbitraryTx = createArbitraryTx(configuration.networkId);
 
-      const recipe = await facade.balanceUnprovenTransaction(
-        arbitraryTx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl, tokenKindsToBalance: ['dust'] },
-      );
+      const recipe = await facade.balanceUnprovenTransaction(sealed('Unproven', arbitraryTx), {
+        ttl,
+        tokenKindsToBalance: ['dust'],
+      });
 
-      const imbalances = getImbalances(recipe.transaction, 0);
+      const imbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.transaction), 0);
 
       // Verify unshielded is NOT balanced (imbalance < 0n)
       expect(imbalances.unshielded).toBeLessThan(0n);
@@ -262,16 +247,9 @@ describe('Optional Balancing', () => {
       await facade.waitForSyncedState();
 
       const arbitraryTx = createArbitraryTx(configuration.networkId);
-      const recipe = await facade.balanceUnprovenTransaction(
-        arbitraryTx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl },
-      );
+      const recipe = await facade.balanceUnprovenTransaction(sealed('Unproven', arbitraryTx), { ttl });
 
-      const imbalances = getImbalances(recipe.transaction, 0);
+      const imbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.transaction), 0);
 
       // Verify unshielded IS balanced (imbalance = 0n)
       expect(imbalances.unshielded).toEqual(0n);
@@ -292,20 +270,16 @@ describe('Optional Balancing', () => {
       const arbitraryTx = createArbitraryTx(configuration.networkId);
       const unboundTx = await provingService.prove(arbitraryTx);
 
-      const recipe = await facade.balanceUnboundTransaction(
-        unboundTx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl, tokenKindsToBalance: ['shielded'] },
-      );
+      const recipe = await facade.balanceUnboundTransaction(sealed('Unbound', unboundTx), {
+        ttl,
+        tokenKindsToBalance: ['shielded'],
+      });
 
       // Verify balancing transaction exists (shielded balancing creates a balancing tx)
       expect(recipe.balancingTransaction).toBeDefined();
 
-      const balancingImbalances = getImbalances(recipe.balancingTransaction!, 0);
-      const baseImbalances = getImbalances(recipe.baseTransaction, 0);
+      const balancingImbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.balancingTransaction!), 0);
+      const baseImbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.baseTransaction), 0);
 
       // Verify shielded IS balanced (provides surplus to offset base tx deficit)
       expect(balancingImbalances.shielded).toBeGreaterThan(0n);
@@ -336,14 +310,10 @@ describe('Optional Balancing', () => {
             ledger.LedgerParameters.initialParameters().transactionCostModel.runtimeCostModel,
           ),
       );
-      const recipe = await facade.balanceUnboundTransaction(
-        tx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl, tokenKindsToBalance: ['shielded'] },
-      );
+      const recipe = await facade.balanceUnboundTransaction(sealed('Unbound', tx), {
+        ttl,
+        tokenKindsToBalance: ['shielded'],
+      });
 
       const signed = await facade.signRecipe(recipe, () => {
         throw new Error('Should not be called');
@@ -359,19 +329,15 @@ describe('Optional Balancing', () => {
       const arbitraryTx = createArbitraryTx(configuration.networkId);
       const unboundTx = await provingService.prove(arbitraryTx);
 
-      const recipe = await facade.balanceUnboundTransaction(
-        unboundTx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl, tokenKindsToBalance: ['unshielded'] },
-      );
+      const recipe = await facade.balanceUnboundTransaction(sealed('Unbound', unboundTx), {
+        ttl,
+        tokenKindsToBalance: ['unshielded'],
+      });
 
       // Verify balancing transaction does NOT exist (unshielded balancing occurs in place)
       expect(recipe.balancingTransaction).toBeUndefined();
 
-      const baseImbalances = getImbalances(recipe.baseTransaction, 0);
+      const baseImbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.baseTransaction), 0);
 
       // Verify base transaction IS balanced (unshielded = 0n)
       expect(baseImbalances.unshielded).toEqual(0n);
@@ -384,19 +350,15 @@ describe('Optional Balancing', () => {
       const arbitraryTx = createArbitraryTx(configuration.networkId);
       const unboundTx = await provingService.prove(arbitraryTx);
 
-      const recipe = await facade.balanceUnboundTransaction(
-        unboundTx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl, tokenKindsToBalance: ['dust'] },
-      );
+      const recipe = await facade.balanceUnboundTransaction(sealed('Unbound', unboundTx), {
+        ttl,
+        tokenKindsToBalance: ['dust'],
+      });
 
       // Verify balancing transaction exists with dust fees
       expect(recipe.balancingTransaction).toBeDefined();
 
-      const balancingImbalances = getImbalances(recipe.balancingTransaction!, 0);
+      const balancingImbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.balancingTransaction!), 0);
 
       // Verify dust IS balanced (dust imbalance > 0n - surplus)
       expect(balancingImbalances.dust).toBeGreaterThan(0n);
@@ -407,7 +369,7 @@ describe('Optional Balancing', () => {
       // Verify unshielded is NOT balanced (unshielded imbalance = 0n - no contribution)
       expect(balancingImbalances.unshielded).toEqual(0n);
 
-      const baseImbalances = getImbalances(recipe.baseTransaction, 0);
+      const baseImbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.baseTransaction), 0);
 
       // Verify base tx unshielded is NOT balanced (unshielded imbalance < 0n)
       expect(baseImbalances.unshielded).toBeLessThan(0n);
@@ -420,20 +382,13 @@ describe('Optional Balancing', () => {
       const arbitraryTx = createArbitraryTx(configuration.networkId);
       const unboundTx = await provingService.prove(arbitraryTx);
 
-      const recipe = await facade.balanceUnboundTransaction(
-        unboundTx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl },
-      );
+      const recipe = await facade.balanceUnboundTransaction(sealed('Unbound', unboundTx), { ttl });
 
       // Verify balancing transaction exists
       expect(recipe.balancingTransaction).toBeDefined();
 
-      const balancingImbalances = getImbalances(recipe.balancingTransaction!, 0);
-      const baseImbalances = getImbalances(recipe.baseTransaction, 0);
+      const balancingImbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.balancingTransaction!), 0);
+      const baseImbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.baseTransaction), 0);
 
       // Verify shielded IS balanced (provides surplus to offset base tx deficit)
       expect(balancingImbalances.shielded).toBeGreaterThan(0n);
@@ -466,16 +421,12 @@ describe('Optional Balancing', () => {
       await facade.waitForSyncedState();
 
       // Balance the finalized transaction with only shielded
-      const recipe = await facade.balanceFinalizedTransaction(
-        finalizedTx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl, tokenKindsToBalance: ['shielded'] },
-      );
+      const recipe = await facade.balanceFinalizedTransaction(sealed('Finalized', finalizedTx), {
+        ttl,
+        tokenKindsToBalance: ['shielded'],
+      });
 
-      const imbalances = getImbalances(recipe.balancingTransaction, 0);
+      const imbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.balancingTransaction), 0);
 
       // Verify balancing transaction has shielded balancing (shielded imbalance > 0n - surplus)
       expect(imbalances.shielded).toBeGreaterThan(0n);
@@ -495,14 +446,10 @@ describe('Optional Balancing', () => {
         (offer) => ledger.Transaction.fromParts(configuration.networkId, offer),
         (tx) => tx.mockProve(),
       );
-      const recipe = await facade.balanceFinalizedTransaction(
-        tx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl, tokenKindsToBalance: ['shielded'] },
-      );
+      const recipe = await facade.balanceFinalizedTransaction(sealed('Finalized', tx), {
+        ttl,
+        tokenKindsToBalance: ['shielded'],
+      });
 
       const signed = await facade.signRecipe(recipe, () => {
         throw new Error('Should not be called');
@@ -515,16 +462,12 @@ describe('Optional Balancing', () => {
       await facade.waitForSyncedState();
 
       // Balance the finalized transaction with only unshielded
-      const recipe = await facade.balanceFinalizedTransaction(
-        finalizedTx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl, tokenKindsToBalance: ['unshielded'] },
-      );
+      const recipe = await facade.balanceFinalizedTransaction(sealed('Finalized', finalizedTx), {
+        ttl,
+        tokenKindsToBalance: ['unshielded'],
+      });
 
-      const imbalances = getImbalances(recipe.balancingTransaction, 0);
+      const imbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.balancingTransaction), 0);
 
       // Verify shielded is NOT balanced (no shielded contribution, imbalance = 0)
       expect(imbalances.shielded).toBe(0n);
@@ -540,16 +483,12 @@ describe('Optional Balancing', () => {
       await facade.waitForSyncedState();
 
       // Balance the finalized transaction with only dust
-      const recipe = await facade.balanceFinalizedTransaction(
-        finalizedTx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl, tokenKindsToBalance: ['dust'] },
-      );
+      const recipe = await facade.balanceFinalizedTransaction(sealed('Finalized', finalizedTx), {
+        ttl,
+        tokenKindsToBalance: ['dust'],
+      });
 
-      const imbalances = getImbalances(recipe.balancingTransaction, 0);
+      const imbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.balancingTransaction), 0);
 
       // Verify shielded is NOT balanced (no shielded contribution, imbalance = 0)
       expect(imbalances.shielded).toBe(0n);
@@ -565,16 +504,9 @@ describe('Optional Balancing', () => {
       await facade.waitForSyncedState();
 
       // Balance the finalized transaction with all
-      const recipe = await facade.balanceFinalizedTransaction(
-        finalizedTx,
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
-        { ttl },
-      );
+      const recipe = await facade.balanceFinalizedTransaction(sealed('Finalized', finalizedTx), { ttl });
 
-      const imbalances = getImbalances(recipe.balancingTransaction, 0);
+      const imbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.balancingTransaction), 0);
 
       // Verify shielded is balanced (shielded imbalance > 0)
       expect(imbalances.shielded).toBeGreaterThan(0n);
@@ -609,14 +541,10 @@ describe('Optional Balancing', () => {
             ],
           },
         ],
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
         { ttl, payFees: false },
       );
 
-      const imbalances = getImbalances(recipe.transaction, 0);
+      const imbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.transaction), 0);
 
       // Verify dust fees are NOT paid (dust imbalance = 0n)
       expect(imbalances.dust).toEqual(0n);
@@ -643,14 +571,10 @@ describe('Optional Balancing', () => {
             ],
           },
         ],
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
         { ttl, payFees: true },
       );
 
-      const imbalances = getImbalances(recipe.transaction, 0);
+      const imbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.transaction), 0);
 
       // Verify dust fees ARE paid (dust imbalance > 0n)
       expect(imbalances.dust).toBeGreaterThan(0n);
@@ -677,10 +601,6 @@ describe('Optional Balancing', () => {
             ],
           },
         ],
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
         { ttl, payFees: false },
       );
 
@@ -709,14 +629,10 @@ describe('Optional Balancing', () => {
             ],
           },
         ],
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
         { ttl, payFees: false },
       );
 
-      const imbalances = getImbalances(recipe.transaction, 0);
+      const imbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.transaction), 0);
 
       // Verify dust fees are NOT paid (dust imbalance = 0n)
       expect(imbalances.dust).toEqual(0n);
@@ -738,14 +654,10 @@ describe('Optional Balancing', () => {
             ],
           },
         ],
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
         { ttl, payFees: true },
       );
 
-      const imbalances = getImbalances(recipe.transaction, 0);
+      const imbalances = getImbalances(carried<ledger.FinalizedTransaction>(recipe.transaction), 0);
 
       // Verify dust fees ARE paid (dust imbalance > 0n)
       expect(imbalances.dust).toBeGreaterThan(0n);
@@ -767,10 +679,6 @@ describe('Optional Balancing', () => {
             ],
           },
         ],
-        {
-          shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedSeed),
-          dustSecretKey: ledger.DustSecretKey.fromSeed(dustSeed),
-        },
         { ttl, payFees: false },
       );
 

--- a/packages/e2e-tests/src/tests/projectionsBasedSync.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/projectionsBasedSync.undeployed.test.ts
@@ -27,6 +27,7 @@ import {
   makeEventLessSyncService,
 } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { V2Builder } from '@midnightntwrk/wallet-sdk-dust-wallet/v2';
+import { carried } from './helpers/transactions.js';
 
 /** @group undeployed */
 
@@ -193,14 +194,7 @@ describe('Projections-based synchronisation model', () => {
     await receiver.wallet.doSync(receiver.dustSecretKey);
 
     const ttl = new Date(Date.now() + 30 * 60 * 1000);
-    const txRecipe = await funded.wallet.transferTransaction(
-      outputsToCreate,
-      {
-        shieldedSecretKeys: funded.shieldedSecretKeys,
-        dustSecretKey: funded.dustSecretKey,
-      },
-      { ttl },
-    );
+    const txRecipe = await funded.wallet.transferTransaction(outputsToCreate, { ttl });
     const signedTxRecipe = await funded.wallet.signRecipe(txRecipe, funded.unshieldedKeystore.signDataAsync);
     const finalizedTx = await funded.wallet.finalizeRecipe(signedTxRecipe);
     const txId = await funded.wallet.submitTransaction(finalizedTx);
@@ -267,16 +261,12 @@ describe('Projections-based synchronisation model', () => {
           outputs: [{ type: shieldedTokenRaw, amount: outputValue, receiverAddress }],
         },
       ],
-      {
-        shieldedSecretKeys: fundedEventsSynced.shieldedSecretKeys,
-        dustSecretKey: fundedEventsSynced.dustSecretKey,
-      },
       { ttl: new Date(Date.now() + 30 * 60 * 1000) },
     );
     const finalizedTx = await fundedEventsSynced.wallet.finalizeRecipe(txRecipe);
     await fundedEventsSynced.wallet.submitTransaction(finalizedTx);
 
-    const txHash = finalizedTx.transactionHash();
+    const txHash = carried<ledger.FinalizedTransaction>(finalizedTx).transactionHash();
     await utils.waitForTxInHistory(txHash, fundedEventsSynced.wallet, {
       ready: (entry) => entry.shielded !== undefined && entry.dust !== undefined,
     });

--- a/packages/e2e-tests/src/tests/smoke.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/smoke.undeployed.test.ts
@@ -28,6 +28,7 @@ import {
 } from '@midnightntwrk/wallet-sdk-facade';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { DustWallet, type DustWalletClass } from '@midnightntwrk/wallet-sdk-dust-wallet';
+import { carried } from './helpers/transactions.js';
 
 /** Smoke tests */
 
@@ -118,21 +119,14 @@ describe('Smoke tests', () => {
           ],
         },
       ];
-      const txRecipe = await funded.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: funded.shieldedSecretKeys,
-          dustSecretKey: funded.dustSecretKey,
-        },
-        {
-          ttl: new Date(Date.now() + 30 * 60 * 1000),
-        },
-      );
+      const txRecipe = await funded.wallet.transferTransaction(outputsToCreate, {
+        ttl: new Date(Date.now() + 30 * 60 * 1000),
+      });
       const signedTxRecipe = await funded.wallet.signRecipe(txRecipe, unshieldedFundedKeyStore.signDataAsync);
       const finalizedTx = await funded.wallet.finalizeRecipe(signedTxRecipe);
       const txId = await funded.wallet.submitTransaction(finalizedTx);
       logger.info('Transaction id: ' + txId);
-      const txHash = finalizedTx.transactionHash();
+      const txHash = carried<ledger.FinalizedTransaction>(finalizedTx).transactionHash();
 
       const pendingState = await utils.waitForFacadePending(funded.wallet);
       expect(pendingState.shielded.totalCoins.length).toBe(7);

--- a/packages/e2e-tests/src/tests/swap.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/swap.undeployed.test.ts
@@ -32,6 +32,7 @@ import {
 } from '@midnightntwrk/wallet-sdk-facade';
 import { getDustSeed, getShieldedSeed, getUnshieldedSeed, tokenValue } from './utils.js';
 import { makeWasmProvingService } from '@midnightntwrk/wallet-sdk-capabilities';
+import { carried, sealed } from './helpers/transactions.js';
 
 vi.setConfig({ testTimeout: 800_000, hookTimeout: 800_000 });
 
@@ -189,33 +190,18 @@ describe('Swaps', () => {
       },
     ];
 
-    const swapTxRecipe = await walletAFacade.initSwap(
-      desiredInputs,
-      desiredOutputs,
-      {
-        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedWalletASeed),
-        dustSecretKey: ledger.DustSecretKey.fromSeed(dustWalletASeed),
-      },
-      {
-        ttl,
-      },
-    );
+    const swapTxRecipe = await walletAFacade.initSwap(desiredInputs, desiredOutputs, {
+      ttl,
+    });
 
     // proving the tx instead of calling finalizeRecipe directly, because we want to test the balance of the unbound tx
-    const unboundSwapTx = await provingService.prove(swapTxRecipe.transaction);
+    const unboundSwapTx = await provingService.prove(carried<ledger.UnprovenTransaction>(swapTxRecipe.transaction));
 
     // assuming the tx is submitted to a dex pool and another wallet (wallet B) picks it up
 
-    const walletBBalancedTxRecipe = await walletBFacade.balanceUnboundTransaction(
-      unboundSwapTx,
-      {
-        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedWalletBSeed),
-        dustSecretKey: ledger.DustSecretKey.fromSeed(dustWalletBSeed),
-      },
-      {
-        ttl: new Date(Date.now() + 60 * 60 * 1000),
-      },
-    );
+    const walletBBalancedTxRecipe = await walletBFacade.balanceUnboundTransaction(sealed('Unbound', unboundSwapTx), {
+      ttl: new Date(Date.now() + 60 * 60 * 1000),
+    });
 
     const finalizedTx = await walletBFacade.finalizeRecipe(walletBBalancedTxRecipe);
 
@@ -282,17 +268,9 @@ describe('Swaps', () => {
       },
     ];
 
-    const swapTxRecipe = await walletAFacade.initSwap(
-      desiredInputs,
-      desiredOutputs,
-      {
-        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedWalletASeed),
-        dustSecretKey: ledger.DustSecretKey.fromSeed(dustWalletASeed),
-      },
-      {
-        ttl,
-      },
-    );
+    const swapTxRecipe = await walletAFacade.initSwap(desiredInputs, desiredOutputs, {
+      ttl,
+    });
 
     const signedSwapTxRecipe = await walletAFacade.signRecipe(swapTxRecipe, (payload) => {
       return unshieldedWalletAKeystore.signDataAsync(payload);
@@ -301,16 +279,9 @@ describe('Swaps', () => {
     const finalizedSwapTx = await walletAFacade.finalizeRecipe(signedSwapTxRecipe);
 
     // the tx is picked up by another wallet (wallet B)
-    const walletBBalancedTxRecipe = await walletBFacade.balanceFinalizedTransaction(
-      finalizedSwapTx,
-      {
-        shieldedSecretKeys: ledger.ZswapSecretKeys.fromSeed(shieldedWalletBSeed),
-        dustSecretKey: ledger.DustSecretKey.fromSeed(dustWalletBSeed),
-      },
-      {
-        ttl,
-      },
-    );
+    const walletBBalancedTxRecipe = await walletBFacade.balanceFinalizedTransaction(finalizedSwapTx, {
+      ttl,
+    });
 
     const walletBSignedTxRecipe = await walletBFacade.signRecipe(walletBBalancedTxRecipe, (payload) => {
       return unshieldedWalletBKeystore.signDataAsync(payload);

--- a/packages/e2e-tests/src/tests/tokenTransfer.remote.test.ts
+++ b/packages/e2e-tests/src/tests/tokenTransfer.remote.test.ts
@@ -34,6 +34,7 @@ import {
   registerTokenTransferHealthchecks,
   useTokenTransferWallets,
 } from '@midnightntwrk/wallet-sdk-testkit/scenarios';
+import { carried, sealed } from './helpers/transactions.js';
 
 const getEnv = useWalletTestEnvironment(() =>
   createTestContainersEnvironment({ network: process.env['NETWORK'] as MidnightNetwork }),
@@ -80,16 +81,9 @@ describe('Token transfer (extended)', () => {
         },
       ];
       logger.info('Transfer transaction...');
-      const txRecipe = await sender.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: sender.shieldedSecretKeys,
-          dustSecretKey: sender.dustSecretKey,
-        },
-        {
-          ttl: new Date(Date.now() + 30 * 60 * 1000),
-        },
-      );
+      const txRecipe = await sender.wallet.transferTransaction(outputsToCreate, {
+        ttl: new Date(Date.now() + 30 * 60 * 1000),
+      });
       logger.info('Transaction to prove...');
       logger.info(txRecipe);
       const finalizedTx = await sender.wallet.finalizeRecipe(txRecipe);
@@ -104,7 +98,7 @@ describe('Token transfer (extended)', () => {
       expect(pendingState.shielded.availableCoins.length).toBeLessThan(initialState.shielded.availableCoins.length);
       expect(pendingState.shielded.totalCoins.length).toBe(initialState.shielded.totalCoins.length);
 
-      const txHash = finalizedTx.transactionHash();
+      const txHash = carried<ledger.FinalizedTransaction>(finalizedTx).transactionHash();
       const txEntry = await waitForTxInHistory(txHash, sender.wallet, (e) => e.shielded !== undefined);
       const finalState = await sender.wallet.waitForSyncedState();
       logger.info(`Wallet 1 available coins: ${finalState.shielded.availableCoins.length}`);
@@ -158,10 +152,6 @@ describe('Token transfer (extended)', () => {
         },
       ],
       {
-        shieldedSecretKeys: sender.shieldedSecretKeys,
-        dustSecretKey: sender.dustSecretKey,
-      },
-      {
         ttl,
         payFees: false,
       },
@@ -170,16 +160,9 @@ describe('Token transfer (extended)', () => {
     const wallet1TxId = await sender.wallet.submitTransaction(finalizedTx);
     logger.info('Transaction id: ' + wallet1TxId);
 
-    const wallet2BalancedTx = await receiver.wallet.balanceFinalizedTransaction(
-      finalizedTx,
-      {
-        shieldedSecretKeys: receiver.shieldedSecretKeys,
-        dustSecretKey: receiver.dustSecretKey,
-      },
-      {
-        ttl,
-      },
-    );
+    const wallet2BalancedTx = await receiver.wallet.balanceFinalizedTransaction(finalizedTx, {
+      ttl,
+    });
     const finalizedSwapTx = await receiver.wallet.finalizeRecipe(wallet2BalancedTx);
     const wallet2TxId = await receiver.wallet.submitTransaction(finalizedSwapTx);
     logger.info('Transaction id 2: ' + wallet2TxId);
@@ -220,7 +203,7 @@ describe('Token transfer (extended)', () => {
       );
       const offer = ledger.ZswapOffer.fromOutput(output, shieldedTokenRaw, outputValue);
       const unprovenTx = ledger.Transaction.fromParts(networkId, offer);
-      const finalizedTx = await sender.wallet.finalizeTransaction(unprovenTx);
+      const finalizedTx = await sender.wallet.finalizeTransaction(sealed('Unproven', unprovenTx));
       await expect(
         Promise.all([sender.wallet.submitTransaction(finalizedTx), sender.wallet.submitTransaction(finalizedTx)]),
       ).rejects.toThrow();
@@ -264,16 +247,9 @@ describe('Token transfer (extended)', () => {
         },
       ];
 
-      const txRecipe = await sender.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: sender.shieldedSecretKeys,
-          dustSecretKey: sender.dustSecretKey,
-        },
-        {
-          ttl: new Date(),
-        },
-      );
+      const txRecipe = await sender.wallet.transferTransaction(outputsToCreate, {
+        ttl: new Date(),
+      });
       await expect(sender.wallet.finalizeRecipe(txRecipe)).rejects.toThrow();
 
       const finalState = await waitForFinalizedShieldedBalance(sender.wallet.shielded);
@@ -308,16 +284,9 @@ describe('Token transfer (extended)', () => {
         },
       ];
       try {
-        const txRecipe = await sender.wallet.transferTransaction(
-          outputsToCreate,
-          {
-            shieldedSecretKeys: sender.shieldedSecretKeys,
-            dustSecretKey: sender.dustSecretKey,
-          },
-          {
-            ttl: new Date(),
-          },
-        );
+        const txRecipe = await sender.wallet.transferTransaction(outputsToCreate, {
+          ttl: new Date(),
+        });
         const finalizedTx = await sender.wallet.finalizeRecipe(txRecipe);
         await sender.wallet.submitTransaction(finalizedTx);
       } catch (e: unknown) {
@@ -354,16 +323,9 @@ describe('Token transfer (extended)', () => {
         },
       ];
       await expect(
-        sender.wallet.transferTransaction(
-          outputsToCreate,
-          {
-            shieldedSecretKeys: sender.shieldedSecretKeys,
-            dustSecretKey: sender.dustSecretKey,
-          },
-          {
-            ttl: new Date(),
-          },
-        ),
+        sender.wallet.transferTransaction(outputsToCreate, {
+          ttl: new Date(),
+        }),
       ).rejects.toThrow('The amount needs to be positive');
     },
     timeout,
@@ -393,16 +355,9 @@ describe('Token transfer (extended)', () => {
       ];
 
       await expect(
-        sender.wallet.transferTransaction(
-          outputsToCreate,
-          {
-            shieldedSecretKeys: sender.shieldedSecretKeys,
-            dustSecretKey: sender.dustSecretKey,
-          },
-          {
-            ttl: new Date(),
-          },
-        ),
+        sender.wallet.transferTransaction(outputsToCreate, {
+          ttl: new Date(),
+        }),
       ).rejects.toThrow('The amount needs to be positive');
     },
     timeout,
@@ -417,16 +372,9 @@ describe('Token transfer (extended)', () => {
       logger.info(`Wallet 1 balance is: ${initialBalance}`);
 
       await expect(
-        sender.wallet.transferTransaction(
-          [],
-          {
-            shieldedSecretKeys: sender.shieldedSecretKeys,
-            dustSecretKey: sender.dustSecretKey,
-          },
-          {
-            ttl: new Date(),
-          },
-        ),
+        sender.wallet.transferTransaction([], {
+          ttl: new Date(),
+        }),
       ).rejects.toThrow('At least one shielded or unshielded output is required.');
     },
     timeout,

--- a/packages/e2e-tests/src/tests/tokenTransfer.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/tokenTransfer.undeployed.test.ts
@@ -18,6 +18,8 @@ import * as utils from './utils.js';
 import { logger } from './logger.js';
 import { type CombinedTokenTransfer, type WalletEntry } from '@midnightntwrk/wallet-sdk-facade';
 import { randomBytes } from 'node:crypto';
+import { type FinalizedTx } from '@midnightntwrk/wallet-sdk';
+import { carried, sealed } from './helpers/transactions.js';
 
 /** Tests performing a token transfer */
 
@@ -88,16 +90,9 @@ describe('Token transfer', () => {
           ],
         },
       ];
-      const txRecipe = await funded.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: funded.shieldedSecretKeys,
-          dustSecretKey: funded.dustSecretKey,
-        },
-        {
-          ttl: new Date(Date.now() + 60 * 60 * 1000),
-        },
-      );
+      const txRecipe = await funded.wallet.transferTransaction(outputsToCreate, {
+        ttl: new Date(Date.now() + 60 * 60 * 1000),
+      });
       logger.info('Sending transaction...');
       const finalizedTx = await funded.wallet.finalizeRecipe(txRecipe);
       const txId = await funded.wallet.submitTransaction(finalizedTx);
@@ -117,7 +112,7 @@ describe('Token transfer', () => {
       expect(pendingState.shielded.pendingCoins.length).toBeLessThanOrEqual(2);
       expect(pendingState.shielded.totalCoins.length).toBe(initialState.shielded.totalCoins.length);
 
-      const txHash = finalizedTx.transactionHash();
+      const txHash = carried<ledger.FinalizedTransaction>(finalizedTx).transactionHash();
       const senderTxEntry = await utils.waitForTxInHistory(txHash, funded.wallet, {
         ready: (e) => e.shielded !== undefined,
       });
@@ -191,16 +186,9 @@ describe('Token transfer', () => {
           ],
         },
       ];
-      const txRecipe = await funded.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: funded.shieldedSecretKeys,
-          dustSecretKey: funded.dustSecretKey,
-        },
-        {
-          ttl: new Date(Date.now() + 60 * 60 * 1000),
-        },
-      );
+      const txRecipe = await funded.wallet.transferTransaction(outputsToCreate, {
+        ttl: new Date(Date.now() + 60 * 60 * 1000),
+      });
       const signedTxRecipe = await funded.wallet.signRecipe(txRecipe, funded.unshieldedKeystore.signDataAsync);
       const finalizedTx = await funded.wallet.finalizeRecipe(signedTxRecipe);
       const txId = await funded.wallet.submitTransaction(finalizedTx);
@@ -216,7 +204,7 @@ describe('Token transfer', () => {
       expect(pendingState.unshielded.pendingCoins.length).toBeLessThanOrEqual(2);
       expect(pendingState.unshielded.totalCoins.length).toBe(initialState.unshielded.totalCoins.length);
 
-      const txHash = finalizedTx.transactionHash();
+      const txHash = carried<ledger.FinalizedTransaction>(finalizedTx).transactionHash();
       const senderTxEntry = await utils.waitForTxInHistory(txHash, funded.wallet, {
         ready: (e) => e.unshielded !== undefined,
       });
@@ -307,16 +295,9 @@ describe('Token transfer', () => {
           ],
         },
       ];
-      const txRecipe = await funded.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: funded.shieldedSecretKeys,
-          dustSecretKey: funded.dustSecretKey,
-        },
-        {
-          ttl: new Date(Date.now() + 60 * 60 * 1000),
-        },
-      );
+      const txRecipe = await funded.wallet.transferTransaction(outputsToCreate, {
+        ttl: new Date(Date.now() + 60 * 60 * 1000),
+      });
       logger.info('Sending transaction...');
       const provenTx = await funded.wallet.finalizeRecipe(txRecipe);
       const txId = await funded.wallet.submitTransaction(provenTx);
@@ -328,7 +309,7 @@ describe('Token transfer', () => {
       logger.info(pendingState.shielded.balances);
       logger.info(`Wallet 1: ${pendingState.dust.balance(new Date())} tDUST`);
 
-      const txHash = provenTx.transactionHash();
+      const txHash = carried<ledger.FinalizedTransaction>(provenTx).transactionHash();
       const senderTxEntry = await utils.waitForTxInHistory(txHash, funded.wallet, {
         ready: (e) => e.shielded !== undefined,
       });
@@ -404,23 +385,16 @@ describe('Token transfer', () => {
           ],
         },
       ];
-      const txRecipe = await funded.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: funded.shieldedSecretKeys,
-          dustSecretKey: funded.dustSecretKey,
-        },
-        {
-          ttl: new Date(Date.now() + 60 * 60 * 1000),
-        },
-      );
+      const txRecipe = await funded.wallet.transferTransaction(outputsToCreate, {
+        ttl: new Date(Date.now() + 60 * 60 * 1000),
+      });
       logger.info('Sending transaction...');
       const finalizedTx = await funded.wallet.finalizeRecipe(txRecipe);
       const txId = await funded.wallet.submitTransaction(finalizedTx);
       const txFees = await funded.wallet.calculateTransactionFee(finalizedTx);
       logger.info('Transaction id: ' + txId);
 
-      const txHash = finalizedTx.transactionHash();
+      const txHash = carried<ledger.FinalizedTransaction>(finalizedTx).transactionHash();
       const txEntry = await utils.waitForTxInHistory(txHash, funded.wallet, {
         ready: (entry) =>
           entry.shielded !== undefined &&
@@ -508,16 +482,9 @@ describe('Token transfer', () => {
           ],
         },
       ];
-      const txRecipe = await funded.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: funded.shieldedSecretKeys,
-          dustSecretKey: funded.dustSecretKey,
-        },
-        {
-          ttl: new Date(Date.now() + 60 * 60 * 1000),
-        },
-      );
+      const txRecipe = await funded.wallet.transferTransaction(outputsToCreate, {
+        ttl: new Date(Date.now() + 60 * 60 * 1000),
+      });
       logger.info('Sending transaction...');
       const signedTxRecipe = await funded.wallet.signRecipe(txRecipe, funded.unshieldedKeystore.signDataAsync);
       const finalizedTx = await funded.wallet.finalizeRecipe(signedTxRecipe);
@@ -525,7 +492,7 @@ describe('Token transfer', () => {
       const txFees = await funded.wallet.calculateTransactionFee(finalizedTx);
       logger.info('Transaction id: ' + txId);
       logger.info('Wait for pending...');
-      const txHash = finalizedTx.transactionHash();
+      const txHash = carried<ledger.FinalizedTransaction>(finalizedTx).transactionHash();
       await utils.waitForUnshieldedCoinUpdate(receiver1.wallet, 0);
       await utils.waitForUnshieldedCoinUpdate(receiver2.wallet, 0);
       const finalState = await funded.wallet.waitForSyncedState();
@@ -621,16 +588,9 @@ describe('Token transfer', () => {
           ],
         },
       ];
-      const txRecipe = await funded.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: funded.shieldedSecretKeys,
-          dustSecretKey: funded.dustSecretKey,
-        },
-        {
-          ttl: new Date(Date.now() + 60 * 60 * 1000),
-        },
-      );
+      const txRecipe = await funded.wallet.transferTransaction(outputsToCreate, {
+        ttl: new Date(Date.now() + 60 * 60 * 1000),
+      });
       logger.info('Sending transaction...');
       const signedTxRecipe = await funded.wallet.signRecipe(txRecipe, funded.unshieldedKeystore.signDataAsync);
       const finalizedTx = await funded.wallet.finalizeRecipe(signedTxRecipe);
@@ -658,7 +618,7 @@ describe('Token transfer', () => {
       logger.info(`Dust registration tx id: ${dustRegistrationTxid}`);
 
       // Init swap token 1
-      const swapCoin1Tx: ledger.FinalizedTransaction = await receiver1.wallet
+      const swapCoin1Tx: FinalizedTx = await receiver1.wallet
         .initSwap(
           { shielded: { [shieldedToken1]: outputValue } },
           [
@@ -673,17 +633,13 @@ describe('Token transfer', () => {
               ],
             },
           ],
-          {
-            shieldedSecretKeys: receiver1.shieldedSecretKeys,
-            dustSecretKey: receiver1.dustSecretKey,
-          },
           { ttl: new Date(Date.now() + 30 * 60 * 1000) },
         )
         .then((tx) => receiver1.wallet.finalizeRecipe(tx));
       logger.info('Swap coin 1 transaction prepared');
 
       // Init swap token 2
-      const swapCoin2Tx: ledger.FinalizedTransaction = await receiver2.wallet
+      const swapCoin2Tx: FinalizedTx = await receiver2.wallet
         .initSwap(
           { shielded: { [shieldedToken2]: outputValue } },
           [
@@ -698,10 +654,6 @@ describe('Token transfer', () => {
               ],
             },
           ],
-          {
-            shieldedSecretKeys: receiver2.shieldedSecretKeys,
-            dustSecretKey: receiver2.dustSecretKey,
-          },
           { ttl: new Date(Date.now() + 30 * 60 * 1000) },
         )
         .then((tx) => receiver2.wallet.finalizeRecipe(tx));
@@ -710,11 +662,12 @@ describe('Token transfer', () => {
       // Pay fees and submit tx
       await utils.waitForDustBalance(receiver3.wallet);
       const balancedTransactionRecipe = await receiver3.wallet.balanceFinalizedTransaction(
-        swapCoin1Tx.merge(swapCoin2Tx),
-        {
-          shieldedSecretKeys: receiver3.shieldedSecretKeys,
-          dustSecretKey: receiver3.dustSecretKey,
-        },
+        // Merged by the caller, so the two are opened at the version they were both built at and the result sealed
+        // back — a merge is only defined between transactions of one ledger version.
+        sealed(
+          'Finalized',
+          carried<ledger.FinalizedTransaction>(swapCoin1Tx).merge(carried<ledger.FinalizedTransaction>(swapCoin2Tx)),
+        ),
         { ttl: new Date(Date.now() + 30 * 60 * 1000) },
       );
 
@@ -764,8 +717,8 @@ describe('Token transfer', () => {
       );
       const offer = ledger.ZswapOffer.fromOutput(output, shieldedTokenRaw, outputValue);
       const unprovenTx = ledger.Transaction.fromParts(NetworkId.NetworkId.Undeployed, offer);
-      const finalizedTx = await funded.wallet.finalizeTransaction(unprovenTx);
-      const txHash = finalizedTx.transactionHash();
+      const finalizedTx = await funded.wallet.finalizeTransaction(sealed('Unproven', unprovenTx));
+      const txHash = carried<ledger.FinalizedTransaction>(finalizedTx).transactionHash();
       await expect(
         Promise.all([funded.wallet.submitTransaction(finalizedTx), funded.wallet.submitTransaction(finalizedTx)]),
       ).rejects.toThrow();
@@ -813,16 +766,9 @@ describe('Token transfer', () => {
         },
       ];
       await expect(
-        funded.wallet.transferTransaction(
-          outputsToCreate,
-          {
-            shieldedSecretKeys: funded.shieldedSecretKeys,
-            dustSecretKey: funded.dustSecretKey,
-          },
-          {
-            ttl: new Date(Date.now() + 60 * 60 * 1000),
-          },
-        ),
+        funded.wallet.transferTransaction(outputsToCreate, {
+          ttl: new Date(Date.now() + 60 * 60 * 1000),
+        }),
       ).rejects.toThrow(`Insufficient funds`);
     },
     timeout,
@@ -851,16 +797,9 @@ describe('Token transfer', () => {
         },
       ];
       await expect(
-        funded.wallet.transferTransaction(
-          outputsToCreate,
-          {
-            shieldedSecretKeys: funded.shieldedSecretKeys,
-            dustSecretKey: funded.dustSecretKey,
-          },
-          {
-            ttl: new Date(Date.now() + 60 * 60 * 1000),
-          },
-        ),
+        funded.wallet.transferTransaction(outputsToCreate, {
+          ttl: new Date(Date.now() + 60 * 60 * 1000),
+        }),
       ).rejects.toThrow(`Insufficient funds`);
     },
     timeout,
@@ -890,16 +829,9 @@ describe('Token transfer', () => {
         },
       ];
       await expect(
-        funded.wallet.transferTransaction(
-          outputsToCreate,
-          {
-            shieldedSecretKeys: funded.shieldedSecretKeys,
-            dustSecretKey: funded.dustSecretKey,
-          },
-          {
-            ttl: new Date(Date.now() + 60 * 60 * 1000),
-          },
-        ),
+        funded.wallet.transferTransaction(outputsToCreate, {
+          ttl: new Date(Date.now() + 60 * 60 * 1000),
+        }),
       ).rejects.toThrow(`Failed to process desired outputs`);
     },
     timeout,
@@ -926,16 +858,9 @@ describe('Token transfer', () => {
         },
       ];
       await expect(
-        funded.wallet.transferTransaction(
-          outputsToCreate,
-          {
-            shieldedSecretKeys: funded.shieldedSecretKeys,
-            dustSecretKey: funded.dustSecretKey,
-          },
-          {
-            ttl: new Date(Date.now() + 60 * 60 * 1000),
-          },
-        ),
+        funded.wallet.transferTransaction(outputsToCreate, {
+          ttl: new Date(Date.now() + 60 * 60 * 1000),
+        }),
       ).rejects.toThrow('The amount needs to be positive');
     },
     timeout,
@@ -962,16 +887,9 @@ describe('Token transfer', () => {
       ];
 
       await expect(
-        funded.wallet.transferTransaction(
-          outputsToCreate,
-          {
-            shieldedSecretKeys: funded.shieldedSecretKeys,
-            dustSecretKey: funded.dustSecretKey,
-          },
-          {
-            ttl: new Date(Date.now() + 60 * 60 * 1000),
-          },
-        ),
+        funded.wallet.transferTransaction(outputsToCreate, {
+          ttl: new Date(Date.now() + 60 * 60 * 1000),
+        }),
       ).rejects.toThrow('The amount needs to be positive');
     },
     timeout,
@@ -1000,15 +918,7 @@ describe('Token transfer', () => {
       ];
 
       await expect(
-        funded.wallet.initSwap(
-          desiredInputs,
-          desiredOutputs,
-          {
-            shieldedSecretKeys: funded.shieldedSecretKeys,
-            dustSecretKey: funded.dustSecretKey,
-          },
-          { ttl: new Date(Date.now() + 60 * 60 * 1000) },
-        ),
+        funded.wallet.initSwap(desiredInputs, desiredOutputs, { ttl: new Date(Date.now() + 60 * 60 * 1000) }),
       ).rejects.toThrow('The amount needs to be positive');
     },
     timeout,
@@ -1039,15 +949,7 @@ describe('Token transfer', () => {
       ];
 
       await expect(
-        funded.wallet.initSwap(
-          desiredInputs,
-          desiredOutputs,
-          {
-            shieldedSecretKeys: funded.shieldedSecretKeys,
-            dustSecretKey: funded.dustSecretKey,
-          },
-          { ttl: new Date(Date.now() + 60 * 60 * 1000) },
-        ),
+        funded.wallet.initSwap(desiredInputs, desiredOutputs, { ttl: new Date(Date.now() + 60 * 60 * 1000) }),
       ).rejects.toThrow('The input amounts need to be positive');
     },
     timeout,
@@ -1061,16 +963,9 @@ describe('Token transfer', () => {
       logger.info(`Wallet 1 balance is: ${initialBalance}`);
 
       await expect(
-        funded.wallet.transferTransaction(
-          [],
-          {
-            shieldedSecretKeys: funded.shieldedSecretKeys,
-            dustSecretKey: funded.dustSecretKey,
-          },
-          {
-            ttl: new Date(),
-          },
-        ),
+        funded.wallet.transferTransaction([], {
+          ttl: new Date(),
+        }),
       ).rejects.toThrow('At least one shielded or unshielded output is required.');
     },
     timeout,
@@ -1108,7 +1003,7 @@ describe('Token transfer', () => {
       );
       const offer = ledger.ZswapOffer.fromOutput(output, tokenTypeHash, outputValueNativeToken);
       const unprovenTx = ledger.Transaction.fromParts(NetworkId.NetworkId.Undeployed, offer);
-      const finalizedTx = await funded.wallet.finalizeTransaction(unprovenTx);
+      const finalizedTx = await funded.wallet.finalizeTransaction(sealed('Unproven', unprovenTx));
 
       await expect(
         Promise.all([funded.wallet.submitTransaction(finalizedTx), funded.wallet.submitTransaction(finalizedTx)]),
@@ -1125,79 +1020,10 @@ describe('Token transfer', () => {
     timeout,
   );
 
-  test(
-    'error message when attempting to make transfer using incorrect shielded secret key',
-    async () => {
-      const incorrectSecretKey = ledger.ZswapSecretKeys.fromSeed(utils.getShieldedSeed(seed));
-      const syncedState = await funded.wallet.waitForSyncedState();
-      const initialBalance = syncedState?.shielded.balances[dustTokenHash] ?? 0n;
-      logger.info(`Wallet 1 balance is: ${initialBalance}`);
-
-      const initialState2 = await rx.firstValueFrom(funded.wallet.state());
-      const outputsToCreate: CombinedTokenTransfer[] = [
-        {
-          type: 'shielded',
-          outputs: [
-            {
-              type: dustTokenHash,
-              amount: outputValue,
-              receiverAddress: initialState2.shielded.address,
-            },
-          ],
-        },
-      ];
-      const txRecipe = await funded.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: incorrectSecretKey,
-          dustSecretKey: funded.dustSecretKey,
-        },
-        {
-          ttl: new Date(Date.now() + 60 * 60 * 1000),
-        },
-      );
-      await expect(funded.wallet.finalizeRecipe(txRecipe)).rejects.toThrow('Failed to prove transaction');
-    },
-    timeout,
-  );
-
-  test(
-    'error message when attempting to make transfer using incorrect dust secret key',
-    async () => {
-      const incorrectDustKey = receiver.dustSecretKey;
-      const syncedState = await funded.wallet.waitForSyncedState();
-      const initialBalance = syncedState?.shielded.balances[dustTokenHash] ?? 0n;
-      logger.info(`Wallet 1 balance is: ${initialBalance}`);
-
-      const initialState2 = await rx.firstValueFrom(funded.wallet.state());
-
-      const outputsToCreate: CombinedTokenTransfer[] = [
-        {
-          type: 'shielded',
-          outputs: [
-            {
-              type: shieldedTokenRaw,
-              amount: outputValue,
-              receiverAddress: initialState2.shielded.address,
-            },
-          ],
-        },
-      ];
-      await expect(
-        funded.wallet.transferTransaction(
-          outputsToCreate,
-          {
-            shieldedSecretKeys: funded.shieldedSecretKeys,
-            dustSecretKey: incorrectDustKey,
-          },
-          {
-            ttl: new Date(Date.now() + 60 * 60 * 1000),
-          },
-        ),
-      ).rejects.toThrow("attempted to spend Dust UTXO that's not in the wallet state:");
-    },
-    timeout,
-  );
+  // The two tests that stood here asked what happens when a caller passes the *wrong* secret key to a transfer. That
+  // question no longer has a way to be asked: a wallet spanning a protocol boundary derives the key its current
+  // variant needs from what it was started with, because a caller-supplied key object can only ever belong to one
+  // ledger version. What the tests pinned is now unrepresentable rather than merely untested.
 
   test(
     'coin becomes available when tx does not get proved',
@@ -1226,16 +1052,9 @@ describe('Token transfer', () => {
             ],
           },
         ];
-        const txRecipe = await funded.wallet.transferTransaction(
-          outputsToCreate,
-          {
-            shieldedSecretKeys: funded.shieldedSecretKeys,
-            dustSecretKey: funded.dustSecretKey,
-          },
-          {
-            ttl: new Date(Date.now() + 60 * 60 * 1000),
-          },
-        );
+        const txRecipe = await funded.wallet.transferTransaction(outputsToCreate, {
+          ttl: new Date(Date.now() + 60 * 60 * 1000),
+        });
         await expect(funded.wallet.finalizeRecipe(txRecipe)).rejects.toThrow();
 
         const finalState = await utils.waitForFacadePendingClear(funded.wallet);
@@ -1272,16 +1091,9 @@ describe('Token transfer', () => {
           ],
         },
       ];
-      const txRecipe = await funded.wallet.transferTransaction(
-        outputsToCreate,
-        {
-          shieldedSecretKeys: funded.shieldedSecretKeys,
-          dustSecretKey: funded.dustSecretKey,
-        },
-        {
-          ttl: new Date(Date.now() + 60 * 60 * 1000),
-        },
-      );
+      const txRecipe = await funded.wallet.transferTransaction(outputsToCreate, {
+        ttl: new Date(Date.now() + 60 * 60 * 1000),
+      });
       const finalizedTx = await funded.wallet.finalizeRecipe(txRecipe);
 
       // Verify coins are pending after finalization

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -27,10 +27,7 @@ import {
   type DustWalletAPI,
   type DustWalletState,
 } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import {
-  type AnyTransaction as DustAnyTransaction,
-  type CoinsAndBalances as DustCoinsAndBalances,
-} from '@midnightntwrk/wallet-sdk-dust-wallet/v2';
+import { type CoinsAndBalances as DustCoinsAndBalances } from '@midnightntwrk/wallet-sdk-dust-wallet/v2';
 import {
   type DefaultShieldedConfiguration,
   type ShieldedWalletAPI,
@@ -53,7 +50,18 @@ import { Clock } from '@midnightntwrk/wallet-sdk-utilities';
 import { FetchTermsAndConditions as FetchTermsAndConditionsQuery } from '@midnightntwrk/wallet-sdk-indexer-client';
 import { QueryRunner } from '@midnightntwrk/wallet-sdk-indexer-client/effect';
 import { Array as Arr, Either, Option, pipe, Schema } from 'effect';
-import { ProtocolVersion, TransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  type AnyTx,
+  type FinalizedTx,
+  ProtocolVersion,
+  type ProtocolVersionMismatchError,
+  TransactionHistoryStorage,
+  type UnboundTx,
+  type UnprovenTx,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
+import * as PreForkSignatures from '@midnightntwrk/wallet-sdk-capabilities/signatures';
 import {
   BehaviorSubject,
   combineLatest,
@@ -72,13 +80,15 @@ import {
   PendingTransactionsServiceImpl,
 } from '@midnightntwrk/wallet-sdk-capabilities';
 import {
+  type AnyLedgerParameters,
+  type AnyVersionValidatableTransaction,
   type BlockData,
   type BlockDataFetcher,
   makeDefaultBlockDataFetcher,
-  makeDefaultValidationService,
+  makeDefaultVersionedValidationService,
   type ValidateTxOptions,
   ValidationFetchError,
-  type ValidationService,
+  type VersionedValidationService,
   WellFormedError,
   type WellFormedStrictnessFlags,
 } from '@midnightntwrk/wallet-sdk-capabilities/validation';
@@ -175,28 +185,59 @@ export function mergeWalletEntries(existing: WalletEntry, incoming: WalletEntry)
 }
 
 /**
- * Every transaction shape the facade will take from a caller: unproven, proven-but-unbound, finalized, or proof-erased.
+ * What the facade itself does to a transaction, stated structurally rather than by ledger version.
  *
  * @remarks
- *   Named here because the facade's own signatures take it. It was previously reachable only as
- *   `@midnightntwrk/wallet-sdk-dust-wallet/v2`'s `AnyTransaction` — a variant-scoped internal of a package a
- *   facade-only app need not depend on at all, and one with a differently-typed pre-fork twin under `/v1`. The facade
- *   owning the name is what keeps that an implementation detail.
+ *   The facade merges, binds and reads identifiers off transactions, and both ledger versions do all of that with the
+ *   same member names — the types are nominally distinct only because of what is _inside_ them. So once the handle's
+ *   stamp has settled which epoch a transaction belongs to, one code path serves both, and the epoch check is the whole
+ *   of the guarantee. Naming either ledger version's class here instead would be naming the thing that breaks when the
+ *   chain moves on.
  *
- *   Transitional, and deliberately an alias rather than a fresh declaration so it cannot drift from what these methods
- *   actually accept. `WalletTransaction` handles are what replace these signatures — at which point the version a
- *   transaction was authored for travels with it instead of being lost at this boundary, and this alias goes with
- *   them.
+ *   Deliberately the minimum: every member below is one the facade actually calls. Nothing here can mix epochs, because
+ *   the only way to obtain one of these is to unwrap a handle within a single epoch's range.
  */
-export type AnyTransaction = DustAnyTransaction;
+type Carried = Readonly<{
+  identifiers: () => readonly string[];
+  transactionHash: () => unknown;
+  serialize: () => Uint8Array;
+}>;
+
+/** An intent as the facade reads it, for finding and signing a dust registration. */
+type CarriedIntent = Readonly<{
+  dustActions?: Readonly<{ registrations?: readonly unknown[] }> | undefined;
+  signatureData: (segment: number) => Uint8Array;
+}>;
+
+/** An unproven transaction the facade can merge with another of the same epoch, and inspect for a registration. */
+type CarriedUnproven = Carried &
+  Readonly<{
+    merge: (other: CarriedUnproven) => CarriedUnproven;
+    mockProve: () => CarriedUnbound;
+    intents?: Readonly<{ get: (segment: number) => CarriedIntent | undefined }> | undefined;
+  }>;
+
+/** A proven transaction that has not yet been bound to its own contents. */
+type CarriedUnbound = Carried & Readonly<{ bind: () => CarriedFinalized }>;
+
+/** A finalized transaction, which the facade merges with the balancing transaction it finalized alongside it. */
+type CarriedFinalized = Carried & Readonly<{ merge: (other: CarriedFinalized) => CarriedFinalized }>;
+
+/**
+ * Every transaction shape the facade will take from a caller.
+ *
+ * @remarks
+ *   Now a handle: what an application carries between facade calls is sealed together with the protocol version it was
+ *   built at, so it can be routed rather than guessed about. The name is kept because it is what these signatures have
+ *   always been stated in terms of.
+ */
+export type AnyTransaction = AnyTx;
 
 /**
  * Storage key for a tx we're about to submit (record as pending). The hash comes from {@link txHistoryHash}, which the
  * revert side uses too — so a tx keyed here while pending resolves to the same key when later confirmed or reverted.
  */
-const submitTxHistoryKey = (
-  tx: ledger.FinalizedTransaction,
-): { readonly hash: string; readonly identifiers: readonly string[] } => ({
+const submitTxHistoryKey = (tx: Carried): { readonly hash: string; readonly identifiers: readonly string[] } => ({
   hash: txHistoryHash(tx),
   identifiers: tx.identifiers(),
 });
@@ -207,11 +248,40 @@ const submitTxHistoryKey = (
  * all (nothing to revert).
  */
 const revertTxHistoryKey = (
-  tx: AnyTransaction,
+  tx: Carried,
 ): { readonly hash: string; readonly identifiers: readonly string[] } | undefined => {
   const identifiers = tx.identifiers();
   if (identifiers.length === 0) return undefined;
   return { hash: txHistoryHash(tx), identifiers };
+};
+
+/**
+ * The ledger operations the facade performs for itself rather than through a wallet, per protocol epoch.
+ *
+ * @remarks
+ *   One place only: estimating what a dust registration will cost needs a signature over a transaction nobody will
+ *   submit, and a signature comes from a ledger version's own primitives. Everything the facade hands back is in the
+ *   current ledger version's shape — a scheme and its bytes — so the pre-fork entry lifts what its ledger version
+ *   writes as bare hex.
+ */
+type EpochAuthoring = Readonly<{
+  sampleSigningKey: () => unknown;
+  signatureVerifyingKey: (signingKey: never) => ledger.SignatureVerifyingKey;
+  signData: (signingKey: never, data: Uint8Array) => ledger.Signature;
+}>;
+
+const currentLedgerAuthoring: EpochAuthoring = {
+  sampleSigningKey: () => ledger.sampleSigningKey(),
+  signatureVerifyingKey: (signingKey: never) => ledger.signatureVerifyingKey(signingKey),
+  signData: (signingKey: never, data: Uint8Array) => ledger.signData(signingKey, data),
+};
+
+const preForkAuthoring: EpochAuthoring = {
+  sampleSigningKey: () => preForkLedger.sampleSigningKey(),
+  signatureVerifyingKey: (signingKey: never) =>
+    PreForkSignatures.liftSignatureVerifyingKey(preForkLedger.signatureVerifyingKey(signingKey)),
+  signData: (signingKey: never, data: Uint8Array) =>
+    PreForkSignatures.liftSignature(preForkLedger.signData(signingKey, data)),
 };
 
 type TokenKind = 'dust' | 'shielded' | 'unshielded';
@@ -237,28 +307,28 @@ export type FinalizedTransactionRecipe = {
   type: 'FINALIZED_TRANSACTION';
   /** The protocol version this recipe was built for, and so the version its parts have to be proved at. */
   protocolVersion: ProtocolVersion.ProtocolVersion;
-  originalTransaction: ledger.FinalizedTransaction;
-  balancingTransaction: ledger.UnprovenTransaction;
-  blockData?: BlockData;
+  originalTransaction: FinalizedTx;
+  balancingTransaction: UnprovenTx;
+  blockData?: BlockData<AnyLedgerParameters>;
 };
 
 export type UnboundTransactionRecipe = {
   type: 'UNBOUND_TRANSACTION';
   /** The protocol version this recipe was built for, and so the version its parts have to be proved at. */
   protocolVersion: ProtocolVersion.ProtocolVersion;
-  baseTransaction: UnboundTransaction;
+  baseTransaction: UnboundTx;
   // balancingTransaction is optional because if the user decides to balance only the unshielded part,
   // it occurs "in place" so the baseTransaction is modified
-  balancingTransaction?: ledger.UnprovenTransaction | undefined;
-  blockData?: BlockData;
+  balancingTransaction?: UnprovenTx | undefined;
+  blockData?: BlockData<AnyLedgerParameters>;
 };
 
 export type UnprovenTransactionRecipe = {
   type: 'UNPROVEN_TRANSACTION';
   /** The protocol version this recipe was built for, and so the version its parts have to be proved at. */
   protocolVersion: ProtocolVersion.ProtocolVersion;
-  transaction: ledger.UnprovenTransaction;
-  blockData?: BlockData;
+  transaction: UnprovenTx;
+  blockData?: BlockData<AnyLedgerParameters>;
 };
 
 export type BalancingRecipe = FinalizedTransactionRecipe | UnboundTransactionRecipe | UnprovenTransactionRecipe;
@@ -273,7 +343,7 @@ export const BalancingRecipe = {
       ['FINALIZED_TRANSACTION', 'UNBOUND_TRANSACTION', 'UNPROVEN_TRANSACTION'].includes(value.type)
     );
   },
-  getTransactions: (recipe: BalancingRecipe): readonly AnyTransaction[] => {
+  getTransactions: (recipe: BalancingRecipe): readonly AnyTx[] => {
     switch (recipe.type) {
       case 'FINALIZED_TRANSACTION': {
         return [recipe.originalTransaction, recipe.balancingTransaction];
@@ -350,7 +420,7 @@ export class FacadeState {
   public readonly shielded: ShieldedWalletState;
   public readonly unshielded: UnshieldedWalletState;
   public readonly dust: DustWalletState;
-  public readonly pending: PendingTransactions.PendingTransactions<ledger.FinalizedTransaction>;
+  public readonly pending: PendingTransactions.PendingTransactions<FinalizedTx>;
 
   /** The protocol version each of the three wallets has reached. */
   public get protocolVersion(): WalletProtocolVersions {
@@ -384,7 +454,7 @@ export class FacadeState {
     shielded: ShieldedWalletState,
     unshielded: UnshieldedWalletState,
     dust: DustWalletState,
-    pending: PendingTransactions.PendingTransactions<ledger.FinalizedTransaction>,
+    pending: PendingTransactions.PendingTransactions<FinalizedTx>,
   ) {
     this.shielded = shielded;
     this.unshielded = unshielded;
@@ -455,10 +525,8 @@ export type InitParams<TConfig extends DefaultConfiguration> = {
   configuration: TConfig;
   /** Optional factory for the clock abstraction. Defaults to system clock (`() => new Date()`). */
   clock?: (config: TConfig) => MaybePromise<Clock.Clock>;
-  submissionService?: (config: TConfig) => MaybePromise<SubmissionService<ledger.FinalizedTransaction>>;
-  pendingTransactionsService?: (
-    config: TConfig,
-  ) => MaybePromise<PendingTransactionsService<ledger.FinalizedTransaction>>;
+  submissionService?: (config: TConfig) => MaybePromise<SubmissionService<FinalizedTx>>;
+  pendingTransactionsService?: (config: TConfig) => MaybePromise<PendingTransactionsService<FinalizedTx>>;
   provingService?: (config: TConfig) => MaybePromise<VersionedProvingService<UnboundTransaction>>;
   /**
    * Optional factory for the block-data fetcher used by validation. Defaults to an HTTP indexer-backed fetcher built
@@ -469,7 +537,7 @@ export type InitParams<TConfig extends DefaultConfiguration> = {
   validationService?: (
     config: TConfig,
     deps: { fetchBlockData: BlockDataFetcher; clock: Clock.Clock },
-  ) => MaybePromise<ValidationService>;
+  ) => MaybePromise<VersionedValidationService<AnyVersionValidatableTransaction, AnyLedgerParameters>>;
   shielded: (config: TConfig) => MaybePromise<ShieldedWalletAPI>;
   unshielded: (config: TConfig) => MaybePromise<UnshieldedWalletAPI>;
   dust: (config: TConfig) => MaybePromise<DustWalletAPI>;
@@ -481,7 +549,7 @@ export type InitParams<TConfig extends DefaultConfiguration> = {
 export {
   type BlockDataFetcher,
   type ValidateTxOptions,
-  type ValidationService,
+  type VersionedValidationService,
   ValidationFetchError,
   WellFormedError,
   type WellFormedStrictnessFlags,
@@ -490,14 +558,16 @@ export {
 export class WalletFacade {
   private static makeDefaultSubmissionService<TConfig extends DefaultSubmissionConfiguration>(
     config: TConfig,
-  ): SubmissionService<ledger.FinalizedTransaction> {
-    return makeDefaultSubmissionService<ledger.FinalizedTransaction>(config);
+  ): SubmissionService<FinalizedTx> {
+    // A handle serializes itself, which is all submission needs of a transaction — and the one thing every ledger
+    // version's transaction does identically.
+    return makeDefaultSubmissionService<FinalizedTx>(config);
   }
 
   private static makeDefaultPendingTransactionsService<
     TConfig extends DefaultPendingTransactionsServiceConfiguration & { forkVersion: ProtocolVersion.ProtocolVersion },
-  >(config: TConfig): Promise<PendingTransactionsServiceImpl<ledger.FinalizedTransaction>> {
-    return PendingTransactionsServiceImpl.init<ledger.FinalizedTransaction>({
+  >(config: TConfig): Promise<PendingTransactionsServiceImpl<FinalizedTx>> {
+    return PendingTransactionsServiceImpl.init<FinalizedTx>({
       configuration: config,
       txTraits: finalizedTransactionTraits(config.forkVersion),
     });
@@ -592,11 +662,14 @@ export class WalletFacade {
     const validationService = await Promise.resolve(
       initParams.validationService
         ? initParams.validationService(initParams.configuration, { fetchBlockData, clock })
-        : makeDefaultValidationService({
-            fetchBlockData,
-            networkId: initParams.configuration.networkId,
-            clock,
-          }),
+        : makeDefaultVersionedValidationService(
+            {
+              fetchBlockData,
+              networkId: initParams.configuration.networkId,
+              clock,
+            },
+            initParams.configuration.forkVersion,
+          ),
     );
     return new WalletFacade(
       shielded,
@@ -607,6 +680,7 @@ export class WalletFacade {
       provingService,
       validationService,
       initParams.configuration.txHistoryStorage,
+      initParams.configuration.forkVersion,
       clock,
     );
   }
@@ -614,10 +688,10 @@ export class WalletFacade {
   readonly shielded: ShieldedWalletAPI;
   readonly unshielded: UnshieldedWalletAPI;
   readonly dust: DustWalletAPI;
-  readonly submissionService: SubmissionService<ledger.FinalizedTransaction>;
-  readonly pendingTransactionsService: PendingTransactionsService<ledger.FinalizedTransaction>;
+  readonly submissionService: SubmissionService<FinalizedTx>;
+  readonly pendingTransactionsService: PendingTransactionsService<FinalizedTx>;
   readonly provingService: VersionedProvingService<UnboundTransaction>;
-  readonly validationService: ValidationService;
+  readonly validationService: VersionedValidationService<AnyVersionValidatableTransaction, AnyLedgerParameters>;
   #txHistoryStorage: TransactionHistoryStorage.TransactionHistoryStorage<WalletEntry>;
   readonly clock: Clock.Clock;
   #pendingSubscription: Subscription;
@@ -631,6 +705,9 @@ export class WalletFacade {
    */
   #observedProtocolVersion = new BehaviorSubject<Option.Option<ProtocolVersion.ProtocolVersion>>(Option.none());
 
+  /** Where the chain hands over from one ledger version to the next, which is what divides the two epochs. */
+  readonly #forkVersion: ProtocolVersion.ProtocolVersion;
+
   /**
    * Constructor is private on purpose - much of initialization of the facade is potentially asynchronous, and adding
    * new parameters is a breaking change to the users Use {@link WalletFacade.init} instead
@@ -641,11 +718,12 @@ export class WalletFacade {
     shieldedWallet: ShieldedWalletAPI,
     unshieldedWallet: UnshieldedWalletAPI,
     dustWallet: DustWalletAPI,
-    submissionService: SubmissionService<ledger.FinalizedTransaction>,
-    pendingTransactionsService: PendingTransactionsService<ledger.FinalizedTransaction>,
+    submissionService: SubmissionService<FinalizedTx>,
+    pendingTransactionsService: PendingTransactionsService<FinalizedTx>,
     provingService: VersionedProvingService<UnboundTransaction>,
-    validationService: ValidationService,
+    validationService: VersionedValidationService<AnyVersionValidatableTransaction, AnyLedgerParameters>,
     txHistoryStorage: TransactionHistoryStorage.TransactionHistoryStorage<WalletEntry>,
+    forkVersion: ProtocolVersion.ProtocolVersion,
     clock: Clock.Clock = Clock.systemClock,
   ) {
     this.shielded = shieldedWallet;
@@ -656,6 +734,7 @@ export class WalletFacade {
     this.provingService = provingService;
     this.validationService = validationService;
     this.#txHistoryStorage = txHistoryStorage;
+    this.#forkVersion = forkVersion;
     this.clock = clock;
     this.#pendingSubscription = this.pendingTransactionsService
       .state()
@@ -683,14 +762,53 @@ export class WalletFacade {
   }
 
   /**
-   * The version a transaction is proved at: its own stamp when it has one, and otherwise the version the wallets have
-   * reached — which is the best available answer, not a correct one, for a transaction that never recorded what it was
-   * built for.
+   * The protocol version the facade is currently acting at.
+   *
+   * @remarks
+   *   The lowest the three wallets have reached, once they have all reported; the minimum supported version until then,
+   *   which is the epoch a wallet with no history belongs to. It is what a transaction the facade builds is stamped
+   *   with, and what the side of the boundary it accepts transactions from is measured against.
    */
-  private provingVersion(stamp?: ProtocolVersion.ProtocolVersion): ProtocolVersion.ProtocolVersion {
-    return (
-      stamp ?? Option.getOrElse(this.#observedProtocolVersion.getValue(), () => ProtocolVersion.MinSupportedVersion)
+  private currentVersion(): ProtocolVersion.ProtocolVersion {
+    return Option.getOrElse(this.#observedProtocolVersion.getValue(), () => ProtocolVersion.MinSupportedVersion);
+  }
+
+  /** The range of protocol versions on the facade's current side of the boundary. */
+  private currentEpoch(): ProtocolVersion.ProtocolVersion.Range {
+    return ProtocolVersion.epochOf(this.currentVersion(), this.#forkVersion);
+  }
+
+  /**
+   * Reads a transaction an application handed in, refusing one built on the other side of the boundary.
+   *
+   * @remarks
+   *   The enforcement point for everything that enters the facade — a transaction the wallets built, or one an
+   *   application authored and sealed with `WalletTransaction.adopt`. Only the current epoch is accepted, because a
+   *   transaction of the other one cannot be merged, proved or submitted alongside anything the facade would build for
+   *   it. Both a stranded pre-fork transaction after the crossing and a post-fork transaction offered before it are
+   *   refused here, by name, with the versions written down.
+   * @param handle The handle to read.
+   * @returns The carried transaction.
+   * @throws {@link ProtocolVersionMismatchError} When the transaction was built on the other side of the boundary.
+   */
+  private accept<T>(handle: AnyTx): T {
+    return Either.getOrThrowWith(
+      WalletTransaction.unwrapWithin<T>(handle, this.currentEpoch()),
+      (error: ProtocolVersionMismatchError) => error,
     );
+  }
+
+  /** Seals a transaction the facade or a wallet produced, at the version the facade is acting at. */
+  private seal<TStage extends WalletTransaction.Stage>(
+    stage: TStage,
+    transaction: { serialize: () => Uint8Array },
+  ): WalletTransaction<TStage> {
+    return WalletTransaction.adopt(stage, transaction, this.currentVersion());
+  }
+
+  /** The ledger primitives the facade signs with on its current side of the boundary. */
+  private authoring(): EpochAuthoring {
+    return this.currentVersion() < this.#forkVersion ? preForkAuthoring : currentLedgerAuthoring;
   }
 
   private defaultTtl(): Date {
@@ -742,18 +860,32 @@ export class WalletFacade {
    * @throws {@link WellFormedError} If the transaction fails any enabled check.
    * @throws {@link ValidationFetchError} If the block-data fetch fails.
    */
-  async validateTransaction(
-    tx: ledger.FinalizedTransaction | UnboundTransaction | ledger.UnprovenTransaction,
-    options: ValidateTxOptions,
-  ): Promise<void> {
-    return this.validationService.validateTx(tx, options);
+  async validateTransaction(tx: AnyTx, options: ValidateTxOptions<AnyLedgerParameters>): Promise<void> {
+    // Checked at the version the transaction says it was authored for, and never at the version the chain has since
+    // reached: well-formedness asks whether the ledger that produced these bytes would accept them, and a fork landing
+    // afterwards cannot change that answer. The transaction is read at its own epoch for the same reason.
+    return this.validationService.validateTx(
+      Either.getOrThrowWith(
+        WalletTransaction.unwrapWithin<AnyVersionValidatableTransaction>(
+          tx,
+          ProtocolVersion.epochOf(tx.protocolVersion, this.#forkVersion),
+        ),
+        (error: ProtocolVersionMismatchError) => error,
+      ),
+      tx.protocolVersion,
+      options,
+    );
   }
 
-  private mergeUnprovenTransactions(
-    a: ledger.UnprovenTransaction | undefined,
-    b: ledger.UnprovenTransaction | undefined,
-  ): ledger.UnprovenTransaction | undefined {
-    if (a && b) return a.merge(b);
+  /**
+   * Merges two unproven transactions of the same epoch, or returns whichever there is.
+   *
+   * @remarks
+   *   Both are unwrapped before merging, which is where a pair from different epochs is refused: a merge across the
+   *   boundary is not a failure to compute, it is unrepresentable, and saying so is the whole point of the stamp.
+   */
+  private mergeUnprovenTransactions(a: UnprovenTx | undefined, b: UnprovenTx | undefined): UnprovenTx | undefined {
+    if (a && b) return this.seal('Unproven', this.accept<CarriedUnproven>(a).merge(this.accept<CarriedUnproven>(b)));
     return a ?? b;
   }
 
@@ -762,7 +894,7 @@ export class WalletFacade {
     nightUtxos: readonly UtxoWithMeta[],
     nightVerifyingKey: ledger.SignatureVerifyingKey,
     signDustRegistration: SignSegment,
-  ): Promise<ledger.UnprovenTransaction> {
+  ): Promise<UnprovenTx> {
     const ttl = this.defaultTtl();
     const now = this.clock.now();
     const isRegistration = action.type === 'registration';
@@ -808,7 +940,7 @@ export class WalletFacade {
 
     // Step 3 — Dust attaches its DustActions onto the intent the unshielded wallet just built.
     // If this fails we must unbook the UTxOs so the caller can retry.
-    let txWithDustActions: ledger.UnprovenTransaction;
+    let txWithDustActions: UnprovenTx;
     try {
       txWithDustActions = await this.dust.attachDustRegistration(
         txWithOffers,
@@ -843,7 +975,7 @@ export class WalletFacade {
     // offers and the dust registration. Signing failures also need to release the booking.
     try {
       const signedRecipe = await this.signRecipe(
-        { type: 'UNPROVEN_TRANSACTION', protocolVersion: this.provingVersion(), transaction: txWithDustActions },
+        { type: 'UNPROVEN_TRANSACTION', protocolVersion: this.currentVersion(), transaction: txWithDustActions },
         signDustRegistration,
       );
       if (signedRecipe.type !== 'UNPROVEN_TRANSACTION') {
@@ -891,13 +1023,14 @@ export class WalletFacade {
    * @returns The transaction identifier.
    * @throws {@link WellFormedError} — call {@link validateTransaction} first to get this error early.
    */
-  async submitTransaction(tx: ledger.FinalizedTransaction): Promise<TransactionIdentifier> {
-    const identifiers = tx.identifiers();
+  async submitTransaction(tx: FinalizedTx): Promise<TransactionIdentifier> {
+    const carried = this.accept<Carried>(tx);
+    const identifiers = carried.identifiers();
     try {
       await this.pendingTransactionsService.addPendingTransaction(tx, this.#observedProtocolVersion.getValue());
       // Insert before awaiting submission so the entry exists while the tx is in flight — the per-wallet sync
       // handlers' gotFinalized call clears the pending entry on confirmation.
-      const key = submitTxHistoryKey(tx);
+      const key = submitTxHistoryKey(carried);
       await this.#txHistoryStorage.gotPending({ ...key, submittedAt: this.clock.now() });
       await this.submissionService.submitTransaction(tx, 'Finalized');
 
@@ -921,17 +1054,12 @@ export class WalletFacade {
    * @returns A {@link FinalizedTransactionRecipe} containing the original and balancing transactions.
    */
   async balanceFinalizedTransaction(
-    tx: ledger.FinalizedTransaction,
-    secretKeys: {
-      shieldedSecretKeys: ledger.ZswapSecretKeys;
-      dustSecretKey: ledger.DustSecretKey;
-    },
+    tx: FinalizedTx,
     options: {
       ttl: Date;
       tokenKindsToBalance?: TokenKindsToBalance;
     },
   ): Promise<FinalizedTransactionRecipe> {
-    const { shieldedSecretKeys, dustSecretKey } = secretKeys;
     const { ttl, tokenKindsToBalance = 'all' } = options;
 
     const { shouldBalanceDust, shouldBalanceShielded, shouldBalanceUnshielded } =
@@ -942,16 +1070,14 @@ export class WalletFacade {
       ? await this.unshielded.balanceFinalizedTransaction(tx)
       : undefined;
 
-    const shieldedBalancingTx = shouldBalanceShielded
-      ? await this.shielded.balanceTransaction(shieldedSecretKeys, tx)
-      : undefined;
+    const shieldedBalancingTx = shouldBalanceShielded ? await this.shielded.balanceTransaction(tx) : undefined;
 
     // Step 2: Merge unshielded and shielded balancing
     const mergedBalancingTx = this.mergeUnprovenTransactions(shieldedBalancingTx, unshieldedBalancingTx);
 
     // Step 3: Conditionally add dust/fee balancing
     const dustResult = shouldBalanceDust
-      ? await this.dust.balanceTransactions(dustSecretKey, mergedBalancingTx ? [tx, mergedBalancingTx] : [tx], ttl)
+      ? await this.dust.balanceTransactions(mergedBalancingTx ? [tx, mergedBalancingTx] : [tx], ttl)
       : undefined;
     const feeBalancingTx = dustResult?.transaction;
 
@@ -964,7 +1090,7 @@ export class WalletFacade {
 
     return {
       type: 'FINALIZED_TRANSACTION',
-      protocolVersion: this.provingVersion(),
+      protocolVersion: this.currentVersion(),
       originalTransaction: tx,
       balancingTransaction: balancingTx,
       ...(dustResult ? { blockData: dustResult.blockData } : {}),
@@ -984,26 +1110,19 @@ export class WalletFacade {
    * @returns An {@link UnboundTransactionRecipe} containing the base and optional balancing transactions.
    */
   async balanceUnboundTransaction(
-    tx: UnboundTransaction,
-    secretKeys: {
-      shieldedSecretKeys: ledger.ZswapSecretKeys;
-      dustSecretKey: ledger.DustSecretKey;
-    },
+    tx: UnboundTx,
     options: {
       ttl: Date;
       tokenKindsToBalance?: TokenKindsToBalance;
     },
   ): Promise<UnboundTransactionRecipe> {
-    const { shieldedSecretKeys, dustSecretKey } = secretKeys;
     const { ttl, tokenKindsToBalance = 'all' } = options;
 
     const { shouldBalanceDust, shouldBalanceShielded, shouldBalanceUnshielded } =
       TokenKindsToBalance.toFlags(tokenKindsToBalance);
 
     // Step 1: Run unshielded and shielded balancing
-    const shieldedBalancingTx = shouldBalanceShielded
-      ? await this.shielded.balanceTransaction(shieldedSecretKeys, tx)
-      : undefined;
+    const shieldedBalancingTx = shouldBalanceShielded ? await this.shielded.balanceTransaction(tx) : undefined;
 
     // For unbound transactions, unshielded balancing happens in place not with a balancing transaction
     const balancedUnshieldedTx = shouldBalanceUnshielded
@@ -1015,11 +1134,7 @@ export class WalletFacade {
 
     // Step 3: Conditionally add dust/fee balancing
     const dustResult = shouldBalanceDust
-      ? await this.dust.balanceTransactions(
-          dustSecretKey,
-          shieldedBalancingTx ? [baseTx, shieldedBalancingTx] : [baseTx],
-          ttl,
-        )
+      ? await this.dust.balanceTransactions(shieldedBalancingTx ? [baseTx, shieldedBalancingTx] : [baseTx], ttl)
       : undefined;
     const feeBalancingTransaction = dustResult?.transaction;
 
@@ -1033,7 +1148,7 @@ export class WalletFacade {
 
     return {
       type: 'UNBOUND_TRANSACTION',
-      protocolVersion: this.provingVersion(),
+      protocolVersion: this.currentVersion(),
       baseTransaction: baseTx,
       balancingTransaction: balancingTransaction ?? undefined,
       ...(dustResult ? { blockData: dustResult.blockData } : {}),
@@ -1053,26 +1168,19 @@ export class WalletFacade {
    * @returns An {@link UnprovenTransactionRecipe} containing the balanced transaction.
    */
   async balanceUnprovenTransaction(
-    tx: ledger.UnprovenTransaction,
-    secretKeys: {
-      shieldedSecretKeys: ledger.ZswapSecretKeys;
-      dustSecretKey: ledger.DustSecretKey;
-    },
+    tx: UnprovenTx,
     options: {
       ttl: Date;
       tokenKindsToBalance?: TokenKindsToBalance;
     },
   ): Promise<UnprovenTransactionRecipe> {
-    const { shieldedSecretKeys, dustSecretKey } = secretKeys;
     const { ttl, tokenKindsToBalance = 'all' } = options;
 
     const { shouldBalanceDust, shouldBalanceShielded, shouldBalanceUnshielded } =
       TokenKindsToBalance.toFlags(tokenKindsToBalance);
 
     // Step 1: Run unshielded and shielded balancing
-    const shieldedBalancingTx = shouldBalanceShielded
-      ? await this.shielded.balanceTransaction(shieldedSecretKeys, tx)
-      : undefined;
+    const shieldedBalancingTx = shouldBalanceShielded ? await this.shielded.balanceTransaction(tx) : undefined;
 
     // For unproven transactions, unshielded balancing happens in place
     const balancedUnshieldedTx = shouldBalanceUnshielded
@@ -1086,9 +1194,7 @@ export class WalletFacade {
     const mergedTx = this.mergeUnprovenTransactions(baseTx, shieldedBalancingTx)!;
 
     // Step 4: Conditionally add dust/fee balancing
-    const dustResult = shouldBalanceDust
-      ? await this.dust.balanceTransactions(dustSecretKey, [mergedTx], ttl)
-      : undefined;
+    const dustResult = shouldBalanceDust ? await this.dust.balanceTransactions([mergedTx], ttl) : undefined;
     const feeBalancingTx = dustResult?.transaction;
 
     // Step 5: Merge fee balancing if present
@@ -1096,32 +1202,39 @@ export class WalletFacade {
 
     return {
       type: 'UNPROVEN_TRANSACTION',
-      protocolVersion: this.provingVersion(),
+      protocolVersion: this.currentVersion(),
       transaction: balancedTx,
       ...(dustResult ? { blockData: dustResult.blockData } : {}),
     };
   }
 
-  async finalizeRecipe(recipe: BalancingRecipe): Promise<ledger.FinalizedTransaction> {
+  async finalizeRecipe(recipe: BalancingRecipe): Promise<FinalizedTx> {
     return Promise.resolve(recipe)
-      .then(async (recipe) => {
+      .then(async (recipe): Promise<FinalizedTx> => {
         switch (recipe.type) {
           case 'FINALIZED_TRANSACTION': {
-            const finalizedBalancing = await this.finalizeTransaction(
-              recipe.balancingTransaction,
-              recipe.protocolVersion,
+            const finalizedBalancing = await this.finalizeTransaction(recipe.balancingTransaction);
+            return this.seal(
+              'Finalized',
+              this.accept<CarriedFinalized>(recipe.originalTransaction).merge(
+                this.accept<CarriedFinalized>(finalizedBalancing),
+              ),
             );
-            return recipe.originalTransaction.merge(finalizedBalancing);
           }
           case 'UNBOUND_TRANSACTION': {
             const finalizedBalancingTx = recipe.balancingTransaction
-              ? await this.finalizeTransaction(recipe.balancingTransaction, recipe.protocolVersion)
+              ? await this.finalizeTransaction(recipe.balancingTransaction)
               : undefined;
-            const finalizedTransaction = recipe.baseTransaction.bind();
-            return finalizedBalancingTx ? finalizedTransaction.merge(finalizedBalancingTx) : finalizedTransaction;
+            const finalizedTransaction = this.accept<CarriedUnbound>(recipe.baseTransaction).bind();
+            return this.seal(
+              'Finalized',
+              finalizedBalancingTx
+                ? finalizedTransaction.merge(this.accept<CarriedFinalized>(finalizedBalancingTx))
+                : finalizedTransaction,
+            );
           }
           case 'UNPROVEN_TRANSACTION': {
-            return await this.finalizeTransaction(recipe.transaction, recipe.protocolVersion);
+            return await this.finalizeTransaction(recipe.transaction);
           }
         }
       })
@@ -1175,11 +1288,8 @@ export class WalletFacade {
     }
   }
 
-  async #signDustRegistrationIfPresent(
-    tx: ledger.UnprovenTransaction,
-    signSegment: SignSegment,
-  ): Promise<ledger.UnprovenTransaction> {
-    const intent = tx.intents?.get(1);
+  async #signDustRegistrationIfPresent(tx: UnprovenTx, signSegment: SignSegment): Promise<UnprovenTx> {
+    const intent = this.accept<CarriedUnproven>(tx).intents?.get(1);
     const registrations = intent?.dustActions?.registrations ?? [];
     if (!intent || registrations.length === 0) {
       return tx;
@@ -1188,33 +1298,33 @@ export class WalletFacade {
     return await this.dust.addDustRegistrationSignature(tx, signature);
   }
 
-  async signUnprovenTransaction(
-    tx: ledger.UnprovenTransaction,
-    signSegment: SignSegment,
-  ): Promise<ledger.UnprovenTransaction> {
+  async signUnprovenTransaction(tx: UnprovenTx, signSegment: SignSegment): Promise<UnprovenTx> {
     return await this.unshielded.signUnprovenTransaction(tx, signSegment);
   }
 
-  async signUnboundTransaction(tx: UnboundTransaction, signSegment: SignSegment): Promise<UnboundTransaction> {
+  async signUnboundTransaction(tx: UnboundTx, signSegment: SignSegment): Promise<UnboundTx> {
     return await this.unshielded.signUnboundTransaction(tx, signSegment);
   }
 
   /**
    * Proves and binds an unproven transaction, and records it as pending.
    *
+   * @remarks
+   *   Proved at the version stamped on the transaction itself, which is the version that fixed its bytes. A fork landing
+   *   between building a transaction and proving it therefore cannot send it to the wrong prover — and a transaction of
+   *   the epoch the facade is no longer in is refused rather than proved into something nobody can include.
    * @param tx The unproven transaction.
-   * @param protocolVersion The version the transaction was built for. Pass it whenever it is known — a fork can land
-   *   between building a transaction and proving it, and the bytes were fixed when it was built. Omitted, the version
-   *   the wallets have reached is used.
    * @returns The finalized transaction.
    */
-  async finalizeTransaction(
-    tx: ledger.UnprovenTransaction,
-    protocolVersion?: ProtocolVersion.ProtocolVersion,
-  ): Promise<ledger.FinalizedTransaction> {
+  async finalizeTransaction(tx: UnprovenTx): Promise<FinalizedTx> {
     try {
-      const unboundTx = await this.provingService.prove(tx, this.provingVersion(protocolVersion));
-      const finalizedTx = unboundTx.bind();
+      // Named as the prover's input rather than its output: the router hands the transaction to the prover registered
+      // for the version it was authored at, and what comes back is that ledger version's unbound transaction.
+      const unboundTx = await this.provingService.prove(
+        this.accept<ledger.UnprovenTransaction>(tx),
+        tx.protocolVersion,
+      );
+      const finalizedTx = this.seal('Finalized', (unboundTx as unknown as CarriedUnbound).bind());
       await this.pendingTransactionsService.addPendingTransaction(
         finalizedTx,
         this.#observedProtocolVersion.getValue(),
@@ -1231,35 +1341,29 @@ export class WalletFacade {
   }
 
   /** Estimates the fee for the given transaction only. This lacks the fees of the balancing transaction. */
-  async calculateTransactionFee(tx: AnyTransaction): Promise<bigint> {
+  async calculateTransactionFee(tx: AnyTx): Promise<bigint> {
     return await this.dust.calculateFee([tx]);
   }
 
   /** Calculates the total fee for the given transaction plus the fee of the balancing transaction. */
   async estimateTransactionFee(
-    tx: AnyTransaction,
-    secretKey: ledger.DustSecretKey,
+    tx: AnyTx,
     options?: {
       ttl?: Date;
       currentTime?: Date;
     },
   ): Promise<bigint> {
     const ttl = options?.ttl ?? this.defaultTtl();
-    return await this.dust.estimateFee(secretKey, [tx], ttl, options?.currentTime);
+    return await this.dust.estimateFee([tx], ttl, options?.currentTime);
   }
 
   async transferTransaction(
     outputs: CombinedTokenTransfer[],
-    secretKeys: {
-      shieldedSecretKeys: ledger.ZswapSecretKeys;
-      dustSecretKey: ledger.DustSecretKey;
-    },
     options: {
       ttl: Date;
       payFees?: boolean;
     },
   ): Promise<UnprovenTransactionRecipe> {
-    const { shieldedSecretKeys, dustSecretKey } = secretKeys;
     const { ttl, payFees = true } = options;
 
     const unshieldedOutputs = outputs
@@ -1273,9 +1377,7 @@ export class WalletFacade {
     }
 
     const shieldedTx =
-      shieldedOutputs.length > 0
-        ? await this.shielded.transferTransaction(shieldedSecretKeys, shieldedOutputs)
-        : undefined;
+      shieldedOutputs.length > 0 ? await this.shielded.transferTransaction(shieldedOutputs) : undefined;
 
     const unshieldedTx =
       unshieldedOutputs.length > 0 ? await this.unshielded.transferTransaction(unshieldedOutputs, ttl) : undefined;
@@ -1283,14 +1385,14 @@ export class WalletFacade {
     const mergedTxs = this.mergeUnprovenTransactions(shieldedTx, unshieldedTx)!;
 
     // Add fee payment
-    const dustResult = payFees ? await this.dust.balanceTransactions(dustSecretKey, [mergedTxs], ttl) : undefined;
+    const dustResult = payFees ? await this.dust.balanceTransactions([mergedTxs], ttl) : undefined;
     const feeBalancingTx = dustResult?.transaction;
 
     const finalTx = this.mergeUnprovenTransactions(mergedTxs, feeBalancingTx)!;
 
     return {
       type: 'UNPROVEN_TRANSACTION',
-      protocolVersion: this.provingVersion(),
+      protocolVersion: this.currentVersion(),
       transaction: finalTx,
       ...(dustResult ? { blockData: dustResult.blockData } : {}),
     };
@@ -1320,8 +1422,11 @@ export class WalletFacade {
       (estimatedUtxos) => dustState.splitNightUtxos(estimatedUtxos),
       (split) => split.guaranteed,
     );
-    const fakeSigningKey = ledger.sampleSigningKey();
-    const fakeVerifyingKey = ledger.signatureVerifyingKey(fakeSigningKey);
+    const authoring = this.authoring();
+    // Type cast required because: a signing key belongs to one ledger version's runtime and the two are nominally
+    // distinct, so the epoch's own primitives are the only things that may touch it; it never leaves this block.
+    const fakeSigningKey = authoring.sampleSigningKey() as never;
+    const fakeVerifyingKey = authoring.signatureVerifyingKey(fakeSigningKey);
 
     // Use the legacy dust-only construction path here so estimation does NOT book real UTxOs in the
     // unshielded wallet state. (The race-fix path in createDustActionTransaction books on purpose;
@@ -1338,15 +1443,14 @@ export class WalletFacade {
       fakeVerifyingKey,
       dustState.address,
     );
-    const intent = fakeUnsignedTx.intents?.get(1);
+    const intent = this.accept<CarriedUnproven>(fakeUnsignedTx).intents?.get(1);
     if (!intent) {
       throw Error('Dust generation transaction is missing intent segment 1.');
     }
-    const signatureData = intent.signatureData(1);
-    const signature = ledger.signData(fakeSigningKey, signatureData);
+    const signature = authoring.signData(fakeSigningKey, intent.signatureData(1));
     const fakeSignedTx = await this.dust.addDustGenerationSignature(fakeUnsignedTx, signature);
 
-    const finalizedFakeTx = fakeSignedTx.mockProve().bind();
+    const finalizedFakeTx = this.seal('Finalized', this.accept<CarriedUnproven>(fakeSignedTx).mockProve().bind());
 
     const fee = await this.calculateTransactionFee(finalizedFakeTx);
 
@@ -1359,16 +1463,11 @@ export class WalletFacade {
   async initSwap(
     desiredInputs: CombinedSwapInputs,
     desiredOutputs: CombinedSwapOutputs[],
-    secretKeys: {
-      shieldedSecretKeys: ledger.ZswapSecretKeys;
-      dustSecretKey: ledger.DustSecretKey;
-    },
     options: {
       ttl: Date;
       payFees?: boolean;
     },
   ): Promise<UnprovenTransactionRecipe> {
-    const { shieldedSecretKeys, dustSecretKey } = secretKeys;
     const { ttl, payFees = false } = options;
 
     const { shielded: shieldedInputs, unshielded: unshieldedInputs } = desiredInputs;
@@ -1392,7 +1491,7 @@ export class WalletFacade {
 
     const shieldedTx =
       hasShieldedPart && shieldedInputs !== undefined
-        ? await this.shielded.initSwap(shieldedSecretKeys, shieldedInputs, shieldedOutputs)
+        ? await this.shielded.initSwap(shieldedInputs, shieldedOutputs)
         : undefined;
 
     const unshieldedTx =
@@ -1406,14 +1505,14 @@ export class WalletFacade {
       throw Error('Unexpected transaction state.');
     }
 
-    const dustResult = payFees ? await this.dust.balanceTransactions(dustSecretKey, [combinedTx], ttl) : undefined;
+    const dustResult = payFees ? await this.dust.balanceTransactions([combinedTx], ttl) : undefined;
     const feeBalancingTx = dustResult?.transaction;
 
     const finalTx = this.mergeUnprovenTransactions(combinedTx, feeBalancingTx)!;
 
     return {
       type: 'UNPROVEN_TRANSACTION',
-      protocolVersion: this.provingVersion(),
+      protocolVersion: this.currentVersion(),
       transaction: finalTx,
       ...(dustResult ? { blockData: dustResult.blockData } : {}),
     };
@@ -1440,7 +1539,7 @@ export class WalletFacade {
 
     return {
       type: 'UNPROVEN_TRANSACTION',
-      protocolVersion: this.provingVersion(),
+      protocolVersion: this.currentVersion(),
       transaction: dustRegistrationTx,
     };
   }
@@ -1485,12 +1584,12 @@ export class WalletFacade {
     );
     return {
       type: 'UNPROVEN_TRANSACTION',
-      protocolVersion: this.provingVersion(),
+      protocolVersion: this.currentVersion(),
       transaction: dustDeregistrationTx,
     };
   }
 
-  async revert(txOrRecipe: AnyTransaction | BalancingRecipe, reason?: string): Promise<void> {
+  async revert(txOrRecipe: AnyTx | BalancingRecipe, reason?: string): Promise<void> {
     // avoid instanceof check
     const transactionsToRevert = BalancingRecipe.isRecipe(txOrRecipe)
       ? BalancingRecipe.getTransactions(txOrRecipe)
@@ -1499,14 +1598,21 @@ export class WalletFacade {
     await Promise.all(transactionsToRevert.map((tx) => this.revertTransaction(tx, reason)));
   }
 
-  async revertTransaction(tx: AnyTransaction, reason?: string): Promise<void> {
+  async revertTransaction(tx: AnyTx, reason?: string): Promise<void> {
     await Promise.all([
       this.shielded.revertTransaction(tx),
       this.unshielded.revertTransaction(tx),
       this.dust.revertTransaction(tx),
     ]).then(async () => {
-      await this.pendingTransactionsService.clear(tx as unknown as ledger.FinalizedTransaction);
-      const key = revertTxHistoryKey(tx);
+      // Reverting is total over the stages: a transaction at any of them may have booked coins, and the pending set
+      // recognises only the finalized ones. Narrowing rather than casting is what says so.
+      await this.pendingTransactionsService.clear(tx as FinalizedTx);
+      // A transaction of the other epoch has no history entry of this session's to land on, so there is nothing to
+      // key and nothing to record — the same reason the wallets treat it as nothing of theirs to release.
+      const key = Option.match(Either.getRight(WalletTransaction.unwrapWithin<Carried>(tx, this.currentEpoch())), {
+        onNone: () => undefined,
+        onSome: revertTxHistoryKey,
+      });
       if (key !== undefined) {
         await this.#txHistoryStorage.gotRejected({
           ...key,

--- a/packages/facade/src/transaction.ts
+++ b/packages/facade/src/transaction.ts
@@ -15,9 +15,14 @@
 
 import { Array as Arr, DateTime, Duration, Either, HashSet, Option, Order, pipe } from 'effect';
 import { type PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities';
-import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  ProtocolVersion,
+  WalletTransaction,
+  type AnyTx,
+  type FinalizedTx,
+} from '@midnightntwrk/wallet-sdk-abstractions';
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { type AnyTransaction } from '@midnightntwrk/wallet-sdk-dust-wallet/v2';
 
 /**
  * The key under which a transaction's history entry is stored.
@@ -35,15 +40,15 @@ import { type AnyTransaction } from '@midnightntwrk/wallet-sdk-dust-wallet/v2';
  * (Serialization differs across lifecycle states, so this is only stable for a fixed tx — which is exactly the
  * submit→revert flow.)
  */
-export const txHistoryHash = (tx: AnyTransaction): string => {
+export const txHistoryHash = (tx: { transactionHash: () => unknown; serialize: () => Uint8Array }): string => {
   try {
-    return tx.transactionHash().toString();
+    return String(tx.transactionHash());
   } catch {
     return Buffer.from(tx.serialize()).toString('hex');
   }
 };
 
-export const finalizedTransactionTrait: PendingTransactions.TransactionTrait<ledger.FinalizedTransaction> = {
+const currentLedgerFinalizedTransactionTrait: PendingTransactions.TransactionTrait<ledger.FinalizedTransaction> = {
   areAllTxIdsIncluded(tx: ledger.FinalizedTransaction, txIds: readonly string[]): boolean {
     const txIdsSet = HashSet.fromIterable(tx.identifiers());
     const expectedIdSet = HashSet.fromIterable(txIds);
@@ -105,29 +110,146 @@ export const finalizedTransactionTrait: PendingTransactions.TransactionTrait<led
 };
 
 /**
+ * The pre-fork ledger version's reading of a pending transaction.
+ *
+ * @remarks
+ *   Structurally the same as the current ledger version's — identifiers, a TTL, bytes — against a different ledger
+ *   version's classes. It is the classes that make this a separate trait: `instanceof` distinguishes them, each
+ *   deserializer refuses the other's bytes, and a grace period is read off that version's own initial parameters.
+ */
+const preForkFinalizedTransactionTrait: PendingTransactions.TransactionTrait<preForkLedger.FinalizedTransaction> = {
+  areAllTxIdsIncluded(tx, txIds) {
+    return HashSet.isSubset(HashSet.fromIterable(tx.identifiers()), HashSet.fromIterable(txIds));
+  },
+  deserialize(serialized) {
+    return preForkLedger.Transaction.deserialize('signature', 'proof', 'binding', serialized);
+  },
+  firstId(tx) {
+    return tx.identifiers()[0];
+  },
+  hasTTLExpired(tx, creationTime, now) {
+    const defaultShieldedGracePeriod = preForkLedger.LedgerParameters.initialParameters().dust.dustGracePeriodSeconds;
+    const intentTTLs = pipe(
+      tx.intents?.values().toArray() ?? [],
+      Arr.map((i) => i.ttl),
+      Arr.filterMap(DateTime.make),
+    );
+    const hasDustPayments = pipe(
+      tx.intents?.values().toArray() ?? [],
+      Arr.flatMap((i) => i.dustActions?.spends ?? []),
+      Arr.isNonEmptyArray,
+    );
+    const hasShieldedOffers = tx.guaranteedOffer != null || (tx.fallibleOffer?.size ?? 0) == 0;
+    const maybeShieldedTTL: readonly DateTime.Utc[] =
+      hasDustPayments || hasShieldedOffers
+        ? pipe(creationTime, DateTime.addDuration(Duration.seconds(Number(defaultShieldedGracePeriod))), Arr.of)
+        : Arr.empty();
+
+    return pipe(
+      intentTTLs,
+      Arr.appendAll(maybeShieldedTTL),
+      (arr: readonly DateTime.Utc[]): Option.Option<DateTime.Utc> =>
+        Arr.isNonEmptyReadonlyArray(arr)
+          ? Option.some(Arr.min(arr, Order.mapInput(Order.Date, DateTime.toDate)))
+          : Option.none(),
+      Option.match({
+        onNone: () => false,
+        onSome: (finalTTL: DateTime.Utc) => DateTime.distance(finalTTL, now) > 0,
+      }),
+    );
+  },
+  ids(tx) {
+    return tx.identifiers();
+  },
+  isOneIncludedInOther(tx, otherTx) {
+    const txIds = HashSet.fromIterable(tx.identifiers());
+    const otherTxIds = HashSet.fromIterable(otherTx.identifiers());
+    const smallerSize = Order.min(Order.number)(HashSet.size(txIds), HashSet.size(otherTxIds));
+    return HashSet.size(HashSet.intersection(txIds, otherTxIds)) == smallerSize;
+  },
+  isTx(tx: unknown): tx is preForkLedger.FinalizedTransaction {
+    return tx instanceof preForkLedger.Transaction;
+  },
+  serialize(tx) {
+    return tx.serialize();
+  },
+};
+
+/**
+ * Lifts one ledger version's trait onto the handle the facade actually carries.
+ *
+ * @remarks
+ *   The router has already chosen this trait by the version stamped on the handle, so unwrapping at the same epoch is a
+ *   restatement of the choice rather than a second one — but it is where a handle that does not belong is refused
+ *   rather than handed to a reader that would misread it. A handle it cannot read is reported as not being its
+ *   transaction at all, which is precisely what `isTx` is for.
+ * @param trait The ledger version's own reading of a transaction.
+ * @param epoch The range of protocol versions that ledger version answers for.
+ * @returns The same reading, in terms of handles.
+ */
+const overHandles = <T extends { serialize: () => Uint8Array }>(
+  trait: PendingTransactions.TransactionTrait<T>,
+  epoch: ProtocolVersion.ProtocolVersion.Range,
+): PendingTransactions.TransactionTrait<FinalizedTx> => {
+  const [stamp] = epoch;
+  const carried = (handle: AnyTx): T => Either.getOrThrow(WalletTransaction.unwrapWithin<T>(handle, epoch));
+  return {
+    ids: (tx) => trait.ids(carried(tx)),
+    firstId: (tx) => trait.firstId(carried(tx)),
+    areAllTxIdsIncluded: (tx, txIds) => trait.areAllTxIdsIncluded(carried(tx), txIds),
+    isOneIncludedInOther: (tx, otherTx) => trait.isOneIncludedInOther(carried(tx), carried(otherTx)),
+    hasTTLExpired: (tx, creationTime, now) => trait.hasTTLExpired(carried(tx), creationTime, now),
+    serialize: (tx) => trait.serialize(carried(tx)),
+    deserialize: (serialized) => WalletTransaction.adopt('Finalized', trait.deserialize(serialized), stamp),
+    isTx: (tx: unknown): tx is FinalizedTx =>
+      WalletTransaction.is(tx) &&
+      Either.match(WalletTransaction.unwrapWithin<unknown>(tx, epoch), {
+        onLeft: () => false,
+        onRight: (carried) => trait.isTx(carried),
+      }),
+  };
+};
+
+/**
  * The traits pending transactions are read with, split at the protocol version this chain forks at.
  *
  * @remarks
- *   Both entries hold the same trait today, and that is not an oversight: the facade only ever carries ledger-v9
- *   transaction objects, whichever protocol version the chain was at when they were authored, so one reader answers for
- *   both sides. What the split buys is the boundary itself — it makes pre-fork and post-fork different version epochs,
- *   which is what lets a transaction authored before the fork be recognised as stranded once the wallets cross, instead
- *   of waiting out a TTL for an inclusion that can never happen.
- *
- *   The pre-fork entry becomes a ledger-v8 trait when the facade's transaction surface learns to carry pre-fork bytes.
+ *   One trait per ledger version, each reading the handle it is registered for and refusing the other's. That is what
+ *   lets a transaction authored before the fork be recognised as stranded once the wallets cross — its bytes can never
+ *   be included afterwards — instead of waiting out a TTL for an inclusion that can never happen.
  * @param forkVersion The protocol version this chain forks at.
  * @returns The registry the pending transaction service reads with.
  */
 export const finalizedTransactionTraits = (
   forkVersion: ProtocolVersion.ProtocolVersion,
-): PendingTransactions.VersionedTransactionTrait<ledger.FinalizedTransaction> =>
+): PendingTransactions.VersionedTransactionTrait<FinalizedTx> =>
   Either.getOrThrow(
     ProtocolVersion.makeRegistryFromActivations(
       forkVersion > ProtocolVersion.MinSupportedVersion
         ? [
-            { sinceVersion: ProtocolVersion.MinSupportedVersion, value: finalizedTransactionTrait },
-            { sinceVersion: forkVersion, value: finalizedTransactionTrait },
+            {
+              sinceVersion: ProtocolVersion.MinSupportedVersion,
+              value: overHandles(
+                preForkFinalizedTransactionTrait,
+                ProtocolVersion.epochOf(ProtocolVersion.MinSupportedVersion, forkVersion),
+              ),
+            },
+            {
+              sinceVersion: forkVersion,
+              value: overHandles(
+                currentLedgerFinalizedTransactionTrait,
+                ProtocolVersion.epochOf(forkVersion, forkVersion),
+              ),
+            },
           ]
-        : [{ sinceVersion: ProtocolVersion.MinSupportedVersion, value: finalizedTransactionTrait }],
+        : [
+            {
+              sinceVersion: ProtocolVersion.MinSupportedVersion,
+              value: overHandles(
+                currentLedgerFinalizedTransactionTrait,
+                ProtocolVersion.epochOf(ProtocolVersion.MinSupportedVersion, ProtocolVersion.MinSupportedVersion),
+              ),
+            },
+          ],
     ),
   );

--- a/packages/facade/test/orphanOnFork.test.ts
+++ b/packages/facade/test/orphanOnFork.test.ts
@@ -13,8 +13,15 @@
  * limitations under the License.
  */
 
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  InMemoryTransactionHistoryStorage,
+  NetworkId,
+  ProtocolVersion,
+  WalletTransaction,
+  type FinalizedTx,
+} from '@midnightntwrk/wallet-sdk-abstractions';
 import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import type { PendingTransactionsService } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
@@ -24,14 +31,21 @@ import { DateTime, Option } from 'effect';
 import * as rx from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type DefaultConfiguration, WalletEntrySchema, WalletFacade, mergeWalletEntries } from '../src/index.js';
-import { finalizedTransactionTrait } from '../src/transaction.js';
-import { getDustSeed, getShieldedSeed, getUnshieldedSeed, sleep } from './utils/index.js';
+import { finalizedTransactionTraits } from '../src/transaction.js';
+
+import {
+  createPreForkMockProvingService,
+  getDustSeed,
+  getShieldedSeed,
+  getUnshieldedSeed,
+  sleep,
+} from './utils/index.js';
 
 vi.setConfig({ testTimeout: 20_000, hookTimeout: 120_000 });
 
 type Recorded = Readonly<{
-  added: { tx: ledger.FinalizedTransaction; protocolVersion: Option.Option<ProtocolVersion.ProtocolVersion> }[];
-  cleared: ledger.FinalizedTransaction[];
+  added: { tx: FinalizedTx; protocolVersion: Option.Option<ProtocolVersion.ProtocolVersion> }[];
+  cleared: FinalizedTx[];
   orphanedBeyond: ProtocolVersion.ProtocolVersion[];
 }>;
 
@@ -39,9 +53,9 @@ type Recorded = Readonly<{
  * A pending-transactions service the test drives directly: it records what the facade asks of it, and lets the test
  * push a pending state so the facade's reaction to an orphaned entry is observable without a real fork.
  */
-class RecordingPendingTransactions implements PendingTransactionsService<ledger.FinalizedTransaction> {
+class RecordingPendingTransactions implements PendingTransactionsService<FinalizedTx> {
   readonly recorded: Recorded = { added: [], cleared: [], orphanedBeyond: [] };
-  readonly states = new rx.BehaviorSubject<PendingTransactions.PendingTransactions<ledger.FinalizedTransaction>>(
+  readonly states = new rx.BehaviorSubject<PendingTransactions.PendingTransactions<FinalizedTx>>(
     PendingTransactions.empty(),
   );
 
@@ -53,19 +67,19 @@ class RecordingPendingTransactions implements PendingTransactionsService<ledger.
     return Promise.resolve();
   }
 
-  state(): rx.Observable<PendingTransactions.PendingTransactions<ledger.FinalizedTransaction>> {
+  state(): rx.Observable<PendingTransactions.PendingTransactions<FinalizedTx>> {
     return this.states.asObservable();
   }
 
   addPendingTransaction(
-    tx: ledger.FinalizedTransaction,
+    tx: FinalizedTx,
     protocolVersion: Option.Option<ProtocolVersion.ProtocolVersion>,
   ): Promise<void> {
     this.recorded.added.push({ tx, protocolVersion });
     return Promise.resolve();
   }
 
-  clear(tx: ledger.FinalizedTransaction): Promise<void> {
+  clear(tx: FinalizedTx): Promise<void> {
     this.recorded.cleared.push(tx);
     return Promise.resolve();
   }
@@ -109,6 +123,7 @@ describe('A pending transaction the fork left behind', () => {
       shielded: () => shielded,
       unshielded: () => unshielded,
       dust: () => dust,
+      provingService: () => createPreForkMockProvingService(),
       pendingTransactionsService: () => pending,
     });
     // The wallets are not started: these tests observe the state the facade already has, and starting them
@@ -119,12 +134,18 @@ describe('A pending transaction the fork left behind', () => {
     await facade?.stop();
   });
 
-  const anyTransaction = (): ledger.UnprovenTransaction =>
-    ledger.Transaction.fromParts(
-      configuration.networkId,
-      undefined,
-      undefined,
-      ledger.Intent.new(new Date(Date.now() + 60_000)),
+  const anyTransaction = () =>
+    WalletTransaction.adopt(
+      'Unproven',
+      // The wallets here have never synced, so the facade is on the pre-fork side of the boundary and the ledger
+      // version that owns that epoch is the one that has to have built this.
+      preForkLedger.Transaction.fromParts(
+        configuration.networkId,
+        undefined,
+        undefined,
+        preForkLedger.Intent.new(new Date(Date.now() + 60_000)),
+      ),
+      ProtocolVersion.MinSupportedVersion,
     );
 
   it('asks the pending set to give up on everything the wallets have moved past', async () => {
@@ -180,6 +201,10 @@ describe('A pending transaction the fork left behind', () => {
     expect(rejected[0].lifecycle.status === 'rejected' ? rejected[0].lifecycle.reason : undefined).toBe(
       'orphaned-by-protocol-upgrade',
     );
-    expect(rejected[0].identifiers).toStrictEqual(finalizedTransactionTrait.ids(finalized));
+    expect(rejected[0].identifiers).toStrictEqual(
+      Option.getOrThrow(
+        ProtocolVersion.select(finalizedTransactionTraits(configuration.forkVersion), finalized.protocolVersion),
+      ).ids(finalized),
+    );
   });
 });

--- a/packages/facade/test/pendingTransactions.test.ts
+++ b/packages/facade/test/pendingTransactions.test.ts
@@ -14,13 +14,25 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  InMemoryTransactionHistoryStorage,
+  NetworkId,
+  ProtocolVersion,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { type DefaultConfiguration, WalletEntrySchema, WalletFacade, mergeWalletEntries } from '../src/index.js';
-import { getDustSeed, getShieldedSeed, getUnshieldedSeed, sleep } from './utils/index.js';
+import {
+  createPreForkMockProvingService,
+  getDustSeed,
+  getShieldedSeed,
+  getUnshieldedSeed,
+  sleep,
+} from './utils/index.js';
 import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import * as rx from 'rxjs';
 import { finalizedTransactionTraits } from '../src/transaction.js';
@@ -62,6 +74,7 @@ describe('Wallet Facade handling pending transactions', () => {
       shielded: () => shielded,
       unshielded: () => unshielded,
       dust: () => dust,
+      provingService: () => createPreForkMockProvingService(),
     });
     await facade?.start(ledger.ZswapSecretKeys.fromSeed(shieldedSeed), ledger.DustSecretKey.fromSeed(dustSeed));
   });
@@ -75,11 +88,11 @@ describe('Wallet Facade handling pending transactions', () => {
     const spiedDustRevert = vi.spyOn(dust, 'revertTransaction');
 
     const ttl = new Date(Date.now() + 10);
-    const transaction = ledger.Transaction.fromParts(
-      configuration.networkId,
-      undefined,
-      undefined,
-      ledger.Intent.new(ttl),
+    const transaction = WalletTransaction.adopt(
+      'Unproven',
+      // The wallets here have never synced, so the facade is on the pre-fork side of the boundary.
+      preForkLedger.Transaction.fromParts(configuration.networkId, undefined, undefined, preForkLedger.Intent.new(ttl)),
+      ProtocolVersion.MinSupportedVersion,
     );
 
     const finalized = await facade.finalizeTransaction(transaction); //Submission and finalization actions do save transactions

--- a/packages/facade/test/simulation-mode.test.ts
+++ b/packages/facade/test/simulation-mode.test.ts
@@ -171,14 +171,7 @@ describe('WalletFacade in simulation mode', () => {
       // Step 8: Create, finalize, and submit the transfer transaction with fee payment
       // payFees: true by default - transaction is balanced with Dust spend
       const transferRecipe: UnprovenTransactionRecipe = yield* Effect.promise(() =>
-        senderFacade.transferTransaction(
-          transferOutputs,
-          {
-            shieldedSecretKeys: senderKeys.shieldedKeys,
-            dustSecretKey: senderKeys.dustKey,
-          },
-          { ttl },
-        ),
+        senderFacade.transferTransaction(transferOutputs, { ttl }),
       );
 
       const finalizedTx = yield* Effect.promise(() => senderFacade.finalizeRecipe(transferRecipe));
@@ -307,7 +300,6 @@ describe('WalletFacade in simulation mode', () => {
       const transferRecipe: UnprovenTransactionRecipe = yield* Effect.promise(() =>
         senderFacade.transferTransaction(
           [{ type: 'unshielded', outputs: [{ type: nightTokenType, receiverAddress, amount: tokenValue(100n) }] }],
-          { shieldedSecretKeys: senderKeys.shieldedKeys, dustSecretKey: senderKeys.dustKey },
           { ttl }, // payFees: true (default)
         ),
       );
@@ -405,7 +397,6 @@ describe('WalletFacade in simulation mode', () => {
       const transferRecipe: UnprovenTransactionRecipe = yield* Effect.promise(() =>
         senderFacade.transferTransaction(
           [{ type: 'unshielded', outputs: [{ type: nightTokenType, receiverAddress, amount: tokenValue(100n) }] }],
-          { shieldedSecretKeys: senderKeys.shieldedKeys, dustSecretKey: senderKeys.dustKey },
           { ttl }, // payFees: true (default)
         ),
       );
@@ -495,7 +486,6 @@ describe('WalletFacade in simulation mode', () => {
       const transferRecipe: UnprovenTransactionRecipe = yield* Effect.promise(() =>
         senderFacade.transferTransaction(
           [{ type: 'unshielded', outputs: [{ type: nightTokenType, receiverAddress, amount: tokenValue(100n) }] }],
-          { shieldedSecretKeys: senderKeys.shieldedKeys, dustSecretKey: senderKeys.dustKey },
           { ttl }, // payFees: true (default)
         ),
       );

--- a/packages/facade/test/submission.test.ts
+++ b/packages/facade/test/submission.test.ts
@@ -10,12 +10,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  NetworkId,
+  InMemoryTransactionHistoryStorage,
+  ProtocolVersion,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
 import { type SubmissionService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
+import { Either } from 'effect';
 import * as crypto from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -25,6 +32,8 @@ import {
   isPendingWalletEntry,
   mergeWalletEntries,
 } from '../src/index.js';
+import { txHistoryHash } from '../src/transaction.js';
+import { createPreForkMockProvingService } from './utils/index.js';
 
 /**
  * `vi.mockObject` does not carry accessors across, and a wallet's `state` is one. The facade watches all three wallets'
@@ -129,6 +138,7 @@ describe('Facade submission', () => {
       shielded: () => shielded,
       unshielded: () => unshielded,
       dust: () => dust,
+      provingService: () => createPreForkMockProvingService(),
       submissionService: () => fakeSubmission,
     });
 
@@ -136,14 +146,18 @@ describe('Facade submission', () => {
     const spiedUnshieldedRevert = vi.spyOn(unshielded, 'revertTransaction');
     const spiedDustRevert = vi.spyOn(dust, 'revertTransaction');
 
-    const transaction = ledger.Transaction.fromParts(
-      config.networkId,
-      undefined,
-      undefined,
-      ledger.Intent.new(new Date(Date.now() + 1000)),
-    )
-      .mockProve()
-      .bind();
+    const transaction = WalletTransaction.adopt(
+      'Finalized',
+      preForkLedger.Transaction.fromParts(
+        config.networkId,
+        undefined,
+        undefined,
+        preForkLedger.Intent.new(new Date(Date.now() + 1000)),
+      )
+        .mockProve()
+        .bind(),
+      ProtocolVersion.MinSupportedVersion,
+    );
 
     const submissionResult = await facade.submitTransaction(transaction).then(
       () => 'succeeded',
@@ -159,7 +173,18 @@ describe('Facade submission', () => {
     // `txHistoryHash`), so the failed submission leaves a single entry transitioned in place — not an orphan pair.
     const entries = await txHistoryStorage.getAll();
     expect(entries).toHaveLength(1);
-    expect(entries[0].hash).toBe(transaction.transactionHash().toString());
+    // Read through the handle, because that is now the only way to reach the transaction it names: the key is the
+    // ledger transaction hash exactly as the submit and revert sides both compute it.
+    expect(entries[0].hash).toBe(
+      txHistoryHash(
+        Either.getOrThrow(
+          WalletTransaction.unwrapWithin<preForkLedger.FinalizedTransaction>(
+            transaction,
+            ProtocolVersion.epochOf(ProtocolVersion.MinSupportedVersion, ProtocolVersion.MinSupportedVersion),
+          ),
+        ),
+      ),
+    );
     expect(entries[0].lifecycle.status).toBe('rejected');
   });
 
@@ -200,14 +225,16 @@ describe('Facade submission', () => {
     // The simulator submits proof-erased transactions, whose `transactionHash()` throws — so the key falls back to the
     // serialized bytes. The runtime tx type is erased exactly as the simulator submission service does (helpers.ts),
     // which the static `FinalizedTransaction` type can't express.
-    const proofErased = ledger.Transaction.fromParts(
+    const proofErased = preForkLedger.Transaction.fromParts(
       config.networkId,
       undefined,
       undefined,
-      ledger.Intent.new(new Date(Date.now() + 10_000)),
+      preForkLedger.Intent.new(new Date(Date.now() + 10_000)),
     ).eraseProofs();
     expect(() => proofErased.transactionHash()).toThrow();
-    const transaction = proofErased as unknown as ledger.FinalizedTransaction;
+    // Sealed at the finalized stage because that is the stage the facade takes: what the handle carries is a
+    // proof-erased transaction, which is exactly the case whose history key falls back to its bytes.
+    const transaction = WalletTransaction.adopt('Finalized', proofErased, ProtocolVersion.MinSupportedVersion);
 
     // Submission fails, so submitTransaction writes the pending entry and then reverts — both keyed off the same
     // serialized-bytes hash, so the result is a single entry transitioned in place rather than an orphan pending +

--- a/packages/facade/test/transactionTypes.test.ts
+++ b/packages/facade/test/transactionTypes.test.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, ProtocolVersion, WalletTransaction } from '@midnightntwrk/wallet-sdk-abstractions';
 import { describe, expect, it } from 'vitest';
 import type { AnyTransaction, WalletFacade } from '../src/index.js';
 
@@ -38,13 +38,27 @@ export type AliasIsTheRevertParameter = AssertAssignable<
 describe('Naming the transactions the facade accepts, from the facade alone', () => {
   it('names every transaction shape its fee and revert methods take, without reaching into another package', () => {
     // Each binding is annotated with the facade's own exported name. That the annotations compile is the assertion:
-    // before, a caller had to import the type from a dust-wallet variant subpath to write any of these lines.
-    const unproven: AnyTransaction = ledger.Transaction.fromParts(NETWORK_ID);
-    const finalized: AnyTransaction = ledger.Transaction.fromParts(NETWORK_ID).mockProve();
-    const proofErased: AnyTransaction = ledger.Transaction.fromParts(NETWORK_ID).eraseProofs();
+    // before, a caller had to import the type from a dust-wallet variant subpath to write any of these lines — and
+    // now the name is a handle, so a caller does not name a ledger version even to seal one.
+    const version = ProtocolVersion.MinSupportedVersion;
+    const unproven: AnyTransaction = WalletTransaction.adopt(
+      'Unproven',
+      ledger.Transaction.fromParts(NETWORK_ID),
+      version,
+    );
+    const finalized: AnyTransaction = WalletTransaction.adopt(
+      'Finalized',
+      ledger.Transaction.fromParts(NETWORK_ID).mockProve(),
+      version,
+    );
+    const proofErased: AnyTransaction = WalletTransaction.adopt(
+      'Finalized',
+      ledger.Transaction.fromParts(NETWORK_ID).eraseProofs(),
+      version,
+    );
 
-    expect(unproven).toBeInstanceOf(ledger.Transaction);
-    expect(finalized).toBeInstanceOf(ledger.Transaction);
-    expect(proofErased).toBeInstanceOf(ledger.Transaction);
+    expect(WalletTransaction.is(unproven)).toBe(true);
+    expect(WalletTransaction.is(finalized)).toBe(true);
+    expect(WalletTransaction.is(proofErased)).toBe(true);
   });
 });

--- a/packages/facade/test/utils/helpers.ts
+++ b/packages/facade/test/utils/helpers.ts
@@ -10,14 +10,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import type * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { HDWallet, Roles } from '@midnightntwrk/wallet-sdk-hd';
 import { WalletFacade, type Clock } from '../../src/index.js';
-import {
-  CustomShieldedWallet,
-  type ShieldedWalletAPI,
-  V9_NATIVE_FORK_VERSION,
-} from '@midnightntwrk/wallet-sdk-shielded';
+import { CustomShieldedWallet, type ShieldedWalletAPI } from '@midnightntwrk/wallet-sdk-shielded';
 import {
   Sync as ShieldedSync,
   TransactionHistory as ShieldedTransactionHistory,
@@ -36,7 +33,12 @@ import {
   type UnshieldedSecretKey,
   type UnshieldedWalletAPI,
 } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
-import { NoOpTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  type FinalizedTx,
+  NoOpTransactionHistoryStorage,
+  ProtocolVersion,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
 import { type WalletEntry } from '../../src/index.js';
 import {
   Sync as UnshieldedSync,
@@ -48,11 +50,12 @@ import {
   makeSimulatorProvingServiceEffect,
   type ProvingService,
   type UnboundTransaction,
+  type VersionedProvingService,
 } from '@midnightntwrk/wallet-sdk-capabilities/proving';
 import { type Simulator } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import { makeSimulatorBlockDataFetcher } from '@midnightntwrk/wallet-sdk-capabilities/validation';
 import type { SubmissionService } from '@midnightntwrk/wallet-sdk-capabilities';
-import { Effect, type Scope } from 'effect';
+import { Effect, Either, type Scope } from 'effect';
 import * as rx from 'rxjs';
 
 export const getShieldedSeed = (seed: string): Uint8Array => {
@@ -157,18 +160,27 @@ export const createSimulatorProvingService = (): ProvingService<UnboundTransacti
  * Creates a Promise-based wrapper around the Effect-based simulator submission service. Note: Uses type assertions
  * because simulator uses different transaction types internally.
  */
-export const createSimulatorSubmissionService = (
-  simulator: Simulator,
-): SubmissionService<ledger.FinalizedTransaction> => {
+export const createSimulatorSubmissionService = (simulator: Simulator): SubmissionService<FinalizedTx> => {
   const effectService = Submission.makeSimulatorSubmissionService<ledger.FinalizedTransaction>('InBlock')({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
     simulator: simulator as any,
   });
+  // The simulator takes the ledger's own transaction rather than bytes, so the handle is opened here — at the one
+  // version this simulator ever runs.
+  const wholeTimeline = ProtocolVersion.epochOf(
+    ProtocolVersion.MinSupportedVersion,
+    ProtocolVersion.MinSupportedVersion,
+  );
   return {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    submitTransaction: ((tx: ledger.FinalizedTransaction, waitFor?: 'Submitted' | 'InBlock' | 'Finalized') =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      effectService.submitTransaction(tx, waitFor ?? 'InBlock').pipe(Effect.runPromise)) as any,
+    // The overloaded submit signature is stated once by the service type; this fake answers the widest of its
+    // overloads, which is the one every caller in these suites uses.
+    submitTransaction: ((tx: FinalizedTx, waitFor?: 'Submitted' | 'InBlock' | 'Finalized') =>
+      effectService
+        .submitTransaction(
+          Either.getOrThrow(WalletTransaction.unwrapWithin<ledger.FinalizedTransaction>(tx, wholeTimeline)),
+          waitFor ?? 'InBlock',
+        )
+        .pipe(Effect.runPromise)) as SubmissionService<FinalizedTx>['submitTransaction'],
     close: () => effectService.close().pipe(Effect.runPromise),
   };
 };
@@ -303,7 +315,9 @@ export const makeSimulatorFacade = (
       const facade = await WalletFacade.init({
         configuration: {
           ...config,
-          forkVersion: V9_NATIVE_FORK_VERSION,
+          // A simulator that runs only the current ledger version has never had two epochs, whatever protocol version
+          // its blocks report — so the boundary is at the bottom and everything it produces is post-fork.
+          forkVersion: ProtocolVersion.MinSupportedVersion,
           // Dummy values - not used in simulation mode
           indexerClientConnection: { indexerHttpUrl: 'http://unused' },
           relayURL: new URL('ws://unused'),
@@ -348,3 +362,23 @@ export const waitForUnshieldedBalance = (
       ),
     ),
   );
+
+/**
+ * A prover for the epoch a wallet with no history is in: the pre-fork one.
+ *
+ * @remarks
+ *   The SDK ships no pre-fork proving path — that is the one thing waiting on a proof server for the previous ledger
+ *   version — so a suite whose subject is what the facade does _around_ proving supplies its own. It mock-proves with
+ *   the pre-fork ledger version's own primitives, which is what makes it a fake of the right shape rather than a stand
+ *   in for the wrong one, and hands back something the facade can bind: the proving contract is
+ *   proved-but-not-yet-bound, and `mockProve` binds as it proves.
+ */
+export const createPreForkMockProvingService = (): VersionedProvingService<UnboundTransaction> => ({
+  prove: (tx: unknown) => {
+    const proven = (tx as preForkLedger.UnprovenTransaction).mockProve();
+    return Promise.resolve({
+      bind: () => proven,
+      serialize: () => proven.serialize(),
+    } as unknown as UnboundTransaction);
+  },
+});

--- a/packages/facade/test/versionedProving.test.ts
+++ b/packages/facade/test/versionedProving.test.ts
@@ -14,7 +14,13 @@
  */
 
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  InMemoryTransactionHistoryStorage,
+  NetworkId,
+  ProtocolVersion,
+  ProtocolVersionMismatchError,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
 import type { UnboundTransaction, VersionedProvingService } from '@midnightntwrk/wallet-sdk-capabilities/proving';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
@@ -87,12 +93,16 @@ describe('Proving a transaction at the version it was built for', () => {
     await facade?.stop();
   });
 
-  const anyTransaction = (): ledger.UnprovenTransaction =>
-    ledger.Transaction.fromParts(
-      configuration.networkId,
-      undefined,
-      undefined,
-      ledger.Intent.new(new Date(Date.now() + 60_000)),
+  const anyTransaction = (stamp: ProtocolVersion.ProtocolVersion = ProtocolVersion.MinSupportedVersion) =>
+    WalletTransaction.adopt(
+      'Unproven',
+      ledger.Transaction.fromParts(
+        configuration.networkId,
+        undefined,
+        undefined,
+        ledger.Intent.new(new Date(Date.now() + 60_000)),
+      ),
+      stamp,
     );
 
   it('proves at the version the wallets have reached when nothing says otherwise', async () => {
@@ -111,7 +121,7 @@ describe('Proving a transaction at the version it was built for', () => {
 
     const recipe: BalancingRecipe = {
       type: 'UNPROVEN_TRANSACTION',
-      transaction: anyTransaction(),
+      transaction: anyTransaction(PRE_FORK),
       protocolVersion: PRE_FORK,
     };
 
@@ -120,9 +130,21 @@ describe('Proving a transaction at the version it was built for', () => {
     expect(prover.askedFor).toStrictEqual([PRE_FORK]);
   });
 
-  it('proves at an explicitly given version when one is passed', async () => {
-    await facade.finalizeTransaction(anyTransaction(), PRE_FORK);
+  it('proves at the version the transaction itself was built at, which is the only one it can be proved at', async () => {
+    // There is no way to name a version separately from the transaction any more, and that is the point: the stamp
+    // travels with the bytes it describes, so the two cannot disagree.
+    await facade.finalizeTransaction(anyTransaction(PRE_FORK));
 
     expect(prover.askedFor).toStrictEqual([PRE_FORK]);
+  });
+
+  it('refuses a transaction built on the other side of the boundary, without asking any prover', async () => {
+    const failure = await facade.finalizeTransaction(anyTransaction(V9_NATIVE_FORK_VERSION)).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(ProtocolVersionMismatchError);
+    expect(prover.askedFor).toStrictEqual([]);
   });
 });

--- a/packages/facade/test/wellFormed.test.ts
+++ b/packages/facade/test/wellFormed.test.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, ProtocolVersion, WalletTransaction } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Simulator, immediateBlockProducer } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import { Effect } from 'effect';
 import { describe, expect, it } from 'vitest';
@@ -28,16 +28,21 @@ const NETWORK_ID = NetworkId.NetworkId.Undeployed;
 const SEED = '0000000000000000000000000000000000000000000000000000000000000001';
 
 // A finalized transaction with a TTL in the past fails the non-configurable TTL structural check.
-const expiredFinalizedTx = (): ledger.FinalizedTransaction =>
-  ledger.Transaction.fromParts(NETWORK_ID, undefined, undefined, ledger.Intent.new(new Date(0))).mockProve();
+const sealed = <TStage extends WalletTransaction.Stage>(stage: TStage, tx: { serialize: () => Uint8Array }) =>
+  WalletTransaction.adopt(stage, tx, ProtocolVersion.MinSupportedVersion);
+
+const expiredFinalizedTx = () =>
+  sealed(
+    'Finalized',
+    ledger.Transaction.fromParts(NETWORK_ID, undefined, undefined, ledger.Intent.new(new Date(0))).mockProve(),
+  );
 
 // Transactions built for a different network violate the non-configurable network-ID structural check.
 // The facade is initialised with NETWORK_ID ('undeployed'); these transactions use 'mainnet'.
-const wrongNetworkUnprovenTx = (): ledger.UnprovenTransaction =>
-  ledger.Transaction.fromParts(NetworkId.NetworkId.MainNet);
+const wrongNetworkUnprovenTx = () => sealed('Unproven', ledger.Transaction.fromParts(NetworkId.NetworkId.MainNet));
 
-const wrongNetworkFinalizedTx = (): ledger.FinalizedTransaction =>
-  ledger.Transaction.fromParts(NetworkId.NetworkId.MainNet).mockProve();
+const wrongNetworkFinalizedTx = () =>
+  sealed('Finalized', ledger.Transaction.fromParts(NetworkId.NetworkId.MainNet).mockProve());
 
 const setupFacade = (): Effect.Effect<
   WalletFacade,
@@ -58,7 +63,7 @@ describe('WalletFacade.validateTransaction', () => {
   it('does not throw for a well-formed UnprovenTransaction', () =>
     Effect.gen(function* () {
       const facade = yield* setupFacade();
-      const wellFormedTx = ledger.Transaction.fromParts(NETWORK_ID);
+      const wellFormedTx = sealed('Unproven', ledger.Transaction.fromParts(NETWORK_ID));
       yield* Effect.promise(() =>
         expect(
           facade.validateTransaction(wellFormedTx, {
@@ -92,7 +97,11 @@ describe('WalletFacade.validateTransaction', () => {
     Effect.gen(function* () {
       const facade = yield* setupFacade();
       const provingService = createSimulatorProvingService();
-      const unboundTx = yield* Effect.promise(() => provingService.prove(wrongNetworkUnprovenTx()));
+      const unboundTx = yield* Effect.promise(() =>
+        provingService
+          .prove(ledger.Transaction.fromParts(NetworkId.NetworkId.MainNet))
+          .then((tx) => sealed('Unbound', tx)),
+      );
       yield* Effect.promise(() =>
         expect(facade.validateTransaction(unboundTx, { flags: FULL_STRICTNESS })).rejects.toThrow(WellFormedError),
       );

--- a/packages/shielded-wallet/src/ForkingShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ForkingShieldedWallet.ts
@@ -23,7 +23,15 @@
  */
 import type * as v8 from '@midnight-ntwrk/ledger-v8';
 import type * as ledger from '@midnightntwrk/ledger-v9';
-import { type NetworkId, ProtocolVersion, WalletSeed } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  type AnyTx,
+  type NetworkId,
+  ProtocolVersion,
+  type ProtocolVersionMismatchError,
+  type UnprovenTx,
+  WalletSeed,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
 import { type ShieldedAddress } from '@midnightntwrk/wallet-sdk-address-format';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
 import {
@@ -33,53 +41,31 @@ import {
   type WalletLike,
 } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { EitherOps, HList } from '@midnightntwrk/wallet-sdk-utilities';
-import { Data, Effect, Either, Option, Ref, type Scope } from 'effect';
+import { Effect, Either, Option, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
 import { variantForSnapshot } from './Restore.js';
-import { type DefaultShieldedConfiguration, ShieldedWalletState, type ShieldedWalletAPI } from './ShieldedWallet.js';
+import {
+  type DefaultShieldedConfiguration,
+  type ShieldedBalancingResult,
+  ShieldedWalletState,
+  type ShieldedWalletAPI,
+} from './ShieldedWallet.js';
 import { CoreWallet as PreForkCoreWallet, V1Builder, V1Tag, type V1Variant } from './v1/index.js';
 import { type WalletSyncUpdate as PreForkSyncUpdate } from './v1/Sync.js';
 import { CoreWallet, Migration, V2Builder, V2Tag, type V2Variant } from './v2/index.js';
 import { type WalletSyncUpdate as PostForkSyncUpdate } from './v2/Sync.js';
-import { type BalancingResult, type TokenTransfer } from './v2/Transacting.js';
+import { type TokenTransfer } from './v2/Transacting.js';
 import { type WalletError } from './v2/WalletError.js';
 
 /**
- * Raised when a transaction is asked for while the wallet is still on the pre-fork protocol version.
+ * What a transacting call can fail with.
  *
  * @remarks
- *   **This seam is temporary and must not survive to general availability.** Mainnet is pre-fork until the fork happens,
- *   so a wallet that cannot transact pre-fork cannot be the wallet that ships. It closes with the proving-routing
- *   increment (WP-11 together with the carrier and author flows), which routes a recipe to the prover that speaks the
- *   protocol version it was built at; until then the only proving path this SDK has speaks the post-fork ledger
- *   version, and there is nothing honest for the pre-fork branch to return.
- *
- *   Everything else works on both sides of the boundary: synchronization, the state observable and everything it
- *   projects, balances, coins, addresses, serialization, restoring a snapshot, and the migration itself. Transacting is
- *   the single gated operation, and it fails loudly rather than producing a transaction nobody can prove.
+ *   Two failures beyond the variant's own: the wallet may hold no key material the current variant can use — which is
+ *   what a wallet started from post-fork key objects has to say while it is still pre-fork — and a transaction handed
+ *   in may have been built on the other side of the boundary, which no variant here can read.
  */
-export class PreForkTransactingUnsupportedError extends Data.TaggedError(
-  '@midnightntwrk/wallet-sdk-shielded/ForkingShieldedWallet/PreForkTransactingUnsupportedError',
-)<{
-  readonly message: string;
-  /** The wallet operation that was asked for. */
-  readonly operation: string;
-}> {}
-
-/** What a transacting call can fail with: the post-fork variant's own errors, or the pre-fork variant's refusal. */
-type TransactingError = WalletError | PreForkTransactingUnsupportedError;
-
-const preForkTransactingUnsupported = (operation: string): Effect.Effect<never, PreForkTransactingUnsupportedError> =>
-  Effect.fail(
-    new PreForkTransactingUnsupportedError({
-      operation,
-      message:
-        `${operation} is not available while this wallet is on the pre-fork protocol version: it would produce a ` +
-        `transaction of the previous ledger version, which this release has no way to prove. Pre-fork transacting ` +
-        `arrives with version-routed proving; until then the post-fork path is the one that works. Synchronization, ` +
-        `balances, state and serialization are unaffected on either side of the boundary.`,
-    }),
-  );
+type TransactingError = WalletError | StartMaterial.MissingStartAuxError | ProtocolVersionMismatchError;
 
 /** The pre-fork variant a forking shielded wallet registers: the one that reads the chain before the boundary. */
 export type PreForkShieldedVariant<TSyncUpdate> = V1Variant<
@@ -255,6 +241,28 @@ export function CustomForkingShieldedWallet<
   ): Either.Either<ledger.ZswapSecretKeys, StartMaterial.MissingStartAuxError> =>
     StartMaterial.requireAuxFor(retained, V2Tag, (seed) => variants[V2Tag].variant.startAux.fromSeed(seed));
 
+  /**
+   * The protocol versions each variant owns, and the version a transaction it builds is stamped with.
+   *
+   * @remarks
+   *   The stamp is the version at which the variant that built the transaction became current — the floor of its epoch —
+   *   rather than the block height the chain happened to be at. Every decision the stamp is later read for asks which
+   *   side of the boundary the bytes belong to: which prover proves them, which validator checks them, which variant
+   *   may unwrap them. The epoch floor is the one value guaranteed to answer that the same way as any other version in
+   *   the same epoch, and it is derived here from the same `forkVersion` the variants are registered at.
+   */
+  const preForkEpoch = ProtocolVersion.epochOf(ProtocolVersion.MinSupportedVersion, configuration.forkVersion);
+  const postForkEpoch = ProtocolVersion.epochOf(configuration.forkVersion, configuration.forkVersion);
+  const [preForkStamp] = preForkEpoch;
+  const [postForkStamp] = postForkEpoch;
+
+  /** Seals a balancing result, which is absent when the wallet had nothing of its own to add. */
+  const sealPreFork = (result: v8.UnprovenTransaction | undefined): ShieldedBalancingResult =>
+    result === undefined ? undefined : WalletTransaction.adopt('Unproven', result, preForkStamp);
+
+  const sealPostFork = (result: ledger.UnprovenTransaction | undefined): ShieldedBalancingResult =>
+    result === undefined ? undefined : WalletTransaction.adopt('Unproven', result, postForkStamp);
+
   return class ForkingShieldedWalletImplementation
     extends BaseWallet
     implements ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>
@@ -422,39 +430,107 @@ export function CustomForkingShieldedWallet<
       await super.stop();
     }
 
-    balanceTransaction(
-      secretKeys: ledger.ZswapSecretKeys,
-      tx: ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>,
-    ): Promise<BalancingResult> {
+    /**
+     * The key material the variant that is current can use, from what this wallet retained.
+     *
+     * @remarks
+     *   Transacting needs the same secrets synchronization does, and for the same reason: coin selection reads coins only
+     *   their owner can decrypt. A wallet that was never started, or one holding key objects of the other ledger
+     *   version, has none the current variant can use and says so by name.
+     */
+    #requireAux<TAux>(
+      auxFor: (retained: RetainedStartMaterial) => Either.Either<TAux, StartMaterial.MissingStartAuxError>,
+      variantTag: symbol,
+    ): Effect.Effect<TAux, StartMaterial.MissingStartAuxError> {
+      return Ref.get(this.#retainedStartMaterial).pipe(
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new StartMaterial.MissingStartAuxError({
+                  message:
+                    `This wallet holds no key material: it has not been started, or it has been stopped. Start it ` +
+                    `before asking it to build a transaction.`,
+                  variantTag,
+                }),
+              ),
+            onSome: (retained: RetainedStartMaterial) => EitherOps.toEffect(auxFor(retained)),
+          }),
+        ),
+      );
+    }
+
+    /**
+     * Balances a transaction with shielded coins, on whichever side of the boundary it was built.
+     *
+     * @param tx The transaction to balance, which must have been built in the epoch this wallet is currently in.
+     * @returns The balancing transaction, stamped with the version it was built at, or nothing when none is needed.
+     */
+    balanceTransaction(tx: AnyTx): Promise<ShieldedBalancingResult> {
       return this.runtime
-        .dispatch<BalancingResult, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('balanceTransaction'),
-          [V2Tag]: (v2) => v2.balanceTransaction(secretKeys, tx),
+        .dispatch<ShieldedBalancingResult, TransactingError>({
+          [V1Tag]: (v1) =>
+            Effect.all([
+              this.#requireAux(preForkAux, V1Tag),
+              EitherOps.toEffect(
+                WalletTransaction.unwrapWithin<v8.Transaction<v8.Signaturish, v8.Proofish, v8.Bindingish>>(
+                  tx,
+                  preForkEpoch,
+                ),
+              ),
+            ]).pipe(
+              Effect.flatMap(([keys, unwrapped]) => v1.balanceTransaction(keys, unwrapped)),
+              Effect.map(sealPreFork),
+            ),
+          [V2Tag]: (v2) =>
+            Effect.all([
+              this.#requireAux(postForkAux, V2Tag),
+              EitherOps.toEffect(
+                WalletTransaction.unwrapWithin<
+                  ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>
+                >(tx, postForkEpoch),
+              ),
+            ]).pipe(
+              Effect.flatMap(([keys, unwrapped]) => v2.balanceTransaction(keys, unwrapped)),
+              Effect.map(sealPostFork),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    transferTransaction(
-      secretKeys: ledger.ZswapSecretKeys,
-      outputs: readonly TokenTransfer[],
-    ): Promise<ledger.UnprovenTransaction> {
+    transferTransaction(outputs: readonly TokenTransfer[]): Promise<UnprovenTx> {
       return this.runtime
-        .dispatch<ledger.UnprovenTransaction, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('transferTransaction'),
-          [V2Tag]: (v2) => v2.transferTransaction(secretKeys, outputs),
+        .dispatch<UnprovenTx, TransactingError>({
+          [V1Tag]: (v1) =>
+            this.#requireAux(preForkAux, V1Tag).pipe(
+              Effect.flatMap((keys) => v1.transferTransaction(keys, outputs)),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, preForkStamp)),
+            ),
+          [V2Tag]: (v2) =>
+            this.#requireAux(postForkAux, V2Tag).pipe(
+              Effect.flatMap((keys) => v2.transferTransaction(keys, outputs)),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, postForkStamp)),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
     initSwap(
-      secretKeys: ledger.ZswapSecretKeys,
       desiredInputs: Record<ledger.RawTokenType, bigint>,
       desiredOutputs: readonly TokenTransfer[],
-    ): Promise<ledger.UnprovenTransaction> {
+    ): Promise<UnprovenTx> {
       return this.runtime
-        .dispatch<ledger.UnprovenTransaction, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('initSwap'),
-          [V2Tag]: (v2) => v2.initSwap(secretKeys, desiredInputs, desiredOutputs),
+        .dispatch<UnprovenTx, TransactingError>({
+          [V1Tag]: (v1) =>
+            this.#requireAux(preForkAux, V1Tag).pipe(
+              Effect.flatMap((keys) => v1.initSwap(keys, desiredInputs, desiredOutputs)),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, preForkStamp)),
+            ),
+          [V2Tag]: (v2) =>
+            this.#requireAux(postForkAux, V2Tag).pipe(
+              Effect.flatMap((keys) => v2.initSwap(keys, desiredInputs, desiredOutputs)),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, postForkStamp)),
+            ),
         })
         .pipe(Effect.runPromise);
     }
@@ -463,20 +539,30 @@ export function CustomForkingShieldedWallet<
      * Un-records a transaction this wallet produced, releasing the coins it had booked.
      *
      * @remarks
-     *   Nothing to do on the pre-fork variant, and that is a fact about the wallet rather than a convenience: while
-     *   pre-fork transacting is unavailable that variant cannot have produced the transaction being reverted, so it
-     *   holds nothing of it to release. The parameter's type says the same thing — a post-fork transaction is not one
-     *   the pre-fork variant could have built. Unlike the operations that build transactions, this needs no proving, so
-     *   there is nothing here for version-routed proving to unlock later.
+     *   A transaction built on the other side of the boundary is not one the current variant could have booked coins for,
+     *   so there is nothing of it to release and this resolves having done nothing. That is the one place a version
+     *   mismatch is not an error: the facade reverts all three wallets together when a submission fails, and a refusal
+     *   here would strand that whole path over a transaction this wallet was never holding anything for.
      * @param transaction The transaction to un-record.
      */
-    revertTransaction(
-      transaction: ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>,
-    ): Promise<void> {
+    revertTransaction(transaction: AnyTx): Promise<void> {
       return this.runtime
         .dispatch<void, TransactingError>({
-          [V1Tag]: () => Effect.void,
-          [V2Tag]: (v2) => v2.revertTransaction(transaction),
+          [V1Tag]: (v1) =>
+            Either.match(
+              WalletTransaction.unwrapWithin<v8.Transaction<v8.Signaturish, v8.Proofish, v8.Bindingish>>(
+                transaction,
+                preForkEpoch,
+              ),
+              { onLeft: () => Effect.void, onRight: (unwrapped) => v1.revertTransaction(unwrapped) },
+            ),
+          [V2Tag]: (v2) =>
+            Either.match(
+              WalletTransaction.unwrapWithin<
+                ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>
+              >(transaction, postForkEpoch),
+              { onLeft: () => Effect.void, onRight: (unwrapped) => v2.revertTransaction(unwrapped) },
+            ),
         })
         .pipe(Effect.runPromise);
     }

--- a/packages/shielded-wallet/src/ForkingShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ForkingShieldedWallet.ts
@@ -606,8 +606,9 @@ export type ShieldedWalletClass = ForkingShieldedWalletClass<
  *   registered with the cross-ledger migration, which is what makes the hand-over carry identity and a cursor onto a
  *   fresh state rather than start a wallet from nothing.
  *
- *   **Transacting is available only once the wallet is on the post-fork variant** — see
- *   {@link PreForkTransactingUnsupportedError}, a temporary seam that closes with version-routed proving.
+ *   **Transacting works on either side of the boundary**: the active variant builds with its own ledger and its own
+ *   derived keys, and every result travels as a handle stamped with the epoch that built it. Proving a pre-fork
+ *   transaction still requires a proving server registered below the boundary.
  * @param configuration What the wallet and both its variants are built from, including where the boundary lies.
  * @returns The wallet class.
  */

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -11,11 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import {
+  type AnyTx,
   type NetworkId,
   type ProtocolState,
   ProtocolVersion,
+  type ProtocolVersionMismatchError,
   type SyncProgress,
+  type UnprovenTx,
   WalletSeed,
+  WalletTransaction,
 } from '@midnightntwrk/wallet-sdk-abstractions';
 import {
   type BaseV2Configuration,
@@ -28,8 +32,8 @@ import {
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { type Duration, Effect, Either, Option, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
-import { type BalancingResult } from './v2/Transacting.js';
 import { type SerializationCapability } from './v2/Serialization.js';
+import { type WalletError } from './v2/WalletError.js';
 import { type AvailableCoin, type CoinsAndBalancesCapability, type PendingCoin } from './v2/CoinsAndBalances.js';
 import { type KeysCapability } from './v2/Keys.js';
 import {
@@ -175,8 +179,18 @@ export class ShieldedWalletState<TSerialized = string, _TTransaction = ledger.Fi
   }
 }
 
+/**
+ * What balancing a transaction with shielded coins produces: a transaction covering the shortfall, when there is one.
+ *
+ * @remarks
+ *   A handle rather than a ledger transaction, because which ledger version built it is the variant's business and not
+ *   the caller's. Absent when the wallet had nothing to add — the transaction was already balanced on the shielded
+ *   side.
+ */
+export type ShieldedBalancingResult = UnprovenTx | undefined;
+
 export type ShieldedWalletAPI<
-  TStartAux = ledger.ZswapSecretKeys,
+  TStartAux extends ledger.ZswapSecretKeys = ledger.ZswapSecretKeys,
   TTransaction = ledger.FinalizedTransaction,
   TSerialized = string,
 > = {
@@ -184,22 +198,23 @@ export type ShieldedWalletAPI<
 
   start(secretKeys: TStartAux): Promise<void>;
 
+  /**
+   * Balances a transaction with shielded coins.
+   *
+   * @remarks
+   *   No key material is passed: the wallet derives what its current variant needs from what it was started with. A
+   *   caller-supplied key object could only ever belong to one ledger version, which is exactly what a wallet spanning
+   *   a protocol boundary cannot assume.
+   */
   // we can balance bound and unbound txs
-  balanceTransaction(
-    secretKeys: ledger.ZswapSecretKeys,
-    tx: ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>,
-  ): Promise<BalancingResult>;
+  balanceTransaction(tx: AnyTx): Promise<ShieldedBalancingResult>;
 
-  transferTransaction(
-    secretKeys: ledger.ZswapSecretKeys,
-    outputs: readonly TokenTransfer[],
-  ): Promise<ledger.UnprovenTransaction>;
+  transferTransaction(outputs: readonly TokenTransfer[]): Promise<UnprovenTx>;
 
   initSwap(
-    secretKeys: ledger.ZswapSecretKeys,
     desiredInputs: Record<ledger.RawTokenType, bigint>,
     desiredOutputs: readonly TokenTransfer[],
-  ): Promise<ledger.UnprovenTransaction>;
+  ): Promise<UnprovenTx>;
 
   serializeState(): Promise<TSerialized>;
 
@@ -207,15 +222,13 @@ export type ShieldedWalletAPI<
 
   getAddress(): Promise<ShieldedAddress>;
 
-  revertTransaction(
-    transaction: ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>,
-  ): Promise<void>;
+  revertTransaction(transaction: AnyTx): Promise<void>;
 
   stop(): Promise<void>;
 };
 
 export type CustomizedShieldedWallet<
-  TStartAux = ledger.ZswapSecretKeys,
+  TStartAux extends ledger.ZswapSecretKeys = ledger.ZswapSecretKeys,
   TTransaction = ledger.FinalizedTransaction,
   TSyncUpdate = WalletSyncUpdate,
   TSerialized = string,
@@ -273,7 +286,7 @@ export type DefaultShieldedConfiguration = {
 };
 
 export interface CustomizedShieldedWalletClass<
-  TStartAux = ledger.ZswapSecretKeys,
+  TStartAux extends ledger.ZswapSecretKeys = ledger.ZswapSecretKeys,
   TTransaction = ledger.FinalizedTransaction,
   TSyncUpdate = WalletSyncUpdate,
   TSerialized = string,
@@ -302,7 +315,7 @@ export interface CustomizedShieldedWalletClass<
  */
 export function CustomShieldedWallet<
   TConfig extends BaseV2Configuration = DefaultV2Configuration,
-  TStartAux = ledger.ZswapSecretKeys,
+  TStartAux extends ledger.ZswapSecretKeys = ledger.ZswapSecretKeys,
   TTransaction = ledger.FinalizedTransaction,
   TSyncUpdate = WalletSyncUpdate,
   TSerialized = string,
@@ -505,44 +518,108 @@ export function CustomShieldedWallet<
       await super.stop();
     }
 
-    balanceTransaction(
-      secretKeys: ledger.ZswapSecretKeys,
-      tx: ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>,
-    ): Promise<BalancingResult> {
+    /**
+     * The key material this wallet's one variant uses, from what it was started with.
+     *
+     * @remarks
+     *   Typed as the variant's own start-aux, which for a single-variant wallet is whatever the application handed to
+     *   `start` — there is no other variant to derive for, so a retained seed is only ever used through the variant's
+     *   own derivation.
+     */
+    #requireAux(): Effect.Effect<TStartAux, StartMaterial.MissingStartAuxError> {
+      return Effect.gen(this, function* () {
+        const current = yield* this.runtime.currentVariant;
+        const variantTag = Poly.getTag(current);
+        const retained = yield* Ref.get(this.#retainedStartMaterial);
+        return yield* Option.match(retained, {
+          onNone: () =>
+            Effect.fail(
+              new StartMaterial.MissingStartAuxError({
+                message:
+                  `This wallet holds no key material: it has not been started, or it has been stopped. Start it ` +
+                  `before asking it to build a transaction.`,
+                variantTag,
+              }),
+            ),
+          onSome: (material: StartMaterial.StartMaterial<TStartAux>) =>
+            EitherOps.toEffect(
+              StartMaterial.requireAuxFor(material, variantTag, (seed) =>
+                CustomShieldedWalletImplementation.allVariantsRecord()[V2Tag].variant.startAux.fromSeed(seed),
+              ),
+            ),
+        });
+      });
+    }
+
+    /** The whole of the protocol timeline: one variant answers for every version this wallet will ever see. */
+    static readonly #epoch = ProtocolVersion.epochOf(
+      ProtocolVersion.MinSupportedVersion,
+      ProtocolVersion.MinSupportedVersion,
+    );
+
+    balanceTransaction(tx: AnyTx): Promise<ShieldedBalancingResult> {
       return this.runtime
-        .dispatch({
-          [V2Tag]: (v2) => v2.balanceTransaction(secretKeys, tx),
+        .dispatch<
+          ShieldedBalancingResult,
+          WalletError | StartMaterial.MissingStartAuxError | ProtocolVersionMismatchError
+        >({
+          [V2Tag]: (v2) =>
+            Effect.all([
+              this.#requireAux(),
+              EitherOps.toEffect(
+                WalletTransaction.unwrapWithin<
+                  ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>
+                >(tx, CustomShieldedWalletImplementation.#epoch),
+              ),
+            ]).pipe(
+              Effect.flatMap(([keys, unwrapped]) => v2.balanceTransaction(keys, unwrapped)),
+              Effect.map((result) =>
+                result === undefined
+                  ? undefined
+                  : WalletTransaction.adopt('Unproven', result, ProtocolVersion.MinSupportedVersion),
+              ),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    transferTransaction(
-      secretKeys: ledger.ZswapSecretKeys,
-      outputs: readonly TokenTransfer[],
-    ): Promise<ledger.UnprovenTransaction> {
+    transferTransaction(outputs: readonly TokenTransfer[]): Promise<UnprovenTx> {
       return this.runtime
-        .dispatch({
-          [V2Tag]: (v2) => v2.transferTransaction(secretKeys, outputs),
+        .dispatch<UnprovenTx, WalletError | StartMaterial.MissingStartAuxError>({
+          [V2Tag]: (v2) =>
+            this.#requireAux().pipe(
+              Effect.flatMap((keys) => v2.transferTransaction(keys, outputs)),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, ProtocolVersion.MinSupportedVersion)),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
     initSwap(
-      secretKeys: ledger.ZswapSecretKeys,
       desiredInputs: Record<ledger.RawTokenType, bigint>,
       desiredOutputs: readonly TokenTransfer[],
-    ): Promise<ledger.UnprovenTransaction> {
+    ): Promise<UnprovenTx> {
       return this.runtime
-        .dispatch({ [V2Tag]: (v2) => v2.initSwap(secretKeys, desiredInputs, desiredOutputs) })
+        .dispatch<UnprovenTx, WalletError | StartMaterial.MissingStartAuxError>({
+          [V2Tag]: (v2) =>
+            this.#requireAux().pipe(
+              Effect.flatMap((keys) => v2.initSwap(keys, desiredInputs, desiredOutputs)),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, ProtocolVersion.MinSupportedVersion)),
+            ),
+        })
         .pipe(Effect.runPromise);
     }
 
-    revertTransaction(
-      transaction: ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>,
-    ): Promise<void> {
+    revertTransaction(transaction: AnyTx): Promise<void> {
       return this.runtime
-        .dispatch({
-          [V2Tag]: (v2) => v2.revertTransaction(transaction),
+        .dispatch<void, WalletError>({
+          [V2Tag]: (v2) =>
+            Either.match(
+              WalletTransaction.unwrapWithin<
+                ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>
+              >(transaction, CustomShieldedWalletImplementation.#epoch),
+              { onLeft: () => Effect.void, onRight: (unwrapped) => v2.revertTransaction(unwrapped) },
+            ),
         })
         .pipe(Effect.runPromise);
     }

--- a/packages/shielded-wallet/src/test/forkSimulation.integration.test.ts
+++ b/packages/shielded-wallet/src/test/forkSimulation.integration.test.ts
@@ -61,7 +61,7 @@ import { V1Tag } from '../v1/index.js';
 import { V2Tag } from '../v2/index.js';
 import { type ReplayedCoin, makeReplayChain, mintable, preForkPayment, simulatedChainRoot } from './forkReplay.js';
 import { makeForkWallet } from './forkHarness.js';
-import { coinIndices, coinValues, merkleRoot, totalValue, treeSize } from './forkWalletAssertions.js';
+import { carried, coinIndices, coinValues, merkleRoot, totalValue, treeSize } from './forkWalletAssertions.js';
 
 const networkId = NetworkId.NetworkId.Undeployed;
 
@@ -220,11 +220,11 @@ describe('a shielded wallet crossing a byte-faithful hard fork', () => {
       // --- and it can transact against the translation ----------------------------------------------------------
       const transferred = 150n;
       const transfer = yield* Effect.promise(() =>
-        wallet.shielded.transferTransaction(wallet.keys.postFork, [
+        wallet.shielded.transferTransaction([
           { amount: transferred, type: v9.shieldedToken().raw, receiverAddress: recipientAddress() },
         ]),
       );
-      const spend = transfer.eraseProofs();
+      const spend = carried<v9.UnprovenTransaction>(transfer, forkVersion).eraseProofs();
 
       // Submitted to the chain that holds the *translated* ledger, not to the replay the wallet learned from. The
       // Merkle path in this spend was built from the wallet's own tree; the translated chain recognises it only if

--- a/packages/shielded-wallet/src/test/forkSimulation.test.ts
+++ b/packages/shielded-wallet/src/test/forkSimulation.test.ts
@@ -51,7 +51,7 @@ import { V1Tag } from '../v1/index.js';
 import { V2Tag } from '../v2/index.js';
 import { type ReplayedCoin, makeReplayChain, mintable, preForkPayment } from './forkReplay.js';
 import { type ForkWallet, makeForkWallet } from './forkHarness.js';
-import { ascending, coinIndices, coinValues, totalValue, treeSize } from './forkWalletAssertions.js';
+import { ascending, carried, coinIndices, coinValues, totalValue, treeSize } from './forkWalletAssertions.js';
 
 const networkId = NetworkId.NetworkId.Undeployed;
 
@@ -234,13 +234,15 @@ describe('a shielded wallet crossing a hard fork', () => {
       // --- the re-discovered coins are spendable ----------------------------------------------------------------
       const transferred = 150n;
       const transfer = yield* Effect.promise(() =>
-        wallet.shielded.transferTransaction(wallet.keys.postFork, [
+        wallet.shielded.transferTransaction([
           { amount: transferred, type: v9.shieldedToken().raw, receiverAddress: recipientAddress() },
         ]),
       );
 
       const replayChain = yield* Deferred.await(replayed);
-      const block = yield* replayChain.submitTransaction(transfer.eraseProofs());
+      const block = yield* replayChain.submitTransaction(
+        carried<v9.UnprovenTransaction>(transfer, forkVersion).eraseProofs(),
+      );
       // The chain accepting this is the claim: a spend carries a Merkle path built from the wallet's own tree, and is
       // only recognised if that path resolves to a root the chain holds. A tree rebuilt one index off would not.
       expect(block.transactions[0].result.type).toBe('success');

--- a/packages/shielded-wallet/src/test/forkStart.test.ts
+++ b/packages/shielded-wallet/src/test/forkStart.test.ts
@@ -30,7 +30,13 @@
 
 import * as v8 from '@midnight-ntwrk/ledger-v8';
 import * as v9 from '@midnightntwrk/ledger-v9';
-import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  type AnyTx,
+  NetworkId,
+  ProtocolVersion,
+  ProtocolVersionMismatchError,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
 import {
   ShieldedAddress,
   ShieldedCoinPublicKey,
@@ -41,12 +47,11 @@ import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstr
 import { type LedgerOps } from '@midnightntwrk/wallet-sdk-utilities';
 import { Cause, Effect, Option, Runtime, type Scope } from 'effect';
 import { describe, expect, it } from 'vitest';
-import { PreForkTransactingUnsupportedError } from '../ForkingShieldedWallet.js';
 import { V1Tag } from '../v1/index.js';
 import { V2Tag } from '../v2/index.js';
 import { type ForkWallet, makeForkWallet } from './forkHarness.js';
 import { type ReplayedCoin, makeReplayChain, mintable, preForkPayment } from './forkReplay.js';
-import { coinValues, totalValue } from './forkWalletAssertions.js';
+import { carried, coinValues, totalValue } from './forkWalletAssertions.js';
 
 const networkId = NetworkId.NetworkId.Undeployed;
 
@@ -132,20 +137,27 @@ const failureOf = (call: Promise<unknown>): Effect.Effect<Option.Option<unknown>
  * Every call that builds a transaction, named as the wallet names it.
  *
  * @remarks
- *   `revertTransaction` is deliberately not among them: it builds nothing and needs no proving, so it is not what the
- *   pre-fork seam is about — see the test below for what it does instead.
+ *   `revertTransaction` is deliberately not among them: it builds nothing, so what it does with a transaction of the
+ *   other epoch is a different question — see the test below.
  */
-const transactionBuildingCalls = (wallet: ForkWallet): readonly (readonly [string, () => Promise<unknown>])[] => {
-  const transfer = { amount: 1n, type: v9.shieldedToken().raw, receiverAddress: strangerAddress() };
+const transactionBuildingCalls = (
+  wallet: ForkWallet,
+): readonly (readonly [string, () => Promise<AnyTx | undefined>])[] => {
+  const transfer = { amount: 1n, type: v8.shieldedToken().raw, receiverAddress: strangerAddress() };
   return [
-    ['balanceTransaction', () => wallet.shielded.balanceTransaction(wallet.keys.postFork, someTransaction())],
-    ['transferTransaction', () => wallet.shielded.transferTransaction(wallet.keys.postFork, [transfer])],
-    ['initSwap', () => wallet.shielded.initSwap(wallet.keys.postFork, {}, [transfer])],
+    ['balanceTransaction', () => wallet.shielded.balanceTransaction(preForkTransaction())],
+    ['transferTransaction', () => wallet.shielded.transferTransaction([transfer])],
+    ['initSwap', () => wallet.shielded.initSwap({ [v8.shieldedToken().raw]: 1n }, [transfer])],
   ];
 };
 
-/** A transaction of the post-fork ledger version, which is the only kind this wallet's API accepts. */
-const someTransaction = (): v9.UnprovenTransaction => v9.Transaction.fromParts(networkId);
+/** A transaction of the pre-fork ledger version, sealed as an application would seal one it built for itself. */
+const preForkTransaction = (): AnyTx =>
+  WalletTransaction.adopt('Unproven', v8.Transaction.fromParts(networkId), ProtocolVersion.MinSupportedVersion);
+
+/** A transaction of the post-fork ledger version, sealed at the version the post-fork variant answers for. */
+const postForkTransaction = (): AnyTx =>
+  WalletTransaction.adopt('Unproven', v9.Transaction.fromParts(networkId), forkVersion);
 
 /**
  * A wallet on a chain that has not forked, synchronized and holding its coins.
@@ -234,30 +246,65 @@ describe('a shielded wallet starting on a chain that has not forked', () => {
     }).pipe(Effect.scoped, Effect.runPromise));
 
   it.each(['balanceTransaction', 'transferTransaction', 'initSwap'])(
-    'refuses %s while it is still pre-fork, and says why',
+    'builds %s while it is still pre-fork, stamped with the version that built it',
     async (operation) =>
       Effect.gen(function* () {
         const wallet = yield* syncedPreForkWallet;
 
         const call = transactionBuildingCalls(wallet).find(([name]) => name === operation)!;
-        const failure = Option.getOrThrow(yield* failureOf(call[1]()));
+        const built = yield* Effect.promise(call[1]);
 
-        // Typed, and naming the operation: the pre-fork branch cannot produce a transaction anybody can prove, and
-        // says so instead of producing one nobody can.
-        expect(failure).toBeInstanceOf(PreForkTransactingUnsupportedError);
-        expect(failure).toMatchObject({ operation });
+        // It answered rather than refusing, and whatever it produced is stamped with the ledger version the chain is
+        // actually on — so everything that routes on the version afterwards (which prover, which validator) has the
+        // answer it needs. `balanceTransaction` alone may legitimately produce nothing: a transaction that needs no
+        // shielded coins needs no shielded balancing.
+        if (built !== undefined) {
+          expect(WalletTransaction.is(built)).toBe(true);
+          expect(built.protocolVersion).toBeLessThan(forkVersion);
+        }
+        // Still pre-fork: building a transaction is not what moves a wallet across the boundary.
+        expect(yield* wallet.activeTag).toBe(V1Tag);
       }).pipe(Effect.scoped, Effect.runPromise),
   );
 
-  it('reverts a transaction it cannot have made, by doing nothing to its state', async () =>
+  it('spends what it holds, so a pre-fork transfer is a real one', async () =>
     Effect.gen(function* () {
-      // Reverting releases coins a transaction booked, and no transaction of this wallet's can have booked any: it
-      // could not have built one. So this resolves, changes nothing, and is deliberately not part of the seam above —
-      // it needs no proving, so version-routed proving has nothing to unlock here. The facade reverts all three
-      // wallets together when a submission fails, and a refusal here would strand that whole path.
+      // The refusal these replaced could be satisfied by any wallet at all; this cannot. The transfer is built from
+      // the coins the pre-fork variant synchronized, by the pre-fork ledger version, and carries them.
       const wallet = yield* syncedPreForkWallet;
 
-      yield* Effect.promise(() => wallet.shielded.revertTransaction(someTransaction()));
+      const transfer = yield* Effect.promise(() =>
+        wallet.shielded.transferTransaction([
+          { amount: 50n, type: v8.shieldedToken().raw, receiverAddress: strangerAddress() },
+        ]),
+      );
+
+      const built = carried<v8.UnprovenTransaction>(transfer, forkVersion);
+      expect(built).toBeInstanceOf(v8.Transaction);
+      expect(built.guaranteedOffer?.inputs.length ?? 0).toBeGreaterThan(0);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('refuses a transaction built on the other side of the boundary, naming both versions', async () =>
+    Effect.gen(function* () {
+      // The enforcement the stamp exists for. A post-fork transaction's bytes are of a ledger version the pre-fork
+      // variant cannot read, so balancing it is not something to attempt and fail at — it is refused by name.
+      const wallet = yield* syncedPreForkWallet;
+
+      const failure = Option.getOrThrow(yield* failureOf(wallet.shielded.balanceTransaction(postForkTransaction())));
+
+      expect(failure).toBeInstanceOf(ProtocolVersionMismatchError);
+      expect(failure).toMatchObject({ authoredFor: forkVersion });
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('reverts a transaction of the other epoch by doing nothing to its state', async () =>
+    Effect.gen(function* () {
+      // Reverting releases coins a transaction booked, and a transaction of the other ledger version cannot have
+      // booked any of this variant's. So this resolves, changes nothing, and is deliberately not a version mismatch:
+      // the facade reverts all three wallets together when a submission fails, and a refusal here would strand that
+      // whole path.
+      const wallet = yield* syncedPreForkWallet;
+
+      yield* Effect.promise(() => wallet.shielded.revertTransaction(postForkTransaction()));
 
       const after = yield* wallet.currentState;
       expect(totalValue(after.state)).toBe(walletTotal);

--- a/packages/shielded-wallet/src/test/forkWalletAssertions.ts
+++ b/packages/shielded-wallet/src/test/forkWalletAssertions.ts
@@ -20,11 +20,29 @@
  *   both versions express identically, so these read the union rather than being written twice.
  */
 
+import { ProtocolVersion, WalletTransaction, type AnyTx } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Either } from 'effect';
 import { type CoreWallet as PreForkWallet } from '../v1/CoreWallet.js';
 import { type CoreWallet as PostForkWallet } from '../v2/CoreWallet.js';
 
 /** A wallet on either side of the boundary. */
 export type EitherWallet = PreForkWallet | PostForkWallet;
+
+/**
+ * The transaction a handle carries, read at the epoch its own stamp names.
+ *
+ * @remarks
+ *   A test assertion is entitled to look inside, and this is the only place these suites do. The result type is the
+ *   caller's to name, which is exactly the choice the stamp has already settled — so a suite that names the wrong
+ *   ledger version is making a claim the surrounding assertions will refute.
+ * @param handle The handle to read.
+ * @param forkVersion The boundary the epoch is measured against.
+ * @returns The carried transaction.
+ */
+export const carried = <T>(handle: AnyTx, forkVersion: ProtocolVersion.ProtocolVersion): T =>
+  Either.getOrThrow(
+    WalletTransaction.unwrapWithin<T>(handle, ProtocolVersion.epochOf(handle.protocolVersion, forkVersion)),
+  );
 
 /** Ascending order for bigints, which `Array.prototype.sort`'s default (string) comparison gets wrong. */
 export const ascending = (left: bigint, right: bigint): number => (left < right ? -1 : left > right ? 1 : 0);

--- a/packages/unshielded-wallet/src/ForkingUnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/ForkingUnshieldedWallet.ts
@@ -29,13 +29,23 @@
  *   The one place the two ledger versions genuinely disagree is the _shape_ of a verifying key, and that is resolved
  *   once, at start, by {@link asPreForkPublicKey}.
  */
+import type * as v8 from '@midnight-ntwrk/ledger-v8';
 import type * as ledger from '@midnightntwrk/ledger-v9';
-import { type NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  type AnyTx,
+  type NetworkId,
+  ProtocolVersion,
+  type ProtocolVersionMismatchError,
+  type UnboundTx,
+  type UnprovenTx,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
 import { type UnshieldedAddress } from '@midnightntwrk/wallet-sdk-address-format';
+import * as PreForkSignatures from '@midnightntwrk/wallet-sdk-capabilities/signatures';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
 import { type Variant, type VariantBuilder, type WalletLike } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
-import { HList } from '@midnightntwrk/wallet-sdk-utilities';
-import { Data, Effect, Either, Option, Ref, type Scope } from 'effect';
+import { EitherOps, HList } from '@midnightntwrk/wallet-sdk-utilities';
+import { Effect, Either, Option, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
 import { type PublicKey } from './KeyStore.js';
 import { variantForSnapshot } from './Restore.js';
@@ -48,56 +58,23 @@ import { CoreWallet as PreForkCoreWallet, V1Builder, V1Tag, type V1Variant } fro
 import { type PublicKey as PreForkPublicKey } from './v1/KeyStore.js';
 import { type WalletSyncUpdate as PreForkSyncUpdate } from './v1/SyncSchema.js';
 import { CoreWallet, Migration, V2Builder, V2Tag, type V2Variant } from './v2/index.js';
+import { type SignSegment as PreForkSignSegment } from './v1/Signing.js';
+import { type UnboundTransaction as PreForkUnboundTransaction } from './v1/TransactionOps.js';
 import { type SignSegment } from './v2/Signing.js';
 import { type WalletSyncUpdate as PostForkSyncUpdate } from './v2/SyncSchema.js';
-import {
-  type FinalizedTransactionBalanceResult,
-  type TokenTransfer,
-  type UnboundTransactionBalanceResult,
-  type UnprovenTransactionBalanceResult,
-} from './v2/Transacting.js';
+import { type TokenTransfer } from './v2/Transacting.js';
 import { type UnboundTransaction } from './v2/TransactionOps.js';
 import { type UtxoWithMeta } from './v2/UnshieldedState.js';
 import { type WalletError } from './v2/WalletError.js';
 
 /**
- * Raised when a transaction is asked for while the wallet is still on the pre-fork protocol version.
+ * What a transacting call can fail with.
  *
  * @remarks
- *   **This seam is temporary and must not survive to general availability.** Mainnet is pre-fork until the fork happens,
- *   so a wallet that cannot move Night pre-fork cannot be the wallet that ships. It closes with the proving-routing
- *   increment (WP-11 together with the carrier and author flows), which routes a recipe to the prover that speaks the
- *   protocol version it was built at; until then the only proving path this SDK has speaks the post-fork ledger
- *   version, and there is nothing honest for the pre-fork branch to return — every operation gated below either takes
- *   or produces a transaction of the post-fork ledger version, which the pre-fork variant cannot even hold.
- *
- *   Everything else works on both sides of the boundary: synchronization, the state observable and everything it
- *   projects, balances, coins, the address, serialization, restoring a snapshot, reverting, and the migration itself.
+ *   Two failures beyond the variant's own: a transaction handed in may have been built on the other side of the boundary,
+ *   and a signature the caller's signer returns may name a scheme the pre-fork ledger version does not have.
  */
-export class PreForkUnshieldedTransactingUnsupportedError extends Data.TaggedError(
-  '@midnightntwrk/wallet-sdk-unshielded-wallet/ForkingUnshieldedWallet/PreForkUnshieldedTransactingUnsupportedError',
-)<{
-  readonly message: string;
-  /** The wallet operation that was asked for. */
-  readonly operation: string;
-}> {}
-
-/** What a transacting call can fail with: the post-fork variant's own errors, or the pre-fork variant's refusal. */
-type TransactingError = WalletError | PreForkUnshieldedTransactingUnsupportedError;
-
-const preForkTransactingUnsupported = (
-  operation: string,
-): Effect.Effect<never, PreForkUnshieldedTransactingUnsupportedError> =>
-  Effect.fail(
-    new PreForkUnshieldedTransactingUnsupportedError({
-      operation,
-      message:
-        `${operation} is not available while this wallet is on the pre-fork protocol version: it takes or produces a ` +
-        `transaction of the previous ledger version, which this release has no way to prove. Pre-fork transacting ` +
-        `arrives with version-routed proving; until then the post-fork path is the one that works. Synchronization, ` +
-        `balances, coins, the address, state and serialization are unaffected on either side of the boundary.`,
-    }),
-  );
+type TransactingError = WalletError | ProtocolVersionMismatchError | PreForkSignatures.UnsupportedSignatureKindError;
 
 /** The pre-fork variant a forking unshielded wallet registers: the one that reads the chain before the boundary. */
 export type PreForkUnshieldedVariant<TSyncUpdate> = V1Variant<string, TSyncUpdate>;
@@ -254,6 +231,49 @@ export function CustomForkingUnshieldedWallet<
 
   const variants = BaseWallet.allVariantsRecord();
 
+  /**
+   * The protocol versions each variant owns, and the version a transaction it builds is stamped with.
+   *
+   * @remarks
+   *   The stamp is the floor of the variant's epoch: every decision it is later read for asks which side of the boundary
+   *   the bytes belong to, and the floor answers that the same way as any other version in the same epoch.
+   */
+  const preForkEpoch = ProtocolVersion.epochOf(ProtocolVersion.MinSupportedVersion, configuration.forkVersion);
+  const postForkEpoch = ProtocolVersion.epochOf(configuration.forkVersion, configuration.forkVersion);
+  const [preForkStamp] = preForkEpoch;
+  const [postForkStamp] = postForkEpoch;
+
+  /** Reads a transaction built before the boundary, refusing one built after it. */
+  const preForkTx = <T>(handle: AnyTx): Effect.Effect<T, ProtocolVersionMismatchError> =>
+    EitherOps.toEffect(WalletTransaction.unwrapWithin<T>(handle, preForkEpoch));
+
+  /** Reads a transaction built from the boundary, refusing one built before it. */
+  const postForkTx = <T>(handle: AnyTx): Effect.Effect<T, ProtocolVersionMismatchError> =>
+    EitherOps.toEffect(WalletTransaction.unwrapWithin<T>(handle, postForkEpoch));
+
+  /** Seals a balancing result, which is absent when the wallet had nothing of its own to add. */
+  const sealPreFork = (result: v8.UnprovenTransaction | undefined): UnprovenTx | undefined =>
+    result === undefined ? undefined : WalletTransaction.adopt('Unproven', result, preForkStamp);
+
+  const sealPostFork = (result: ledger.UnprovenTransaction | undefined): UnprovenTx | undefined =>
+    result === undefined ? undefined : WalletTransaction.adopt('Unproven', result, postForkStamp);
+
+  /**
+   * Adapts the caller's signer to the pre-fork ledger version's signature shape.
+   *
+   * @remarks
+   *   The SDK's signing callback speaks the current ledger version's signature — a scheme and its bytes — because that is
+   *   the shape an application writes against once. What the pre-fork ledger version reads is the bytes alone, and only
+   *   of the one scheme it has, so a signer that answers with any other is refused by name here rather than at the WASM
+   *   boundary.
+   */
+  const loweredSigner =
+    (signSegment: SignSegment): PreForkSignSegment =>
+    (data: Uint8Array) =>
+      signSegment(data).then((signature) =>
+        Either.getOrThrowWith(PreForkSignatures.lowerSignature(signature), (error) => error),
+      );
+
   return class ForkingUnshieldedWalletImplementation
     extends BaseWallet
     implements ForkingUnshieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>
@@ -388,38 +408,77 @@ export function CustomForkingUnshieldedWallet<
       await super.stop();
     }
 
-    balanceFinalizedTransaction(tx: ledger.FinalizedTransaction): Promise<FinalizedTransactionBalanceResult> {
+    balanceFinalizedTransaction(tx: AnyTx): Promise<UnprovenTx | undefined> {
       return this.runtime
-        .dispatch<FinalizedTransactionBalanceResult, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('balanceFinalizedTransaction'),
-          [V2Tag]: (v2) => v2.balanceFinalizedTransaction(tx),
+        .dispatch<UnprovenTx | undefined, TransactingError>({
+          [V1Tag]: (v1) =>
+            preForkTx<v8.FinalizedTransaction>(tx).pipe(
+              Effect.flatMap((unwrapped) => v1.balanceFinalizedTransaction(unwrapped)),
+              Effect.map(sealPreFork),
+            ),
+          [V2Tag]: (v2) =>
+            postForkTx<ledger.FinalizedTransaction>(tx).pipe(
+              Effect.flatMap((unwrapped) => v2.balanceFinalizedTransaction(unwrapped)),
+              Effect.map(sealPostFork),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    balanceUnboundTransaction(tx: UnboundTransaction): Promise<UnboundTransactionBalanceResult> {
+    /**
+     * Balances an unbound transaction, which happens in place rather than by producing a second transaction.
+     *
+     * @returns The transaction with this wallet's inputs added, or nothing when it needed none.
+     */
+    balanceUnboundTransaction(tx: AnyTx): Promise<UnboundTx | undefined> {
       return this.runtime
-        .dispatch<UnboundTransactionBalanceResult, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('balanceUnboundTransaction'),
-          [V2Tag]: (v2) => v2.balanceUnboundTransaction(tx),
+        .dispatch<UnboundTx | undefined, TransactingError>({
+          [V1Tag]: (v1) =>
+            preForkTx<PreForkUnboundTransaction>(tx).pipe(
+              Effect.flatMap((unwrapped) => v1.balanceUnboundTransaction(unwrapped)),
+              Effect.map((result) =>
+                result === undefined ? undefined : WalletTransaction.adopt('Unbound', result, preForkStamp),
+              ),
+            ),
+          [V2Tag]: (v2) =>
+            postForkTx<UnboundTransaction>(tx).pipe(
+              Effect.flatMap((unwrapped) => v2.balanceUnboundTransaction(unwrapped)),
+              Effect.map((result) =>
+                result === undefined ? undefined : WalletTransaction.adopt('Unbound', result, postForkStamp),
+              ),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    balanceUnprovenTransaction(tx: ledger.UnprovenTransaction): Promise<UnprovenTransactionBalanceResult> {
+    balanceUnprovenTransaction(tx: AnyTx): Promise<UnprovenTx | undefined> {
       return this.runtime
-        .dispatch<UnprovenTransactionBalanceResult, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('balanceUnprovenTransaction'),
-          [V2Tag]: (v2) => v2.balanceUnprovenTransaction(tx),
+        .dispatch<UnprovenTx | undefined, TransactingError>({
+          [V1Tag]: (v1) =>
+            preForkTx<v8.UnprovenTransaction>(tx).pipe(
+              Effect.flatMap((unwrapped) => v1.balanceUnprovenTransaction(unwrapped)),
+              Effect.map(sealPreFork),
+            ),
+          [V2Tag]: (v2) =>
+            postForkTx<ledger.UnprovenTransaction>(tx).pipe(
+              Effect.flatMap((unwrapped) => v2.balanceUnprovenTransaction(unwrapped)),
+              Effect.map(sealPostFork),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    transferTransaction(outputs: readonly TokenTransfer[], ttl: Date): Promise<ledger.UnprovenTransaction> {
+    transferTransaction(outputs: readonly TokenTransfer[], ttl: Date): Promise<UnprovenTx> {
       return this.runtime
-        .dispatch<ledger.UnprovenTransaction, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('transferTransaction'),
-          [V2Tag]: (v2) => v2.transferTransaction(outputs, ttl),
+        .dispatch<UnprovenTx, TransactingError>({
+          [V1Tag]: (v1) =>
+            v1
+              .transferTransaction(outputs, ttl)
+              .pipe(Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, preForkStamp))),
+          [V2Tag]: (v2) =>
+            v2
+              .transferTransaction(outputs, ttl)
+              .pipe(Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, postForkStamp))),
         })
         .pipe(Effect.runPromise);
     }
@@ -429,11 +488,18 @@ export function CustomForkingUnshieldedWallet<
       fallibleUtxos: readonly UtxoWithMeta[],
       nightVerifyingKey: ledger.SignatureVerifyingKey,
       ttl: Date,
-    ): Promise<ledger.UnprovenTransaction> {
+    ): Promise<UnprovenTx> {
       return this.runtime
-        .dispatch<ledger.UnprovenTransaction, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('rotateUtxos'),
-          [V2Tag]: (v2) => v2.rotateUtxos(guaranteedUtxos, fallibleUtxos, nightVerifyingKey, ttl),
+        .dispatch<UnprovenTx, TransactingError>({
+          [V1Tag]: (v1) =>
+            EitherOps.toEffect(PreForkSignatures.lowerSignatureVerifyingKey(nightVerifyingKey)).pipe(
+              Effect.flatMap((key) => v1.rotateUtxos(guaranteedUtxos, fallibleUtxos, key, ttl)),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, preForkStamp)),
+            ),
+          [V2Tag]: (v2) =>
+            v2
+              .rotateUtxos(guaranteedUtxos, fallibleUtxos, nightVerifyingKey, ttl)
+              .pipe(Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, postForkStamp))),
         })
         .pipe(Effect.runPromise);
     }
@@ -442,32 +508,51 @@ export function CustomForkingUnshieldedWallet<
       desiredInputs: Record<ledger.RawTokenType, bigint>,
       desiredOutputs: readonly TokenTransfer[],
       ttl: Date,
-    ): Promise<ledger.UnprovenTransaction> {
+    ): Promise<UnprovenTx> {
       return this.runtime
-        .dispatch<ledger.UnprovenTransaction, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('initSwap'),
-          [V2Tag]: (v2) => v2.initSwap(desiredInputs, desiredOutputs, ttl),
+        .dispatch<UnprovenTx, TransactingError>({
+          [V1Tag]: (v1) =>
+            v1
+              .initSwap(desiredInputs, desiredOutputs, ttl)
+              .pipe(Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, preForkStamp))),
+          [V2Tag]: (v2) =>
+            v2
+              .initSwap(desiredInputs, desiredOutputs, ttl)
+              .pipe(Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, postForkStamp))),
         })
         .pipe(Effect.runPromise);
     }
 
-    signUnprovenTransaction(
-      transaction: ledger.UnprovenTransaction,
-      signSegment: SignSegment,
-    ): Promise<ledger.UnprovenTransaction> {
+    signUnprovenTransaction(transaction: AnyTx, signSegment: SignSegment): Promise<UnprovenTx> {
       return this.runtime
-        .dispatch<ledger.UnprovenTransaction, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('signUnprovenTransaction'),
-          [V2Tag]: (v2) => v2.signUnprovenTransaction(transaction, signSegment),
+        .dispatch<UnprovenTx, TransactingError>({
+          [V1Tag]: (v1) =>
+            preForkTx<v8.UnprovenTransaction>(transaction).pipe(
+              Effect.flatMap((unwrapped) => v1.signUnprovenTransaction(unwrapped, loweredSigner(signSegment))),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, preForkStamp)),
+            ),
+          [V2Tag]: (v2) =>
+            postForkTx<ledger.UnprovenTransaction>(transaction).pipe(
+              Effect.flatMap((unwrapped) => v2.signUnprovenTransaction(unwrapped, signSegment)),
+              Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, postForkStamp)),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    signUnboundTransaction(transaction: UnboundTransaction, signSegment: SignSegment): Promise<UnboundTransaction> {
+    signUnboundTransaction(transaction: AnyTx, signSegment: SignSegment): Promise<UnboundTx> {
       return this.runtime
-        .dispatch<UnboundTransaction, TransactingError>({
-          [V1Tag]: () => preForkTransactingUnsupported('signUnboundTransaction'),
-          [V2Tag]: (v2) => v2.signUnboundTransaction(transaction, signSegment),
+        .dispatch<UnboundTx, TransactingError>({
+          [V1Tag]: (v1) =>
+            preForkTx<PreForkUnboundTransaction>(transaction).pipe(
+              Effect.flatMap((unwrapped) => v1.signUnboundTransaction(unwrapped, loweredSigner(signSegment))),
+              Effect.map((tx) => WalletTransaction.adopt('Unbound', tx, preForkStamp)),
+            ),
+          [V2Tag]: (v2) =>
+            postForkTx<UnboundTransaction>(transaction).pipe(
+              Effect.flatMap((unwrapped) => v2.signUnboundTransaction(unwrapped, signSegment)),
+              Effect.map((tx) => WalletTransaction.adopt('Unbound', tx, postForkStamp)),
+            ),
         })
         .pipe(Effect.runPromise);
     }
@@ -476,21 +561,30 @@ export function CustomForkingUnshieldedWallet<
      * Un-books the UTxOs a transaction of this wallet's had reserved, returning them to the available set.
      *
      * @remarks
-     *   Nothing to do on the pre-fork variant, and that is a fact about the wallet rather than a convenience: while
-     *   pre-fork transacting is unavailable that variant cannot have built the transaction being reverted, so it has
-     *   booked nothing of it to release. The parameter's type says the same thing. Unlike the operations that build
-     *   transactions, this needs no proving, so there is nothing here for version-routed proving to unlock later — and
-     *   the facade reverts all three wallets together when a submission fails, so a refusal here would strand that
-     *   whole path.
+     *   A transaction built on the other side of the boundary cannot have booked any of this variant's UTxOs, so there is
+     *   nothing to release and this resolves having done nothing. That is the one place a version mismatch is not an
+     *   error: the facade reverts all three wallets together when a submission fails, and a refusal here would strand
+     *   that whole path over a transaction this wallet was never holding anything for.
      * @param transaction The transaction to un-book.
      */
-    revertTransaction(
-      transaction: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>,
-    ): Promise<void> {
+    revertTransaction(transaction: AnyTx): Promise<void> {
       return this.runtime
         .dispatch<void, WalletError>({
-          [V1Tag]: () => Effect.void,
-          [V2Tag]: (v2) => v2.revertTransaction(transaction),
+          [V1Tag]: (v1) =>
+            Either.match(
+              WalletTransaction.unwrapWithin<v8.Transaction<v8.SignatureEnabled, v8.Proofish, v8.Bindingish>>(
+                transaction,
+                preForkEpoch,
+              ),
+              { onLeft: () => Effect.void, onRight: (unwrapped) => v1.revertTransaction(unwrapped) },
+            ),
+          [V2Tag]: (v2) =>
+            Either.match(
+              WalletTransaction.unwrapWithin<
+                ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>
+              >(transaction, postForkEpoch),
+              { onLeft: () => Effect.void, onRight: (unwrapped) => v2.revertTransaction(unwrapped) },
+            ),
         })
         .pipe(Effect.runPromise);
     }
@@ -533,9 +627,8 @@ export type UnshieldedWalletClass = ForkingUnshieldedWalletClass<
  *   in the same storage, and both are built from the same application configuration, because what they ask for is
  *   identical — unshielded sync carries no ledger object in either direction, only public UTXO records as JSON.
  *
- *   **Transacting is available only once the wallet is on the post-fork variant** — see
- *   {@link PreForkUnshieldedTransactingUnsupportedError}, a temporary seam that closes with version-routed proving.
- *   Synchronization, balances, coins, addresses, serialization, restore and reverting work on both sides.
+ *   Transacting, synchronization, balances, coins, addresses, serialization, restore and reverting all work on both
+ *   sides: each variant builds with its own ledger version, and what it produces says which version built it.
  * @param configuration What the wallet and both its variants are built from, including where the boundary lies.
  * @returns The wallet class.
  */

--- a/packages/unshielded-wallet/src/UnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/UnshieldedWallet.ts
@@ -10,7 +10,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { type NetworkId, type ProtocolState, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  type AnyTx,
+  type NetworkId,
+  type ProtocolState,
+  ProtocolVersion,
+  type ProtocolVersionMismatchError,
+  type UnboundTx,
+  type UnprovenTx,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
+import { EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
 import {
   type BaseV2Configuration,
   type DefaultV2Configuration,
@@ -28,12 +38,7 @@ import { type UnshieldedHistoryStorage } from './v2/TransactionHistory.js';
 import { type IndexerClientConnection } from './v2/Sync.js';
 import { type CoinsAndBalancesCapability } from './v2/CoinsAndBalances.js';
 import { type KeysCapability } from './v2/Keys.js';
-import {
-  type TokenTransfer,
-  type FinalizedTransactionBalanceResult,
-  type UnboundTransactionBalanceResult,
-  type UnprovenTransactionBalanceResult,
-} from './v2/Transacting.js';
+import { type TokenTransfer } from './v2/Transacting.js';
 import { type WalletSyncUpdate } from './v2/SyncSchema.js';
 import { type RunningV2Variant } from './v2/RunningV2Variant.js';
 import { type SignSegment } from './v2/Signing.js';
@@ -189,13 +194,13 @@ export type UnshieldedWalletAPI<TSerialized = string> = {
 
   start(): Promise<void>;
 
-  balanceFinalizedTransaction(tx: ledger.FinalizedTransaction): Promise<FinalizedTransactionBalanceResult>;
+  balanceFinalizedTransaction(tx: AnyTx): Promise<UnprovenTx | undefined>;
 
-  balanceUnboundTransaction(tx: UnboundTransaction): Promise<UnboundTransactionBalanceResult>;
+  balanceUnboundTransaction(tx: AnyTx): Promise<UnboundTx | undefined>;
 
-  balanceUnprovenTransaction(tx: ledger.UnprovenTransaction): Promise<UnprovenTransactionBalanceResult>;
+  balanceUnprovenTransaction(tx: AnyTx): Promise<UnprovenTx | undefined>;
 
-  transferTransaction(outputs: readonly TokenTransfer[], ttl: Date): Promise<ledger.UnprovenTransaction>;
+  transferTransaction(outputs: readonly TokenTransfer[], ttl: Date): Promise<UnprovenTx>;
 
   /**
    * Books a caller-supplied set of Night UTxOs and returns an unproven transaction that moves them back to the same
@@ -208,28 +213,23 @@ export type UnshieldedWalletAPI<TSerialized = string> = {
     fallibleUtxos: readonly UtxoWithMeta[],
     nightVerifyingKey: ledger.SignatureVerifyingKey,
     ttl: Date,
-  ): Promise<ledger.UnprovenTransaction>;
+  ): Promise<UnprovenTx>;
 
   initSwap(
     desiredInputs: Record<ledger.RawTokenType, bigint>,
     desiredOutputs: readonly TokenTransfer[],
     ttl: Date,
-  ): Promise<ledger.UnprovenTransaction>;
+  ): Promise<UnprovenTx>;
 
-  signUnprovenTransaction(
-    transaction: ledger.UnprovenTransaction,
-    signSegment: SignSegment,
-  ): Promise<ledger.UnprovenTransaction>;
+  signUnprovenTransaction(transaction: AnyTx, signSegment: SignSegment): Promise<UnprovenTx>;
 
-  signUnboundTransaction(transaction: UnboundTransaction, signSegment: SignSegment): Promise<UnboundTransaction>;
+  signUnboundTransaction(transaction: AnyTx, signSegment: SignSegment): Promise<UnboundTx>;
 
   serializeState(): Promise<TSerialized>;
 
   waitForSyncedState(allowedGap?: bigint): Promise<UnshieldedWalletState<TSerialized>>;
 
-  revertTransaction(
-    transaction: ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>,
-  ): Promise<void>;
+  revertTransaction(transaction: AnyTx): Promise<void>;
 
   getAddress(): Promise<UnshieldedAddress>;
 
@@ -273,6 +273,26 @@ export function CustomUnshieldedWallet<
     [Variant.VersionedVariant<V2Variant<TSerialized, TSyncUpdate>>],
     TConfig
   >;
+
+  /** The whole of the protocol timeline: one variant answers for every version this wallet will ever see. */
+  const wholeTimeline = ProtocolVersion.epochOf(
+    ProtocolVersion.MinSupportedVersion,
+    ProtocolVersion.MinSupportedVersion,
+  );
+
+  /** Reads a transaction a caller handed in, which a single-variant wallet accepts at any version. */
+  const carried = <T>(handle: AnyTx): Effect.Effect<T, ProtocolVersionMismatchError> =>
+    EitherOps.toEffect(WalletTransaction.unwrapWithin<T>(handle, wholeTimeline));
+
+  /** Seals a transaction this wallet built, at the version its one variant answers from. */
+  const seal = (transaction: ledger.UnprovenTransaction): UnprovenTx =>
+    WalletTransaction.adopt('Unproven', transaction, ProtocolVersion.MinSupportedVersion);
+
+  const sealUnproven = (result: ledger.UnprovenTransaction | undefined): UnprovenTx | undefined =>
+    result === undefined ? undefined : seal(result);
+
+  const sealUnbound = (result: UnboundTransaction | undefined): UnboundTx | undefined =>
+    result === undefined ? undefined : WalletTransaction.adopt('Unbound', result, ProtocolVersion.MinSupportedVersion);
 
   return class CustomUnshieldedWalletImplementation
     extends BaseWallet
@@ -359,34 +379,46 @@ export function CustomUnshieldedWallet<
       await super.stop();
     }
 
-    balanceFinalizedTransaction(tx: ledger.FinalizedTransaction): Promise<FinalizedTransactionBalanceResult> {
+    balanceFinalizedTransaction(tx: AnyTx): Promise<UnprovenTx | undefined> {
       return this.runtime
         .dispatch({
-          [V2Tag]: (v2) => v2.balanceFinalizedTransaction(tx),
+          [V2Tag]: (v2) =>
+            carried<ledger.FinalizedTransaction>(tx).pipe(
+              Effect.flatMap((unwrapped) => v2.balanceFinalizedTransaction(unwrapped)),
+              Effect.map(sealUnproven),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    balanceUnboundTransaction(tx: UnboundTransaction): Promise<UnboundTransactionBalanceResult> {
+    balanceUnboundTransaction(tx: AnyTx): Promise<UnboundTx | undefined> {
       return this.runtime
         .dispatch({
-          [V2Tag]: (v2) => v2.balanceUnboundTransaction(tx),
+          [V2Tag]: (v2) =>
+            carried<UnboundTransaction>(tx).pipe(
+              Effect.flatMap((unwrapped) => v2.balanceUnboundTransaction(unwrapped)),
+              Effect.map(sealUnbound),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    balanceUnprovenTransaction(tx: ledger.UnprovenTransaction): Promise<UnprovenTransactionBalanceResult> {
+    balanceUnprovenTransaction(tx: AnyTx): Promise<UnprovenTx | undefined> {
       return this.runtime
         .dispatch({
-          [V2Tag]: (v2) => v2.balanceUnprovenTransaction(tx),
+          [V2Tag]: (v2) =>
+            carried<ledger.UnprovenTransaction>(tx).pipe(
+              Effect.flatMap((unwrapped) => v2.balanceUnprovenTransaction(unwrapped)),
+              Effect.map(sealUnproven),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    transferTransaction(outputs: readonly TokenTransfer[], ttl: Date): Promise<ledger.UnprovenTransaction> {
+    transferTransaction(outputs: readonly TokenTransfer[], ttl: Date): Promise<UnprovenTx> {
       return this.runtime
         .dispatch({
-          [V2Tag]: (v2) => v2.transferTransaction(outputs, ttl),
+          [V2Tag]: (v2) => v2.transferTransaction(outputs, ttl).pipe(Effect.map(seal)),
         })
         .pipe(Effect.runPromise);
     }
@@ -396,10 +428,11 @@ export function CustomUnshieldedWallet<
       fallibleUtxos: readonly UtxoWithMeta[],
       nightVerifyingKey: ledger.SignatureVerifyingKey,
       ttl: Date,
-    ): Promise<ledger.UnprovenTransaction> {
+    ): Promise<UnprovenTx> {
       return this.runtime
         .dispatch({
-          [V2Tag]: (v2) => v2.rotateUtxos(guaranteedUtxos, fallibleUtxos, nightVerifyingKey, ttl),
+          [V2Tag]: (v2) =>
+            v2.rotateUtxos(guaranteedUtxos, fallibleUtxos, nightVerifyingKey, ttl).pipe(Effect.map(seal)),
         })
         .pipe(Effect.runPromise);
     }
@@ -408,37 +441,46 @@ export function CustomUnshieldedWallet<
       desiredInputs: Record<ledger.RawTokenType, bigint>,
       desiredOutputs: readonly TokenTransfer[],
       ttl: Date,
-    ): Promise<ledger.UnprovenTransaction> {
+    ): Promise<UnprovenTx> {
       return this.runtime
-        .dispatch({ [V2Tag]: (v2) => v2.initSwap(desiredInputs, desiredOutputs, ttl) })
+        .dispatch({ [V2Tag]: (v2) => v2.initSwap(desiredInputs, desiredOutputs, ttl).pipe(Effect.map(seal)) })
         .pipe(Effect.runPromise);
     }
 
-    signUnprovenTransaction(
-      transaction: ledger.UnprovenTransaction,
-      signSegment: SignSegment,
-    ): Promise<ledger.UnprovenTransaction> {
+    signUnprovenTransaction(transaction: AnyTx, signSegment: SignSegment): Promise<UnprovenTx> {
       return this.runtime
         .dispatch({
-          [V2Tag]: (v2) => v2.signUnprovenTransaction(transaction, signSegment),
+          [V2Tag]: (v2) =>
+            carried<ledger.UnprovenTransaction>(transaction).pipe(
+              Effect.flatMap((unwrapped) => v2.signUnprovenTransaction(unwrapped, signSegment)),
+              Effect.map(seal),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    signUnboundTransaction(transaction: UnboundTransaction, signSegment: SignSegment): Promise<UnboundTransaction> {
+    signUnboundTransaction(transaction: AnyTx, signSegment: SignSegment): Promise<UnboundTx> {
       return this.runtime
         .dispatch({
-          [V2Tag]: (v2) => v2.signUnboundTransaction(transaction, signSegment),
+          [V2Tag]: (v2) =>
+            carried<UnboundTransaction>(transaction).pipe(
+              Effect.flatMap((unwrapped) => v2.signUnboundTransaction(unwrapped, signSegment)),
+              Effect.map((tx) => WalletTransaction.adopt('Unbound', tx, ProtocolVersion.MinSupportedVersion)),
+            ),
         })
         .pipe(Effect.runPromise);
     }
 
-    revertTransaction(
-      transaction: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>,
-    ): Promise<void> {
+    revertTransaction(transaction: AnyTx): Promise<void> {
       return this.runtime
         .dispatch({
-          [V2Tag]: (v2) => v2.revertTransaction(transaction),
+          [V2Tag]: (v2) =>
+            Either.match(
+              WalletTransaction.unwrapWithin<
+                ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>
+              >(transaction, wholeTimeline),
+              { onLeft: () => Effect.void, onRight: (unwrapped) => v2.revertTransaction(unwrapped) },
+            ),
         })
         .pipe(Effect.runPromise);
     }

--- a/packages/unshielded-wallet/src/test/forkStart.test.ts
+++ b/packages/unshielded-wallet/src/test/forkStart.test.ts
@@ -33,16 +33,23 @@
  *   version a chain reports is a property of the chain, and the real fork's value is not final.
  */
 
+import * as v8 from '@midnight-ntwrk/ledger-v8';
 import * as v9 from '@midnightntwrk/ledger-v9';
-import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Cause, Effect, Fiber, Option, Runtime, type Scope } from 'effect';
+import {
+  type AnyTx,
+  NetworkId,
+  ProtocolVersion,
+  ProtocolVersionMismatchError,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
+import { Cause, Effect, Either, Fiber, Option, Runtime, type Scope } from 'effect';
 import { describe, expect, it } from 'vitest';
-import { PreForkUnshieldedTransactingUnsupportedError } from '../ForkingUnshieldedWallet.js';
 import { peekProtocolVersion } from '../Restore.js';
 import { V1Tag } from '../v1/RunningV1Variant.js';
 import { type SignSegment } from '../v2/Signing.js';
-import { type UnboundTransaction } from '../v2/TransactionOps.js';
 import { V2Tag } from '../v2/RunningV2Variant.js';
+import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { type UtxoWithMeta } from '../v2/UnshieldedState.js';
 import { type CarriedUtxo, type ForkWallet, makeForkWallet, utxosOf } from './forkHarness.js';
 import { ecdsaIdentity, postForkIdentity, preForkIdentity, timelineTransaction } from './forkTimeline.js';
 
@@ -105,24 +112,51 @@ const failureOf = (call: Promise<unknown>): Effect.Effect<Option.Option<unknown>
     ),
   );
 
-/** A transaction of the post-fork ledger version, which is the only kind this wallet's API accepts. */
-const someTransaction = (): v9.UnprovenTransaction => v9.Transaction.fromParts(networkId);
+/** A transaction of the pre-fork ledger version, sealed as an application would seal one it built for itself. */
+const someTransaction = (): AnyTx =>
+  WalletTransaction.adopt('Unproven', v8.Transaction.fromParts(networkId), ProtocolVersion.MinSupportedVersion);
 
 /** The same transaction, proven and bound. */
-const someFinalizedTransaction = (): v9.FinalizedTransaction => someTransaction().mockProve();
+const someFinalizedTransaction = (): AnyTx =>
+  WalletTransaction.adopt(
+    'Finalized',
+    v8.Transaction.fromParts(networkId).mockProve(),
+    ProtocolVersion.MinSupportedVersion,
+  );
 
 /**
  * The same transaction at the unbound stage.
  *
  * @remarks
- *   Only a prover produces one — `mockProve` binds as it proves — and a unit-tier proof has no prover.
+ *   Only a prover produces one — `mockProve` binds as it proves — and a unit-tier proof has no prover. The handle seals
+ *   the stage as data, so what a caller declares here is what the wallet routes on.
  */
-// Type cast required because: the unbound stage is reachable only through a real proving provider, which this tier
-// deliberately does not have, and `Binding`/`PreBinding` are nominal. The gated branch refuses before touching the
-// argument, so what is load-bearing here is the static type of the parameter and never the value.
-const someUnboundTransaction = (): UnboundTransaction => someTransaction() as unknown as UnboundTransaction;
+const someUnboundTransaction = (): AnyTx =>
+  WalletTransaction.adopt('Unbound', v8.Transaction.fromParts(networkId), ProtocolVersion.MinSupportedVersion);
+
+/** A transaction of the post-fork ledger version, sealed at the version the post-fork variant answers for. */
+const postForkTransaction = (): AnyTx =>
+  WalletTransaction.adopt('Unproven', v9.Transaction.fromParts(networkId), forkVersion);
 
 const signSegment: SignSegment = (data) => Promise.resolve(v9.signData(v9.sampleSigningKey(), data));
+
+/** One of the UTxOs the wallet has actually synchronized, in the shape its own API takes. */
+const heldUtxo = (wallet: ForkWallet): Effect.Effect<UtxoWithMeta, WalletRuntimeError> =>
+  wallet.currentState.pipe(
+    Effect.map((state) => {
+      const [held] = utxosOf(state.state);
+      return {
+        utxo: {
+          value: held.value,
+          owner: held.owner,
+          type: held.type,
+          intentHash: held.intentHash,
+          outputNo: held.outputNo,
+        },
+        meta: { ctime: new Date(held.ctime), registeredForDustGeneration: false },
+      };
+    }),
+  );
 
 /**
  * Every call that builds, balances or signs a transaction, named as the wallet names it.
@@ -130,7 +164,7 @@ const signSegment: SignSegment = (data) => Promise.resolve(v9.signData(v9.sample
  * @remarks
  *   `revertTransaction` is deliberately not among them — see the test below for what it does instead.
  */
-const gatedCalls = (wallet: ForkWallet): readonly (readonly [string, () => Promise<unknown>])[] => {
+const transactionBuildingCalls = (wallet: ForkWallet): readonly (readonly [string, () => Promise<unknown>])[] => {
   const ttl = new Date(Date.now() + 3_600_000);
   const verifyingKey = v9.signatureVerifyingKey(v9.sampleSigningKey());
   return [
@@ -138,7 +172,15 @@ const gatedCalls = (wallet: ForkWallet): readonly (readonly [string, () => Promi
     ['balanceUnboundTransaction', () => wallet.unshielded.balanceUnboundTransaction(someUnboundTransaction())],
     ['balanceUnprovenTransaction', () => wallet.unshielded.balanceUnprovenTransaction(someTransaction())],
     ['transferTransaction', () => wallet.unshielded.transferTransaction([], ttl)],
-    ['rotateUtxos', () => wallet.unshielded.rotateUtxos([], [], verifyingKey, ttl)],
+    [
+      'rotateUtxos',
+      // Rotation moves UTxOs the wallet holds, so it is given one of its own — the point is that the pre-fork variant
+      // can do it, not that it can be asked to do nothing.
+      async () => {
+        const held = await Effect.runPromise(heldUtxo(wallet));
+        return wallet.unshielded.rotateUtxos([held], [], verifyingKey, ttl);
+      },
+    ],
     ['initSwap', () => wallet.unshielded.initSwap({}, [], ttl)],
     ['signUnprovenTransaction', () => wallet.unshielded.signUnprovenTransaction(someTransaction(), signSegment)],
     ['signUnboundTransaction', () => wallet.unshielded.signUnboundTransaction(someUnboundTransaction(), signSegment)],
@@ -207,33 +249,116 @@ describe('an unshielded wallet starting on a chain that has not forked', () => {
     'balanceUnboundTransaction',
     'balanceUnprovenTransaction',
     'transferTransaction',
-    'rotateUtxos',
     'initSwap',
     'signUnprovenTransaction',
     'signUnboundTransaction',
-  ])('refuses %s while it is still pre-fork, and says why', async (operation) =>
+  ])('answers %s while it is still pre-fork, with the ledger version the chain is on', async (operation) =>
     Effect.gen(function* () {
       const wallet = yield* syncedPreForkWallet;
 
-      const call = gatedCalls(wallet).find(([name]) => name === operation)!;
-      const failure = Option.getOrThrow(yield* failureOf(call[1]()));
+      const call = transactionBuildingCalls(wallet).find(([name]) => name === operation)!;
+      const answer = yield* Effect.promise(call[1]);
 
-      // Typed, and naming the operation: the pre-fork branch cannot hold a transaction of the post-fork ledger
-      // version, let alone produce one anybody can prove, and says so instead of producing one nobody can.
-      expect(failure).toBeInstanceOf(PreForkUnshieldedTransactingUnsupportedError);
-      expect(failure).toMatchObject({ operation });
+      // It answered rather than refusing, and whatever it produced is stamped with the ledger version the chain is
+      // actually on. The balancing calls may legitimately produce nothing — a transaction needing no Night of this
+      // wallet's needs no unshielded balancing.
+      if (answer !== undefined) {
+        expect(WalletTransaction.is(answer)).toBe(true);
+        expect((answer as AnyTx).protocolVersion).toBeLessThan(forkVersion);
+      }
+      expect(yield* wallet.activeTag).toBe(V1Tag);
     }).pipe(Effect.scoped, Effect.runPromise),
   );
 
-  it('reverts a transaction it cannot have made, by doing nothing to its state', async () =>
+  it('builds with the pre-fork ledger version itself, not merely with something', async () =>
     Effect.gen(function* () {
-      // Reverting releases UTXOs a transaction booked, and no transaction of this wallet's can have booked any: it
-      // could not have built one. So this resolves, changes nothing, and is deliberately not part of the seam above —
-      // it needs no proving. The facade reverts all three wallets together when a submission fails, and a refusal here
-      // would strand that whole path.
+      // The refusal this replaced could be satisfied by any wallet at all; this cannot. What comes back is an object
+      // of the previous ledger version's own `Transaction` class — the thing the post-fork variant provably cannot
+      // produce, and the whole reason the handle exists.
       const wallet = yield* syncedPreForkWallet;
 
-      yield* Effect.promise(() => wallet.unshielded.revertTransaction(someFinalizedTransaction()));
+      const built = yield* Effect.promise(() =>
+        wallet.unshielded.transferTransaction([], new Date(Date.now() + 3_600_000)),
+      );
+
+      const carried = Either.getOrThrow(
+        WalletTransaction.unwrapWithin<v8.UnprovenTransaction>(
+          built,
+          ProtocolVersion.epochOf(ProtocolVersion.MinSupportedVersion, forkVersion),
+        ),
+      );
+      expect(carried).toBeInstanceOf(v8.Transaction);
+      expect(carried).not.toBeInstanceOf(v9.Transaction);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('rotates UTxOs on the pre-fork variant, which is what raises when the UTxO is not one a ledger can read', async () =>
+    Effect.gen(function* () {
+      // The UTxOs this harness's timeline carries are plain sync fixtures rather than ledger-real ones, so a rotation
+      // cannot be completed here. What is asserted instead is the thing the refusal it replaced hid: the call reaches
+      // the pre-fork variant's own transacting and is answered by the pre-fork *ledger*, rather than turned away at
+      // the wallet layer.
+      const wallet = yield* syncedPreForkWallet;
+      const held = yield* heldUtxo(wallet);
+
+      // Raised by the ledger rather than reported through the typed failure channel, which is itself the point: it is
+      // the pre-fork ledger's own complaint about the bytes, from inside the pre-fork variant.
+      const rejection = yield* Effect.promise(() =>
+        wallet.unshielded
+          .rotateUtxos([held], [], v9.signatureVerifyingKey(v9.sampleSigningKey()), new Date(Date.now() + 3_600_000))
+          .then(
+            () => undefined,
+            (error: unknown) => error,
+          ),
+      );
+
+      expect(rejection).not.toBeInstanceOf(ProtocolVersionMismatchError);
+      expect(String(rejection)).toContain('Invalid character');
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('refuses a transaction built on the other side of the boundary, naming both versions', async () =>
+    Effect.gen(function* () {
+      const wallet = yield* syncedPreForkWallet;
+
+      const failure = Option.getOrThrow(
+        yield* failureOf(wallet.unshielded.balanceUnprovenTransaction(postForkTransaction())),
+      );
+
+      expect(failure).toBeInstanceOf(ProtocolVersionMismatchError);
+      expect(failure).toMatchObject({ authoredFor: forkVersion });
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('refuses a signer that answers with a scheme the pre-fork ledger version does not have', async () =>
+    Effect.gen(function* () {
+      // The one scalar that genuinely changed shape at the fork. The SDK's signing callback speaks the current ledger
+      // version's signature, and an ecdsa one has no pre-fork encoding at all.
+      const wallet = yield* syncedPreForkWallet;
+      const ecdsaSigner: SignSegment = () => Promise.resolve({ tag: 'ecdsa', value: '00'.repeat(64) });
+      // A transaction with a segment to sign: an empty one asks the signer nothing, and the point here is what the
+      // signer answers with.
+      const toSign = WalletTransaction.adopt(
+        'Unproven',
+        v8.Transaction.fromParts(networkId, undefined, undefined, v8.Intent.new(new Date(Date.now() + 3_600_000))),
+        ProtocolVersion.MinSupportedVersion,
+      );
+
+      const failure = Option.getOrThrow(
+        yield* failureOf(wallet.unshielded.signUnprovenTransaction(toSign, ecdsaSigner)),
+      );
+
+      // The signing service reports a signer that raised as a `SignError`, carrying what it raised: the typed refusal
+      // naming the scheme the pre-fork ledger version does not have.
+      expect(failure).toMatchObject({ cause: { kind: 'ecdsa' } });
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('reverts a transaction of the other epoch by doing nothing to its state', async () =>
+    Effect.gen(function* () {
+      // Reverting releases UTXOs a transaction booked, and a transaction of the other ledger version cannot have
+      // booked any of this variant's. So this resolves, changes nothing, and is deliberately not a version mismatch:
+      // the facade reverts all three wallets together when a submission fails, and a refusal here would strand that
+      // whole path.
+      const wallet = yield* syncedPreForkWallet;
+
+      yield* Effect.promise(() => wallet.unshielded.revertTransaction(postForkTransaction()));
 
       const after = yield* wallet.currentState;
       expect(valuesOf(utxosOf(after.state))).toEqual([100n, 200n]);

--- a/packages/wallet-sdk-testkit/src/scenarios/dust.ts
+++ b/packages/wallet-sdk-testkit/src/scenarios/dust.ts
@@ -140,10 +140,6 @@ export function registerDustHealthchecks({ getEnv, seed, syncCacheDir, timeout =
         const balancedTransactionRecipe = await wallet.wallet.balanceUnprovenTransaction(
           dustDeregistrationRecipe.transaction,
           {
-            shieldedSecretKeys: wallet.shieldedSecretKeys,
-            dustSecretKey: wallet.dustSecretKey,
-          },
-          {
             ttl: new Date(Date.now() + 30 * 60 * 1000),
           },
         );

--- a/packages/wallet-sdk-testkit/src/scenarios/token-transfer.ts
+++ b/packages/wallet-sdk-testkit/src/scenarios/token-transfer.ts
@@ -16,10 +16,11 @@
 // token-transfer tests (self-transaction, swap, error cases, dev TODOs) stay in the upstream
 // e2e-tests suite; they share the two-wallet setup via the exported `useTokenTransferWallets`.
 import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { Either } from 'effect';
 import { firstValueFrom } from 'rxjs';
 import { inspect } from 'node:util';
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type NetworkId, ProtocolVersion, WalletTransaction } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type CombinedTokenTransfer } from '@midnightntwrk/wallet-sdk-facade';
 import { type WalletTestEnvironment } from '../types.js';
 import { provideWallet, saveState, type WalletInit } from '../wallet.js';
@@ -210,16 +211,9 @@ export function registerTokenTransferHealthchecks(deps: TokenTransferScenarioDep
           },
         ];
 
-        const txRecipe = await sender.wallet.transferTransaction(
-          outputsToCreate,
-          {
-            shieldedSecretKeys: sender.shieldedSecretKeys,
-            dustSecretKey: sender.dustSecretKey,
-          },
-          {
-            ttl: new Date(Date.now() + 30 * 60 * 1000),
-          },
-        );
+        const txRecipe = await sender.wallet.transferTransaction(outputsToCreate, {
+          ttl: new Date(Date.now() + 30 * 60 * 1000),
+        });
         logger.info('Signing tx...');
         logger.info(txRecipe);
         const signedTxRecipe = await sender.wallet.signRecipe(txRecipe, sender.unshieldedKeystore.signDataAsync);
@@ -227,9 +221,20 @@ export function registerTokenTransferHealthchecks(deps: TokenTransferScenarioDep
         logger.info(signedTxRecipe);
         const finalizedTx = await sender.wallet.finalizeRecipe(signedTxRecipe);
         logger.info('Submitting transaction...');
-        logger.info(finalizedTx.toString());
+        logger.info(inspect(finalizedTx));
         const txId = await sender.wallet.submitTransaction(finalizedTx);
-        const txHash = finalizedTx.transactionHash();
+        // The transaction's own hash, read through the handle at exactly the version it says it was built at — a
+        // one-wide range, which is how a caller asks for the transaction it is holding and no other.
+        const carried = Either.getOrThrow(
+          WalletTransaction.unwrapWithin<ledger.FinalizedTransaction>(
+            finalizedTx,
+            ProtocolVersion.makeRange(
+              finalizedTx.protocolVersion,
+              ProtocolVersion.ProtocolVersion(finalizedTx.protocolVersion + 1n),
+            ),
+          ),
+        );
+        const txHash = carried.transactionHash();
         logger.info('txProcessing');
         logger.info('Transaction id: ' + txId);
         logger.info('waiting for tx in history');


### PR DESCRIPTION
Tenth increment of the dual-ledger public API redesign — the seam-closure cascade. Stacked on #683. **Pre-fork transacting is now real**: all three temporary `PreFork*TransactingUnsupportedError` seams are deleted (their must-not-survive-GA promise fulfilled), and the facade carries opaque version-stamped handles end to end.

## What's here

- **The three seams are gone.** Each wallet's v1 branch builds through its own variant `Transacting` with its own derived keys; every result travels as a `WalletTransaction` handle stamped with the **epoch floor** of the variant that built it (the one value guaranteed to sit inside the epoch every routing decision keys on). The 18 refusal pins became 40 working-path pins across the three `forkStart` suites (8/16/16) — including "spends what it holds, so a pre-fork transfer is a real one" (a genuine `v8.Transaction` with real inputs), "pays a fee out of the dust it actually holds" (v8 `LedgerParameters` in the recipe's block data), cross-boundary refusals naming both versions, and ecdsa refusals.
- **`secretKeys` parameters are dropped** from transfer/balance/swap across the wallets and facade (~70 deletions swept through e2e/docs-snippets/testkit; two now-unrepresentable "wrong secret key" tests removed). The wallets' retained `StartMaterial` was already the source of truth.
- **The facade speaks handles**: `UnprovenTx`/`UnboundTx`/`FinalizedTx`/`AnyTx` across every transaction signature (full table in the PR description's first commit). Internally there is ONE unwrap point — `accept<T>()` within the current epoch — and the facade's own merge/bind/identifiers go through four minimal structural types both ledgers satisfy, so per-version dispatch exists at exactly one place (throwaway-signature authoring for registration estimates). `finalizeTransaction` takes a handle; the stamp is authoritative; the observed-version fallback is deleted.
- **Enforcement (user decision 4)**: at every facade entry point (submit, finalize, merges, dust-registration signing) a handle from the other side of the boundary is refused with `ProtocolVersionMismatchError`. Two deliberate exceptions, documented: `validateTransaction` routes on the transaction's OWN stamp (well-formedness is the producing ledger's question — a later fork cannot change the answer), and `revertTransaction` treats a mismatch as "nothing of mine to release" (the facade reverts all three wallets together on failed submission).
- **Validation is fully wired** (closing #683's stop-and-report): the default codec registry splits at `forkVersion` (v8 below, v9 from it), block data is decoded at the block's REPORTED version, and the genuine v8 validator is registered below the boundary. Pinned: a pre-fork transaction validates through real v8 `wellFormed`; cross-epoch offers refuse.
- **The pending registry carries a genuine ledger-v8 trait** below the boundary — each per-ledger trait lifted onto handles (`overHandles`), unwrapping at its epoch, adopting on deserialize, disowning the other epoch's handles. The plan's "pending v8 txs are silently orphaned today" is now false. `FacadeState.pending` kept its shape (only the transaction type changed) — the dust-sponsorship snippet needed zero adaptation.
- **A minimal internal signature adapter** (`capabilities/signatures`: lower/lift between v8 bare-hex and v9 `{tag, value}`, typed `UnsupportedSignatureKindError`) — in scope by necessity (dust registration and the unshielded signer carry these shapes); this is NOT the Flow-7 public `Signature` change, which stays in the next increment.

## Findings for reviewers

- **v8 and v9 `LedgerParameters` are mutually assignable** (structurally identical), so `AnyLedgerParameters` is a statement of intent and the codec routing has to be *right* rather than merely well-typed — hence the decode-at-reported-version pins. The `Transaction` types are nominally distinct, so those unions are real.
- Pre-fork **proving** remains typed-unavailable without a registered pre-fork proving server (external ask: proof-server-8) — building, balancing, validating, and fee calculation all work; three facade unit suites inject a pre-fork mock prover for exactly this reason.
- Simulator-backed facade tests now use `forkVersion: MinSupportedVersion` — a single-ledger simulator has never had two epochs, and pretending otherwise made those facades nominally pre-fork while every object was v9.
- Two harness-limit pins are stop-and-reported honestly rather than faked: dust's `attachDustRegistration` can only act on an intent the *unshielded* wallet builds, and unshielded's `rotateUtxos` cannot complete on plain sync fixtures — each pin asserts the true reachable behavior.

## Tests & gate

Red-first throughout (the pin flips written first and confirmed red against the still-gated implementation, then gate + old pin deleted together). Gate: dist 17/17, typecheck 37/37, lint 58/58, unit 54/54 tasks (shielded 182 / dust 187 / unshielded 215 / facade 46 / capabilities 182), shielded fork-simulation integration 3/3, effect-language-service 0 findings on all changed files, format + changesets green. 58 files changed; sweep resolved to 28 consumer files actually needing edits (the survey's 47 included files that turned out to import only version-stable names). Changesets: three wallet majors + facade major + capabilities minor.