### PR TITLE
feat(facade,wallets,hd)!: the ledger-free public surface — seeds, tokens, statuses, one vocabulary

### DIFF
--- a/.changeset/facade-pending-statuses.md
+++ b/.changeset/facade-pending-statuses.md
@@ -1,0 +1,24 @@
+---
+'@midnightntwrk/wallet-sdk-facade': major
+---
+
+**BREAKING:** `FacadeState.pending` is now `readonly PendingTransaction[]` with a tagged `PendingStatus`, in place of
+the pending set the services work in.
+
+Each entry carries the transaction handle, when it was submitted, the protocol version it was authored for, and one of
+four statuses: `Submitted`, `Confirmed`, `Rejected` (with the segments the chain reported), and `Orphaned` — which
+carries `authoredFor` and `chainNow`.
+
+`Orphaned` is deliberately its own arm rather than another rejection. A rejection is the chain's verdict: the node saw
+the transaction and refused it. An orphaned transaction has no verdict at all and never will, because its bytes were
+authored under a protocol version the chain has moved past and nothing can include them afterwards. The wallet has
+already unbooked the coins and recorded the rejection either way; what differs is what an application can tell a user,
+and whether resubmitting the same bytes could ever help. The distinction existed underneath already — it was only
+reachable by comparing an indexer-shaped status string against a constant the SDK did not export.
+
+The persistence story is unchanged: pending transactions remain session-scoped and are orphaned on a fork.
+
+```diff
+- rx.filter((s) => s.pending.all.length === 0)
++ rx.filter((s) => s.pending.length === 0)
+```

--- a/.changeset/facade-protocol-phase.md
+++ b/.changeset/facade-protocol-phase.md
@@ -1,0 +1,12 @@
+---
+'@midnightntwrk/wallet-sdk-facade': major
+---
+
+**BREAKING:** `FacadeState`'s constructor takes the fork version as a fifth argument.
+
+Adds `FacadeState.protocol`, additively: a tagged reading of whether the three wallets are settled on one side of the
+protocol boundary or still crossing it. Three protocol versions cannot say this on their own — a difference within one
+epoch is ordinary synchronization, not a crossing — and around a fork the three wallets disagree for a while because
+each learns of the change when its own synchronization reaches it. `Crossing` names the wallets still on the near side,
+so an application can say what it is waiting for; `from` is the version the facade stays bound to meanwhile, which is
+what `activeProtocolVersion` answers and what anything built during the window is stamped with.

--- a/.changeset/hd-wallet-seeds.md
+++ b/.changeset/hd-wallet-seeds.md
@@ -1,0 +1,18 @@
+---
+'@midnightntwrk/wallet-sdk-hd': minor
+---
+
+`WalletSeeds.fromMasterSeed(masterSeed, options?)` names the walk from one master seed down to the three per-wallet
+seeds, and wipes the BIP32 tree before it returns. Six near-identical copies of that walk existed across this
+repository, each writing out the same three derivations and each silently discarding the failure branches.
+
+`options` selects the account, the address index, and which role the unshielded seed comes from — `Roles.NightExternal`
+by default, which is the signing scheme that works on both sides of the protocol boundary, or `Roles.EcdsaUnshielded`
+for a wallet that will sign with ECDSA.
+
+It throws rather than returning a result: this sits at a boundary an application calls directly and its failures are
+programming errors, not ordinary states. `HDWallet` remains for a caller that would rather branch on a tagged result.
+
+The derivation is pinned by test against its current behaviour, not against a published specification: the
+spec-reference vectors cover the hop *after* this one and take the per-wallet seed as given, so nothing published states
+what a master seed derives to per role. What the vectors protect is that naming the walk changed nothing.

--- a/.changeset/sdk-signing-vocabulary.md
+++ b/.changeset/sdk-signing-vocabulary.md
@@ -1,0 +1,19 @@
+---
+'@midnightntwrk/wallet-sdk-abstractions': minor
+'@midnightntwrk/wallet-sdk-capabilities': minor
+'@midnightntwrk/wallet-sdk': minor
+---
+
+`Signing.Signature`, `Signing.SignatureVerifyingKey`, `Signing.SigningKey` and `Signing.SignatureKind` state the
+signature shape in a package that names no ledger version — the one scalar that genuinely changed shape at the protocol
+boundary, where the pre-fork ledger writes bare hexadecimal and the current one names the scheme alongside the bytes.
+
+They are structurally the **current** ledger version's own types, so a signer already written against `ledger.Signature`
+compiles unchanged. The SDK speaks that shape everywhere and lowers it for the pre-fork variant rather than the reverse:
+lifting is total, because the pre-fork ledger has exactly one scheme and naming it is never a guess, while lowering is
+partial and refuses a scheme that ledger has never heard of instead of handing over bytes it would misread.
+
+The pre-fork adapter is now stated in terms of these types rather than the ledger's, so there is one definition and not
+two, and `UnsupportedSignatureKindError` reaches the umbrella package's root by **promotion**, not restatement: the
+class an application catches is the class the SDK threw. Nothing here loads a ledger's WebAssembly — the adapter names
+both versions in `import type` alone.

--- a/.changeset/sdk-token-vocabulary.md
+++ b/.changeset/sdk-token-vocabulary.md
@@ -1,0 +1,24 @@
+---
+'@midnightntwrk/wallet-sdk-abstractions': minor
+'@midnightntwrk/wallet-sdk-capabilities': minor
+'@midnightntwrk/wallet-sdk-dust-wallet': minor
+'@midnightntwrk/wallet-sdk-unshielded-wallet': minor
+---
+
+The SDK now names token types for itself: `TokenType`, the `Token` constants and `parseTokenType`. An application that
+wanted the Night token type had to call `nativeToken().raw` on a ledger package — importing the thing that changes at a
+protocol boundary to read a constant that does not.
+
+`TokenType` is a plain `string` and deliberately **not** a branded type, which is a considered exception to this
+codebase's parse-don't-validate default. Balances are `Record<TokenType, bigint>` and a branded key type does not
+produce a string index signature: branding here would break every balance read in the SDK and in every application, to
+buy a guarantee the values did not need. The guarantee that is worth having is made once, at the boundary, by
+`parseTokenType`.
+
+`Token.night` is a string literal rather than a call into a ledger, because it reaches an application through the
+umbrella package's root barrel, where no ledger's WebAssembly may be loaded. A test holds the literal to **both** ledger
+versions, so it cannot drift from what either chain means.
+
+There is one constant because there is one raw type to name: both ledger versions report the same thirty-two bytes for
+the native, shielded and unshielded token, and what distinguishes them is a `tag` on the ledger's own wrapper, which a
+balance is not keyed by.

--- a/.changeset/seed-first-starts.md
+++ b/.changeset/seed-first-starts.md
@@ -1,0 +1,46 @@
+---
+'@midnightntwrk/wallet-sdk-shielded': major
+'@midnightntwrk/wallet-sdk-dust-wallet': major
+'@midnightntwrk/wallet-sdk-facade': major
+'@midnightntwrk/wallet-sdk-testkit': major
+---
+
+**Wallets are started from seeds.** A seed is the only key material that crosses a protocol boundary — every ledger
+version derives its own keys from the same seed and arrives at the same identity — so a wallet started from seeds can
+follow the chain across a fork, and one started from key objects of a single ledger version cannot.
+
+**BREAKING — deleted, with no shim:**
+
+- `ShieldedWallet(...).startWithSecretKeys(secretKeys)`
+- `DustWallet(...).startWithSecretKey(secretKey, dustParameters)`
+
+Both took key objects of one ledger version, which is precisely the wallet that cannot read half the chain. The upgrade
+is a compile error on purpose: an alias would have kept the foot-gun and hidden it.
+
+**What replaces them:**
+
+- `startWithSeed(seed)` — the primary path, unchanged in name.
+- `startWithKeys({ v8, v9 })` — the escape hatch for a caller that will not part with a seed, with **both** sides
+  required. A partial product would rebuild the very foot-gun the single-key start was. It costs the caller an import of
+  both ledger packages and the same derivation performed twice; a seed costs neither.
+
+**BREAKING — `facade.start`** takes `WalletSeeds` (or the both-epochs key product) and an options object, in place of
+two positional key objects and a trailing boolean. `facade.doSync` takes the same material.
+
+```diff
+- await facade.start(shieldedSecretKeys, dustSecretKey, true);
++ await facade.start(seeds, { manualSync: true });
+```
+
+**`DustParameters` is now optional plain data** on every start path — three scalar rates, which both ledger versions'
+classes remain structurally assignable to, so an existing `LedgerParameters.initialParameters().dust` argument still
+compiles. Omitting it is what removes the last reason a wallet start had to import a ledger.
+
+**Seed hygiene.** A seed-accepting start now derives *both* epochs' key objects eagerly and retains those; the seed
+reference is dropped with the calling frame, so from that moment the wallet holds strictly less than it did before and
+does the same work. Retained keys are still released by `stop()`, and a wallet that holds only one side says so by name
+rather than handing over keys the other ledger runtime would misread. The unshielded wallet retains no key material at
+all, as before — its identity is a public address.
+
+As everywhere in this SDK, "cleared" means the SDK stops holding a reference. Neither JavaScript nor WebAssembly offers
+a way to guarantee bytes are gone from memory, and no wallet on a general-purpose runtime can promise otherwise.

--- a/.changeset/wallets-try-restore.md
+++ b/.changeset/wallets-try-restore.md
@@ -1,0 +1,17 @@
+---
+'@midnightntwrk/wallet-sdk-shielded': minor
+'@midnightntwrk/wallet-sdk-dust-wallet': minor
+'@midnightntwrk/wallet-sdk-unshielded-wallet': minor
+---
+
+Adds `tryRestore` beside `restore` on all three wallet classes, returning `Either` rather than throwing.
+
+`restore` is unchanged and remains right for a snapshot the application has just written itself, where a failure is a
+bug. It is the wrong shape for one it has not — a snapshot a user supplied, or one written by a build of the SDK that is
+no longer the one running — where "I cannot read this" is an ordinary answer. It is also lossy: the exception `restore`
+raises carries none of the reason, which is the whole point of the additive shape.
+
+The error is named per package (`ShieldedRestoreError`, `DustRestoreError`, `UnshieldedRestoreError`) because all three
+reach an application through one barrel, and covers both failures the restore path already produces: a protocol version
+no registered variant reads, and bytes the variant that owns them cannot make sense of. `restore` is now stated as
+`tryRestore` with the reason thrown away, so the two cannot come to disagree about which snapshots are readable.

--- a/apps/test-website/src/wallet.ts
+++ b/apps/test-website/src/wallet.ts
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
-import * as ledger from '@midnightntwrk/ledger-v9';
 import {
   type DefaultConfiguration,
   DustWallet,

--- a/apps/test-website/src/wallet.ts
+++ b/apps/test-website/src/wallet.ts
@@ -19,13 +19,12 @@ import {
   InMemoryTransactionHistoryStorage,
   WalletEntrySchema,
   WalletFacade,
-  HDWallet,
-  Roles,
   ShieldedWallet,
   createKeystore,
   PublicKey,
   type UnshieldedKeystore,
   UnshieldedWallet,
+  WalletSeeds,
   mergeWalletEntries,
 } from '@midnightntwrk/wallet-sdk';
 import { type Buffer } from 'buffer';
@@ -80,41 +79,18 @@ export const init = async (
   configuration: Configuration = defaultConfiguration,
 ): Promise<{
   wallet: WalletFacade;
-  shieldedSecretKeys: ledger.ZswapSecretKeys;
-  dustSecretKey: ledger.DustSecretKey;
+  seeds: WalletSeeds;
   unshieldedKeystore: UnshieldedKeystore;
 }> => {
-  const hdWallet = HDWallet.fromSeed(seed);
-
-  if (hdWallet.type !== 'seedOk') {
-    throw new Error('Failed to initialize HDWallet');
-  }
-
-  const derivationResult = hdWallet.hdWallet
-    .selectAccount(0)
-    .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust])
-    .deriveKeysAt(0);
-
-  if (derivationResult.type !== 'keysDerived') {
-    throw new Error('Failed to derive keys');
-  }
-
-  hdWallet.hdWallet.clear();
-
-  const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(derivationResult.keys[Roles.Zswap]);
-  const dustSecretKey = ledger.DustSecretKey.fromSeed(derivationResult.keys[Roles.Dust]);
-  const unshieldedKeystore = createKeystore(
-    { kind: 'schnorr', secret: derivationResult.keys[Roles.NightExternal] },
-    configuration.networkId,
-  );
+  const seeds = WalletSeeds.fromMasterSeed(seed);
+  const unshieldedKeystore = createKeystore({ kind: 'schnorr', secret: seeds.unshielded }, configuration.networkId);
 
   const wallet: WalletFacade = await WalletFacade.init({
     configuration,
-    shielded: (config) => ShieldedWallet(config).startWithSecretKeys(shieldedSecretKeys),
+    shielded: (config) => ShieldedWallet(config).startWithSeed(seeds.shielded),
     unshielded: (config) => UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
-    dust: (config) =>
-      DustWallet(config).startWithSecretKey(dustSecretKey, ledger.LedgerParameters.initialParameters().dust),
+    dust: (config) => DustWallet(config).startWithSeed(seeds.dust),
   });
-  await wallet.start(shieldedSecretKeys, dustSecretKey);
-  return { wallet, shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
+  await wallet.start(seeds);
+  return { wallet, seeds, unshieldedKeystore };
 };

--- a/packages/abstractions/src/Signing.ts
+++ b/packages/abstractions/src/Signing.ts
@@ -1,0 +1,43 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * How the SDK writes a signature, whichever ledger version is underneath.
+ *
+ * @remarks
+ *   The one scalar that genuinely changed shape at the protocol boundary. The pre-fork ledger version has a single
+ *   signature scheme and writes a signature as bare hexadecimal; the current one has more than one and names the scheme
+ *   alongside the bytes. Everything else an application reads — token types, addresses, nullifiers, transaction
+ *   identifiers — is byte-identical across the two.
+ *
+ *   The SDK speaks the current shape everywhere and lowers it for the pre-fork variant, rather than the reverse. Lifting
+ *   is total — the pre-fork ledger has exactly one scheme, so naming it is never a guess — while lowering is partial,
+ *   and a scheme the pre-fork ledger has never heard of is refused rather than handed over as bytes it would misread.
+ *   Speaking the older shape would have made the common case lossy instead.
+ *
+ *   Stated here, in a package that names no ledger version, so an application can annotate a signer without importing
+ *   one. These are structurally the current ledger version's own types: a signer already written against them compiles
+ *   unchanged.
+ */
+
+/** The signature schemes the chain knows. Only `schnorr` exists before the protocol boundary. */
+export type SignatureKind = 'schnorr' | 'ecdsa';
+
+/** A signature: the scheme that produced it, and its bytes as hexadecimal. */
+export type Signature = Readonly<{ tag: SignatureKind; value: string }>;
+
+/** The public half of a signing key, named with the scheme it belongs to. */
+export type SignatureVerifyingKey = Readonly<{ tag: SignatureKind; value: string }>;
+
+/** A signing key, named with the scheme it belongs to. */
+export type SigningKey = Readonly<{ tag: SignatureKind; value: string }>;

--- a/packages/abstractions/src/TokenType.ts
+++ b/packages/abstractions/src/TokenType.ts
@@ -1,0 +1,94 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The names the SDK gives to token types, so an application never has to ask a ledger version for one.
+ *
+ * @remarks
+ *   A token type is thirty-two bytes, written as hexadecimal, and it is the same thirty-two bytes on either side of a
+ *   protocol boundary — which is the whole reason the SDK can name one for itself. Until now an application wanting the
+ *   Night token type had to call `nativeToken().raw` on a ledger package, which meant importing a ledger version to
+ *   read a constant that does not depend on one.
+ */
+import * as Data from 'effect/Data';
+import * as Either from 'effect/Either';
+
+/**
+ * A token type, in the raw form every balance and coin is keyed by.
+ *
+ * @remarks
+ *   Deliberately a plain `string` and **not** a branded type, which is a considered exception to this codebase's
+ *   parse-don't-validate default. Balances are `Record<TokenType, bigint>`, and a branded key type does not produce a
+ *   string index signature: branding here would break every balance read in the SDK and in every application, to buy a
+ *   guarantee that the values are not confusable with anything else a caller holds anyway. Use {@link parseTokenType} at
+ *   the boundary where a token type arrives from outside, which is where the guarantee is actually worth having.
+ */
+export type TokenType = string;
+
+/** Raised when a value offered as a token type is not one. */
+export class InvalidTokenTypeError extends Data.TaggedError(
+  '@midnightntwrk/wallet-sdk-abstractions/TokenType/InvalidTokenTypeError',
+)<{
+  readonly message: string;
+  /** What was offered, so the caller can report it alongside the field it came from. */
+  readonly value: string;
+}> {}
+
+/** Thirty-two bytes of lower-case hexadecimal: the form both ledger versions write a token type in. */
+const TOKEN_TYPE_PATTERN = /^[0-9a-f]{64}$/;
+
+/**
+ * The token types the SDK names.
+ *
+ * @remarks
+ *   String literals rather than calls into a ledger, and that is load-bearing: these constants reach an application
+ *   through the umbrella package's root barrel, which is the one place no ledger version's WebAssembly may be loaded. A
+ *   test pins each of them against both ledger versions, so the literal cannot drift away from what the chain means.
+ *
+ *   There is one constant because there is one raw type to name. Both ledger versions report the same thirty-two bytes
+ *   for the native, shielded and unshielded token; what distinguishes them is a `tag` on the ledger's own wrapper, and
+ *   a balance is keyed by the raw type alone.
+ */
+export const Token = {
+  /** Night: the token the chain is denominated in, and the resource Dust is generated from. */
+  night: '0000000000000000000000000000000000000000000000000000000000000000',
+} as const satisfies Readonly<Record<string, TokenType>>;
+
+/**
+ * Reads a token type from a value that came from outside the SDK.
+ *
+ * @remarks
+ *   The boundary check the unbranded {@link TokenType} does not make for itself: a dApp request, a URL parameter or a
+ *   configuration file can carry anything, and a token type that is quietly wrong selects no coins rather than failing.
+ *   Returns rather than throws, because "this is not a token type" is an ordinary thing for input to be.
+ * @example
+ *   ```typescript
+ *   const tokenType = parseTokenType(request.tokenType).pipe(
+ *     Either.getOrElse(() => Token.night),
+ *   );
+ *   ```;
+ *
+ * @param value The value offered as a token type.
+ * @returns The token type, or an {@link InvalidTokenTypeError} naming what was offered.
+ */
+export const parseTokenType = (value: string): Either.Either<TokenType, InvalidTokenTypeError> =>
+  TOKEN_TYPE_PATTERN.test(value)
+    ? Either.right(value)
+    : Either.left(
+        new InvalidTokenTypeError({
+          message:
+            `"${value}" is not a token type: a token type is thirty-two bytes written as sixty-four lower-case ` +
+            `hexadecimal characters.`,
+          value,
+        }),
+      );

--- a/packages/abstractions/src/index.ts
+++ b/packages/abstractions/src/index.ts
@@ -17,6 +17,7 @@ export * as ProtocolState from './ProtocolState.js';
 export * as ProtocolVersion from './ProtocolVersion.js';
 export * as NetworkId from './NetworkId.js';
 export * as SyncProgress from './SyncProgress.js';
+export * from './TokenType.js';
 export * from './WalletTransaction.js';
 export * from './InMemoryTransactionHistoryStorage.js';
 export * from './NoOpTransactionHistoryStorage.js';

--- a/packages/abstractions/src/index.ts
+++ b/packages/abstractions/src/index.ts
@@ -17,6 +17,7 @@ export * as ProtocolState from './ProtocolState.js';
 export * as ProtocolVersion from './ProtocolVersion.js';
 export * as NetworkId from './NetworkId.js';
 export * as SyncProgress from './SyncProgress.js';
+export * as Signing from './Signing.js';
 export * from './TokenType.js';
 export * from './WalletTransaction.js';
 export * from './InMemoryTransactionHistoryStorage.js';

--- a/packages/abstractions/src/test/tokenType.test.ts
+++ b/packages/abstractions/src/test/tokenType.test.ts
@@ -1,0 +1,59 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { Either } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { InvalidTokenTypeError, parseTokenType, Token, type TokenType } from '../TokenType.js';
+
+describe('the token types the SDK names for itself', () => {
+  it('names Night without asking a ledger version for it', () => {
+    // A plain string literal, not a call into either ledger's WebAssembly: this constant reaches an application
+    // through the umbrella package's root, which is the one place no ledger may be loaded.
+    expect(Token.night).toBe('0000000000000000000000000000000000000000000000000000000000000000');
+    expect(typeof Token.night).toBe('string');
+  });
+
+  it('is a string, so a balance record still has a string index signature', () => {
+    // Deliberately unbranded. A branded key type does not produce a string index signature, and every balance read in
+    // the SDK is `balances[someTokenType]`.
+    const balances: Record<TokenType, bigint> = { [Token.night]: 7n };
+    const key: string = Token.night;
+
+    expect(balances[key]).toBe(7n);
+  });
+});
+
+describe('reading a token type an application supplied', () => {
+  it('accepts the raw form a ledger writes', () => {
+    expect(parseTokenType(Token.night)).toStrictEqual(Either.right(Token.night));
+    expect(parseTokenType('772032da83618448e5cf06d3033e368642fb27150a8cdb3af5820d4d2fa04f2d')).toStrictEqual(
+      Either.right('772032da83618448e5cf06d3033e368642fb27150a8cdb3af5820d4d2fa04f2d'),
+    );
+  });
+
+  it('refuses anything that is not thirty-two bytes of lower-case hex', () => {
+    const tooShort = parseTokenType('00');
+    const notHex = parseTokenType('zz32032da83618448e5cf06d3033e368642fb27150a8cdb3af5820d4d2fa04f2d');
+    const upperCase = parseTokenType('772032DA83618448E5CF06D3033E368642FB27150A8CDB3AF5820D4D2FA04F2D');
+
+    expect(Either.getOrThrow(Either.flip(tooShort))).toBeInstanceOf(InvalidTokenTypeError);
+    expect(Either.getOrThrow(Either.flip(notHex))).toBeInstanceOf(InvalidTokenTypeError);
+    expect(Either.getOrThrow(Either.flip(upperCase))).toBeInstanceOf(InvalidTokenTypeError);
+  });
+
+  it('says what it was given, so the caller can name the field that was wrong', () => {
+    const error = Either.getOrThrow(Either.flip(parseTokenType('nonsense')));
+
+    expect(error.value).toBe('nonsense');
+    expect(error.message).toContain('nonsense');
+  });
+});

--- a/packages/capabilities/src/signatures/preForkSignatures.ts
+++ b/packages/capabilities/src/signatures/preForkSignatures.ts
@@ -22,11 +22,11 @@
  *   heard of cannot be lowered at all, and says so rather than being handed over as bytes it would misread.
  */
 import type * as preForkLedger from '@midnight-ntwrk/ledger-v8';
-import type * as ledger from '@midnightntwrk/ledger-v9';
+import { type Signing } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Data, Either } from 'effect';
 
 /** The signature scheme the pre-fork ledger version has, and the only one a lowered value can name. */
-const PRE_FORK_SIGNATURE_KIND: ledger.SignatureKind = 'schnorr';
+const PRE_FORK_SIGNATURE_KIND: Signing.SignatureKind = 'schnorr';
 
 /** Raised when a signature or verifying key names a scheme the pre-fork ledger version does not have. */
 export class UnsupportedSignatureKindError extends Data.TaggedError(
@@ -34,11 +34,11 @@ export class UnsupportedSignatureKindError extends Data.TaggedError(
 )<{
   readonly message: string;
   /** The scheme that was named. */
-  readonly kind: ledger.SignatureKind;
+  readonly kind: Signing.SignatureKind;
 }> {}
 
 const lower = (
-  value: Readonly<{ tag: ledger.SignatureKind; value: string }>,
+  value: Signing.Signature | Signing.SignatureVerifyingKey,
   what: string,
 ): Either.Either<string, UnsupportedSignatureKindError> =>
   value.tag === PRE_FORK_SIGNATURE_KIND
@@ -60,7 +60,7 @@ const lower = (
  * @returns The bare hex the pre-fork ledger version reads, or the reason it cannot be expressed there.
  */
 export const lowerSignature = (
-  signature: ledger.Signature,
+  signature: Signing.Signature,
 ): Either.Either<preForkLedger.Signature, UnsupportedSignatureKindError> => lower(signature, 'signature');
 
 /**
@@ -70,7 +70,7 @@ export const lowerSignature = (
  * @returns The bare hex the pre-fork ledger version reads, or the reason it cannot be expressed there.
  */
 export const lowerSignatureVerifyingKey = (
-  key: ledger.SignatureVerifyingKey,
+  key: Signing.SignatureVerifyingKey,
 ): Either.Either<preForkLedger.SignatureVerifyingKey, UnsupportedSignatureKindError> => lower(key, 'verifying key');
 
 /**
@@ -81,7 +81,7 @@ export const lowerSignatureVerifyingKey = (
  * @param signature The signature, as the pre-fork ledger version writes it.
  * @returns The same signature, with the scheme it necessarily used named.
  */
-export const liftSignature = (signature: preForkLedger.Signature): ledger.Signature => ({
+export const liftSignature = (signature: preForkLedger.Signature): Signing.Signature => ({
   tag: PRE_FORK_SIGNATURE_KIND,
   value: signature,
 });
@@ -92,7 +92,7 @@ export const liftSignature = (signature: preForkLedger.Signature): ledger.Signat
  * @param key The verifying key, as the pre-fork ledger version writes it.
  * @returns The same key, with the scheme it necessarily used named.
  */
-export const liftSignatureVerifyingKey = (key: preForkLedger.SignatureVerifyingKey): ledger.SignatureVerifyingKey => ({
+export const liftSignatureVerifyingKey = (key: preForkLedger.SignatureVerifyingKey): Signing.SignatureVerifyingKey => ({
   tag: PRE_FORK_SIGNATURE_KIND,
   value: key,
 });

--- a/packages/capabilities/src/simulation/v8/Simulator.ts
+++ b/packages/capabilities/src/simulation/v8/Simulator.ts
@@ -48,7 +48,7 @@ import {
   type ZswapSecretKeys,
 } from '@midnight-ntwrk/ledger-v8';
 import { DateOps, LedgerOps } from '@midnightntwrk/wallet-sdk-utilities';
-import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, ProtocolVersion, Token } from '@midnightntwrk/wallet-sdk-abstractions';
 
 import {
   addToMempool,
@@ -91,10 +91,10 @@ const isShieldedMint = (mint: GenesisMint): mint is ShieldedGenesisMint => mint.
 const isUnshieldedMint = (mint: GenesisMint): mint is UnshieldedGenesisMint => mint.type === 'unshielded';
 
 /**
- * Check if an unshielded mint is for the native Night token. Night is auto-detected by comparing tokenType with
- * ledger.nativeToken().raw.
+ * Check if an unshielded mint is for the native Night token. Night is auto-detected by comparing tokenType with the
+ * SDK's own `Token.night`, which is what both ledger versions call the native token.
  */
-const isNightToken = (tokenType: string): boolean => tokenType === nativeToken().raw;
+const isNightToken = (tokenType: string): boolean => tokenType === Token.night;
 
 // Re-export types from SimulatorState for backward compatibility
 export type {
@@ -273,7 +273,7 @@ export class Simulator {
 
   /**
    * Initialize simulator with genesis mints (pre-funded accounts). Supports shielded and unshielded token mints. Night
-   * tokens are auto-detected by comparing tokenType with nativeToken().raw.
+   * tokens are auto-detected by comparing tokenType with `Token.night`.
    */
   private static initWithGenesis(
     genesisMints: Arr.NonEmptyArray<GenesisMint>,
@@ -295,7 +295,7 @@ export class Simulator {
         : [];
 
     // Pure function to extract Night mint data from unshielded mints (returns array for flatMap)
-    // Night is auto-detected by comparing tokenType with nativeToken().raw
+    // Night is auto-detected by comparing tokenType with `Token.night`
     const toNightMint = (mint: GenesisMint) =>
       isUnshieldedMint(mint) && isNightToken(mint.tokenType) && mint.verifyingKey !== undefined
         ? [{ amount: mint.amount, recipient: mint.recipient, verifyingKey: mint.verifyingKey }]

--- a/packages/capabilities/src/simulation/v8/Simulator.ts
+++ b/packages/capabilities/src/simulation/v8/Simulator.ts
@@ -31,7 +31,6 @@ import {
   createShieldedCoinInfo,
   Intent,
   LedgerState,
-  nativeToken,
   type PreBinding,
   type PreProof,
   type ProofErasedTransaction,

--- a/packages/capabilities/src/simulation/v9/Simulator.ts
+++ b/packages/capabilities/src/simulation/v9/Simulator.ts
@@ -31,7 +31,6 @@ import {
   createShieldedCoinInfo,
   Intent,
   LedgerState,
-  nativeToken,
   type PreBinding,
   type PreProof,
   type ProofErasedTransaction,

--- a/packages/capabilities/src/simulation/v9/Simulator.ts
+++ b/packages/capabilities/src/simulation/v9/Simulator.ts
@@ -48,7 +48,7 @@ import {
   type ZswapSecretKeys,
 } from '@midnightntwrk/ledger-v9';
 import { DateOps, LedgerOps } from '@midnightntwrk/wallet-sdk-utilities';
-import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, ProtocolVersion, Token } from '@midnightntwrk/wallet-sdk-abstractions';
 
 import {
   addToMempool,
@@ -91,10 +91,10 @@ const isShieldedMint = (mint: GenesisMint): mint is ShieldedGenesisMint => mint.
 const isUnshieldedMint = (mint: GenesisMint): mint is UnshieldedGenesisMint => mint.type === 'unshielded';
 
 /**
- * Check if an unshielded mint is for the native Night token. Night is auto-detected by comparing tokenType with
- * ledger.nativeToken().raw.
+ * Check if an unshielded mint is for the native Night token. Night is auto-detected by comparing tokenType with the
+ * SDK's own `Token.night`, which is what both ledger versions call the native token.
  */
-const isNightToken = (tokenType: string): boolean => tokenType === nativeToken().raw;
+const isNightToken = (tokenType: string): boolean => tokenType === Token.night;
 
 // Re-export types from SimulatorState for backward compatibility
 export type {
@@ -273,7 +273,7 @@ export class Simulator {
 
   /**
    * Initialize simulator with genesis mints (pre-funded accounts). Supports shielded and unshielded token mints. Night
-   * tokens are auto-detected by comparing tokenType with nativeToken().raw.
+   * tokens are auto-detected by comparing tokenType with `Token.night`.
    */
   private static initWithGenesis(
     genesisMints: Arr.NonEmptyArray<GenesisMint>,
@@ -295,7 +295,7 @@ export class Simulator {
         : [];
 
     // Pure function to extract Night mint data from unshielded mints (returns array for flatMap)
-    // Night is auto-detected by comparing tokenType with nativeToken().raw
+    // Night is auto-detected by comparing tokenType with `Token.night`
     const toNightMint = (mint: GenesisMint) =>
       isUnshieldedMint(mint) && isNightToken(mint.tokenType) && mint.verifyingKey !== undefined
         ? [{ amount: mint.amount, recipient: mint.recipient, verifyingKey: mint.verifyingKey }]

--- a/packages/docs-snippets/src/snippets/balancing.ts
+++ b/packages/docs-snippets/src/snippets/balancing.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { generateRandomSeed, ProtocolVersion, WalletTransaction } from '@midnightntwrk/wallet-sdk';
+import { generateRandomSeed, ProtocolVersion, Token, WalletTransaction } from '@midnightntwrk/wallet-sdk';
 import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
 import { Buffer } from 'buffer';
 import * as rx from 'rxjs';
@@ -22,7 +22,7 @@ const sender = await initWalletWithSeed(
 const receiver = await initWalletWithSeed(Buffer.from(generateRandomSeed()));
 
 const initialSenderState = await rx.firstValueFrom(sender.wallet.state().pipe(rx.filter((s) => s.isSynced)));
-const initialBalance = initialSenderState.unshielded.balances[ledger.nativeToken().raw] ?? 0n;
+const initialBalance = initialSenderState.unshielded.balances[Token.night] ?? 0n;
 
 const makeTransactionBlueprint = () => {
   const unshieldedOffer = ledger.UnshieldedOffer.new(
@@ -31,7 +31,7 @@ const makeTransactionBlueprint = () => {
       {
         value: initialBalance,
         owner: receiver.unshieldedKeystore.getAddress(),
-        type: ledger.nativeToken().raw,
+        type: Token.night,
       },
     ],
     [],
@@ -61,18 +61,15 @@ const finalSenderState = await rx.firstValueFrom(sender.wallet.state().pipe(rx.f
 const receiverState = await rx.firstValueFrom(
   receiver.wallet.state().pipe(
     rx.filter((s) => s.isSynced),
-    rx.filter((s) => (s.unshielded.balances[ledger.nativeToken().raw] ?? 0n) !== 0n),
+    rx.filter((s) => (s.unshielded.balances[Token.night] ?? 0n) !== 0n),
   ),
 );
 
 console.log('Unshielded transfer by balancing completed');
-console.log(
-  'Did sender send all its Night?',
-  (finalSenderState.unshielded.balances[ledger.nativeToken().raw] ?? 0n) === 0n,
-);
+console.log('Did sender send all its Night?', (finalSenderState.unshielded.balances[Token.night] ?? 0n) === 0n);
 console.log(
   'Did receiver receive all the Night?',
-  (receiverState.unshielded.balances[ledger.nativeToken().raw] ?? 0n) === initialBalance,
+  (receiverState.unshielded.balances[Token.night] ?? 0n) === initialBalance,
 );
 
 await receiver.wallet.stop();

--- a/packages/docs-snippets/src/snippets/combined-transfer.ts
+++ b/packages/docs-snippets/src/snippets/combined-transfer.ts
@@ -12,7 +12,6 @@
 // limitations under the License.
 import { initWalletWithSeed } from '../utils.ts';
 import * as rx from 'rxjs';
-import * as ledger from '@midnightntwrk/ledger-v9';
 import { Buffer } from 'buffer';
 import { generateRandomSeed, Token } from '@midnightntwrk/wallet-sdk';
 
@@ -42,7 +41,7 @@ await sender.wallet
           {
             amount: 1_000_000n,
             receiverAddress: await receiver.wallet.shielded.getAddress(),
-            type: ledger.shieldedToken().raw,
+            type: Token.night,
           },
         ],
       },
@@ -67,7 +66,7 @@ const receiverState = await rx.firstValueFrom(
 
 console.log('Transfer completed;');
 console.log('  Night balance:', receiverState.unshielded.balances[Token.night] ?? 0n);
-console.log('  shielded token balance:', receiverState.shielded.balances[ledger.shieldedToken().raw] ?? 0n);
+console.log('  shielded token balance:', receiverState.shielded.balances[Token.night] ?? 0n);
 
 await receiver.wallet.stop();
 await sender.wallet.stop();

--- a/packages/docs-snippets/src/snippets/combined-transfer.ts
+++ b/packages/docs-snippets/src/snippets/combined-transfer.ts
@@ -14,7 +14,7 @@ import { initWalletWithSeed } from '../utils.ts';
 import * as rx from 'rxjs';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { Buffer } from 'buffer';
-import { generateRandomSeed } from '@midnightntwrk/wallet-sdk';
+import { generateRandomSeed, Token } from '@midnightntwrk/wallet-sdk';
 
 const sender = await initWalletWithSeed(
   Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex'),
@@ -32,7 +32,7 @@ await sender.wallet
           {
             amount: 1_000_000n,
             receiverAddress: await receiver.wallet.unshielded.getAddress(),
-            type: ledger.unshieldedToken().raw,
+            type: Token.night,
           },
         ],
       },
@@ -59,14 +59,14 @@ const receiverState = await rx.firstValueFrom(
   receiver.wallet.state().pipe(
     rx.filter((s) => s.isSynced),
     rx.filter((s) => {
-      const nightBalance = s.unshielded.balances[ledger.unshieldedToken().raw] ?? 0n;
+      const nightBalance = s.unshielded.balances[Token.night] ?? 0n;
       return nightBalance > 0n;
     }),
   ),
 );
 
 console.log('Transfer completed;');
-console.log('  Night balance:', receiverState.unshielded.balances[ledger.unshieldedToken().raw] ?? 0n);
+console.log('  Night balance:', receiverState.unshielded.balances[Token.night] ?? 0n);
 console.log('  shielded token balance:', receiverState.shielded.balances[ledger.shieldedToken().raw] ?? 0n);
 
 await receiver.wallet.stop();

--- a/packages/docs-snippets/src/snippets/designation.ts
+++ b/packages/docs-snippets/src/snippets/designation.ts
@@ -11,11 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // #region setup
-import * as ledger from '@midnightntwrk/ledger-v9';
 import { Buffer } from 'buffer';
 import * as rx from 'rxjs';
 import { initWalletWithSeed } from '../utils.ts';
-import { generateRandomSeed } from '@midnightntwrk/wallet-sdk';
+import { generateRandomSeed, Token } from '@midnightntwrk/wallet-sdk';
 
 const sender = await initWalletWithSeed(
   Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex'),
@@ -33,7 +32,7 @@ await sender.wallet
           {
             amount: 500_000_000_000n,
             receiverAddress: await wallet.unshielded.getAddress(),
-            type: ledger.nativeToken().raw,
+            type: Token.night,
           },
         ],
       },
@@ -50,7 +49,7 @@ await sender.wallet
       wallet.state().pipe(
         rx.filter((s) => s.isSynced),
         rx.filter((s) => {
-          const nightBalance = s.unshielded.balances[ledger.nativeToken().raw] ?? 0n;
+          const nightBalance = s.unshielded.balances[Token.night] ?? 0n;
           return nightBalance > 0n;
         }),
       ),

--- a/packages/docs-snippets/src/snippets/dust-fast-sync.ts
+++ b/packages/docs-snippets/src/snippets/dust-fast-sync.ts
@@ -11,16 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
-import * as ledger from '@midnightntwrk/ledger-v9';
 import {
+  WalletSeeds,
   type DefaultConfiguration,
   type DefaultDustConfiguration,
   CustomDustWallet,
   InMemoryTransactionHistoryStorage,
   WalletEntrySchema,
   WalletFacade,
-  HDWallet,
-  Roles,
   ShieldedWallet,
   createKeystore,
   makeEventLessSyncCapability,
@@ -79,44 +77,24 @@ const fastSyncDustWallet = (config: DefaultDustConfiguration) =>
   );
 
 const initWalletWithSeed = async (seed: Buffer) => {
-  const hdWallet = HDWallet.fromSeed(seed);
-
-  if (hdWallet.type !== 'seedOk') {
-    throw new Error('Failed to initialize HDWallet');
-  }
-
-  const derivationResult = hdWallet.hdWallet
-    .selectAccount(0)
-    .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust])
-    .deriveKeysAt(0);
-
-  if (derivationResult.type !== 'keysDerived') {
-    throw new Error('Failed to derive keys');
-  }
-
-  hdWallet.hdWallet.clear();
-
-  const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(derivationResult.keys[Roles.Zswap]);
-  const dustSecretKey = ledger.DustSecretKey.fromSeed(derivationResult.keys[Roles.Dust]);
-  const unshieldedKeystore = createKeystore(
-    { kind: 'schnorr', secret: derivationResult.keys[Roles.NightExternal] },
-    configuration.networkId,
-  );
+  // One master seed, three wallet seeds. A seed is the only key material that crosses a protocol boundary, so this is
+  // what lets one wallet follow the chain through a fork.
+  const seeds = WalletSeeds.fromMasterSeed(seed);
+  const unshieldedKeystore = createKeystore({ kind: 'schnorr', secret: seeds.unshielded }, configuration.networkId);
 
   const wallet: WalletFacade = await WalletFacade.init({
     configuration,
-    shielded: (config) => ShieldedWallet(config).startWithSecretKeys(shieldedSecretKeys),
+    shielded: (config) => ShieldedWallet(config).startWithSeed(seeds.shielded),
     unshielded: (config) => UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
-    dust: (config) =>
-      fastSyncDustWallet(config).startWithSecretKey(dustSecretKey, ledger.LedgerParameters.initialParameters().dust),
+    dust: (config) => fastSyncDustWallet(config).startWithSeed(seeds.dust),
   });
 
   // The fast-syncing dust wallet joins background synchronization like any other; pass
-  // `manualSync: true` as the third argument and drive it with `wallet.doSync(dustSecretKey)`
+  // `manualSync: true` as the third argument and drive it with `wallet.doSync(seeds)`
   // to control when snapshots are taken instead.
-  await wallet.start(shieldedSecretKeys, dustSecretKey);
+  await wallet.start(seeds);
 
-  return { wallet, shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
+  return { wallet, seeds, unshieldedKeystore };
 };
 
 const { wallet } = await initWalletWithSeed(

--- a/packages/docs-snippets/src/snippets/dust-sponsorship.ts
+++ b/packages/docs-snippets/src/snippets/dust-sponsorship.ts
@@ -122,7 +122,7 @@ await sponsor.wallet
 const finalSponsorState = await rx.firstValueFrom(
   sponsor.wallet.state().pipe(
     rx.filter((s) => s.isSynced),
-    rx.filter((s) => s.pending.all.length === 0),
+    rx.filter((s) => s.pending.length === 0),
   ),
 );
 const finalUserState = await user.wallet.waitForSyncedState();

--- a/packages/docs-snippets/src/snippets/dust-sponsorship.ts
+++ b/packages/docs-snippets/src/snippets/dust-sponsorship.ts
@@ -11,7 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
-import { generateRandomSeed, ProtocolVersion, type UnboundTx, WalletTransaction } from '@midnightntwrk/wallet-sdk';
+import {
+  generateRandomSeed,
+  ProtocolVersion,
+  Token,
+  type UnboundTx,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import * as rx from 'rxjs';
 import { aFakeProvingProvider, initWalletWithSeed } from '../utils.ts';
@@ -37,7 +43,7 @@ const user = await initWalletWithSeed(Buffer.from(generateRandomSeed()));
 const nightAmountToSend = 1000n * 10n ** 6n;
 
 const initialSenderState = await sponsor.wallet.waitForSyncedState();
-const initialBalance = initialSenderState.unshielded.balances[ledger.nativeToken().raw] ?? 0n;
+const initialBalance = initialSenderState.unshielded.balances[Token.night] ?? 0n;
 
 await sponsor.wallet
   .transferTransaction(
@@ -48,7 +54,7 @@ await sponsor.wallet
           {
             amount: nightAmountToSend,
             receiverAddress: await user.wallet.unshielded.getAddress(),
-            type: ledger.nativeToken().raw,
+            type: Token.night,
           },
         ],
       },
@@ -62,13 +68,10 @@ await sponsor.wallet
 const userReceivedNight = await rx.firstValueFrom(
   user.wallet.state().pipe(
     rx.filter((state) => state.isSynced),
-    rx.filter((state) => state.unshielded.balances[ledger.nativeToken().raw] > 0n),
+    rx.filter((state) => state.unshielded.balances[Token.night] > 0n),
   ),
 );
-console.log(
-  'User received night for main transaction',
-  userReceivedNight.unshielded.balances[ledger.nativeToken().raw],
-);
+console.log('User received night for main transaction', userReceivedNight.unshielded.balances[Token.night]);
 
 const prepareTransactionToBalance = async (): Promise<UnboundTx> => {
   const unshieldedOffer = ledger.UnshieldedOffer.new(
@@ -77,7 +80,7 @@ const prepareTransactionToBalance = async (): Promise<UnboundTx> => {
       {
         value: nightAmountToSend,
         owner: sponsor.unshieldedKeystore.getAddress(),
-        type: ledger.nativeToken().raw,
+        type: Token.night,
       },
     ],
     [],
@@ -127,12 +130,9 @@ const finalUserState = await user.wallet.waitForSyncedState();
 console.log('Sponsored transfer completed');
 console.log(
   'Did sponsor receive their night back?',
-  (finalSponsorState.unshielded.balances[ledger.nativeToken().raw] ?? 0n) === initialBalance,
+  (finalSponsorState.unshielded.balances[Token.night] ?? 0n) === initialBalance,
 );
-console.log(
-  'Did user spent all the Night?',
-  (finalUserState.unshielded.balances[ledger.nativeToken().raw] ?? 0n) === 0n,
-);
+console.log('Did user spent all the Night?', (finalUserState.unshielded.balances[Token.night] ?? 0n) === 0n);
 
 await user.wallet.stop();
 await sponsor.wallet.stop();

--- a/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
+++ b/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
@@ -11,16 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
-import * as ledger from '@midnightntwrk/ledger-v9';
 import {
   type DefaultConfiguration,
   DustWallet,
   InMemoryTransactionHistoryStorage,
   WalletEntrySchema,
   WalletFacade,
-  HDWallet,
   Roles,
   ShieldedWallet,
+  WalletSeeds,
   createKeystore,
   PublicKey,
   UnshieldedWallet,
@@ -53,46 +52,24 @@ const configuration: DefaultConfiguration = {
 };
 
 const initEcdsaWalletWithSeed = async (seed: Buffer) => {
-  const hdWallet = HDWallet.fromSeed(seed);
-
-  if (hdWallet.type !== 'seedOk') {
-    throw new Error('Failed to initialize HDWallet');
-  }
-
   // ECDSA unshielded keys live under their own HD role (4), so the scalar is
   // never shared with the Schnorr roles (0/1) derived from the same account.
-  const derivationResult = hdWallet.hdWallet
-    .selectAccount(0)
-    .selectRoles([Roles.Zswap, Roles.EcdsaUnshielded, Roles.Dust])
-    .deriveKeysAt(0);
-
-  if (derivationResult.type !== 'keysDerived') {
-    throw new Error('Failed to derive keys');
-  }
-
-  hdWallet.hdWallet.clear();
-
-  const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(derivationResult.keys[Roles.Zswap]);
-  const dustSecretKey = ledger.DustSecretKey.fromSeed(derivationResult.keys[Roles.Dust]);
+  const seeds = WalletSeeds.fromMasterSeed(seed, { unshieldedRole: Roles.EcdsaUnshielded });
   // The keystore kind selects the signature scheme; an ECDSA key hashes to a
   // different address than a Schnorr key, so UTXOs owned by this wallet can
   // only ever be spent with ECDSA signatures.
-  const unshieldedKeystore = createKeystore(
-    { kind: 'ecdsa', secret: derivationResult.keys[Roles.EcdsaUnshielded] },
-    configuration.networkId,
-  );
+  const unshieldedKeystore = createKeystore({ kind: 'ecdsa', secret: seeds.unshielded }, configuration.networkId);
 
   const wallet: WalletFacade = await WalletFacade.init({
     configuration,
-    shielded: (config) => ShieldedWallet(config).startWithSecretKeys(shieldedSecretKeys),
+    shielded: (config) => ShieldedWallet(config).startWithSeed(seeds.shielded),
     unshielded: (config) => UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
-    dust: (config) =>
-      DustWallet(config).startWithSecretKey(dustSecretKey, ledger.LedgerParameters.initialParameters().dust),
+    dust: (config) => DustWallet(config).startWithSeed(seeds.dust),
   });
 
-  await wallet.start(shieldedSecretKeys, dustSecretKey);
+  await wallet.start(seeds);
 
-  return { wallet, shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
+  return { wallet, seeds, unshieldedKeystore };
 };
 
 const { wallet, unshieldedKeystore } = await initEcdsaWalletWithSeed(

--- a/packages/docs-snippets/src/snippets/initialization.ts
+++ b/packages/docs-snippets/src/snippets/initialization.ts
@@ -11,15 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
-import * as ledger from '@midnightntwrk/ledger-v9';
 import {
+  WalletSeeds,
   type DefaultConfiguration,
   DustWallet,
   InMemoryTransactionHistoryStorage,
   WalletEntrySchema,
   WalletFacade,
-  HDWallet,
-  Roles,
   ShieldedWallet,
   createKeystore,
   PublicKey,
@@ -53,41 +51,21 @@ const configuration: DefaultConfiguration = {
 };
 
 const initWalletWithSeed = async (seed: Buffer) => {
-  const hdWallet = HDWallet.fromSeed(seed);
-
-  if (hdWallet.type !== 'seedOk') {
-    throw new Error('Failed to initialize HDWallet');
-  }
-
-  const derivationResult = hdWallet.hdWallet
-    .selectAccount(0)
-    .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust])
-    .deriveKeysAt(0);
-
-  if (derivationResult.type !== 'keysDerived') {
-    throw new Error('Failed to derive keys');
-  }
-
-  hdWallet.hdWallet.clear();
-
-  const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(derivationResult.keys[Roles.Zswap]);
-  const dustSecretKey = ledger.DustSecretKey.fromSeed(derivationResult.keys[Roles.Dust]);
-  const unshieldedKeystore = createKeystore(
-    { kind: 'schnorr', secret: derivationResult.keys[Roles.NightExternal] },
-    configuration.networkId,
-  );
+  // One master seed, three wallet seeds. A seed is the only key material that crosses a protocol boundary, so this is
+  // what lets one wallet follow the chain through a fork.
+  const seeds = WalletSeeds.fromMasterSeed(seed);
+  const unshieldedKeystore = createKeystore({ kind: 'schnorr', secret: seeds.unshielded }, configuration.networkId);
 
   const wallet: WalletFacade = await WalletFacade.init({
     configuration,
-    shielded: (config) => ShieldedWallet(config).startWithSecretKeys(shieldedSecretKeys),
+    shielded: (config) => ShieldedWallet(config).startWithSeed(seeds.shielded),
     unshielded: (config) => UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
-    dust: (config) =>
-      DustWallet(config).startWithSecretKey(dustSecretKey, ledger.LedgerParameters.initialParameters().dust),
+    dust: (config) => DustWallet(config).startWithSeed(seeds.dust),
   });
 
-  await wallet.start(shieldedSecretKeys, dustSecretKey);
+  await wallet.start(seeds);
 
-  return { wallet, shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
+  return { wallet, seeds, unshieldedKeystore };
 };
 
 const { wallet } = await initWalletWithSeed(

--- a/packages/docs-snippets/src/snippets/shielded-transfer.ts
+++ b/packages/docs-snippets/src/snippets/shielded-transfer.ts
@@ -12,9 +12,8 @@
 // limitations under the License.
 import { initWalletWithSeed } from '../utils.ts';
 import * as rx from 'rxjs';
-import * as ledger from '@midnightntwrk/ledger-v9';
 import { Buffer } from 'buffer';
-import { generateRandomSeed } from '@midnightntwrk/wallet-sdk';
+import { generateRandomSeed, Token } from '@midnightntwrk/wallet-sdk';
 
 const sender = await initWalletWithSeed(
   Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex'),
@@ -32,7 +31,7 @@ await sender.wallet
           {
             amount: 1_000_000n,
             receiverAddress: await receiver.wallet.shielded.getAddress(),
-            type: ledger.shieldedToken().raw,
+            type: Token.night,
           },
         ],
       },
@@ -51,10 +50,7 @@ const receiverState = await rx.firstValueFrom(
   ),
 );
 
-console.log(
-  'Shielded transfer completed; shielded balance:',
-  receiverState.shielded.balances[ledger.shieldedToken().raw] ?? 0n,
-);
+console.log('Shielded transfer completed; shielded balance:', receiverState.shielded.balances[Token.night] ?? 0n);
 
 await receiver.wallet.stop();
 await sender.wallet.stop();

--- a/packages/docs-snippets/src/snippets/unshielded-transfer.ts
+++ b/packages/docs-snippets/src/snippets/unshielded-transfer.ts
@@ -12,7 +12,6 @@
 // limitations under the License.
 import { initWalletWithSeed } from '../utils.ts';
 import * as rx from 'rxjs';
-import * as ledger from '@midnightntwrk/ledger-v9';
 import { Buffer } from 'buffer';
 import { generateRandomSeed, Token } from '@midnightntwrk/wallet-sdk';
 

--- a/packages/docs-snippets/src/snippets/unshielded-transfer.ts
+++ b/packages/docs-snippets/src/snippets/unshielded-transfer.ts
@@ -14,7 +14,7 @@ import { initWalletWithSeed } from '../utils.ts';
 import * as rx from 'rxjs';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { Buffer } from 'buffer';
-import { generateRandomSeed } from '@midnightntwrk/wallet-sdk';
+import { generateRandomSeed, Token } from '@midnightntwrk/wallet-sdk';
 
 const sender = await initWalletWithSeed(
   Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex'),
@@ -32,7 +32,7 @@ await sender.wallet
           {
             amount: 1_000_000n,
             receiverAddress: await receiver.wallet.unshielded.getAddress(),
-            type: ledger.unshieldedToken().raw,
+            type: Token.night,
           },
         ],
       },
@@ -49,16 +49,13 @@ const receiverState = await rx.firstValueFrom(
   receiver.wallet.state().pipe(
     rx.filter((s) => s.isSynced),
     rx.filter((s) => {
-      const nightBalance = s.unshielded.balances[ledger.unshieldedToken().raw] ?? 0n;
+      const nightBalance = s.unshielded.balances[Token.night] ?? 0n;
       return nightBalance > 0n;
     }),
   ),
 );
 
-console.log(
-  'Unshielded transfer completed; night balance:',
-  receiverState.unshielded.balances[ledger.unshieldedToken().raw] ?? 0n,
-);
+console.log('Unshielded transfer completed; night balance:', receiverState.unshielded.balances[Token.night] ?? 0n);
 
 await receiver.wallet.stop();
 await sender.wallet.stop();

--- a/packages/docs-snippets/src/snippets/wasm-prover.ts
+++ b/packages/docs-snippets/src/snippets/wasm-prover.ts
@@ -11,15 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
-import * as ledger from '@midnightntwrk/ledger-v9';
 import {
+  WalletSeeds,
   type DefaultConfiguration,
   DustWallet,
   InMemoryTransactionHistoryStorage,
   WalletEntrySchema,
   WalletFacade,
-  HDWallet,
-  Roles,
   ShieldedWallet,
   createKeystore,
   PublicKey,
@@ -52,42 +50,22 @@ const configuration: DefaultConfiguration = {
 };
 
 const initWalletWithSeed = async (seed: Buffer) => {
-  const hdWallet = HDWallet.fromSeed(seed);
-
-  if (hdWallet.type !== 'seedOk') {
-    throw new Error('Failed to initialize HDWallet');
-  }
-
-  const derivationResult = hdWallet.hdWallet
-    .selectAccount(0)
-    .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust])
-    .deriveKeysAt(0);
-
-  if (derivationResult.type !== 'keysDerived') {
-    throw new Error('Failed to derive keys');
-  }
-
-  hdWallet.hdWallet.clear();
-
-  const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(derivationResult.keys[Roles.Zswap]);
-  const dustSecretKey = ledger.DustSecretKey.fromSeed(derivationResult.keys[Roles.Dust]);
-  const unshieldedKeystore = createKeystore(
-    { kind: 'schnorr', secret: derivationResult.keys[Roles.NightExternal] },
-    configuration.networkId,
-  );
+  // One master seed, three wallet seeds. A seed is the only key material that crosses a protocol boundary, so this is
+  // what lets one wallet follow the chain through a fork.
+  const seeds = WalletSeeds.fromMasterSeed(seed);
+  const unshieldedKeystore = createKeystore({ kind: 'schnorr', secret: seeds.unshielded }, configuration.networkId);
 
   const wallet: WalletFacade = await WalletFacade.init({
     configuration,
-    shielded: (config) => ShieldedWallet(config).startWithSecretKeys(shieldedSecretKeys),
+    shielded: (config) => ShieldedWallet(config).startWithSeed(seeds.shielded),
     unshielded: (config) => UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
-    dust: (config) =>
-      DustWallet(config).startWithSecretKey(dustSecretKey, ledger.LedgerParameters.initialParameters().dust),
+    dust: (config) => DustWallet(config).startWithSeed(seeds.dust),
     provingService: () => makeWasmProvingService(),
   });
 
-  await wallet.start(shieldedSecretKeys, dustSecretKey);
+  await wallet.start(seeds);
 
-  return { wallet, shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
+  return { wallet, seeds, unshieldedKeystore };
 };
 
 const { wallet } = await initWalletWithSeed(

--- a/packages/docs-snippets/src/snippets/well-formed-validation.ts
+++ b/packages/docs-snippets/src/snippets/well-formed-validation.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
-import { generateRandomSeed, ProtocolVersion, WalletTransaction } from '@midnightntwrk/wallet-sdk';
+import { generateRandomSeed, ProtocolVersion, Token, WalletTransaction } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import * as rx from 'rxjs';
 import { initWalletWithSeed } from '../utils.ts';
@@ -22,12 +22,12 @@ const sender = await initWalletWithSeed(
 const receiver = await initWalletWithSeed(Buffer.from(generateRandomSeed()));
 
 const initialSenderState = await rx.firstValueFrom(sender.wallet.state().pipe(rx.filter((s) => s.isSynced)));
-const initialBalance = initialSenderState.unshielded.balances[ledger.nativeToken().raw] ?? 0n;
+const initialBalance = initialSenderState.unshielded.balances[Token.night] ?? 0n;
 
 const buildUnprovenTransaction = () => {
   const unshieldedOffer = ledger.UnshieldedOffer.new(
     [],
-    [{ value: initialBalance, owner: receiver.unshieldedKeystore.getAddress(), type: ledger.nativeToken().raw }],
+    [{ value: initialBalance, owner: receiver.unshieldedKeystore.getAddress(), type: Token.night }],
     [],
   );
   const intent = ledger.Intent.new(new Date(Date.now() + 30 * 60 * 1000));
@@ -69,7 +69,7 @@ await sender.wallet.submitTransaction(finalizedTx);
 await rx.firstValueFrom(
   receiver.wallet.state().pipe(
     rx.filter((s) => s.isSynced),
-    rx.filter((s) => (s.unshielded.balances[ledger.nativeToken().raw] ?? 0n) !== 0n),
+    rx.filter((s) => (s.unshielded.balances[Token.night] ?? 0n) !== 0n),
   ),
 );
 

--- a/packages/docs-snippets/src/utils.ts
+++ b/packages/docs-snippets/src/utils.ts
@@ -18,13 +18,12 @@ import {
   InMemoryTransactionHistoryStorage,
   WalletEntrySchema,
   WalletFacade,
-  HDWallet,
-  Roles,
   ShieldedWallet,
   createKeystore,
   PublicKey as UnshieldedPublicKey,
   UnshieldedWallet,
   type UnshieldedKeystore,
+  WalletSeeds,
   mergeWalletEntries,
 } from '@midnightntwrk/wallet-sdk';
 import { type Buffer } from 'buffer';
@@ -56,46 +55,26 @@ export const initWalletWithSeed = async (
   seed: Buffer,
 ): Promise<{
   wallet: WalletFacade;
-  shieldedSecretKeys: ledger.ZswapSecretKeys;
-  dustSecretKey: ledger.DustSecretKey;
+  seeds: WalletSeeds;
   unshieldedKeystore: UnshieldedKeystore;
 }> => {
-  const hdWallet = HDWallet.fromSeed(seed);
+  // One master seed, three wallet seeds. A seed is the only key material that crosses a protocol boundary, so this is
+  // what lets one wallet follow the chain through a fork.
+  const seeds = WalletSeeds.fromMasterSeed(seed);
 
-  if (hdWallet.type !== 'seedOk') {
-    throw new Error('Failed to initialize HDWallet');
-  }
-
-  const derivationResult = hdWallet.hdWallet
-    .selectAccount(0)
-    .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust])
-    .deriveKeysAt(0);
-
-  if (derivationResult.type !== 'keysDerived') {
-    throw new Error('Failed to derive keys');
-  }
-
-  hdWallet.hdWallet.clear();
-
-  const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(derivationResult.keys[Roles.Zswap]);
-  const dustSecretKey = ledger.DustSecretKey.fromSeed(derivationResult.keys[Roles.Dust]);
-  const unshieldedKeystore = createKeystore(
-    { kind: 'schnorr', secret: derivationResult.keys[Roles.NightExternal] },
-    configuration.networkId,
-  );
+  const unshieldedKeystore = createKeystore({ kind: 'schnorr', secret: seeds.unshielded }, configuration.networkId);
 
   const wallet: WalletFacade = await WalletFacade.init({
     configuration,
-    shielded: (config) => ShieldedWallet(config).startWithSecretKeys(shieldedSecretKeys),
+    shielded: (config) => ShieldedWallet(config).startWithSeed(seeds.shielded),
     unshielded: (config) =>
       UnshieldedWallet(config).startWithPublicKey(UnshieldedPublicKey.fromKeyStore(unshieldedKeystore)),
-    dust: (config) =>
-      DustWallet(config).startWithSecretKey(dustSecretKey, ledger.LedgerParameters.initialParameters().dust),
+    dust: (config) => DustWallet(config).startWithSeed(seeds.dust),
   });
 
-  await wallet.start(shieldedSecretKeys, dustSecretKey);
+  await wallet.start(seeds);
 
-  return { wallet, shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
+  return { wallet, seeds, unshieldedKeystore };
 };
 
 export const aFakeProvingProvider: ledger.ProvingProvider = {

--- a/packages/docs-snippets/src/utils.ts
+++ b/packages/docs-snippets/src/utils.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
-import * as ledger from '@midnightntwrk/ledger-v9';
+import type * as ledger from '@midnightntwrk/ledger-v9';
 import {
   type DefaultConfiguration,
   DustWallet,

--- a/packages/dust-wallet/src/DustWallet.ts
+++ b/packages/dust-wallet/src/DustWallet.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 import {
   type DustParameters,
+  LedgerParameters,
   type DustPublicKey,
   DustSecretKey,
   type FinalizedTransaction,
@@ -359,11 +360,11 @@ export interface CustomizedDustWalletClass<
   configuration: TConfig;
   startWithSeed(
     seed: Uint8Array,
-    dustParameters: DustParameters,
+    dustParameters?: DustParameters,
   ): CustomizedDustWallet<TStartAux, TTransaction, TSyncUpdate, TSerialized>;
   startWithSecretKey(
     secretKey: DustSecretKey,
-    dustParameters: DustParameters,
+    dustParameters?: DustParameters,
   ): CustomizedDustWallet<TStartAux, TTransaction, TSyncUpdate, TSerialized>;
   restore(serializedState: TSerialized): CustomizedDustWallet<TStartAux, TTransaction, TSyncUpdate, TSerialized>;
 }
@@ -410,7 +411,12 @@ export function CustomDustWallet<
     extends BaseWallet
     implements CustomizedDustWallet<TStartAux, TTransaction, TSyncUpdate, TSerialized>
   {
-    static startWithSeed(seed: Uint8Array, dustParameters: DustParameters): CustomDustWalletImplementation {
+    static startWithSeed(
+      seed: Uint8Array,
+      // The ledger's own initial parameters when a caller names none: three rates that do not depend on this wallet,
+      // and asking for them made an application import a ledger version to start one.
+      dustParameters: DustParameters = LedgerParameters.initialParameters().dust,
+    ): CustomDustWalletImplementation {
       const dustSecretKey = DustSecretKey.fromSeed(seed);
       return CustomDustWalletImplementation.startFirst(
         CustomDustWalletImplementation,
@@ -420,7 +426,7 @@ export function CustomDustWallet<
 
     static startWithSecretKey(
       secretKey: DustSecretKey,
-      dustParameters: DustParameters,
+      dustParameters: DustParameters = LedgerParameters.initialParameters().dust,
     ): CustomDustWalletImplementation {
       return CustomDustWalletImplementation.startFirst(
         CustomDustWalletImplementation,

--- a/packages/dust-wallet/src/ForkingDustWallet.ts
+++ b/packages/dust-wallet/src/ForkingDustWallet.ts
@@ -124,6 +124,21 @@ export type ForkingDustConfiguration = {
   forkVersion: ProtocolVersion.ProtocolVersion;
 };
 
+/**
+ * One ledger version's dust secret key per side of a protocol boundary.
+ *
+ * @remarks
+ *   Both sides are required. A caller holding key objects rather than a seed has to hold both, because the two belong to
+ *   different ledger runtimes and neither can be derived from the other; a product with one side optional would let a
+ *   wallet be built that cannot read half the chain, which is the shape this replaced.
+ */
+export type DustKeysByEpoch = Readonly<{
+  /** The pre-fork ledger version's dust secret key. */
+  v8: v8.DustSecretKey;
+  /** The post-fork ledger version's dust secret key. */
+  v9: ledger.DustSecretKey;
+}>;
+
 /** A running dust wallet that spans a protocol boundary. */
 export type ForkingDustWallet<TPreForkSyncUpdate, TPostForkSyncUpdate> = DustWalletAPI<ledger.DustSecretKey, string> &
   WalletLike.WalletLike<ForkingDustVariants<TPreForkSyncUpdate, TPostForkSyncUpdate>>;
@@ -150,24 +165,24 @@ export interface ForkingDustWalletClass<
    */
   startWithSeed(
     seed: Uint8Array,
-    dustParameters: ledger.DustParameters,
+    dustParameters?: DustGenerationRates,
   ): ForkingDustWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
   /**
-   * Builds a wallet from a post-fork dust key, starting it on the post-fork variant.
+   * Builds a wallet from dust keys of both ledger versions.
    *
    * @remarks
-   *   A `DustSecretKey` belongs to one ledger version's runtime, so it answers for one variant and no other: there is
-   *   nothing to convert, and the dust public keys being identical either side does not help — reading dust needs the
-   *   secret. A wallet built this way therefore starts on the variant its key belongs to and stays there. It cannot
-   *   read a chain that is still pre-fork, which is the honest consequence of holding only a post-fork key; start from
-   *   a seed to do that.
-   * @param secretKey The post-fork ledger version's dust secret key.
+   *   The escape hatch for a caller that will not hand over a seed. Both sides are required, and that is the whole point:
+   *   a `DustSecretKey` belongs to one ledger version's runtime — there is nothing to convert, and the dust public keys
+   *   being identical either side does not help, because reading dust needs the secret — so a wallet given one side
+   *   alone could not read the other side of the chain. It costs the caller an import of both ledger packages and the
+   *   same derivation done twice; a seed costs neither.
+   * @param keys One ledger version's dust secret key per side of the boundary.
    * @param dustParameters The post-fork ledger version's dust parameters.
-   * @returns A wallet started on the post-fork variant.
+   * @returns A wallet started on the pre-fork variant, which is where a wallet with no history belongs.
    */
-  startWithSecretKey(
-    secretKey: ledger.DustSecretKey,
-    dustParameters: ledger.DustParameters,
+  startWithKeys(
+    keys: DustKeysByEpoch,
+    dustParameters?: DustGenerationRates,
   ): ForkingDustWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
   /**
    * Restores a wallet from a snapshot, into whichever registered variant wrote it.
@@ -205,7 +220,25 @@ export interface ForkingDustWalletClass<
  * @param parameters The post-fork ledger version's dust parameters.
  * @returns The same generation and decay rates, as a pre-fork `DustParameters`.
  */
-export const asPreForkDustParameters = (parameters: ledger.DustParameters): v8.DustParameters =>
+/**
+ * The rates dust is generated and decays at, as plain data.
+ *
+ * @remarks
+ *   Structurally what both ledger versions' `DustParameters` are — three scalars and nothing else — which is why the
+ *   ledger classes remain assignable to this and a caller who already holds one can go on passing it. What it removes
+ *   is the reason to obtain one: three numbers do not need a ledger version to express, and asking for a
+ *   `LedgerParameters.initialParameters().dust` made an application import a ledger to start a wallet.
+ */
+export type DustGenerationRates = Readonly<{
+  /** How much dust one Night generates, at the cap. */
+  nightDustRatio: bigint;
+  /** How fast dust decays once its Night is spent. */
+  generationDecayRate: bigint;
+  /** How long dust survives after its Night is spent. */
+  dustGracePeriodSeconds: bigint;
+}>;
+
+export const asPreForkDustParameters = (parameters: DustGenerationRates): v8.DustParameters =>
   new v8.DustParameters(parameters.nightDustRatio, parameters.generationDecayRate, parameters.dustGracePeriodSeconds);
 
 /**
@@ -245,7 +278,6 @@ export function CustomForkingDustWallet<
   postFork: SelfConfiguredDustVariant<PostForkDustVariant<TPostForkSyncUpdate>, TPostForkConfig>,
 ): ForkingDustWalletClass<TPreForkSyncUpdate, TPostForkSyncUpdate, TConfiguration> {
   type Variants = ForkingDustVariants<TPreForkSyncUpdate, TPostForkSyncUpdate>;
-  type RetainedStartMaterial = StartMaterial.StartMaterial<ledger.DustSecretKey>;
 
   // Registered through the shape the builder states rather than through the one this function was handed. The two are
   // the same builder; what is dropped is the configuration *type*, which the parameter types have already paired with
@@ -263,25 +295,69 @@ export function CustomForkingDustWallet<
 
   const variants = BaseWallet.allVariantsRecord();
 
+  /** What the rates are when a caller names none: the ledger's own initial parameters. */
+  const defaultRates: DustGenerationRates = ledger.LedgerParameters.initialParameters().dust;
+
   /**
-   * The pre-fork variant's key material, which only a retained seed can produce.
+   * The key material this wallet holds, one entry per side of the protocol boundary.
    *
    * @remarks
-   *   The wallet's public API speaks the post-fork ledger version's `DustSecretKey`, and the pre-fork variant cannot use
-   *   one: they belong to different ledger runtimes and each declares a private constructor, so the type system agrees.
-   *   A wallet holding a key object therefore has nothing this variant can start with, and says so instead of handing
-   *   over a key it would silently misuse.
+   *   The two ledger versions' `DustSecretKey` belong to different runtimes and each declares a private constructor, so
+   *   neither can be made from the other and the type system agrees. "The key this wallet holds" is therefore two
+   *   questions, and the type says so: each side is present or it is not, independently.
+   *
+   *   A seed is not among them. A seed can produce either side, so a wallet given one derives both at once and keeps the
+   *   results — the same capability with a shorter-lived secret, since from that moment the seed is not this wallet's
+   *   to hold.
    */
-  const preForkAux = (
-    retained: RetainedStartMaterial,
-  ): Either.Either<v8.DustSecretKey, StartMaterial.MissingStartAuxError> =>
-    StartMaterial.requireDerivedAuxFor(retained, V1Tag, (seed) => variants[V1Tag].variant.startAux.fromSeed(seed));
+  type RetainedKeys = Readonly<{
+    preFork: Option.Option<v8.DustSecretKey>;
+    postFork: Option.Option<ledger.DustSecretKey>;
+  }>;
 
-  /** The post-fork variant's key material: what the application handed over, or the retained seed's derivation. */
+  /** Nothing retained: never started, or stopped. */
+  const noKeys: RetainedKeys = { preFork: Option.none(), postFork: Option.none() };
+
+  /** Both sides, derived from one seed. */
+  const keysFromSeed = (seed: WalletSeed.WalletSeed): RetainedKeys => ({
+    preFork: Option.some(variants[V1Tag].variant.startAux.fromSeed(seed)),
+    postFork: Option.some(variants[V2Tag].variant.startAux.fromSeed(seed)),
+  });
+
+  /**
+   * What a variant can be started with, or why it cannot be.
+   *
+   * @remarks
+   *   Two different failures, deliberately distinguished: a wallet that was never started (or has been stopped) holds
+   *   nothing at all, while one started with the other side's key object holds something it must not use here.
+   */
+  const auxFor = <TAux>(
+    retained: RetainedKeys,
+    side: Option.Option<TAux>,
+    variantTag: symbol,
+  ): Either.Either<TAux, StartMaterial.MissingStartAuxError> =>
+    Either.fromOption(
+      side,
+      () =>
+        new StartMaterial.MissingStartAuxError({
+          message:
+            Option.isNone(retained.preFork) && Option.isNone(retained.postFork)
+              ? `This wallet holds no key material: it has not been started, or it has been stopped. Start it before ` +
+                `asking it to synchronize or to pay a fee.`
+              : `This wallet was started with key material of the other protocol version, which the variant ` +
+                `${String(variantTag)} cannot use: a Dust secret key belongs to one ledger version's runtime. Start ` +
+                `it from a seed, or hand it both versions' keys.`,
+          variantTag,
+        }),
+    );
+
+  const preForkAux = (retained: RetainedKeys): Either.Either<v8.DustSecretKey, StartMaterial.MissingStartAuxError> =>
+    auxFor(retained, retained.preFork, V1Tag);
+
   const postForkAux = (
-    retained: RetainedStartMaterial,
+    retained: RetainedKeys,
   ): Either.Either<ledger.DustSecretKey, StartMaterial.MissingStartAuxError> =>
-    StartMaterial.requireAuxFor(retained, V2Tag, (seed) => variants[V2Tag].variant.startAux.fromSeed(seed));
+    auxFor(retained, retained.postFork, V2Tag);
 
   /**
    * The protocol versions each variant owns, and the version a transaction it builds is stamped with.
@@ -309,37 +385,37 @@ export function CustomForkingDustWallet<
   {
     static readonly configuration: TConfiguration = configuration;
 
-    static startWithSeed(seed: Uint8Array, dustParameters: ledger.DustParameters): ForkingDustWalletImplementation {
-      const walletSeed = WalletSeed.WalletSeed(seed);
+    static startWithSeed(
+      seed: Uint8Array,
+      dustParameters: DustGenerationRates = defaultRates,
+    ): ForkingDustWalletImplementation {
+      const derived = keysFromSeed(WalletSeed.WalletSeed(seed));
       const wallet = ForkingDustWalletImplementation.startFirst(
         ForkingDustWalletImplementation,
         // Valued against the same rates the caller named, rebuilt by the ledger version that owns this state — see
         // {@link asPreForkDustParameters}. The post-fork side's own empty state is the migration's business.
         PreForkCoreWallet.initEmpty(
           asPreForkDustParameters(dustParameters),
-          variants[V1Tag].variant.startAux.fromSeed(walletSeed),
+          Option.getOrThrow(derived.preFork),
           configuration.networkId,
         ),
       );
-      wallet.#retainSeed(walletSeed);
+      // Both sides derived here and now, and the seed reference dropped with this frame: from this point the wallet
+      // holds key objects only, which is strictly less than it held before and does the same work.
+      wallet.#retainKeys(derived);
       return wallet;
     }
 
-    static startWithSecretKey(
-      secretKey: ledger.DustSecretKey,
-      dustParameters: ledger.DustParameters,
+    static startWithKeys(
+      keys: DustKeysByEpoch,
+      dustParameters: DustGenerationRates = defaultRates,
     ): ForkingDustWalletImplementation {
-      return ForkingDustWalletImplementation.startAtVariant(
+      const wallet = ForkingDustWalletImplementation.startFirst(
         ForkingDustWalletImplementation,
-        variants[V2Tag],
-        // Stamped with the boundary version rather than left at the minimum: a variant that starts from a state
-        // outside its own activation range reports that on sight, which is how a stranded snapshot heals — and here
-        // there is no variant above this one to hand over to. The state does belong to this variant, so it says so.
-        CoreWallet.withProtocolVersion(
-          CoreWallet.initEmpty(dustParameters, secretKey, configuration.networkId),
-          configuration.forkVersion,
-        ),
+        PreForkCoreWallet.initEmpty(asPreForkDustParameters(dustParameters), keys.v8, configuration.networkId),
       );
+      wallet.#retainKeys({ preFork: Option.some(keys.v8), postFork: Option.some(keys.v9) });
+      return wallet;
     }
 
     static tryRestore(serializedState: string): Either.Either<ForkingDustWalletImplementation, DustRestoreError> {
@@ -380,13 +456,11 @@ export function CustomForkingDustWallet<
      *   answers only for the post-fork one, which is the ledger version this wallet's public API speaks. Cleared by
      *   {@link stop} so a stopped wallet cannot be resurrected by a late activation.
      */
-    readonly #retainedStartMaterial = Ref.unsafeMake<Option.Option<RetainedStartMaterial>>(Option.none());
+    readonly #retainedKeys = Ref.unsafeMake<RetainedKeys>(noKeys);
 
-    /** Remembers a seed, which supersedes any key object retained for an individual variant. */
-    #retainSeed(seed: WalletSeed.WalletSeed): void {
-      Ref.set(this.#retainedStartMaterial, Option.some(StartMaterial.fromSeed<ledger.DustSecretKey>(seed))).pipe(
-        Effect.runSync,
-      );
+    /** Remembers key material for both sides of the boundary. */
+    #retainKeys(keys: RetainedKeys): void {
+      Ref.set(this.#retainedKeys, keys).pipe(Effect.runSync);
     }
 
     /**
@@ -397,16 +471,14 @@ export function CustomForkingDustWallet<
      */
     #resumeSyncOn<TStartAux>(
       running: { startSyncInBackground: (aux: TStartAux) => Effect.Effect<void> },
-      auxFor: (retained: RetainedStartMaterial) => Either.Either<TStartAux, StartMaterial.MissingStartAuxError>,
+      keysFor: (retained: RetainedKeys) => Either.Either<TStartAux, StartMaterial.MissingStartAuxError>,
     ): Effect.Effect<void, StartMaterial.MissingStartAuxError> {
-      return Ref.get(this.#retainedStartMaterial).pipe(
-        Effect.flatMap(
-          Option.match({
-            // Stopped, or never started: there is nothing to resume and nothing to resume it with.
-            onNone: () => Effect.void,
-            onSome: (retained: RetainedStartMaterial) =>
-              EitherOps.toEffect(auxFor(retained)).pipe(Effect.flatMap((aux) => running.startSyncInBackground(aux))),
-          }),
+      return Ref.get(this.#retainedKeys).pipe(
+        Effect.flatMap((retained) =>
+          // Stopped, or never started: there is nothing to resume and nothing to resume it with.
+          Option.isNone(retained.preFork) && Option.isNone(retained.postFork)
+            ? Effect.void
+            : EitherOps.toEffect(keysFor(retained)).pipe(Effect.flatMap((aux) => running.startSyncInBackground(aux))),
         ),
       );
     }
@@ -414,15 +486,13 @@ export function CustomForkingDustWallet<
     /** One synchronization step on a variant, with key material it can use. */
     #stepSyncOn<TStartAux, TError>(
       running: { sync: (aux: TStartAux) => Effect.Effect<void, TError> },
-      auxFor: (retained: RetainedStartMaterial) => Either.Either<TStartAux, StartMaterial.MissingStartAuxError>,
+      keysFor: (retained: RetainedKeys) => Either.Either<TStartAux, StartMaterial.MissingStartAuxError>,
     ): Effect.Effect<void, TError | StartMaterial.MissingStartAuxError> {
-      return Ref.get(this.#retainedStartMaterial).pipe(
-        Effect.flatMap(
-          Option.match({
-            onNone: () => Effect.void,
-            onSome: (retained: RetainedStartMaterial) =>
-              EitherOps.toEffect(auxFor(retained)).pipe(Effect.flatMap((aux) => running.sync(aux))),
-          }),
+      return Ref.get(this.#retainedKeys).pipe(
+        Effect.flatMap((retained) =>
+          Option.isNone(retained.preFork) && Option.isNone(retained.postFork)
+            ? Effect.void
+            : EitherOps.toEffect(keysFor(retained)).pipe(Effect.flatMap((aux) => running.sync(aux))),
         ),
       );
     }
@@ -463,19 +533,10 @@ export function CustomForkingDustWallet<
      */
     start(secretKey: ledger.DustSecretKey): Promise<void> {
       return Effect.gen(this, function* () {
-        yield* Ref.update(this.#retainedStartMaterial, (retained) =>
-          Option.some(
-            Option.match(retained, {
-              onNone: () => StartMaterial.forVariant<ledger.DustSecretKey>(V2Tag, secretKey),
-              // A retained seed already answers for every variant, including ones this wallet has not met, so a key
-              // object for one of them adds nothing. Otherwise the objects accumulate per variant tag.
-              onSome: (existing: RetainedStartMaterial) =>
-                existing._tag === 'FromSeed'
-                  ? existing
-                  : StartMaterial.forVariants<ledger.DustSecretKey>([...existing.byTag, [V2Tag, secretKey]]),
-            }),
-          ),
-        );
+        // The post-fork side only: this key belongs to that ledger version's runtime. Whatever the wallet already
+        // holds for the pre-fork side is left as it is, so a wallet built from a seed keeps the ability to read a
+        // chain that has not forked yet.
+        yield* Ref.update(this.#retainedKeys, (retained) => ({ ...retained, postFork: Option.some(secretKey) }));
 
         // Registered before the first dispatch, and only once: `onVariantActivation` resolves only after its
         // subscription is live, so an activation racing this call is queued rather than missed.
@@ -497,7 +558,7 @@ export function CustomForkingDustWallet<
     async stop(): Promise<void> {
       // Released before the runtime is torn down: the key material outlives neither the wallet nor an in-flight
       // activation.
-      Ref.set(this.#retainedStartMaterial, Option.none()).pipe(Effect.runSync);
+      Ref.set(this.#retainedKeys, noKeys).pipe(Effect.runSync);
       await super.stop();
     }
 
@@ -527,25 +588,9 @@ export function CustomForkingDustWallet<
      *   and says so by name.
      */
     #requireAux<TAux>(
-      auxFor: (retained: RetainedStartMaterial) => Either.Either<TAux, StartMaterial.MissingStartAuxError>,
-      variantTag: symbol,
+      keysFor: (retained: RetainedKeys) => Either.Either<TAux, StartMaterial.MissingStartAuxError>,
     ): Effect.Effect<TAux, StartMaterial.MissingStartAuxError> {
-      return Ref.get(this.#retainedStartMaterial).pipe(
-        Effect.flatMap(
-          Option.match({
-            onNone: () =>
-              Effect.fail(
-                new StartMaterial.MissingStartAuxError({
-                  message:
-                    `This wallet holds no key material: it has not been started, or it has been stopped. Start it ` +
-                    `before asking it to pay a fee.`,
-                  variantTag,
-                }),
-              ),
-            onSome: (retained: RetainedStartMaterial) => EitherOps.toEffect(auxFor(retained)),
-          }),
-        ),
-      );
+      return Ref.get(this.#retainedKeys).pipe(Effect.flatMap((retained) => EitherOps.toEffect(keysFor(retained))));
     }
 
     createDustGenerationTransaction(
@@ -684,14 +729,13 @@ export function CustomForkingDustWallet<
         .dispatch<bigint, TransactingError>({
           [V1Tag]: (v1) =>
             Effect.all([
-              this.#requireAux(preForkAux, V1Tag),
+              this.#requireAux(preForkAux),
               Effect.forEach(transactions, preForkTx<PreForkAnyTransaction>),
             ]).pipe(Effect.flatMap(([key, txs]) => v1.estimateFee(key, txs, effectiveTtl, currentTime))),
           [V2Tag]: (v2) =>
-            Effect.all([
-              this.#requireAux(postForkAux, V2Tag),
-              Effect.forEach(transactions, postForkTx<AnyTransaction>),
-            ]).pipe(Effect.flatMap(([key, txs]) => v2.estimateFee(key, txs, effectiveTtl, currentTime))),
+            Effect.all([this.#requireAux(postForkAux), Effect.forEach(transactions, postForkTx<AnyTransaction>)]).pipe(
+              Effect.flatMap(([key, txs]) => v2.estimateFee(key, txs, effectiveTtl, currentTime)),
+            ),
         })
         .pipe(Effect.runPromise);
     }
@@ -705,7 +749,7 @@ export function CustomForkingDustWallet<
         .dispatch<{ transaction: UnprovenTx; blockData: PricedBlockData }, TransactingError>({
           [V1Tag]: (v1) =>
             Effect.all([
-              this.#requireAux(preForkAux, V1Tag),
+              this.#requireAux(preForkAux),
               Effect.forEach(transactions, preForkTx<PreForkAnyTransaction>),
             ]).pipe(
               Effect.flatMap(([key, txs]) => v1.balanceTransactions(key, txs, ttl, currentTime)),
@@ -715,10 +759,7 @@ export function CustomForkingDustWallet<
               })),
             ),
           [V2Tag]: (v2) =>
-            Effect.all([
-              this.#requireAux(postForkAux, V2Tag),
-              Effect.forEach(transactions, postForkTx<AnyTransaction>),
-            ]).pipe(
+            Effect.all([this.#requireAux(postForkAux), Effect.forEach(transactions, postForkTx<AnyTransaction>)]).pipe(
               Effect.flatMap(([key, txs]) => v2.balanceTransactions(key, txs, ttl, currentTime)),
               Effect.map(({ transaction, blockData }) => ({
                 transaction: WalletTransaction.adopt('Unproven', transaction, postForkStamp),

--- a/packages/dust-wallet/src/ForkingDustWallet.ts
+++ b/packages/dust-wallet/src/ForkingDustWallet.ts
@@ -44,7 +44,7 @@ import {
 import { type Clock, EitherOps, HList } from '@midnightntwrk/wallet-sdk-utilities';
 import { Effect, Either, Option, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
-import { variantForSnapshot } from './Restore.js';
+import { type UnsupportedSnapshotVersionError, variantForSnapshot } from './Restore.js';
 import { type DefaultDustConfiguration, type DustWalletAPI, DustWalletState } from './DustWallet.js';
 import { type BlockData as PricedBlockData } from '@midnightntwrk/wallet-sdk-capabilities/validation';
 import { CoreWallet as PreForkCoreWallet, V1Builder, V1Tag, type V1Variant } from './v1/index.js';
@@ -56,7 +56,19 @@ import { type UtxoWithMeta } from './v2/types/Dust.js';
 import { type NetworkId } from './v2/types/index.js';
 import { type AnyTransaction as PreForkAnyTransaction } from './v1/types/ledger.js';
 import { type AnyTransaction } from './v2/types/ledger.js';
+import { type WalletError as PreForkWalletError } from './v1/WalletError.js';
 import { type WalletError } from './v2/WalletError.js';
+
+/**
+ * What restoring a Dust wallet from a snapshot can fail with.
+ *
+ * @remarks
+ *   Two failures, and they mean different things. The snapshot may declare a protocol version no registered variant
+ *   reads, which is a fact about this build of the SDK rather than about the snapshot; or the variant that owns it may
+ *   be unable to make sense of the bytes, which is a fact about the snapshot. Either is an ordinary thing to meet when
+ *   restoring something a user supplied, which is why `tryRestore` reports them rather than throwing.
+ */
+export type DustRestoreError = UnsupportedSnapshotVersionError | PreForkWalletError | WalletError;
 
 /**
  * What a transacting call can fail with.
@@ -165,6 +177,21 @@ export interface ForkingDustWalletClass<
    * @throws UnsupportedSnapshotVersionError if the snapshot declares a version no registered variant reads.
    */
   restore(serializedState: string): ForkingDustWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+  /**
+   * Restores a wallet from a snapshot, reporting what it could not read rather than throwing.
+   *
+   * @remarks
+   *   Additive alongside {@link restore}, which is unchanged and still the right shape for a snapshot the application has
+   *   just written itself. This is the shape for one it has not: a snapshot a user supplied, or one written by a build
+   *   of the SDK that is no longer the one running, where "I cannot read this" is an ordinary answer rather than a bug.
+   *   The two cannot disagree — `restore` is this, with the reason thrown.
+   * @param serializedState The serialized wallet state.
+   * @returns A wallet started from that state, or the reason the snapshot could not be read. See
+   *   {@link DustRestoreError}.
+   */
+  tryRestore(
+    serializedState: string,
+  ): Either.Either<ForkingDustWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>, DustRestoreError>;
 }
 
 /**
@@ -315,21 +342,31 @@ export function CustomForkingDustWallet<
       );
     }
 
-    static restore(serializedState: string): ForkingDustWalletImplementation {
+    static tryRestore(serializedState: string): Either.Either<ForkingDustWalletImplementation, DustRestoreError> {
       const headVariant = HList.head(ForkingDustWalletImplementation.allVariants());
-      const variant = variantForSnapshot(
+      return variantForSnapshot(
         serializedState,
         (version) => ForkingDustWalletImplementation.variantFor(version),
         headVariant,
-      ).pipe(Either.getOrThrow);
-      // Stated with its result type because the resolved variant is either of the two, so its deserializer is either
-      // of theirs: what comes back is a state of whichever one wrote the snapshot, which is what `startAtVariant`
-      // takes.
-      const deserialized = Either.getOrThrow<PreForkCoreWallet | CoreWallet, unknown>(
-        variant.variant.deserializeState(serializedState),
+      ).pipe(
+        // Stated with its result type because the resolved variant is either of the two, so its deserializer is
+        // either of theirs: what comes back is a state of whichever one wrote the snapshot, which is what
+        // `startAtVariant` takes.
+        Either.flatMap((variant): Either.Either<ForkingDustWalletImplementation, DustRestoreError> => {
+          // Annotated rather than inferred because the resolved variant is either of the two, so its deserializer is
+          // either of theirs: what comes back is a state of whichever one wrote the snapshot, which is what
+          // `startAtVariant` takes.
+          const deserialized: Either.Either<PreForkCoreWallet | CoreWallet, DustRestoreError> =
+            variant.variant.deserializeState(serializedState);
+          return Either.map(deserialized, (state) =>
+            ForkingDustWalletImplementation.startAtVariant(ForkingDustWalletImplementation, variant, state),
+          );
+        }),
       );
+    }
 
-      return ForkingDustWalletImplementation.startAtVariant(ForkingDustWalletImplementation, variant, deserialized);
+    static restore(serializedState: string): ForkingDustWalletImplementation {
+      return Either.getOrThrow(ForkingDustWalletImplementation.tryRestore(serializedState));
     }
 
     readonly state: rx.Observable<DustWalletState<string>>;

--- a/packages/dust-wallet/src/ForkingDustWallet.ts
+++ b/packages/dust-wallet/src/ForkingDustWallet.ts
@@ -49,7 +49,7 @@ import { type DefaultDustConfiguration, type DustWalletAPI, DustWalletState } fr
 import { type BlockData as PricedBlockData } from '@midnightntwrk/wallet-sdk-capabilities/validation';
 import { CoreWallet as PreForkCoreWallet, V1Builder, V1Tag, type V1Variant } from './v1/index.js';
 import { type WalletSyncUpdate as PreForkSyncUpdate } from './v1/Sync.js';
-import { CoreWallet, Migration, V2Builder, V2Tag, type V2Variant } from './v2/index.js';
+import { type CoreWallet, Migration, V2Builder, V2Tag, type V2Variant } from './v2/index.js';
 import { type WalletSyncUpdate as PostForkSyncUpdate } from './v2/SyncSchema.js';
 import { type NightUtxoSplitForDustRegistration } from './v2/Transacting.js';
 import { type UtxoWithMeta } from './v2/types/Dust.js';

--- a/packages/dust-wallet/src/test/tryRestore.test.ts
+++ b/packages/dust-wallet/src/test/tryRestore.test.ts
@@ -1,0 +1,81 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Restoring a Dust wallet from a snapshot that might not be readable. See the shielded wallet's suite of the same name
+ * for why the additive shape exists; the claims are the wallet-layer ones, and they hold identically here.
+ */
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Either } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { type DefaultDustConfiguration } from '../DustWallet.js';
+import { DustWallet } from '../ForkingDustWallet.js';
+import { UnsupportedSnapshotVersionError } from '../Restore.js';
+import { TransactionHistory } from '../v2/index.js';
+
+const configuration: DefaultDustConfiguration = {
+  networkId: NetworkId.NetworkId.Undeployed,
+  indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.DustTransactionHistoryEntrySchema),
+  costParameters: { feeBlocksMargin: 0 },
+  forkVersion: ProtocolVersion.ProtocolVersion(2_000_000n),
+};
+
+/** A snapshot declaring a protocol version far beyond anything this build registers a variant for. */
+const fromTheFuture = JSON.stringify({
+  state: 'deadbeef',
+  protocolVersion: String(ProtocolVersion.MaxSupportedVersion),
+  networkId: 'undeployed',
+});
+
+/** A snapshot no variant can read: routed to the head variant, which then cannot deserialize it. */
+const unreadable = JSON.stringify({ protocolVersion: '1', state: 'not a state at all' });
+
+const seed = Buffer.alloc(32, 7);
+
+describe('a Dust wallet restored from a snapshot it can read', () => {
+  it('comes back as a wallet, rather than as a reason it could not', async () => {
+    const source = DustWallet(configuration).startWithSeed(seed, ledger.LedgerParameters.initialParameters().dust);
+    const written = await source.serializeState();
+    await source.stop();
+
+    const restored = DustWallet(configuration).tryRestore(written);
+
+    expect(Either.isRight(restored)).toBe(true);
+    await Either.getOrThrow(restored).stop();
+  });
+});
+
+describe('a Dust wallet restored from a snapshot it cannot read', () => {
+  it('reports a protocol version no registered variant owns, instead of throwing', () => {
+    const failure = DustWallet(configuration).tryRestore(fromTheFuture).pipe(Either.flip, Either.getOrThrow);
+
+    expect(failure).toBeInstanceOf(UnsupportedSnapshotVersionError);
+  });
+
+  it('reports bytes that are not a wallet state, instead of throwing', () => {
+    expect(Either.isLeft(DustWallet(configuration).tryRestore(unreadable))).toBe(true);
+  });
+
+  it('refuses exactly the snapshots restore refuses, and keeps the reason restore discards', () => {
+    for (const snapshot of [fromTheFuture, unreadable]) {
+      expect(() => DustWallet(configuration).restore(snapshot)).toThrow();
+      expect(Either.isLeft(DustWallet(configuration).tryRestore(snapshot))).toBe(true);
+    }
+
+    expect(DustWallet(configuration).tryRestore(fromTheFuture).pipe(Either.flip, Either.getOrThrow)).toBeInstanceOf(
+      UnsupportedSnapshotVersionError,
+    );
+  });
+});

--- a/packages/dust-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/dust-wallet/src/v1/RunningV1Variant.ts
@@ -26,13 +26,12 @@ import {
 import { type TransactionHistoryService } from './TransactionHistory.js';
 import {
   type DustSecretKey,
-  nativeToken,
   type Signature,
   type SignatureVerifyingKey,
   type FinalizedTransaction,
   type UnprovenTransaction,
 } from '@midnight-ntwrk/ledger-v8';
-import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { ProtocolVersion, Token } from '@midnightntwrk/wallet-sdk-abstractions';
 import { OtherWalletError, type WalletError } from './WalletError.js';
 import { ArrayOps, EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
 import {
@@ -290,7 +289,7 @@ export class RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
     nightVerifyingKey: SignatureVerifyingKey,
     dustReceiverAddress: DustAddress | undefined,
   ): Effect.Effect<UnprovenTransaction, WalletError> {
-    if (nightUtxos.some((utxo) => utxo.type !== nativeToken().raw)) {
+    if (nightUtxos.some((utxo) => utxo.type !== Token.night)) {
       return Effect.fail(new OtherWalletError({ message: 'Token of a non-Night type received' }));
     }
     return Effect.Do.pipe(
@@ -323,7 +322,7 @@ export class RunningV1Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
     nightUtxos: ReadonlyArray<UtxoWithMeta>,
     isRegistration: boolean,
   ): Effect.Effect<NightUtxoSplitForDustRegistration, WalletError> {
-    if (nightUtxos.some((utxo) => utxo.type !== nativeToken().raw)) {
+    if (nightUtxos.some((utxo) => utxo.type !== Token.night)) {
       return Effect.fail(new OtherWalletError({ message: 'Token of a non-Night type received' }));
     }
     return Effect.gen(this, function* () {

--- a/packages/dust-wallet/src/v1/Transacting.ts
+++ b/packages/dust-wallet/src/v1/Transacting.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Effect, Either, pipe, BigInt as BigIntOps, Iterable as IterableOps, Option } from 'effect';
+import { Token } from '@midnightntwrk/wallet-sdk-abstractions';
 import {
   DustActions,
   DustRegistration,
@@ -30,7 +31,6 @@ import {
   type UnprovenTransaction,
   addressFromKey,
   type LedgerParameters,
-  nativeToken,
 } from '@midnight-ntwrk/ledger-v8';
 import { type DustAddress } from '@midnightntwrk/wallet-sdk-address-format';
 import { OtherWalletError, TransactingError, type WalletError, InsufficientFundsError } from './WalletError.js';
@@ -262,7 +262,7 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
       }));
       const output: UtxoOutput = {
         owner: addressFromKey(nightVerifyingKey),
-        type: nativeToken().raw,
+        type: Token.night,
         value: totalValue,
       };
 

--- a/packages/dust-wallet/src/v2/RunningV2Variant.ts
+++ b/packages/dust-wallet/src/v2/RunningV2Variant.ts
@@ -26,13 +26,12 @@ import {
 import { type TransactionHistoryService } from './TransactionHistory.js';
 import {
   type DustSecretKey,
-  nativeToken,
   type Signature,
   type SignatureVerifyingKey,
   type FinalizedTransaction,
   type UnprovenTransaction,
 } from '@midnightntwrk/ledger-v9';
-import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { ProtocolVersion, Token } from '@midnightntwrk/wallet-sdk-abstractions';
 import { OtherWalletError, type WalletError } from './WalletError.js';
 import { ArrayOps, EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
 import {
@@ -279,7 +278,7 @@ export class RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
     nightVerifyingKey: SignatureVerifyingKey,
     dustReceiverAddress: DustAddress | undefined,
   ): Effect.Effect<UnprovenTransaction, WalletError> {
-    if (nightUtxos.some((utxo) => utxo.type !== nativeToken().raw)) {
+    if (nightUtxos.some((utxo) => utxo.type !== Token.night)) {
       return Effect.fail(new OtherWalletError({ message: 'Token of a non-Night type received' }));
     }
     return Effect.Do.pipe(
@@ -312,7 +311,7 @@ export class RunningV2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>
     nightUtxos: ReadonlyArray<UtxoWithMeta>,
     isRegistration: boolean,
   ): Effect.Effect<NightUtxoSplitForDustRegistration, WalletError> {
-    if (nightUtxos.some((utxo) => utxo.type !== nativeToken().raw)) {
+    if (nightUtxos.some((utxo) => utxo.type !== Token.night)) {
       return Effect.fail(new OtherWalletError({ message: 'Token of a non-Night type received' }));
     }
     return Effect.gen(this, function* () {

--- a/packages/dust-wallet/src/v2/Transacting.ts
+++ b/packages/dust-wallet/src/v2/Transacting.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Effect, Either, pipe, BigInt as BigIntOps, Iterable as IterableOps, Option } from 'effect';
+import { Token } from '@midnightntwrk/wallet-sdk-abstractions';
 import {
   DustActions,
   DustRegistration,
@@ -30,7 +31,6 @@ import {
   type UnprovenTransaction,
   addressFromKey,
   type LedgerParameters,
-  nativeToken,
 } from '@midnightntwrk/ledger-v9';
 import { type DustAddress } from '@midnightntwrk/wallet-sdk-address-format';
 import { OtherWalletError, TransactingError, type WalletError, InsufficientFundsError } from './WalletError.js';
@@ -262,7 +262,7 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
       }));
       const output: UtxoOutput = {
         owner: addressFromKey(nightVerifyingKey),
-        type: nativeToken().raw,
+        type: Token.night,
         value: totalValue,
       };
 

--- a/packages/e2e-tests/src/tests/dustDeregistration.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dustDeregistration.undeployed.test.ts
@@ -109,10 +109,7 @@ describe('Dust Deregistration', () => {
       submissionService: (configuration) => makeDefaultSubmissionService(configuration),
     });
 
-    await walletFacade.start(
-      ledger.ZswapSecretKeys.fromSeed(shieldedWalletSeed),
-      ledger.DustSecretKey.fromSeed(dustWalletSeed),
-    );
+    await walletFacade.start({ shielded: shieldedWalletSeed, unshielded: shieldedWalletSeed, dust: dustWalletSeed });
   });
 
   afterEach(async () => {

--- a/packages/e2e-tests/src/tests/dustRegistration.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dustRegistration.undeployed.test.ts
@@ -139,14 +139,12 @@ describe('Dust Registration', () => {
     });
 
     await Promise.all([
-      senderFacade.start(
-        ledger.ZswapSecretKeys.fromSeed(shieldedSenderSeed),
-        ledger.DustSecretKey.fromSeed(dustSenderSeed),
-      ),
-      receiverFacade.start(
-        ledger.ZswapSecretKeys.fromSeed(shieldedReceiverSeed),
-        ledger.DustSecretKey.fromSeed(dustReceiverSeed),
-      ),
+      senderFacade.start({ shielded: shieldedSenderSeed, unshielded: shieldedSenderSeed, dust: dustSenderSeed }),
+      receiverFacade.start({
+        shielded: shieldedReceiverSeed,
+        unshielded: shieldedReceiverSeed,
+        dust: dustReceiverSeed,
+      }),
     ]);
   });
 

--- a/packages/e2e-tests/src/tests/emptyWallet.universal.test.ts
+++ b/packages/e2e-tests/src/tests/emptyWallet.universal.test.ts
@@ -67,9 +67,9 @@ describe('Fresh wallet with empty state', () => {
       ...walletConfig,
       txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
     });
-    shieldedWallet = Wallet.startWithSecretKeys(walletSecretKey);
+    shieldedWallet = Wallet.startWithSeed(utils.getShieldedSeed(walletSeed));
     unshieldedWallet = Unshielded.startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore));
-    dustWallet = Dust.startWithSecretKey(dustSecretKey, ledger.LedgerParameters.initialParameters().dust);
+    dustWallet = Dust.startWithSeed(utils.getDustSeed(walletSeed));
     await shieldedWallet.start(walletSecretKey);
     await unshieldedWallet.start();
     await dustWallet.start(dustSecretKey);

--- a/packages/e2e-tests/src/tests/facadeTransfer.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/facadeTransfer.undeployed.test.ts
@@ -130,14 +130,12 @@ describe('Wallet Facade Transfer', () => {
     });
 
     await Promise.all([
-      senderFacade.start(
-        ledger.ZswapSecretKeys.fromSeed(shieldedSenderSeed),
-        ledger.DustSecretKey.fromSeed(dustSenderSeed),
-      ),
-      receiverFacade.start(
-        ledger.ZswapSecretKeys.fromSeed(shieldedReceiverSeed),
-        ledger.DustSecretKey.fromSeed(dustReceiverSeed),
-      ),
+      senderFacade.start({ shielded: shieldedSenderSeed, unshielded: shieldedSenderSeed, dust: dustSenderSeed }),
+      receiverFacade.start({
+        shielded: shieldedReceiverSeed,
+        unshielded: shieldedReceiverSeed,
+        dust: dustReceiverSeed,
+      }),
     ]);
   });
 

--- a/packages/e2e-tests/src/tests/helpers/walletInit.ts
+++ b/packages/e2e-tests/src/tests/helpers/walletInit.ts
@@ -16,6 +16,7 @@ import { existsSync } from 'node:fs';
 import { exit } from 'node:process';
 import * as fsAsync from 'node:fs/promises';
 import * as ledger from '@midnightntwrk/ledger-v9';
+import { type WalletSeeds } from '@midnightntwrk/wallet-sdk-hd';
 import {
   InMemoryTransactionHistoryStorage,
   type TransactionHistoryStorage,
@@ -35,6 +36,8 @@ import { logger } from '../logger.js';
 import { getDustSeed, getShieldedSeed, getUnshieldedSeed } from './seeds.js';
 
 export type WalletInit = {
+  /** The three per-wallet seeds, which is what the facade is started and stepped with. */
+  seeds: WalletSeeds;
   wallet: WalletFacade;
   shieldedSecretKeys: ledger.ZswapSecretKeys;
   dustSecretKey: ledger.DustSecretKey;
@@ -147,6 +150,11 @@ export const provideWallet = async (
     exit(1);
   }
 
+  const seeds: WalletSeeds = {
+    shielded: getShieldedSeed(seed),
+    unshielded: getUnshieldedSeed(seed),
+    dust: getDustSeed(seed),
+  };
   const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(getShieldedSeed(seed));
   const dustSecretKey = ledger.DustSecretKey.fromSeed(getDustSeed(seed));
   const unshieldedKeystore = createKeystore(
@@ -183,7 +191,7 @@ export const provideWallet = async (
       unshielded: () => restoredUnshielded,
       dust: () => restoredDust,
     });
-    await restoredWallet.start(shieldedSecretKeys, dustSecretKey);
+    await restoredWallet.start(seeds);
     // check if wallet is syncing correctly
     await waitForSyncProgress(restoredWallet);
     const restoredWalletState = await rx.firstValueFrom(restoredWallet.state());
@@ -196,7 +204,7 @@ export const provideWallet = async (
       return initWalletWithSeed(seed, fixture);
     } else {
       logger.info('Successfully restored wallet facade.');
-      return { wallet: restoredWallet, shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
+      return { wallet: restoredWallet, shieldedSecretKeys, dustSecretKey, seeds, unshieldedKeystore };
     }
   }
 };
@@ -262,7 +270,7 @@ export type CustomWallets = {
    *   wallet would boot on the pre-fork variant, replay every event, and only reach projections after migrating.
    */
   dustWallet?: (config: DefaultDustConfiguration) => {
-    startWithSeed(seed: Uint8Array, dustParameters: ledger.DustParameters): DustWalletAPI;
+    startWithSeed(seed: Uint8Array, dustParameters?: ledger.DustParameters): DustWalletAPI;
   };
   manualSync?: boolean;
 };
@@ -276,6 +284,11 @@ export const initWalletWithSeed = async (
   customWallets: CustomWallets = {},
 ): Promise<WalletInit> => {
   const walletConfig = fixture.getWalletConfig();
+  const seeds: WalletSeeds = {
+    shielded: getShieldedSeed(seed),
+    unshielded: getUnshieldedSeed(seed),
+    dust: getDustSeed(seed),
+  };
   const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(getShieldedSeed(seed));
   const dustSecretKey = ledger.DustSecretKey.fromSeed(getDustSeed(seed));
   const unshieldedKeystore = createKeystore(
@@ -297,9 +310,8 @@ export const initWalletWithSeed = async (
     },
     shielded: (config) => ShieldedWallet(config).startWithSeed(getShieldedSeed(seed)),
     unshielded: (config) => UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
-    dust: (config) =>
-      dustWalletClass(config).startWithSeed(getDustSeed(seed), ledger.LedgerParameters.initialParameters().dust),
+    dust: (config) => dustWalletClass(config).startWithSeed(getDustSeed(seed)),
   });
-  await facade.start(shieldedSecretKeys, dustSecretKey, manualSync);
-  return { wallet: facade, shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
+  await facade.start(seeds, { manualSync });
+  return { wallet: facade, shieldedSecretKeys, dustSecretKey, seeds, unshieldedKeystore };
 };

--- a/packages/e2e-tests/src/tests/multipleWallets.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/multipleWallets.undeployed.test.ts
@@ -84,7 +84,7 @@ describe('Syncing', () => {
           unshielded: () => unshieldedWallets[i],
           dust: () => dustWallets[i],
         });
-        await facades[i].start(ledger.ZswapSecretKeys.fromSeed(seeds[i]), ledger.DustSecretKey.fromSeed(seeds[i]));
+        await facades[i].start({ shielded: seeds[i], unshielded: seeds[i], dust: seeds[i] });
       }
     }
 

--- a/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
@@ -122,7 +122,7 @@ describe('Optional Balancing', () => {
       provingService: () => makeWasmProvingService(),
     });
 
-    await facade.start(ledger.ZswapSecretKeys.fromSeed(shieldedSeed), ledger.DustSecretKey.fromSeed(dustSeed));
+    await facade.start({ shielded: shieldedSeed, unshielded: shieldedSeed, dust: dustSeed });
   });
 
   afterEach(async () => {

--- a/packages/e2e-tests/src/tests/projectionsBasedSync.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/projectionsBasedSync.undeployed.test.ts
@@ -128,8 +128,8 @@ describe('Projections-based synchronisation model', () => {
     const receiverStateEventsSynced = await receiverEventsSynced.wallet.waitForSyncedState();
 
     // Projections-based sync
-    await funded.wallet.doSync(funded.dustSecretKey);
-    await receiver.wallet.doSync(receiver.dustSecretKey);
+    await funded.wallet.doSync(funded.seeds);
+    await receiver.wallet.doSync(receiver.seeds);
 
     const fundedState = await funded.wallet.waitForSyncedState();
     const receiverState = await receiver.wallet.waitForSyncedState();
@@ -190,8 +190,8 @@ describe('Projections-based synchronisation model', () => {
 
     await utils.waitForBlockAdvancement(fixture.getIndexerUri());
 
-    await funded.wallet.doSync(funded.dustSecretKey);
-    await receiver.wallet.doSync(receiver.dustSecretKey);
+    await funded.wallet.doSync(funded.seeds);
+    await receiver.wallet.doSync(receiver.seeds);
 
     const ttl = new Date(Date.now() + 30 * 60 * 1000);
     const txRecipe = await funded.wallet.transferTransaction(outputsToCreate, { ttl });
@@ -240,7 +240,7 @@ describe('Projections-based synchronisation model', () => {
     logger.info(`Dust registration tx id: ${dustRegistrationTxid}`);
 
     await utils.waitForBlockAdvancement(fixture.getIndexerUri());
-    await receiver.wallet.doSync(receiver.dustSecretKey);
+    await receiver.wallet.doSync(receiver.seeds);
 
     const receiverStateAfterRegistration = await utils.waitForStateAfterDustRegistration(
       receiver.wallet,
@@ -287,7 +287,7 @@ describe('Projections-based synchronisation model', () => {
         expect(deepestDustChain).toBeGreaterThanOrEqual(expectedChainDepth);
       }
 
-      await funded.wallet.doSync(funded.dustSecretKey);
+      await funded.wallet.doSync(funded.seeds);
 
       const eventsState = await fundedEventsSynced.wallet.waitForSyncedState();
       const projectionsState = await funded.wallet.waitForSyncedState();
@@ -302,7 +302,7 @@ describe('Projections-based synchronisation model', () => {
       // receiver starts on a fresh blockchain with no prior UTXOs — the projection snapshot is
       // empty, so the sync should be purely a roundtrip to the indexer with no heavy computation.
       const start = Date.now();
-      await receiver.wallet.doSync(receiver.dustSecretKey);
+      await receiver.wallet.doSync(receiver.seeds);
       const elapsedMs = Date.now() - start;
 
       const state = await receiver.wallet.waitForSyncedState();
@@ -318,7 +318,7 @@ describe('Projections-based synchronisation model', () => {
     'Incremental projections-based sync after new blocks is near-instant',
     async () => {
       // Establish a clean baseline state for receiver (empty wallet).
-      await receiver.wallet.doSync(receiver.dustSecretKey);
+      await receiver.wallet.doSync(receiver.seeds);
       await receiver.wallet.waitForSyncedState();
 
       // Advance the chain without involving the receiver wallet.
@@ -328,7 +328,7 @@ describe('Projections-based synchronisation model', () => {
       await utils.waitForBlockAdvancement(fixture.getIndexerUri());
 
       const start = Date.now();
-      await receiver.wallet.doSync(receiver.dustSecretKey);
+      await receiver.wallet.doSync(receiver.seeds);
       const elapsedMs = Date.now() - start;
 
       const state = await receiver.wallet.waitForSyncedState();

--- a/packages/e2e-tests/src/tests/swap.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/swap.undeployed.test.ts
@@ -137,14 +137,8 @@ describe('Swaps', () => {
     });
 
     await Promise.all([
-      walletAFacade.start(
-        ledger.ZswapSecretKeys.fromSeed(shieldedWalletASeed),
-        ledger.DustSecretKey.fromSeed(dustWalletASeed),
-      ),
-      walletBFacade.start(
-        ledger.ZswapSecretKeys.fromSeed(shieldedWalletBSeed),
-        ledger.DustSecretKey.fromSeed(dustWalletBSeed),
-      ),
+      walletAFacade.start({ shielded: shieldedWalletASeed, unshielded: shieldedWalletASeed, dust: dustWalletASeed }),
+      walletBFacade.start({ shielded: shieldedWalletBSeed, unshielded: shieldedWalletBSeed, dust: dustWalletBSeed }),
     ]);
   });
 

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -49,7 +49,7 @@ import { DustSectionSchema, mergeDustSections } from '@midnightntwrk/wallet-sdk-
 import { Clock } from '@midnightntwrk/wallet-sdk-utilities';
 import { FetchTermsAndConditions as FetchTermsAndConditionsQuery } from '@midnightntwrk/wallet-sdk-indexer-client';
 import { QueryRunner } from '@midnightntwrk/wallet-sdk-indexer-client/effect';
-import { Array as Arr, Either, Option, pipe, Schema } from 'effect';
+import { Array as Arr, type DateTime, Either, Option, pipe, Schema } from 'effect';
 import {
   type AnyTx,
   type FinalizedTx,
@@ -524,11 +524,86 @@ export const protocolPhaseOf = (
   };
 };
 
+/**
+ * What has become of a transaction the wallet submitted.
+ *
+ * @remarks
+ *   Tagged rather than a status string, and deliberately: `Orphaned` and `Rejected` are different facts about the world
+ *   and the difference matters to what an application should do next. A rejection is the chain's verdict — the node saw
+ *   the transaction and refused it. An orphaned transaction has no verdict at all and never will: its bytes were
+ *   authored under a protocol version the chain has moved past, and nothing can include them afterwards. The wallet has
+ *   already unbooked its coins and recorded the rejection either way; what differs is what an application can tell a
+ *   user, and whether re-submitting the same bytes could ever help.
+ */
+export type PendingStatus =
+  | Readonly<{ _tag: 'Submitted' }>
+  | Readonly<{ _tag: 'Confirmed'; segments: readonly Readonly<{ id: number; success: boolean }>[] }>
+  | Readonly<{ _tag: 'Rejected'; segments: readonly Readonly<{ id: number; success: boolean }>[] }>
+  | Readonly<{
+      _tag: 'Orphaned';
+      /** The protocol version the transaction was authored for. */
+      authoredFor: ProtocolVersion.ProtocolVersion;
+      /** The protocol version the chain had reached when the wallet gave up on it. */
+      chainNow: ProtocolVersion.ProtocolVersion;
+    }>;
+
+/** A transaction the wallet has submitted and the chain has not finished answering for. */
+export type PendingTransaction = Readonly<{
+  /** The transaction itself, as the handle an application carries. */
+  transaction: FinalizedTx;
+  /** When the wallet recorded it as pending. */
+  submittedAt: DateTime.Utc;
+  /**
+   * The protocol version it was authored for, when the wallet had observed one.
+   *
+   * @remarks
+   *   `Option.none()` means the wallet never learned which version it was authored against. Such a transaction is never
+   *   orphaned — an unobserved version is not evidence of anything.
+   */
+  authoredFor: Option.Option<ProtocolVersion.ProtocolVersion>;
+  /** What has become of it. See {@link PendingStatus}. */
+  status: PendingStatus;
+}>;
+
+/** Reads what has become of a transaction from the verdict the pending set holds, if it holds one. */
+const pendingStatusOf = (result: PendingTransactions.TransactionResult | undefined): PendingStatus => {
+  if (result === undefined) return { _tag: 'Submitted' };
+  switch (result.status) {
+    case 'SUCCESS':
+      return { _tag: 'Confirmed', segments: result.segments };
+    case 'FAILURE':
+    case 'PARTIAL_SUCCESS':
+      // A transaction only some of whose segments succeeded is still not a transaction that happened as submitted.
+      return { _tag: 'Rejected', segments: result.segments };
+    case 'ORPHANED_BY_FORK':
+      return { _tag: 'Orphaned', authoredFor: result.authoredFor, chainNow: result.chainNow };
+  }
+};
+
+/**
+ * The pending transactions as an application reads them.
+ *
+ * @remarks
+ *   A projection over the pending set the services keep, not a second copy of it: the facts are the same, stated as a
+ *   list of transactions with a status each rather than as the bag the machinery works in.
+ * @param pending The pending set.
+ * @returns One entry per transaction, in the order the wallet recorded them.
+ */
+export const pendingTransactionsOf = (
+  pending: PendingTransactions.PendingTransactions<FinalizedTx>,
+): readonly PendingTransaction[] =>
+  pending.all.map((item) => ({
+    transaction: item.tx,
+    submittedAt: item.creationTime,
+    authoredFor: item.protocolVersion,
+    status: pendingStatusOf('result' in item ? item.result : undefined),
+  }));
+
 export class FacadeState {
   public readonly shielded: ShieldedWalletState;
   public readonly unshielded: UnshieldedWalletState;
   public readonly dust: DustWalletState;
-  public readonly pending: PendingTransactions.PendingTransactions<FinalizedTx>;
+  public readonly pending: readonly PendingTransaction[];
 
   /** The protocol version each of the three wallets has reached. */
   public get protocolVersion(): WalletProtocolVersions {
@@ -582,7 +657,7 @@ export class FacadeState {
     this.shielded = shielded;
     this.unshielded = unshielded;
     this.dust = dust;
-    this.pending = pending;
+    this.pending = pendingTransactionsOf(pending);
     this.#forkVersion = forkVersion;
   }
 }

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -416,6 +416,66 @@ export const lowestProtocolVersion = (versions: WalletProtocolVersions): Protoco
     candidate < lowest ? candidate : lowest,
   );
 
+/** Which of the three wallets a reading is about. */
+export type WalletKind = keyof WalletProtocolVersions;
+
+/**
+ * Whether the three wallets agree about which side of a protocol boundary the chain is on.
+ *
+ * @remarks
+ *   `Settled` is the ordinary state, and says which protocol version the facade is acting at. `Crossing` is the window
+ *   around a fork during which the wallets disagree: each one learns of the change when its own synchronization reaches
+ *   it, so for a while some have crossed and some have not. Nothing the facade builds during that window can span the
+ *   boundary, so it stays bound to the version the laggards are still on — which is what `from` reports, and what
+ *   `activeProtocolVersion` answers.
+ *
+ *   A difference in version _within_ one epoch is not a crossing: two versions on the same side of the boundary are the
+ *   same ledger version, and a wallet lagging there is ordinary synchronization.
+ */
+export type ProtocolPhase =
+  | Readonly<{ _tag: 'Settled'; version: ProtocolVersion.ProtocolVersion }>
+  | Readonly<{
+      _tag: 'Crossing';
+      /** The version the facade is still bound to: the epoch the wallets that have not crossed are in. */
+      from: ProtocolVersion.ProtocolVersion;
+      /** The version the wallets that have crossed have reached. */
+      to: ProtocolVersion.ProtocolVersion;
+      /** The wallets still on the near side, in a fixed order, so an application can say what it is waiting for. */
+      behind: readonly WalletKind[];
+    }>;
+
+/** The three wallets in a fixed order, so {@link protocolPhaseOf} reports them the same way every time. */
+const walletKinds = ['shielded', 'unshielded', 'dust'] as const satisfies readonly WalletKind[];
+
+/**
+ * Reads whether the wallets are settled on one side of a protocol boundary, or still crossing it.
+ *
+ * @remarks
+ *   Derived entirely from the version each wallet has reported and where the boundary lies — the same two facts every
+ *   other version-routing decision in the SDK is made from, so this reading cannot disagree with them.
+ * @param versions The version each wallet has reached.
+ * @param forkVersion The version at which the chain hands over to the next ledger version.
+ * @returns The reading. See {@link ProtocolPhase}.
+ */
+export const protocolPhaseOf = (
+  versions: WalletProtocolVersions,
+  forkVersion: ProtocolVersion.ProtocolVersion,
+): ProtocolPhase => {
+  const reported = walletKinds.map((kind) => [kind, versions[kind]] as const);
+  const from = lowestProtocolVersion(versions);
+  const epoch = ProtocolVersion.epochOf(from, forkVersion);
+  const crossed = reported.filter(([, version]) => !ProtocolVersion.withinRange(version, epoch));
+
+  if (crossed.length === 0) return { _tag: 'Settled', version: from };
+
+  return {
+    _tag: 'Crossing',
+    from,
+    to: crossed.reduce((highest, [, version]) => (version > highest ? version : highest), crossed[0][1]),
+    behind: reported.filter(([, version]) => ProtocolVersion.withinRange(version, epoch)).map(([kind]) => kind),
+  };
+};
+
 export class FacadeState {
   public readonly shielded: ShieldedWalletState;
   public readonly unshielded: UnshieldedWalletState;
@@ -442,6 +502,17 @@ export class FacadeState {
     return lowestProtocolVersion(this.protocolVersion);
   }
 
+  /**
+   * Whether the three wallets are settled on one side of the protocol boundary, or still crossing it.
+   *
+   * @remarks
+   *   Additive, and the reading `protocolVersion` alone cannot give: three versions that differ tell an application
+   *   nothing about whether the difference matters. See {@link ProtocolPhase}.
+   */
+  public get protocol(): ProtocolPhase {
+    return protocolPhaseOf(this.protocolVersion, this.#forkVersion);
+  }
+
   public get isSynced(): boolean {
     return (
       this.shielded.state.progress.isStrictlyComplete() &&
@@ -450,16 +521,21 @@ export class FacadeState {
     );
   }
 
+  /** Where the chain hands over from one ledger version to the next, which is what {@link protocol} is read against. */
+  readonly #forkVersion: ProtocolVersion.ProtocolVersion;
+
   constructor(
     shielded: ShieldedWalletState,
     unshielded: UnshieldedWalletState,
     dust: DustWalletState,
     pending: PendingTransactions.PendingTransactions<FinalizedTx>,
+    forkVersion: ProtocolVersion.ProtocolVersion = ProtocolVersion.MinSupportedVersion,
   ) {
     this.shielded = shielded;
     this.unshielded = unshielded;
     this.dust = dust;
     this.pending = pending;
+    this.#forkVersion = forkVersion;
   }
 }
 
@@ -997,7 +1073,7 @@ export class WalletFacade {
     ]).pipe(
       map(
         ([shieldedState, unshieldedState, dustState, pending]) =>
-          new FacadeState(shieldedState, unshieldedState, dustState, pending),
+          new FacadeState(shieldedState, unshieldedState, dustState, pending, this.#forkVersion),
       ),
     );
   }
@@ -1010,7 +1086,7 @@ export class WalletFacade {
       firstValueFrom(this.pendingTransactionsService.state()),
     ]);
 
-    return new FacadeState(shieldedState, unshieldedState, dustState, pending);
+    return new FacadeState(shieldedState, unshieldedState, dustState, pending, this.#forkVersion);
   }
 
   /**

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -61,6 +61,7 @@ import {
   WalletTransaction,
 } from '@midnightntwrk/wallet-sdk-abstractions';
 import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
+import { type WalletSeeds } from '@midnightntwrk/wallet-sdk-hd';
 import * as PreForkSignatures from '@midnightntwrk/wallet-sdk-capabilities/signatures';
 import {
   BehaviorSubject,
@@ -415,6 +416,53 @@ export const lowestProtocolVersion = (versions: WalletProtocolVersions): Protoco
   [versions.shielded, versions.unshielded, versions.dust].reduce((lowest, candidate) =>
     candidate < lowest ? candidate : lowest,
   );
+
+/**
+ * One ledger version's key objects per side of a protocol boundary.
+ *
+ * @remarks
+ *   The escape hatch for a caller that holds key objects rather than a seed. Both sides are required: key objects belong
+ *   to one ledger version's runtime and neither can be derived from the other, so a facade given one side alone would
+ *   hold wallets that cannot read half the chain. That is the shape seeds exist to avoid, and a product with one side
+ *   optional would reintroduce it.
+ */
+export type FacadeKeysByEpoch = Readonly<{
+  /** The pre-fork ledger version's key objects. */
+  v8: Readonly<{ shielded: preForkLedger.ZswapSecretKeys; dust: preForkLedger.DustSecretKey }>;
+  /** The post-fork ledger version's key objects. */
+  v9: Readonly<{ shielded: ledger.ZswapSecretKeys; dust: ledger.DustSecretKey }>;
+}>;
+
+/** What the facade will start its wallets from: seeds, or both ledger versions' key objects. */
+export type FacadeStartMaterial = WalletSeeds | FacadeKeysByEpoch;
+
+/** How the wallets are started. */
+export type FacadeStartOptions = Readonly<{
+  /**
+   * Leaves the dust wallet unstarted in the background, to be driven a step at a time with `doSync`.
+   *
+   * @remarks
+   *   Requires a dust wallet built with the projections sync service; see `makeEventLessSyncService`.
+   */
+  manualSync?: boolean;
+}>;
+
+/**
+ * The post-fork key objects the wallets' own `start` takes, from whichever material the caller supplied.
+ *
+ * @remarks
+ *   Only the post-fork side is needed here: a wallet built from seeds or from both versions' keys already holds what its
+ *   pre-fork variant needs, retained when it was built. What `start` supplies is the side the wallet's own API speaks.
+ */
+const postForkKeysOf = (
+  material: FacadeStartMaterial,
+): Readonly<{ shielded: ledger.ZswapSecretKeys; dust: ledger.DustSecretKey }> =>
+  'v9' in material
+    ? material.v9
+    : {
+        shielded: ledger.ZswapSecretKeys.fromSeed(material.shielded),
+        dust: ledger.DustSecretKey.fromSeed(material.dust),
+      };
 
 /** Which of the three wallets a reading is about. */
 export type WalletKind = keyof WalletProtocolVersions;
@@ -1702,21 +1750,32 @@ export class WalletFacade {
   /**
    * Starts the wallets and their background synchronization.
    *
-   * @param shieldedSecretKeys - Secret keys for the shielded wallet
-   * @param dustSecretKey - Secret key for the dust wallet
-   * @param manualSync - When true, the dust wallet is not started in the background; drive it explicitly with
+   * @remarks
+   *   Seeds, not key objects. A seed is the only key material that crosses a protocol boundary — every ledger version
+   *   derives its own keys from the same seed and arrives at the same identity — so a wallet started from seeds can
+   *   follow the chain across a fork, and one started from key objects of a single ledger version cannot. Derive them
+   *   once with `WalletSeeds.fromMasterSeed` and hand them over.
+   *
+   *   {@link FacadeKeysByEpoch} is the escape hatch for a caller that will not part with a seed. It requires **both**
+   *   ledger versions' key objects, because a wallet holding one side could not read the other side of the chain, and
+   *   it costs the caller an import of both ledger packages and the same derivation performed twice. A seed costs
+   *   neither.
+   * @example
+   *   ```typescript
+   *   await facade.start(WalletSeeds.fromMasterSeed(masterSeed));
+   *   ```;
+   *
+   * @param material The three wallets' seeds, or both ledger versions' key objects.
+   * @param options `manualSync` leaves the dust wallet unstarted in the background; drive it explicitly with
    *   {@link doSync} instead (requires a dust wallet built with the projections sync service, see
-   *   `makeEventLessSyncService`)
+   *   `makeEventLessSyncService`).
    */
-  async start(
-    shieldedSecretKeys: ledger.ZswapSecretKeys,
-    dustSecretKey: ledger.DustSecretKey,
-    manualSync: boolean = false,
-  ): Promise<void> {
+  async start(material: FacadeStartMaterial, options: FacadeStartOptions = {}): Promise<void> {
+    const keys = postForkKeysOf(material);
     await Promise.all([
-      this.shielded.start(shieldedSecretKeys),
+      this.shielded.start(keys.shielded),
       this.unshielded.start(),
-      !manualSync ? this.dust.start(dustSecretKey) : undefined,
+      !options.manualSync ? this.dust.start(keys.dust) : undefined,
       this.pendingTransactionsService.start(),
     ]);
   }
@@ -1725,10 +1784,10 @@ export class WalletFacade {
    * Runs a single dust synchronization pass and resolves when it completes. Only the dust wallet supports manual sync;
    * the shielded and unshielded wallets keep syncing in the background via {@link start}.
    *
-   * @param dustSecretKey - Secret key for the dust wallet
+   * @param material The same material {@link start} was given.
    */
-  async doSync(dustSecretKey: ledger.DustSecretKey): Promise<void> {
-    await this.dust.stepSync(dustSecretKey);
+  async doSync(material: FacadeStartMaterial): Promise<void> {
+    await this.dust.stepSync(postForkKeysOf(material).dust);
   }
 
   async stop(): Promise<void> {

--- a/packages/facade/test/orphanOnFork.test.ts
+++ b/packages/facade/test/orphanOnFork.test.ts
@@ -148,6 +148,15 @@ describe('A pending transaction the fork left behind', () => {
       ProtocolVersion.MinSupportedVersion,
     );
 
+  it('reports the boundary the wallets are on, and agrees with the version it acts at', async () => {
+    // The reading `activeProtocolVersion` alone cannot give: three versions that differ say nothing about whether the
+    // difference spans the boundary. Here the wallets have never synchronized, so they are all in the epoch a wallet
+    // with no history belongs to — which is a settled chain, at the version the facade is bound to.
+    const observed = await rx.firstValueFrom(facade.state());
+
+    expect(observed.protocol).toStrictEqual({ _tag: 'Settled', version: observed.activeProtocolVersion });
+  });
+
   it('asks the pending set to give up on everything the wallets have moved past', async () => {
     await sleep(0.2);
 

--- a/packages/facade/test/pendingStatus.test.ts
+++ b/packages/facade/test/pendingStatus.test.ts
@@ -1,0 +1,138 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * What an application sees about the transactions it has submitted and the chain has not answered for yet.
+ *
+ * @remarks
+ *   The machinery underneath already distinguishes every one of these: items are stamped with the version they were
+ *   authored for, a fork gives the stranded ones their own verdict, and the wallet reverts them. What the state exposed
+ *   was the machinery — a bag of items, some with a `result` field carrying an indexer-shaped status string, and the
+ *   protocol-upgrade case indistinguishable from a chain rejection unless the reader knew to compare strings. These are
+ *   the same facts as a tagged status an application can exhaust.
+ */
+import {
+  type FinalizedTx,
+  NetworkId,
+  ProtocolVersion,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk-abstractions';
+import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities';
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
+import { DateTime, Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { pendingTransactionsOf } from '../src/index.js';
+
+const authoredFor = ProtocolVersion.MinSupportedVersion;
+const chainNow = ProtocolVersion.ProtocolVersion(2_000_000n);
+const submittedAt = DateTime.unsafeMake(1_700_000_000_000);
+
+const aTransaction = (): FinalizedTx =>
+  WalletTransaction.adopt(
+    'Finalized',
+    preForkLedger.Transaction.fromParts(NetworkId.NetworkId.Undeployed),
+    authoredFor,
+  );
+
+const held = (
+  tx: FinalizedTx,
+  result?: PendingTransactions.TransactionResult,
+): PendingTransactions.PendingTransactions<FinalizedTx> => ({
+  all: [
+    {
+      tx,
+      creationTime: submittedAt,
+      protocolVersion: Option.some(authoredFor),
+      ...(result !== undefined ? { result } : {}),
+    },
+  ],
+});
+
+describe('a transaction the chain has not answered for', () => {
+  it('is submitted, and carries the transaction and when it was submitted', () => {
+    const tx = aTransaction();
+
+    expect(pendingTransactionsOf(held(tx))).toStrictEqual([
+      {
+        transaction: tx,
+        submittedAt,
+        authoredFor: Option.some(authoredFor),
+        status: { _tag: 'Submitted' },
+      },
+    ]);
+  });
+});
+
+describe('a transaction the chain rejected', () => {
+  it('is rejected, with the segments the chain reported', () => {
+    const tx = aTransaction();
+    const segments = [{ id: 0, success: false }];
+
+    expect(pendingTransactionsOf(held(tx, { status: 'FAILURE', segments }))[0].status).toStrictEqual({
+      _tag: 'Rejected',
+      segments,
+    });
+  });
+
+  it('is rejected when only some segments succeeded, which is still not a transaction that happened', () => {
+    const tx = aTransaction();
+    const segments = [
+      { id: 0, success: true },
+      { id: 1, success: false },
+    ];
+
+    expect(pendingTransactionsOf(held(tx, { status: 'PARTIAL_SUCCESS', segments }))[0].status).toStrictEqual({
+      _tag: 'Rejected',
+      segments,
+    });
+  });
+});
+
+describe('a transaction a protocol upgrade left behind', () => {
+  it('is orphaned, and says which version it was authored for and which the chain reached', () => {
+    const tx = aTransaction();
+
+    expect(
+      pendingTransactionsOf(held(tx, { status: 'ORPHANED_BY_FORK', authoredFor, chainNow }))[0].status,
+    ).toStrictEqual({ _tag: 'Orphaned', authoredFor, chainNow });
+  });
+
+  it('is not the same as a rejection, because the chain never said anything about it', () => {
+    // The distinction the previous shape could not make without comparing status strings: the node rejected this,
+    // versus this can never be submitted at all.
+    const rejected = pendingTransactionsOf(held(aTransaction(), { status: 'FAILURE', segments: [] }))[0];
+    const orphaned = pendingTransactionsOf(
+      held(aTransaction(), { status: 'ORPHANED_BY_FORK', authoredFor, chainNow }),
+    )[0];
+
+    expect(rejected.status._tag).not.toBe(orphaned.status._tag);
+  });
+});
+
+describe('a transaction the chain confirmed', () => {
+  it('is confirmed, for the moment before the wallet clears it', () => {
+    const tx = aTransaction();
+    const segments = [{ id: 0, success: true }];
+
+    expect(pendingTransactionsOf(held(tx, { status: 'SUCCESS', segments }))[0].status).toStrictEqual({
+      _tag: 'Confirmed',
+      segments,
+    });
+  });
+});
+
+describe('an empty pending set', () => {
+  it('is an empty list, which is what an application checks for', () => {
+    expect(pendingTransactionsOf(PendingTransactions.empty())).toStrictEqual([]);
+  });
+});

--- a/packages/facade/test/pendingTransactions.test.ts
+++ b/packages/facade/test/pendingTransactions.test.ts
@@ -33,9 +33,7 @@ import {
   getUnshieldedSeed,
   sleep,
 } from './utils/index.js';
-import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import * as rx from 'rxjs';
-import { finalizedTransactionTraits } from '../src/transaction.js';
 
 vi.setConfig({ testTimeout: 20_000, hookTimeout: 120_000 });
 
@@ -104,8 +102,8 @@ describe('Wallet Facade handling pending transactions', () => {
     expect(spiedShieldedRevert).toHaveBeenCalled();
     expect(spiedUnshieldedRevert).toHaveBeenCalled();
     expect(spiedDustRevert).toHaveBeenCalled();
-    expect(
-      PendingTransactions.has(state.pending, finalized, finalizedTransactionTraits(configuration.forkVersion)),
-    ).toBe(true);
+    // Read off the state's own projection now, rather than through the pending set's trait machinery: what an
+    // application sees is a list of transactions with a status each.
+    expect(state.pending.map((entry) => entry.transaction)).toContain(finalized);
   });
 });

--- a/packages/facade/test/pendingTransactions.test.ts
+++ b/packages/facade/test/pendingTransactions.test.ts
@@ -76,7 +76,7 @@ describe('Wallet Facade handling pending transactions', () => {
       dust: () => dust,
       provingService: () => createPreForkMockProvingService(),
     });
-    await facade?.start(ledger.ZswapSecretKeys.fromSeed(shieldedSeed), ledger.DustSecretKey.fromSeed(dustSeed));
+    await facade?.start({ shielded: shieldedSeed, unshielded: unshieldedSeed, dust: dustSeed });
   });
   afterEach(async () => {
     await facade?.stop();

--- a/packages/facade/test/protocolPhase.test.ts
+++ b/packages/facade/test/protocolPhase.test.ts
@@ -1,0 +1,96 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Whether the wallets agree about which side of a protocol boundary they are on.
+ *
+ * @remarks
+ *   The three wallets follow the same chain but not in lock-step: each learns of a protocol version change when its own
+ *   synchronization reaches it. Between the first of them crossing and the last, the facade cannot act at one version,
+ *   and an application that only reads `activeProtocolVersion` cannot tell that moment from an ordinary one. This is
+ *   the reading that can — stated over the version signals the facade already has, and never over a wall clock.
+ */
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { describe, expect, it } from 'vitest';
+import { protocolPhaseOf, type WalletProtocolVersions } from '../src/index.js';
+
+const version = (value: bigint): ProtocolVersion.ProtocolVersion => ProtocolVersion.ProtocolVersion(value);
+
+const forkVersion = version(2_000_000n);
+
+const versions = (shielded: bigint, unshielded: bigint, dust: bigint): WalletProtocolVersions => ({
+  shielded: version(shielded),
+  unshielded: version(unshielded),
+  dust: version(dust),
+});
+
+describe('a chain the wallets all read the same way', () => {
+  it('is settled at the version they act at, when all three are before the boundary', () => {
+    expect(protocolPhaseOf(versions(1n, 1n, 1n), forkVersion)).toStrictEqual({
+      _tag: 'Settled',
+      version: version(1n),
+    });
+  });
+
+  it('is settled when all three are past the boundary', () => {
+    expect(protocolPhaseOf(versions(2_000_000n, 2_000_001n, 2_000_000n), forkVersion)).toStrictEqual({
+      _tag: 'Settled',
+      version: version(2_000_000n),
+    });
+  });
+
+  it('is settled while they differ inside one epoch, because a difference there changes nothing', () => {
+    // Two versions on the same side of the boundary are the same ledger version, so a wallet lagging within the
+    // epoch is ordinary synchronization rather than a crossing.
+    expect(protocolPhaseOf(versions(1n, 5n, 3n), forkVersion)).toStrictEqual({
+      _tag: 'Settled',
+      version: version(1n),
+    });
+  });
+
+  it('is settled on a chain with no boundary at all, whatever the wallets report', () => {
+    expect(protocolPhaseOf(versions(1n, 9n, 4n), ProtocolVersion.MinSupportedVersion)).toStrictEqual({
+      _tag: 'Settled',
+      version: version(1n),
+    });
+  });
+});
+
+describe('a chain the wallets are still crossing', () => {
+  it('is crossing while any one of them is behind the boundary and any other is past it', () => {
+    expect(protocolPhaseOf(versions(2_000_000n, 1n, 2_000_000n), forkVersion)).toStrictEqual({
+      _tag: 'Crossing',
+      from: version(1n),
+      to: version(2_000_000n),
+      behind: ['unshielded'],
+    });
+  });
+
+  it('names every wallet still behind, so an application can say which one it is waiting for', () => {
+    expect(protocolPhaseOf(versions(2_000_000n, 1n, 3n), forkVersion)).toStrictEqual({
+      _tag: 'Crossing',
+      from: version(1n),
+      to: version(2_000_000n),
+      behind: ['unshielded', 'dust'],
+    });
+  });
+
+  it('reports the version the facade acts at as the one the laggards are still on', () => {
+    // `from` is what `activeProtocolVersion` answers, and deliberately so: it is the version the facade is bound to
+    // until the crossing finishes, and the one anything it builds meanwhile is stamped with.
+    const crossing = protocolPhaseOf(versions(1n, 2_000_000n, 2_000_000n), forkVersion);
+
+    expect(crossing._tag).toBe('Crossing');
+    expect(crossing._tag === 'Crossing' && crossing.from).toBe(version(1n));
+  });
+});

--- a/packages/facade/test/submission.test.ts
+++ b/packages/facade/test/submission.test.ts
@@ -101,7 +101,7 @@ describe('Facade submission', () => {
       },
     });
 
-    await facade.start(ledger.ZswapSecretKeys.fromSeed(seed), ledger.DustSecretKey.fromSeed(seed));
+    await facade.start({ shielded: seed, unshielded: seed, dust: seed });
     await facade.stop();
 
     expect(fakeSubmission.gotClosed).toBe(true);

--- a/packages/facade/test/utils/helpers.ts
+++ b/packages/facade/test/utils/helpers.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 import type * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { HDWallet, Roles } from '@midnightntwrk/wallet-sdk-hd';
+import { HDWallet, Roles, type WalletSeeds } from '@midnightntwrk/wallet-sdk-hd';
 import { WalletFacade, type Clock } from '../../src/index.js';
 import { CustomShieldedWallet, type ShieldedWalletAPI } from '@midnightntwrk/wallet-sdk-shielded';
 import {
@@ -263,6 +263,8 @@ export const createSimulatorWalletFactories = (config: SimulatorConfig): Simulat
 export type WalletKeys = {
   shieldedKeys: ledger.ZswapSecretKeys;
   dustKey: ledger.DustSecretKey;
+  /** The per-wallet seeds the keys above were derived from, which is what the facade is started with. */
+  seeds: WalletSeeds;
   unshieldedKeystore: ReturnType<typeof createKeystore>;
   signatureVerifyingKey: ledger.SignatureVerifyingKey;
   userAddress: ledger.UserAddress;
@@ -292,7 +294,14 @@ export const deriveWalletKeys = (
   const signatureVerifyingKey = ledger.signatureVerifyingKey(ledgerSigningKey);
   const userAddress = ledger.addressFromKey(signatureVerifyingKey);
 
-  return { shieldedKeys, dustKey, unshieldedKeystore, signatureVerifyingKey, userAddress };
+  return {
+    shieldedKeys,
+    dustKey,
+    seeds: { shielded: shieldedSeed, unshielded: unshieldedSeed, dust: dustSeed },
+    unshieldedKeystore,
+    signatureVerifyingKey,
+    userAddress,
+  };
 };
 
 /**
@@ -333,7 +342,7 @@ export const makeSimulatorFacade = (
       });
 
       // Start the wallet with keys
-      await facade.start(keys.shieldedKeys, keys.dustKey);
+      await facade.start(keys.seeds);
 
       return facade;
     }),

--- a/packages/hd/src/WalletSeeds.ts
+++ b/packages/hd/src/WalletSeeds.ts
@@ -1,0 +1,130 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The one seed an application holds, and the three the wallets are started from.
+ *
+ * @remarks
+ *   A Midnight wallet is three wallets, and each is started from its own seed derived from one master seed at its own
+ *   place in the BIP32 tree. Everything needed to walk that tree has always been here — {@link HDWallet}, {@link Roles} —
+ *   but the walk itself was left to callers, and every caller wrote it out again: select account zero, select the role,
+ *   derive at index zero, wipe the tree. Naming it once is what this is.
+ */
+import { HDWallet } from './HDWallet.js';
+import { type Role, Roles } from './HDWallet.js';
+
+/**
+ * The seeds the three wallets are started from.
+ *
+ * @remarks
+ *   Plain bytes, and deliberately so: a seed is the only key material that crosses a protocol boundary, because each
+ *   ledger version derives its own keys from it. Anything more specific would be a key object, which belongs to one
+ *   ledger version and cannot cross.
+ */
+export type WalletSeeds = Readonly<{
+  /** The seed the shielded wallet derives its Zswap secret keys from. */
+  shielded: Uint8Array;
+  /** The seed the unshielded wallet's signing key is made from. */
+  unshielded: Uint8Array;
+  /** The seed the Dust wallet derives its secret key from. */
+  dust: Uint8Array;
+}>;
+
+/** How the three seeds are placed in the tree, for a caller that wants somewhere other than the first address. */
+export type WalletSeedsOptions = Readonly<{
+  /** The account to derive within. Defaults to the first. */
+  account?: number;
+  /** The address index within each role. Defaults to the first. */
+  addressIndex?: number;
+  /**
+   * Which role the unshielded seed comes from.
+   *
+   * @remarks
+   *   The unshielded wallet can sign with either of two schemes, and they are different keys at different places in the
+   *   tree. Defaults to {@link Roles.NightExternal}, which is the scheme that works on both sides of the protocol
+   *   boundary; {@link Roles.EcdsaUnshielded} is only available from the post-fork ledger version onwards.
+   */
+  unshieldedRole?: Role;
+}>;
+
+/** Raised when a master seed cannot be walked down to the three per-wallet seeds. */
+export class SeedDerivationError extends Error {
+  override readonly name = 'SeedDerivationError';
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+  }
+}
+
+/**
+ * The seeds an application starts its three wallets from.
+ *
+ * @remarks
+ *   Throws rather than returning a result, because this sits at the boundary an application calls directly and its
+ *   failures are programming errors rather than ordinary states: a master seed BIP32 rejects, or an index outside the
+ *   tree. {@link HDWallet} remains available for a caller that would rather branch on a tagged result than catch.
+ */
+export const WalletSeeds = {
+  /**
+   * Derives the three wallets' seeds from one master seed.
+   *
+   * @remarks
+   *   The master seed itself is never retained: the BIP32 tree's private material is wiped before this returns, and the
+   *   bytes the caller passed in remain the caller's own. As everywhere in this SDK, "cleared" means the SDK stops
+   *   holding a reference — neither JavaScript nor WebAssembly offers a way to guarantee the bytes are gone from
+   *   memory, and no wallet in any language running on a general-purpose runtime can promise otherwise.
+   * @example
+   *   ```typescript
+   *   const seeds = WalletSeeds.fromMasterSeed(masterSeed);
+   *   await facade.start(seeds);
+   *   ```;
+   *
+   * @param masterSeed The master seed, as bytes.
+   * @param options Where in the tree to derive from, and which signing scheme the unshielded wallet will use.
+   * @returns The three per-wallet seeds. See {@link WalletSeeds}.
+   * @throws {@link SeedDerivationError} When the master seed cannot be read, or the account or index falls outside the
+   *   tree.
+   */
+  fromMasterSeed: (masterSeed: Uint8Array, options: WalletSeedsOptions = {}): WalletSeeds => {
+    const { account = 0, addressIndex = 0, unshieldedRole = Roles.NightExternal } = options;
+
+    const opened = HDWallet.fromSeed(masterSeed);
+    if (opened.type !== 'seedOk') {
+      throw new SeedDerivationError(
+        'This master seed is not one a BIP32 tree can be built from, so no wallet seed can be derived from it.',
+        { cause: opened.error },
+      );
+    }
+
+    const derived = opened.hdWallet
+      .selectAccount(account)
+      .selectRoles([Roles.Zswap, unshieldedRole, Roles.Dust])
+      .deriveKeysAt(addressIndex);
+
+    // Wiped whether or not the derivation succeeded: a failed walk is no reason to leave the tree open.
+    opened.hdWallet.clear();
+
+    if (derived.type !== 'keysDerived') {
+      throw new SeedDerivationError(
+        `No key exists at account ${account}, address index ${addressIndex} for ${derived.roles.length === 1 ? 'role' : 'roles'} ` +
+          `${derived.roles.join(', ')}: a BIP32 account, role and index are each whole numbers below 2^31.`,
+      );
+    }
+
+    return {
+      shielded: derived.keys[Roles.Zswap],
+      unshielded: derived.keys[unshieldedRole],
+      dust: derived.keys[Roles.Dust],
+    };
+  },
+};

--- a/packages/hd/src/index.ts
+++ b/packages/hd/src/index.ts
@@ -12,3 +12,4 @@
 // limitations under the License.
 export * from './HDWallet.js';
 export * from './MnemonicUtils.js';
+export * from './WalletSeeds.js';

--- a/packages/hd/test/walletSeeds.test.ts
+++ b/packages/hd/test/walletSeeds.test.ts
@@ -1,0 +1,95 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The one seed an application holds, and the three the wallets need.
+ *
+ * @remarks
+ *   Every consumer in this repository — the test kit, the end-to-end suites, the snippets — has been hand-rolling this
+ *   derivation, six near-identical copies of the same walk down the same tree, each one silently discarding the failure
+ *   branches. The walk is what `packages/hd` is for; naming it is what was missing.
+ *
+ *   The values below are pinned against the derivation as it stands today, not against a published specification. The
+ *   spec-reference test vectors cover the hop _after_ this one — a per-wallet seed to keys and addresses — and take the
+ *   per-wallet seed as given. Nothing published states what a master seed derives to per role, so what these vectors
+ *   protect is that the naming changed nothing.
+ */
+import { describe, expect, it } from 'vitest';
+import { HDWallet, Roles, WalletSeeds } from '../src/index.js';
+
+const hex = (bytes: Uint8Array): string => Buffer.from(bytes).toString('hex');
+
+const masterSeed = Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex');
+
+/** The walk every consumer in this repository has been writing out by hand. */
+const byHand = (role: (typeof Roles)[keyof typeof Roles], account = 0, index = 0): string => {
+  const result = HDWallet.fromSeed(masterSeed);
+  if (result.type !== 'seedOk') throw new Error('seed rejected');
+  const derived = result.hdWallet.selectAccount(account).selectRole(role).deriveKeyAt(index);
+  if (derived.type !== 'keyDerived') throw new Error('derivation out of bounds');
+  return hex(derived.key);
+};
+
+describe('the seeds one master seed derives to', () => {
+  it('gives each wallet the seed that wallet has always been given', () => {
+    const seeds = WalletSeeds.fromMasterSeed(masterSeed);
+
+    expect(hex(seeds.shielded)).toBe(byHand(Roles.Zswap));
+    expect(hex(seeds.unshielded)).toBe(byHand(Roles.NightExternal));
+    expect(hex(seeds.dust)).toBe(byHand(Roles.Dust));
+  });
+
+  it('derives the values it derives today, so naming the walk changed nothing', () => {
+    const seeds = WalletSeeds.fromMasterSeed(masterSeed);
+
+    expect(hex(seeds.shielded)).toBe('9690d4013e42e6739d9496f836b2cbd4339451c02a00624b86e9fb15cc4197a8');
+    expect(hex(seeds.unshielded)).toBe('22b8e577b3f638b2b361f36fd62d7138ed489d9afe3da5f7c325e2d0a95ae043');
+    expect(hex(seeds.dust)).toBe('b9b76cce66828aa6bd798abbb15b012331a6aa1e5f99e678724c37463b5775a1');
+  });
+
+  it('follows the account and address index it is asked for', () => {
+    const seeds = WalletSeeds.fromMasterSeed(masterSeed, { account: 2, addressIndex: 5 });
+
+    expect(hex(seeds.shielded)).toBe(byHand(Roles.Zswap, 2, 5));
+    expect(hex(seeds.unshielded)).toBe(byHand(Roles.NightExternal, 2, 5));
+    expect(hex(seeds.dust)).toBe(byHand(Roles.Dust, 2, 5));
+  });
+
+  it('derives the unshielded seed from whichever signing scheme the wallet will use', () => {
+    const ecdsa = WalletSeeds.fromMasterSeed(masterSeed, { unshieldedRole: Roles.EcdsaUnshielded });
+
+    expect(hex(ecdsa.unshielded)).toBe(byHand(Roles.EcdsaUnshielded));
+    // The other two are the same wallet whichever way its unshielded side signs.
+    expect(hex(ecdsa.shielded)).toBe(byHand(Roles.Zswap));
+    expect(hex(ecdsa.dust)).toBe(byHand(Roles.Dust));
+  });
+
+  it('does not hold the master seed open once it has what it needs', () => {
+    // The private material inside the BIP32 tree is wiped before this returns; an application that reads the master
+    // seed afterwards is reading its own buffer, which is the only copy the SDK never controlled.
+    const seeds = WalletSeeds.fromMasterSeed(masterSeed);
+
+    expect(hex(masterSeed)).toBe('0000000000000000000000000000000000000000000000000000000000000001');
+    expect(seeds.shielded).not.toBe(masterSeed);
+  });
+});
+
+describe('a master seed the tree cannot be walked from', () => {
+  it('says so, rather than deriving from nothing', () => {
+    expect(() => WalletSeeds.fromMasterSeed(new Uint8Array(0))).toThrow();
+  });
+
+  it('says so for an index outside the tree', () => {
+    expect(() => WalletSeeds.fromMasterSeed(masterSeed, { addressIndex: -1 })).toThrow();
+  });
+});

--- a/packages/shielded-wallet/src/ForkingShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ForkingShieldedWallet.ts
@@ -43,7 +43,7 @@ import {
 import { EitherOps, HList } from '@midnightntwrk/wallet-sdk-utilities';
 import { Effect, Either, Option, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
-import { variantForSnapshot } from './Restore.js';
+import { type UnsupportedSnapshotVersionError, variantForSnapshot } from './Restore.js';
 import {
   type DefaultShieldedConfiguration,
   type ShieldedBalancingResult,
@@ -55,7 +55,19 @@ import { type WalletSyncUpdate as PreForkSyncUpdate } from './v1/Sync.js';
 import { CoreWallet, Migration, V2Builder, V2Tag, type V2Variant } from './v2/index.js';
 import { type WalletSyncUpdate as PostForkSyncUpdate } from './v2/Sync.js';
 import { type TokenTransfer } from './v2/Transacting.js';
+import { type WalletError as PreForkWalletError } from './v1/WalletError.js';
 import { type WalletError } from './v2/WalletError.js';
+
+/**
+ * What restoring a shielded wallet from a snapshot can fail with.
+ *
+ * @remarks
+ *   Two failures, and they mean different things. The snapshot may declare a protocol version no registered variant
+ *   reads, which is a fact about this build of the SDK rather than about the snapshot; or the variant that owns it may
+ *   be unable to make sense of the bytes, which is a fact about the snapshot. Either is an ordinary thing to meet when
+ *   restoring something a user supplied, which is why `tryRestore` reports them rather than throwing.
+ */
+export type ShieldedRestoreError = UnsupportedSnapshotVersionError | PreForkWalletError | WalletError;
 
 /**
  * What a transacting call can fail with.
@@ -162,6 +174,21 @@ export interface ForkingShieldedWalletClass<
    * @throws UnsupportedSnapshotVersionError if the snapshot declares a version no registered variant reads.
    */
   restore(serializedState: string): ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+  /**
+   * Restores a wallet from a snapshot, reporting what it could not read rather than throwing.
+   *
+   * @remarks
+   *   Additive alongside {@link restore}, which is unchanged and still the right shape for a snapshot the application has
+   *   just written itself. This is the shape for one it has not: a snapshot a user supplied, or one written by a build
+   *   of the SDK that is no longer the one running, where "I cannot read this" is an ordinary answer rather than a bug.
+   *   The two cannot disagree — `restore` is this, with the reason thrown.
+   * @param serializedState The serialized wallet state.
+   * @returns A wallet started from that state, or the reason the snapshot could not be read. See
+   *   {@link ShieldedRestoreError}.
+   */
+  tryRestore(
+    serializedState: string,
+  ): Either.Either<ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>, ShieldedRestoreError>;
 }
 
 /**
@@ -293,25 +320,33 @@ export function CustomForkingShieldedWallet<
       );
     }
 
-    static restore(serializedState: string): ForkingShieldedWalletImplementation {
+    static tryRestore(
+      serializedState: string,
+    ): Either.Either<ForkingShieldedWalletImplementation, ShieldedRestoreError> {
       const headVariant = HList.head(ForkingShieldedWalletImplementation.allVariants());
-      const variant = variantForSnapshot(
+      return variantForSnapshot(
         serializedState,
         (version) => ForkingShieldedWalletImplementation.variantFor(version),
         headVariant,
-      ).pipe(Either.getOrThrow);
-      // Stated with its result type because the resolved variant is either of the two, so its deserializer is either
-      // of theirs: what comes back is a state of whichever one wrote the snapshot, which is what `startAtVariant`
-      // takes.
-      const deserialized = Either.getOrThrow<PreForkCoreWallet | CoreWallet, unknown>(
-        variant.variant.deserializeState(serializedState),
+      ).pipe(
+        // Stated with its result type because the resolved variant is either of the two, so its deserializer is
+        // either of theirs: what comes back is a state of whichever one wrote the snapshot, which is what
+        // `startAtVariant` takes.
+        Either.flatMap((variant): Either.Either<ForkingShieldedWalletImplementation, ShieldedRestoreError> => {
+          // Annotated rather than inferred because the resolved variant is either of the two, so its deserializer is
+          // either of theirs: what comes back is a state of whichever one wrote the snapshot, which is what
+          // `startAtVariant` takes.
+          const deserialized: Either.Either<PreForkCoreWallet | CoreWallet, ShieldedRestoreError> =
+            variant.variant.deserializeState(serializedState);
+          return Either.map(deserialized, (state) =>
+            ForkingShieldedWalletImplementation.startAtVariant(ForkingShieldedWalletImplementation, variant, state),
+          );
+        }),
       );
+    }
 
-      return ForkingShieldedWalletImplementation.startAtVariant(
-        ForkingShieldedWalletImplementation,
-        variant,
-        deserialized,
-      );
+    static restore(serializedState: string): ForkingShieldedWalletImplementation {
+      return Either.getOrThrow(ForkingShieldedWalletImplementation.tryRestore(serializedState));
     }
 
     readonly state: rx.Observable<ShieldedWalletState<string>>;

--- a/packages/shielded-wallet/src/ForkingShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ForkingShieldedWallet.ts
@@ -52,7 +52,7 @@ import {
 } from './ShieldedWallet.js';
 import { CoreWallet as PreForkCoreWallet, V1Builder, V1Tag, type V1Variant } from './v1/index.js';
 import { type WalletSyncUpdate as PreForkSyncUpdate } from './v1/Sync.js';
-import { CoreWallet, Migration, V2Builder, V2Tag, type V2Variant } from './v2/index.js';
+import { type CoreWallet, Migration, V2Builder, V2Tag, type V2Variant } from './v2/index.js';
 import { type WalletSyncUpdate as PostForkSyncUpdate } from './v2/Sync.js';
 import { type TokenTransfer } from './v2/Transacting.js';
 import { type WalletError as PreForkWalletError } from './v1/WalletError.js';

--- a/packages/shielded-wallet/src/ForkingShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ForkingShieldedWallet.ts
@@ -126,6 +126,21 @@ export type ForkingShieldedConfiguration = {
   forkVersion: ProtocolVersion.ProtocolVersion;
 };
 
+/**
+ * One ledger version's shielded key objects per side of a protocol boundary.
+ *
+ * @remarks
+ *   Both sides are required. A caller holding key objects rather than a seed has to hold both, because the two belong to
+ *   different ledger runtimes and neither can be derived from the other; a product with one side optional would let a
+ *   wallet be built that cannot read half the chain, which is the shape this replaced.
+ */
+export type ShieldedKeysByEpoch = Readonly<{
+  /** The pre-fork ledger version's Zswap secret keys. */
+  v8: v8.ZswapSecretKeys;
+  /** The post-fork ledger version's Zswap secret keys. */
+  v9: ledger.ZswapSecretKeys;
+}>;
+
 /** A running shielded wallet that spans a protocol boundary. */
 export type ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate> = ShieldedWalletAPI<
   ledger.ZswapSecretKeys,
@@ -153,19 +168,17 @@ export interface ForkingShieldedWalletClass<
    */
   startWithSeed(seed: Uint8Array): ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
   /**
-   * Builds a wallet from post-fork key objects, starting it on the post-fork variant.
+   * Builds a wallet from key objects of both ledger versions.
    *
    * @remarks
-   *   Key objects belong to one ledger version's runtime, so they answer for one variant and no other: there is nothing
-   *   to convert, and the public keys being identical either side does not help — decryption needs the secret. A wallet
-   *   built this way therefore starts on the variant its keys belong to and stays there. It cannot read a chain that is
-   *   still pre-fork, which is the honest consequence of holding only post-fork keys; start from a seed to do that.
-   * @param secretKeys The post-fork ledger version's Zswap secret keys.
-   * @returns A wallet started on the post-fork variant.
+   *   The escape hatch for a caller that will not hand over a seed. Both sides are required, and that is the whole point:
+   *   key objects belong to one ledger version's runtime, so a wallet given one side alone could not read the other
+   *   side of the chain — and a partial product here would be exactly the foot-gun the single-key start was. It costs
+   *   the caller an import of both ledger packages and the same derivation done twice; a seed costs neither.
+   * @param keys One ledger version's Zswap secret keys per side of the boundary.
+   * @returns A wallet started on the pre-fork variant, which is where a wallet with no history belongs.
    */
-  startWithSecretKeys(
-    secretKeys: ledger.ZswapSecretKeys,
-  ): ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+  startWithKeys(keys: ShieldedKeysByEpoch): ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
   /**
    * Restores a wallet from a snapshot, into whichever registered variant wrote it.
    *
@@ -228,7 +241,6 @@ export function CustomForkingShieldedWallet<
   postFork: SelfConfiguredShieldedVariant<PostForkShieldedVariant<TPostForkSyncUpdate>, TPostForkConfig>,
 ): ForkingShieldedWalletClass<TPreForkSyncUpdate, TPostForkSyncUpdate, TConfiguration> {
   type Variants = ForkingShieldedVariants<TPreForkSyncUpdate, TPostForkSyncUpdate>;
-  type RetainedStartMaterial = StartMaterial.StartMaterial<ledger.ZswapSecretKeys>;
 
   // Registered through the shape the builder states rather than through the one this function was handed. The two are
   // the same builder; what is dropped is the configuration *type*, which the parameter types have already paired with
@@ -250,23 +262,66 @@ export function CustomForkingShieldedWallet<
   const variants = BaseWallet.allVariantsRecord();
 
   /**
-   * The pre-fork variant's key material, which only a retained seed can produce.
+   * The key material this wallet holds, one entry per side of the protocol boundary.
    *
    * @remarks
-   *   The wallet's public API speaks the post-fork ledger version's key objects, and the pre-fork variant cannot use one:
-   *   they belong to different ledger runtimes. So a wallet holding key objects has nothing this variant can start
-   *   with, and says so instead of handing over keys it would silently misuse.
+   *   Key objects belong to one ledger version's runtime and cannot be converted, so "the keys this wallet holds" is two
+   *   questions, not one, and the type says so: each side is present or it is not, independently. A wallet that holds
+   *   only the post-fork side cannot read a chain that is still pre-fork, and finds that out here rather than by
+   *   handing over keys the other runtime would misread.
+   *
+   *   A seed is not among them. A seed can produce either side, so a wallet given one derives both at once and keeps the
+   *   results — which is the same capability with a shorter-lived secret, since from that moment the seed is not this
+   *   wallet's to hold.
    */
-  const preForkAux = (
-    retained: RetainedStartMaterial,
-  ): Either.Either<v8.ZswapSecretKeys, StartMaterial.MissingStartAuxError> =>
-    StartMaterial.requireDerivedAuxFor(retained, V1Tag, (seed) => variants[V1Tag].variant.startAux.fromSeed(seed));
+  type RetainedKeys = Readonly<{
+    preFork: Option.Option<v8.ZswapSecretKeys>;
+    postFork: Option.Option<ledger.ZswapSecretKeys>;
+  }>;
 
-  /** The post-fork variant's key material: what the application handed over, or the retained seed's derivation. */
+  /** Nothing retained: never started, or stopped. */
+  const noKeys: RetainedKeys = { preFork: Option.none(), postFork: Option.none() };
+
+  /** Both sides, derived from one seed. */
+  const keysFromSeed = (seed: WalletSeed.WalletSeed): RetainedKeys => ({
+    preFork: Option.some(variants[V1Tag].variant.startAux.fromSeed(seed)),
+    postFork: Option.some(variants[V2Tag].variant.startAux.fromSeed(seed)),
+  });
+
+  /**
+   * What a variant can be started with, or why it cannot be.
+   *
+   * @remarks
+   *   Two different failures, deliberately distinguished: a wallet that was never started (or has been stopped) holds
+   *   nothing at all, while one started with the other side's key objects holds something it must not use here.
+   */
+  const auxFor = <TAux>(
+    retained: RetainedKeys,
+    side: Option.Option<TAux>,
+    variantTag: symbol,
+  ): Either.Either<TAux, StartMaterial.MissingStartAuxError> =>
+    Either.fromOption(
+      side,
+      () =>
+        new StartMaterial.MissingStartAuxError({
+          message:
+            Option.isNone(retained.preFork) && Option.isNone(retained.postFork)
+              ? `This wallet holds no key material: it has not been started, or it has been stopped. Start it ` +
+                `before asking it to synchronize or to build a transaction.`
+              : `This wallet was started with key material of the other protocol version, which the variant ` +
+                `${String(variantTag)} cannot use: key objects belong to one ledger version's runtime. Start it from ` +
+                `a seed, or hand it both versions' keys.`,
+          variantTag,
+        }),
+    );
+
+  const preForkAux = (retained: RetainedKeys): Either.Either<v8.ZswapSecretKeys, StartMaterial.MissingStartAuxError> =>
+    auxFor(retained, retained.preFork, V1Tag);
+
   const postForkAux = (
-    retained: RetainedStartMaterial,
+    retained: RetainedKeys,
   ): Either.Either<ledger.ZswapSecretKeys, StartMaterial.MissingStartAuxError> =>
-    StartMaterial.requireAuxFor(retained, V2Tag, (seed) => variants[V2Tag].variant.startAux.fromSeed(seed));
+    auxFor(retained, retained.postFork, V2Tag);
 
   /**
    * The protocol versions each variant owns, and the version a transaction it builds is stamped with.
@@ -297,27 +352,24 @@ export function CustomForkingShieldedWallet<
     static readonly configuration: TConfiguration = configuration;
 
     static startWithSeed(seed: Uint8Array): ForkingShieldedWalletImplementation {
-      const walletSeed = WalletSeed.WalletSeed(seed);
+      const derived = keysFromSeed(WalletSeed.WalletSeed(seed));
       const wallet = ForkingShieldedWalletImplementation.startFirst(
         ForkingShieldedWalletImplementation,
-        PreForkCoreWallet.initEmpty(variants[V1Tag].variant.startAux.fromSeed(walletSeed), configuration.networkId),
+        PreForkCoreWallet.initEmpty(Option.getOrThrow(derived.preFork), configuration.networkId),
       );
-      wallet.#retainSeed(walletSeed);
+      // Both sides derived here and now, and the seed reference dropped with this frame: from this point the wallet
+      // holds key objects only, which is strictly less than it held before and does the same work.
+      wallet.#retainKeys(derived);
       return wallet;
     }
 
-    static startWithSecretKeys(secretKeys: ledger.ZswapSecretKeys): ForkingShieldedWalletImplementation {
-      return ForkingShieldedWalletImplementation.startAtVariant(
+    static startWithKeys(keys: ShieldedKeysByEpoch): ForkingShieldedWalletImplementation {
+      const wallet = ForkingShieldedWalletImplementation.startFirst(
         ForkingShieldedWalletImplementation,
-        variants[V2Tag],
-        // Stamped with the boundary version rather than left at the minimum: a variant that starts from a state
-        // outside its own activation range reports that on sight, which is how a stranded snapshot heals — and here
-        // there is no variant above this one to hand over to. The state does belong to this variant, so it says so.
-        CoreWallet.withProtocolVersion(
-          CoreWallet.initEmpty(secretKeys, configuration.networkId),
-          configuration.forkVersion,
-        ),
+        PreForkCoreWallet.initEmpty(keys.v8, configuration.networkId),
       );
+      wallet.#retainKeys({ preFork: Option.some(keys.v8), postFork: Option.some(keys.v9) });
+      return wallet;
     }
 
     static tryRestore(
@@ -360,13 +412,11 @@ export function CustomForkingShieldedWallet<
      *   answer only for the post-fork one, which is the ledger version this wallet's public API speaks. Cleared by
      *   {@link stop} so a stopped wallet cannot be resurrected by a late activation.
      */
-    readonly #retainedStartMaterial = Ref.unsafeMake<Option.Option<RetainedStartMaterial>>(Option.none());
+    readonly #retainedKeys = Ref.unsafeMake<RetainedKeys>(noKeys);
 
-    /** Remembers a seed, which supersedes any key objects retained for individual variants. */
-    #retainSeed(seed: WalletSeed.WalletSeed): void {
-      Ref.set(this.#retainedStartMaterial, Option.some(StartMaterial.fromSeed<ledger.ZswapSecretKeys>(seed))).pipe(
-        Effect.runSync,
-      );
+    /** Remembers key material for both sides of the boundary. */
+    #retainKeys(keys: RetainedKeys): void {
+      Ref.set(this.#retainedKeys, keys).pipe(Effect.runSync);
     }
 
     /**
@@ -377,16 +427,14 @@ export function CustomForkingShieldedWallet<
      */
     #resumeSyncOn<TStartAux>(
       running: { startSyncInBackground: (aux: TStartAux) => Effect.Effect<void> },
-      auxFor: (retained: RetainedStartMaterial) => Either.Either<TStartAux, StartMaterial.MissingStartAuxError>,
+      keysFor: (retained: RetainedKeys) => Either.Either<TStartAux, StartMaterial.MissingStartAuxError>,
     ): Effect.Effect<void, StartMaterial.MissingStartAuxError> {
-      return Ref.get(this.#retainedStartMaterial).pipe(
-        Effect.flatMap(
-          Option.match({
-            // Stopped, or never started: there is nothing to resume and nothing to resume it with.
-            onNone: () => Effect.void,
-            onSome: (retained: RetainedStartMaterial) =>
-              EitherOps.toEffect(auxFor(retained)).pipe(Effect.flatMap((aux) => running.startSyncInBackground(aux))),
-          }),
+      return Ref.get(this.#retainedKeys).pipe(
+        Effect.flatMap((retained) =>
+          // Stopped, or never started: there is nothing to resume and nothing to resume it with.
+          Option.isNone(retained.preFork) && Option.isNone(retained.postFork)
+            ? Effect.void
+            : EitherOps.toEffect(keysFor(retained)).pipe(Effect.flatMap((aux) => running.startSyncInBackground(aux))),
         ),
       );
     }
@@ -427,19 +475,10 @@ export function CustomForkingShieldedWallet<
      */
     start(secretKeys: ledger.ZswapSecretKeys): Promise<void> {
       return Effect.gen(this, function* () {
-        yield* Ref.update(this.#retainedStartMaterial, (retained) =>
-          Option.some(
-            Option.match(retained, {
-              onNone: () => StartMaterial.forVariant<ledger.ZswapSecretKeys>(V2Tag, secretKeys),
-              // A retained seed already answers for every variant, including ones this wallet has not met, so key
-              // objects for one of them add nothing. Otherwise the objects accumulate per variant tag.
-              onSome: (existing: RetainedStartMaterial) =>
-                existing._tag === 'FromSeed'
-                  ? existing
-                  : StartMaterial.forVariants<ledger.ZswapSecretKeys>([...existing.byTag, [V2Tag, secretKeys]]),
-            }),
-          ),
-        );
+        // The post-fork side only: these keys belong to that ledger version's runtime. Whatever the wallet already
+        // holds for the pre-fork side is left as it is, so a wallet built from a seed keeps the ability to read a
+        // chain that has not forked yet.
+        yield* Ref.update(this.#retainedKeys, (retained) => ({ ...retained, postFork: Option.some(secretKeys) }));
 
         // Registered before the first dispatch, and only once: `onVariantActivation` resolves only after its
         // subscription is live, so an activation racing this call is queued rather than missed.
@@ -461,7 +500,7 @@ export function CustomForkingShieldedWallet<
     async stop(): Promise<void> {
       // Released before the runtime is torn down: the key material outlives neither the wallet nor an in-flight
       // activation.
-      Ref.set(this.#retainedStartMaterial, Option.none()).pipe(Effect.runSync);
+      Ref.set(this.#retainedKeys, noKeys).pipe(Effect.runSync);
       await super.stop();
     }
 
@@ -474,25 +513,9 @@ export function CustomForkingShieldedWallet<
      *   version, has none the current variant can use and says so by name.
      */
     #requireAux<TAux>(
-      auxFor: (retained: RetainedStartMaterial) => Either.Either<TAux, StartMaterial.MissingStartAuxError>,
-      variantTag: symbol,
+      keysFor: (retained: RetainedKeys) => Either.Either<TAux, StartMaterial.MissingStartAuxError>,
     ): Effect.Effect<TAux, StartMaterial.MissingStartAuxError> {
-      return Ref.get(this.#retainedStartMaterial).pipe(
-        Effect.flatMap(
-          Option.match({
-            onNone: () =>
-              Effect.fail(
-                new StartMaterial.MissingStartAuxError({
-                  message:
-                    `This wallet holds no key material: it has not been started, or it has been stopped. Start it ` +
-                    `before asking it to build a transaction.`,
-                  variantTag,
-                }),
-              ),
-            onSome: (retained: RetainedStartMaterial) => EitherOps.toEffect(auxFor(retained)),
-          }),
-        ),
-      );
+      return Ref.get(this.#retainedKeys).pipe(Effect.flatMap((retained) => EitherOps.toEffect(keysFor(retained))));
     }
 
     /**
@@ -506,7 +529,7 @@ export function CustomForkingShieldedWallet<
         .dispatch<ShieldedBalancingResult, TransactingError>({
           [V1Tag]: (v1) =>
             Effect.all([
-              this.#requireAux(preForkAux, V1Tag),
+              this.#requireAux(preForkAux),
               EitherOps.toEffect(
                 WalletTransaction.unwrapWithin<v8.Transaction<v8.Signaturish, v8.Proofish, v8.Bindingish>>(
                   tx,
@@ -519,7 +542,7 @@ export function CustomForkingShieldedWallet<
             ),
           [V2Tag]: (v2) =>
             Effect.all([
-              this.#requireAux(postForkAux, V2Tag),
+              this.#requireAux(postForkAux),
               EitherOps.toEffect(
                 WalletTransaction.unwrapWithin<
                   ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>
@@ -537,12 +560,12 @@ export function CustomForkingShieldedWallet<
       return this.runtime
         .dispatch<UnprovenTx, TransactingError>({
           [V1Tag]: (v1) =>
-            this.#requireAux(preForkAux, V1Tag).pipe(
+            this.#requireAux(preForkAux).pipe(
               Effect.flatMap((keys) => v1.transferTransaction(keys, outputs)),
               Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, preForkStamp)),
             ),
           [V2Tag]: (v2) =>
-            this.#requireAux(postForkAux, V2Tag).pipe(
+            this.#requireAux(postForkAux).pipe(
               Effect.flatMap((keys) => v2.transferTransaction(keys, outputs)),
               Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, postForkStamp)),
             ),
@@ -557,12 +580,12 @@ export function CustomForkingShieldedWallet<
       return this.runtime
         .dispatch<UnprovenTx, TransactingError>({
           [V1Tag]: (v1) =>
-            this.#requireAux(preForkAux, V1Tag).pipe(
+            this.#requireAux(preForkAux).pipe(
               Effect.flatMap((keys) => v1.initSwap(keys, desiredInputs, desiredOutputs)),
               Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, preForkStamp)),
             ),
           [V2Tag]: (v2) =>
-            this.#requireAux(postForkAux, V2Tag).pipe(
+            this.#requireAux(postForkAux).pipe(
               Effect.flatMap((keys) => v2.initSwap(keys, desiredInputs, desiredOutputs)),
               Effect.map((tx) => WalletTransaction.adopt('Unproven', tx, postForkStamp)),
             ),

--- a/packages/shielded-wallet/src/test/tryRestore.test.ts
+++ b/packages/shielded-wallet/src/test/tryRestore.test.ts
@@ -1,0 +1,101 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Restoring a wallet from a snapshot that might not be readable.
+ *
+ * @remarks
+ *   `restore` throws, which is the right shape for the case an application has just written the snapshot itself and a
+ *   failure is a bug. It is the wrong shape for the case an application restores something a user supplied, or
+ *   something written by a build of the SDK that is no longer the one running: a snapshot from a protocol version this
+ *   build has no variant for is an ordinary thing to meet, not an exception. `tryRestore` answers those without
+ *   throwing, and `restore` is left exactly as it was.
+ */
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Either } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { UnsupportedSnapshotVersionError } from '../Restore.js';
+import { type DefaultShieldedConfiguration, V9_NATIVE_FORK_VERSION } from '../ShieldedWallet.js';
+import { ShieldedWallet } from '../ForkingShieldedWallet.js';
+import { TransactionHistory } from '../v2/index.js';
+
+const configuration: DefaultShieldedConfiguration = {
+  networkId: NetworkId.NetworkId.Undeployed,
+  indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
+  forkVersion: V9_NATIVE_FORK_VERSION,
+};
+
+/** A snapshot declaring a protocol version far beyond anything this build registers a variant for. */
+const fromTheFuture = JSON.stringify({
+  publicKeys: { coinPublicKey: 'aa', encryptionPublicKey: 'bb' },
+  state: 'deadbeef',
+  protocolVersion: String(ProtocolVersion.MaxSupportedVersion),
+  networkId: 'undeployed',
+  coinHashes: {},
+});
+
+/** A snapshot no variant can read: routed to the head variant, which then cannot deserialize it. */
+const unreadable = JSON.stringify({ protocolVersion: '1', state: 'not a state at all' });
+
+const seed = Buffer.alloc(32, 7);
+
+describe('a shielded wallet restored from a snapshot it can read', () => {
+  it('comes back as a wallet, rather than as a reason it could not', async () => {
+    const source = ShieldedWallet(configuration).startWithSeed(seed);
+    const written = await source.serializeState();
+    await source.stop();
+
+    const restored = ShieldedWallet(configuration).tryRestore(written);
+
+    expect(Either.isRight(restored)).toBe(true);
+    await Either.getOrThrow(restored).stop();
+  });
+});
+
+describe('a shielded wallet restored from a snapshot it cannot read', () => {
+  it('reports a protocol version no registered variant owns, instead of throwing', () => {
+    const failure = ShieldedWallet(configuration).tryRestore(fromTheFuture).pipe(Either.flip, Either.getOrThrow);
+
+    expect(failure).toBeInstanceOf(UnsupportedSnapshotVersionError);
+  });
+
+  it('reports bytes that are not a wallet state, instead of throwing', () => {
+    const restored = ShieldedWallet(configuration).tryRestore(unreadable);
+
+    expect(Either.isLeft(restored)).toBe(true);
+  });
+
+  it('refuses exactly the snapshots restore refuses, and keeps the reason restore discards', () => {
+    // The two cannot disagree about which snapshots are readable, because `restore` is `tryRestore` with the reason
+    // thrown away. And thrown away is literally what happens: the exception carries none of it, which is the whole
+    // reason for the additive shape.
+    for (const snapshot of [fromTheFuture, unreadable]) {
+      expect(() => ShieldedWallet(configuration).restore(snapshot)).toThrow();
+      expect(Either.isLeft(ShieldedWallet(configuration).tryRestore(snapshot))).toBe(true);
+    }
+
+    const thrown = (() => {
+      try {
+        return ShieldedWallet(configuration).restore(fromTheFuture);
+      } catch (error) {
+        return error;
+      }
+    })();
+
+    expect(thrown).not.toBeInstanceOf(UnsupportedSnapshotVersionError);
+    expect(ShieldedWallet(configuration).tryRestore(fromTheFuture).pipe(Either.flip, Either.getOrThrow)).toBeInstanceOf(
+      UnsupportedSnapshotVersionError,
+    );
+  });
+});

--- a/packages/unshielded-wallet/src/ForkingUnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/ForkingUnshieldedWallet.ts
@@ -48,7 +48,7 @@ import { EitherOps, HList } from '@midnightntwrk/wallet-sdk-utilities';
 import { Effect, Either, Option, Ref, type Scope } from 'effect';
 import * as rx from 'rxjs';
 import { type PublicKey } from './KeyStore.js';
-import { variantForSnapshot } from './Restore.js';
+import { type UnsupportedSnapshotVersionError, variantForSnapshot } from './Restore.js';
 import {
   type DefaultUnshieldedConfiguration,
   type UnshieldedWalletAPI,
@@ -65,7 +65,19 @@ import { type WalletSyncUpdate as PostForkSyncUpdate } from './v2/SyncSchema.js'
 import { type TokenTransfer } from './v2/Transacting.js';
 import { type UnboundTransaction } from './v2/TransactionOps.js';
 import { type UtxoWithMeta } from './v2/UnshieldedState.js';
+import { type WalletError as PreForkWalletError } from './v1/WalletError.js';
 import { type WalletError } from './v2/WalletError.js';
+
+/**
+ * What restoring a unshielded wallet from a snapshot can fail with.
+ *
+ * @remarks
+ *   Two failures, and they mean different things. The snapshot may declare a protocol version no registered variant
+ *   reads, which is a fact about this build of the SDK rather than about the snapshot; or the variant that owns it may
+ *   be unable to make sense of the bytes, which is a fact about the snapshot. Either is an ordinary thing to meet when
+ *   restoring something a user supplied, which is why `tryRestore` reports them rather than throwing.
+ */
+export type UnshieldedRestoreError = UnsupportedSnapshotVersionError | PreForkWalletError | WalletError;
 
 /**
  * What a transacting call can fail with.
@@ -147,6 +159,21 @@ export interface ForkingUnshieldedWalletClass<
    * @throws UnsupportedSnapshotVersionError if the snapshot declares a version no registered variant reads.
    */
   restore(serializedState: string): ForkingUnshieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+  /**
+   * Restores a wallet from a snapshot, reporting what it could not read rather than throwing.
+   *
+   * @remarks
+   *   Additive alongside {@link restore}, which is unchanged and still the right shape for a snapshot the application has
+   *   just written itself. This is the shape for one it has not: a snapshot a user supplied, or one written by a build
+   *   of the SDK that is no longer the one running, where "I cannot read this" is an ordinary answer rather than a bug.
+   *   The two cannot disagree — `restore` is this, with the reason thrown.
+   * @param serializedState The serialized wallet state.
+   * @returns A wallet started from that state, or the reason the snapshot could not be read. See
+   *   {@link UnshieldedRestoreError}.
+   */
+  tryRestore(
+    serializedState: string,
+  ): Either.Either<ForkingUnshieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>, UnshieldedRestoreError>;
 }
 
 /**
@@ -305,25 +332,33 @@ export function CustomForkingUnshieldedWallet<
       });
     }
 
-    static restore(serializedState: string): ForkingUnshieldedWalletImplementation {
+    static tryRestore(
+      serializedState: string,
+    ): Either.Either<ForkingUnshieldedWalletImplementation, UnshieldedRestoreError> {
       const headVariant = HList.head(ForkingUnshieldedWalletImplementation.allVariants());
-      const variant = variantForSnapshot(
+      return variantForSnapshot(
         serializedState,
         (version) => ForkingUnshieldedWalletImplementation.variantFor(version),
         headVariant,
-      ).pipe(Either.getOrThrow);
-      // Stated with its result type because the resolved variant is either of the two, so its deserializer is either
-      // of theirs: what comes back is a state of whichever one wrote the snapshot, which is what `startAtVariant`
-      // takes.
-      const deserialized = Either.getOrThrow<PreForkCoreWallet | CoreWallet, unknown>(
-        variant.variant.deserializeState(serializedState),
+      ).pipe(
+        // Stated with its result type because the resolved variant is either of the two, so its deserializer is
+        // either of theirs: what comes back is a state of whichever one wrote the snapshot, which is what
+        // `startAtVariant` takes.
+        Either.flatMap((variant): Either.Either<ForkingUnshieldedWalletImplementation, UnshieldedRestoreError> => {
+          // Annotated rather than inferred because the resolved variant is either of the two, so its deserializer is
+          // either of theirs: what comes back is a state of whichever one wrote the snapshot, which is what
+          // `startAtVariant` takes.
+          const deserialized: Either.Either<PreForkCoreWallet | CoreWallet, UnshieldedRestoreError> =
+            variant.variant.deserializeState(serializedState);
+          return Either.map(deserialized, (state) =>
+            ForkingUnshieldedWalletImplementation.startAtVariant(ForkingUnshieldedWalletImplementation, variant, state),
+          );
+        }),
       );
+    }
 
-      return ForkingUnshieldedWalletImplementation.startAtVariant(
-        ForkingUnshieldedWalletImplementation,
-        variant,
-        deserialized,
-      );
+    static restore(serializedState: string): ForkingUnshieldedWalletImplementation {
+      return Either.getOrThrow(ForkingUnshieldedWalletImplementation.tryRestore(serializedState));
     }
 
     readonly state: rx.Observable<UnshieldedWalletState<string>>;

--- a/packages/unshielded-wallet/src/test/tryRestore.test.ts
+++ b/packages/unshielded-wallet/src/test/tryRestore.test.ts
@@ -1,0 +1,82 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Restoring an unshielded wallet from a snapshot that might not be readable. See the shielded wallet's suite of the
+ * same name for why the additive shape exists; the claims are the wallet-layer ones, and they hold identically here.
+ */
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Either } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { UnshieldedWallet } from '../ForkingUnshieldedWallet.js';
+import { createKeystore, PublicKey } from '../KeyStore.js';
+import { UnsupportedSnapshotVersionError } from '../Restore.js';
+import { type DefaultUnshieldedConfiguration } from '../UnshieldedWallet.js';
+import { TransactionHistory } from '../v2/index.js';
+
+const configuration: DefaultUnshieldedConfiguration = {
+  networkId: NetworkId.NetworkId.Undeployed,
+  indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.UnshieldedTransactionHistoryEntrySchema),
+  forkVersion: ProtocolVersion.ProtocolVersion(2_000_000n),
+};
+
+/** A snapshot declaring a protocol version far beyond anything this build registers a variant for. */
+const fromTheFuture = JSON.stringify({
+  state: 'deadbeef',
+  protocolVersion: String(ProtocolVersion.MaxSupportedVersion),
+  networkId: 'undeployed',
+});
+
+/** A snapshot no variant can read: routed to the head variant, which then cannot deserialize it. */
+const unreadable = JSON.stringify({ protocolVersion: '1', state: 'not a state at all' });
+
+const identity = PublicKey.fromKeyStore(
+  createKeystore({ kind: 'schnorr', secret: Buffer.alloc(32, 7) }, configuration.networkId),
+);
+
+describe('an unshielded wallet restored from a snapshot it can read', () => {
+  it('comes back as a wallet, rather than as a reason it could not', async () => {
+    const source = UnshieldedWallet(configuration).startWithPublicKey(identity);
+    const written = await source.serializeState();
+    await source.stop();
+
+    const restored = UnshieldedWallet(configuration).tryRestore(written);
+
+    expect(Either.isRight(restored)).toBe(true);
+    await Either.getOrThrow(restored).stop();
+  });
+});
+
+describe('an unshielded wallet restored from a snapshot it cannot read', () => {
+  it('reports a protocol version no registered variant owns, instead of throwing', () => {
+    const failure = UnshieldedWallet(configuration).tryRestore(fromTheFuture).pipe(Either.flip, Either.getOrThrow);
+
+    expect(failure).toBeInstanceOf(UnsupportedSnapshotVersionError);
+  });
+
+  it('reports bytes that are not a wallet state, instead of throwing', () => {
+    expect(Either.isLeft(UnshieldedWallet(configuration).tryRestore(unreadable))).toBe(true);
+  });
+
+  it('refuses exactly the snapshots restore refuses, and keeps the reason restore discards', () => {
+    for (const snapshot of [fromTheFuture, unreadable]) {
+      expect(() => UnshieldedWallet(configuration).restore(snapshot)).toThrow();
+      expect(Either.isLeft(UnshieldedWallet(configuration).tryRestore(snapshot))).toBe(true);
+    }
+
+    expect(
+      UnshieldedWallet(configuration).tryRestore(fromTheFuture).pipe(Either.flip, Either.getOrThrow),
+    ).toBeInstanceOf(UnsupportedSnapshotVersionError);
+  });
+});

--- a/packages/unshielded-wallet/src/v1/Sync.ts
+++ b/packages/unshielded-wallet/src/v1/Sync.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Effect, type Scope, Stream, Schema, pipe, Either, HashMap } from 'effect';
-import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { ProtocolVersion, Token } from '@midnightntwrk/wallet-sdk-abstractions';
 import { CoreWallet } from './CoreWallet.js';
 import { UtxoWithMeta } from './UnshieldedState.js';
 // The simulation package re-exports the ledger-v9 twin unqualified and offers both lines as `V8`/`V9` namespaces. This
@@ -248,7 +248,7 @@ export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, Simula
 
       const { ledger: ledgerState, currentTime } = update.update;
       const walletAddress = state.publicKey.addressHex;
-      const nativeTokenType = ledger.nativeToken().raw;
+      const nativeTokenType = Token.night;
 
       // Heuristic: check if address appears in the ledger's dust delegation table
       const isAddressRegisteredForDust = ledgerState.dust.toString().includes(walletAddress);

--- a/packages/unshielded-wallet/src/v1/Sync.ts
+++ b/packages/unshielded-wallet/src/v1/Sync.ts
@@ -25,7 +25,6 @@ import { WsURL } from '@midnightntwrk/wallet-sdk-utilities/networking';
 import { type TransactionHistoryService } from './TransactionHistory.js';
 import { EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
 import { type WalletSyncUpdate, WalletSyncUpdateSchema } from './SyncSchema.js';
-import * as ledger from '@midnight-ntwrk/ledger-v8';
 
 export interface SyncService<TState, TUpdate> {
   updates: (state: TState) => Stream.Stream<TUpdate, WalletError, Scope.Scope>;

--- a/packages/unshielded-wallet/src/v1/Transacting.ts
+++ b/packages/unshielded-wallet/src/v1/Transacting.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnight-ntwrk/ledger-v8';
-import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type NetworkId, Token } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Either, Option, pipe, Array as Arr } from 'effect';
 import { CoreWallet } from './CoreWallet.js';
 import { InsufficientFundsError, OtherWalletError, TransactingError, type WalletError } from './WalletError.js';
@@ -274,7 +274,7 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
 
       const intent = ledger.Intent.new(ttl);
 
-      const hasNightOutput = ledgerOutputs.some((output) => output.type === ledger.nativeToken().raw);
+      const hasNightOutput = ledgerOutputs.some((output) => output.type === Token.night);
       if (hasNightOutput) {
         intent.fallibleUnshieldedOffer = offer;
       } else {
@@ -326,7 +326,7 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
         );
         const output: ledger.UtxoOutput = {
           owner: ownerAddress,
-          type: ledger.nativeToken().raw,
+          type: Token.night,
           value: totalValue,
         };
         return Option.some(ledger.UnshieldedOffer.new(inputs, [output], []));

--- a/packages/unshielded-wallet/src/v2/Sync.ts
+++ b/packages/unshielded-wallet/src/v2/Sync.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Effect, type Scope, Stream, Schema, pipe, Either, HashMap } from 'effect';
-import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { ProtocolVersion, Token } from '@midnightntwrk/wallet-sdk-abstractions';
 import { CoreWallet } from './CoreWallet.js';
 import { UtxoWithMeta } from './UnshieldedState.js';
 import {
@@ -249,7 +249,7 @@ export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, Simula
 
       const { ledger: ledgerState, currentTime } = update.update;
       const walletAddress = state.publicKey.addressHex;
-      const nativeTokenType = ledger.nativeToken().raw;
+      const nativeTokenType = Token.night;
 
       // Heuristic: check if address appears in the ledger's dust delegation table
       const isAddressRegisteredForDust = ledgerState.dust.toString().includes(walletAddress);

--- a/packages/unshielded-wallet/src/v2/Sync.ts
+++ b/packages/unshielded-wallet/src/v2/Sync.ts
@@ -26,7 +26,6 @@ import { WsURL } from '@midnightntwrk/wallet-sdk-utilities/networking';
 import { type TransactionHistoryService } from './TransactionHistory.js';
 import { EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
 import { type WalletSyncUpdate, WalletSyncUpdateSchema } from './SyncSchema.js';
-import * as ledger from '@midnightntwrk/ledger-v9';
 
 export interface SyncService<TState, TUpdate> {
   updates: (state: TState) => Stream.Stream<TUpdate, WalletError, Scope.Scope>;

--- a/packages/unshielded-wallet/src/v2/Transacting.ts
+++ b/packages/unshielded-wallet/src/v2/Transacting.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type NetworkId, Token } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Either, Option, pipe, Array as Arr } from 'effect';
 import { CoreWallet } from './CoreWallet.js';
 import { InsufficientFundsError, OtherWalletError, TransactingError, type WalletError } from './WalletError.js';
@@ -274,7 +274,7 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
 
       const intent = ledger.Intent.new(ttl);
 
-      const hasNightOutput = ledgerOutputs.some((output) => output.type === ledger.nativeToken().raw);
+      const hasNightOutput = ledgerOutputs.some((output) => output.type === Token.night);
       if (hasNightOutput) {
         intent.fallibleUnshieldedOffer = offer;
       } else {
@@ -326,7 +326,7 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
         );
         const output: ledger.UtxoOutput = {
           owner: ownerAddress,
-          type: ledger.nativeToken().raw,
+          type: Token.night,
           value: totalValue,
         };
         return Option.some(ledger.UnshieldedOffer.new(inputs, [output], []));

--- a/packages/wallet-sdk-testkit/src/wallet.ts
+++ b/packages/wallet-sdk-testkit/src/wallet.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { type WalletSeeds } from '@midnightntwrk/wallet-sdk-hd';
 import * as rx from 'rxjs';
 import { existsSync } from 'node:fs';
 import * as fsAsync from 'node:fs/promises';
@@ -37,6 +38,8 @@ export type WalletInit = {
   wallet: WalletFacade;
   shieldedSecretKeys: ledger.ZswapSecretKeys;
   dustSecretKey: ledger.DustSecretKey;
+  /** The three per-wallet seeds, which is what the facade is started and stepped with. */
+  seeds: WalletSeeds;
   unshieldedKeystore: UnshieldedKeystore;
 };
 
@@ -163,12 +166,14 @@ export const provideWallet = async (env: WalletTestEnvironment, options: Provide
   const dustWalletConfig = { ...env.getDustWalletConfig(), txHistoryStorage };
   const Wallet = ShieldedWallet(walletConfig);
 
-  const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(getShieldedSeed(seed));
-  const dustSecretKey = ledger.DustSecretKey.fromSeed(getDustSeed(seed));
-  const unshieldedKeystore = createKeystore(
-    { kind: 'schnorr', secret: getUnshieldedSeed(seed) },
-    env.endpoints.networkId,
-  );
+  const seeds: WalletSeeds = {
+    shielded: getShieldedSeed(seed),
+    unshielded: getUnshieldedSeed(seed),
+    dust: getDustSeed(seed),
+  };
+  const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(seeds.shielded);
+  const dustSecretKey = ledger.DustSecretKey.fromSeed(seeds.dust);
+  const unshieldedKeystore = createKeystore({ kind: 'schnorr', secret: seeds.unshielded }, env.endpoints.networkId);
 
   const readIfExists = async (p: string): Promise<string | undefined> => {
     try {
@@ -199,7 +204,7 @@ export const provideWallet = async (env: WalletTestEnvironment, options: Provide
       unshielded: () => restoredUnshielded,
       dust: () => restoredDust,
     });
-    await restoredWallet.start(shieldedSecretKeys, dustSecretKey);
+    await restoredWallet.start(seeds);
     // check if wallet is syncing correctly
     await waitForSyncProgress(restoredWallet);
     const restoredWalletState = await rx.firstValueFrom(restoredWallet.state());
@@ -212,7 +217,7 @@ export const provideWallet = async (env: WalletTestEnvironment, options: Provide
       return initWalletWithSeed(env, seed);
     } else {
       logger.info('Successfully restored wallet facade.');
-      return { wallet: restoredWallet, shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
+      return { wallet: restoredWallet, shieldedSecretKeys, dustSecretKey, seeds, unshieldedKeystore };
     }
   }
 };
@@ -265,6 +270,11 @@ export const saveState = async (wallet: WalletFacade, syncCacheDir: string, file
 /** Builds and starts a fresh {@link WalletFacade} from `seed`, with no disk persistence. */
 export const initWalletWithSeed = async (env: WalletTestEnvironment, seed: string): Promise<WalletInit> => {
   const walletConfig = env.getWalletConfig();
+  const seeds: WalletSeeds = {
+    shielded: getShieldedSeed(seed),
+    unshielded: getUnshieldedSeed(seed),
+    dust: getDustSeed(seed),
+  };
   const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(getShieldedSeed(seed));
   const dustSecretKey = ledger.DustSecretKey.fromSeed(getDustSeed(seed));
   const unshieldedKeystore = createKeystore(
@@ -280,9 +290,8 @@ export const initWalletWithSeed = async (env: WalletTestEnvironment, seed: strin
     },
     shielded: (config) => ShieldedWallet(config).startWithSeed(getShieldedSeed(seed)),
     unshielded: (config) => UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
-    dust: (config) =>
-      DustWallet(config).startWithSeed(getDustSeed(seed), ledger.LedgerParameters.initialParameters().dust),
+    dust: (config) => DustWallet(config).startWithSeed(getDustSeed(seed)),
   });
-  await facade.start(shieldedSecretKeys, dustSecretKey);
-  return { wallet: facade, shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
+  await facade.start(seeds);
+  return { wallet: facade, shieldedSecretKeys, dustSecretKey, seeds, unshieldedKeystore };
 };

--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -21,6 +21,16 @@ export * from '@midnightntwrk/wallet-sdk-shielded';
 export * from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 export * from '@midnightntwrk/wallet-sdk-utilities';
 
+/**
+ * The one thing an application signs with, and the one error it can get back.
+ *
+ * @remarks
+ *   Promoted from the internal adapter rather than restated: `UnsupportedSignatureKindError` is the same class the
+ *   pre-fork lowering raises, so an application catching it here catches exactly what the SDK threw. The module names
+ *   both ledger versions in `import type` only, so nothing of either is loaded to reach it.
+ */
+export { UnsupportedSignatureKindError } from '@midnightntwrk/wallet-sdk-capabilities/signatures';
+
 export * as Capabilities from '@midnightntwrk/wallet-sdk-capabilities';
 export * as IndexerClient from '@midnightntwrk/wallet-sdk-indexer-client';
 export * as NodeClient from '@midnightntwrk/wallet-sdk-node-client';

--- a/packages/wallet-sdk/src/test/ledgerSubpaths.test.ts
+++ b/packages/wallet-sdk/src/test/ledgerSubpaths.test.ts
@@ -16,8 +16,10 @@ import {
   NetworkId,
   ProtocolVersion,
   ProtocolVersionMismatchError,
+  type Signing,
   WalletTransaction,
 } from '@midnightntwrk/wallet-sdk-abstractions';
+import * as PreForkSignatures from '@midnightntwrk/wallet-sdk-capabilities/signatures';
 import { Either, Schema } from 'effect';
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
@@ -68,6 +70,61 @@ describe('the ledger subpaths an author builds transactions with', () => {
 
   it('never lets a ledger version out through the root, whatever the subpaths offer', () => {
     expect(Object.keys(sdk).filter((name) => (ledgerOnlyNames as readonly string[]).includes(name))).toStrictEqual([]);
+  });
+
+  it('offers, through the root alone, everything an application needs that is not authoring', () => {
+    // The names an application would otherwise reach for a ledger package to get. Every one of them is here, and
+    // none of them loads either ledger's WebAssembly — which together is what lets an application drop the ledger
+    // dependency from its own manifest.
+    for (const name of [
+      // Keys and start, which is where an application used to need `ZswapSecretKeys` and `DustSecretKey`.
+      'WalletSeeds',
+      'HDWallet',
+      'Roles',
+      // Tokens, which is where it used to need `nativeToken`.
+      'Token',
+      'parseTokenType',
+      // The transactions it carries, which is where it used to name `Transaction` and its stages.
+      'WalletTransaction',
+      'ProtocolVersionMismatchError',
+      // Where the chain is, and whether the wallets agree about it.
+      'ProtocolVersion',
+      'protocolPhaseOf',
+      // Signing, which is the one scalar whose shape genuinely changed at the boundary.
+      'UnsupportedSignatureKindError',
+    ]) {
+      expect(Object.keys(sdk)).toContain(name);
+    }
+  });
+
+  it('promotes the signing error rather than restating it, so a caught error is the one the SDK threw', () => {
+    expect(sdk.UnsupportedSignatureKindError).toBe(PreForkSignatures.UnsupportedSignatureKindError);
+  });
+});
+
+describe('the signature shape the SDK speaks', () => {
+  it('is the current ledger version shape, so a signer already written against it compiles unchanged', () => {
+    const signature: ledgerV9.Signature = { tag: 'schnorr', value: 'aa' };
+    const asSdk: Signing.Signature = signature;
+    const backAgain: ledgerV9.Signature = { ...asSdk };
+
+    expect(backAgain).toStrictEqual(signature);
+  });
+
+  it('lifts what the pre-fork ledger version writes as bare hexadecimal', () => {
+    // The pre-fork ledger has exactly one scheme, so naming it is never a guess — which is why lifting is total and
+    // lowering is not.
+    const lifted: Signing.Signature = PreForkSignatures.liftSignature('aa');
+
+    expect(lifted).toStrictEqual({ tag: 'schnorr', value: 'aa' });
+    expect(Either.getOrThrow(PreForkSignatures.lowerSignature(lifted))).toBe('aa');
+  });
+
+  it('refuses to lower a scheme the pre-fork ledger version has never heard of', () => {
+    const error = PreForkSignatures.lowerSignature({ tag: 'ecdsa', value: 'aa' }).pipe(Either.flip, Either.getOrThrow);
+
+    expect(error).toBeInstanceOf(sdk.UnsupportedSignatureKindError);
+    expect(error.kind).toBe('ecdsa');
   });
 });
 

--- a/packages/wallet-sdk/src/test/tokens.test.ts
+++ b/packages/wallet-sdk/src/test/tokens.test.ts
@@ -1,0 +1,55 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * What the SDK's own token-type constants are worth: that an application which stops calling a ledger for them reads
+ * exactly the same balances afterwards.
+ *
+ * @remarks
+ *   The constants are string literals so they can reach the umbrella package's root without loading either ledger's
+ *   WebAssembly. That is only safe while the literals agree with both ledger versions, which is what this pins — on
+ *   both, because a constant that were right on one side of the protocol boundary and wrong on the other would be worse
+ *   than no constant at all.
+ */
+import * as ledgerV8 from '@midnight-ntwrk/ledger-v8';
+import * as ledgerV9 from '@midnightntwrk/ledger-v9';
+import { describe, expect, it } from 'vitest';
+import * as sdk from '../index.js';
+
+describe('the Night token type the SDK names', () => {
+  it('is what the pre-fork ledger version calls the native token', () => {
+    expect(sdk.Token.night).toBe(ledgerV8.nativeToken().raw);
+  });
+
+  it('is what the post-fork ledger version calls the native token', () => {
+    expect(sdk.Token.night).toBe(ledgerV9.nativeToken().raw);
+  });
+
+  it('is the same raw type on both, which is why one constant can serve both epochs', () => {
+    expect(ledgerV8.nativeToken().raw).toBe(ledgerV9.nativeToken().raw);
+  });
+
+  it('is also what both call the shielded and unshielded token, because the raw form carries no tag', () => {
+    // The ledger distinguishes them with the `tag` on its wrapper, not with the raw type. A balance record is keyed
+    // by the raw type alone, so there is exactly one constant to name here — recorded so that a future ledger which
+    // separates them is caught by this test rather than by an application.
+    expect(ledgerV8.shieldedToken().raw).toBe(sdk.Token.night);
+    expect(ledgerV8.unshieldedToken().raw).toBe(sdk.Token.night);
+    expect(ledgerV9.shieldedToken().raw).toBe(sdk.Token.night);
+    expect(ledgerV9.unshieldedToken().raw).toBe(sdk.Token.night);
+  });
+
+  it('reads as a token type through the parser the SDK offers', () => {
+    expect(sdk.parseTokenType(ledgerV9.nativeToken().raw)._tag).toBe('Right');
+  });
+});


### PR DESCRIPTION
Eleventh and final substantive increment of the dual-ledger public API redesign — Flows 1, 4, 5, 6, 7. Stacked on #684. **After this PR, an application imports a ledger package for exactly one reason: hand-authoring transactions** (via `wallet-sdk/ledger/v8|v9` + `adopt`, by design).

## Flow 1 — keys & start (user decision 1, implemented)

- **`WalletSeeds.fromMasterSeed`** (`packages/hd` — it owns BIP32; no new dependency): one name for the master-seed → per-wallet-seeds walk that six hand-rolled copies were writing across testkit/e2e/snippets. Pinned differentially against the hand-rolled walk plus golden hex vectors. *Honest gap: the spec-reference vectors treat per-wallet seeds as given, so this pins current behavior — adding master-seed derivation to the spec + vectors is a follow-up.*
- **Facade `start(seeds)`** is the primary start (one discriminated parameter, `WalletSeeds | FacadeKeysByEpoch`); the escape hatch `start({v8, v9})` requires BOTH epochs' key objects per the decision.
- **`startWithSecretKeys`/`startWithSecretKey` deleted on the forking classes** — replaced by `startWithKeys({v8, v9})` with both required; every old call site migrated (map in the increment report). Deliberate boundary: the single-variant `Custom*Wallet` classes KEEP their single-key starts — one variant means one key object is the whole truth (the fast-sync dust composition depends on it); the shipped `ShieldedWallet`/`DustWallet` are the forking classes, so the public break is real.
- **Seed hygiene, literal**: seed-accepting starts derive BOTH epochs' keys eagerly and drop the seed reference with the calling frame; key objects are released at `stop()`. Retention is a precise per-epoch product (`{preFork: Option<v8.X>, postFork: Option<v9.X>}`) rather than the homogeneous `StartMaterial` map — zero casts, models both-required directly. JSDoc states plainly that JS/WASM release references without zeroization guarantees.
- `DustParameters` → optional plain scalars on every start path.

## Flow 4 — tokens & protocol phase

- SDK-owned `TokenType = string` (documented unbranded exception) + **`Token.night`** + `parseTokenType`. **One constant, deliberately**: the dual-ledger pin proves `nativeToken().raw` ≡ `shieldedToken().raw` ≡ `unshieldedToken().raw` ≡ 64 zeros on BOTH ledgers — the raw type does not distinguish forms (the API being called does), so a `Token.shieldedNative` alias would assert a distinction that doesn't exist. Zero `nativeToken()` calls remain in production source; the last two snippets using `shieldedToken()` now say `Token.night` (adjudicated during verification), making every non-authoring snippet ledger-free.
- Additive **`FacadeState.protocol: ProtocolPhase`** — `Settled {version}` when all three wallets are in the same epoch, `Crossing {from, to, behind}` otherwise (within-epoch version spread is ordinary sync, not a crossing). Renamed from the plan's `ProtocolState` (root-barrel collision).

## Flow 5 — `tryRestore`

Additive Either-returning restore on the three forking classes; `restore` = `getOrThrow(tryRestore(...))`, one implementation. Typed per-package errors (`ShieldedRestoreError` etc.). One disclosed test-design correction, coverage strictly increased.

## Flow 6 — pending statuses

`FacadeState.pending: readonly PendingTransaction[]` — `{transaction, submittedAt, authoredFor, status}` with tagged `Submitted | Confirmed | Rejected | Orphaned {authoredFor, chainNow}` — a pure projection over the existing machinery (no persistence change). Both real consumers adapted (the plan's zero-consumers claim was false: the dust-sponsorship snippet, plus one facade test).

## Flow 7 — the umbrella

Root barrel exports seeds/tokens/handles/protocol/signing; the ledger-freedom test extended over all of it. **Public `Signature`/`SignatureVerifyingKey` adopt v9's `{tag, value}` shape** in `abstractions/Signing` — the internal #684 adapter now states its current-shape side in these terms (one definition; `import type` only, no WASM) — and `UnsupportedSignatureKindError` is promoted to the root with an identity pin. v9-typed signers compile unchanged, as promised.

## Tests & gate

Red-first throughout; deletion map old-test → new-test complete; forkStart suites preserved untouched (8/16/16). Gate: dist 17/17, typecheck 37/37, lint 58/58, unit 54/54 tasks (shielded 186 / dust 191 / unshielded 219 / facade 61 / abstractions 76 / hd 17 / wallet-sdk 17), fork-simulation integration 3/3, effect-language-service 0 findings on all 57 changed files, format + changesets green. Changesets: facade + shielded + dust majors (deleted starts, start surface, pending reshape), hd minor, abstractions/capabilities/wallet-sdk per impact.