### PR TITLE
feat(wallets,capabilities)!: ask the chain where it is before choosing a variant to start at

### DIFF
--- a/.changeset/start-at-current-chain-version.md
+++ b/.changeset/start-at-current-chain-version.md
@@ -1,0 +1,54 @@
+---
+'@midnightntwrk/wallet-sdk-capabilities': minor
+'@midnightntwrk/wallet-sdk-shielded': major
+'@midnightntwrk/wallet-sdk-dust-wallet': major
+'@midnightntwrk/wallet-sdk-unshielded-wallet': major
+'@midnightntwrk/wallet-sdk-testkit': patch
+---
+
+A wallet that spans a protocol boundary asks the chain where it is before choosing a variant to start at.
+
+A two-variant wallet used to learn the chain's protocol version only from the events it observed, so every start began
+on the pre-fork variant. That cost two things. On a chain already past the boundary it paid a hand-over per start: boot
+the pre-fork variant, apply nothing, migrate, re-sync. And on a chain that had shown the wallet **no events at all** it
+was not a cost but a wrong answer — the wallet stayed pre-fork indefinitely, and since transacting now works on either
+side of the boundary, it built transactions with the ledger version the chain does not run, which fail at the node
+rather than at the wallet.
+
+The wallet now asks. `chainVersionProbe` answers which protocol version the chain is on; the variant that owns it is
+resolved through `variantFor` and started with a fresh state of its own, annotated with the version so it begins inside
+its own activation range. On a v9-native chain a default wallet is therefore on the post-fork variant from the first
+moment, with the right epoch before a single event has arrived — no hand-over, and no migration emitted.
+
+**The default wallets ask the indexer they are about to synchronize from.** `ShieldedWallet(configuration)`,
+`DustWallet(configuration)` and `UnshieldedWallet(configuration)` build the probe from
+`configuration.indexerClientConnection` using the same `BlockHash` query the block-data fetcher already runs, so
+nothing new is configured and nothing new is asked of the indexer. Applications that would rather ask something else —
+a cache, a node RPC, a value they already hold — supply their own `chainVersionProbe` on the configuration.
+`CustomForkingShieldedWallet`, `CustomForkingDustWallet` and `CustomForkingUnshieldedWallet` take the same optional
+field, and omitting it means no probe at all.
+
+**Best-effort, always.** No probe, a probe that rejects, a probe that outlives the wallet's five-second patience, or a
+version no registered variant claims: each leaves the wallet starting exactly where it started before — on the pre-fork
+variant, handing over on the first batch that reports a version it does not own. Offline-first applications and
+simulator-backed compositions are unaffected. Starting a wallet can now be slower; it cannot newly fail.
+
+Two things the probe deliberately does not decide. An unshielded identity only the post-fork ledger version can hold
+(ecdsa) still starts post-fork whatever the chain reports, because there is no decision left for an answer to inform.
+And `restore` does not probe at all: a snapshot's own declared version is authoritative, and the variant that wrote it
+is the variant that reads it.
+
+`@midnightntwrk/wallet-sdk-capabilities` gains the question itself, under a new `./chainVersion` entry point:
+`ChainVersionProbe`, `makeIndexerChainVersionProbe`, `currentChainVersion` and the pure `chainVersionOf`, which reports
+nothing at all for a chain that has produced no block rather than guessing the bottom of the timeline.
+
+Projections fast-sync is unchanged and remains a **single-variant** capability (`CustomDustWallet` +
+`makeEventLessSyncService`). The probe changes where a wallet begins, not what it can sync with: a two-variant wallet
+must be able to read a chain below the boundary, where only the event path exists.
+
+BREAKING CHANGE — the forking wallets' start methods return a promise, because choosing where to begin can mean asking
+the chain: `ShieldedWalletClass.startWithSeed` / `.startWithKeys`, `DustWalletClass.startWithSeed` / `.startWithKeys`,
+and `UnshieldedWalletClass.startWithPublicKey`. Callers `await` the result and need no other change; factories handed
+to `WalletFacade.init` already accept a promise and are unaffected. A seed the SDK will not accept now rejects the
+returned promise instead of throwing synchronously. `restore`, `tryRestore` and the single-variant `CustomShieldedWallet`,
+`CustomDustWallet` and `CustomUnshieldedWallet` starts are unchanged.

--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -28,6 +28,10 @@
       "types": "./dist/balancer/index.d.ts",
       "import": "./dist/balancer/index.js"
     },
+    "./chainVersion": {
+      "types": "./dist/chainVersion/index.d.ts",
+      "import": "./dist/chainVersion/index.js"
+    },
     "./codecs": {
       "types": "./dist/codecs/index.d.ts",
       "import": "./dist/codecs/index.js"

--- a/packages/capabilities/src/chainVersion/chainVersionProbe.ts
+++ b/packages/capabilities/src/chainVersion/chainVersionProbe.ts
@@ -91,9 +91,9 @@ export type DefaultChainVersionProbeConfiguration = {
  * Builds a {@link ChainVersionProbe} that asks the indexer over HTTP for the latest block's protocol version.
  *
  * @remarks
- *   Each call opens a short-lived query client and closes it again, as the default block-data fetcher does. It carries
- *   no timeout of its own: the caller that blocks on it owns how long it is prepared to wait, and the wallet that
- *   starts with one applies its own bound.
+ *   Each call opens a short-lived query client and closes it again, as the default block-data fetcher does. It carries no
+ *   timeout of its own: the caller that blocks on it owns how long it is prepared to wait, and the wallet that starts
+ *   with one applies its own bound.
  * @param config Where to ask.
  * @returns The probe.
  */

--- a/packages/capabilities/src/chainVersion/chainVersionProbe.ts
+++ b/packages/capabilities/src/chainVersion/chainVersionProbe.ts
@@ -1,0 +1,119 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Asking the chain which protocol version it is currently on.
+ *
+ * @remarks
+ *   A wallet that registers a variant either side of a protocol boundary learns the chain's version from the events it
+ *   observes, which is too late for one decision: which variant to start on. Until an event arrives its only guess is
+ *   the bottom of the timeline, so it starts pre-fork — and on a chain that is entirely past the boundary that costs a
+ *   hand-over per start, or, on a chain that has produced no event this wallet can see, is simply wrong for as long as
+ *   the wallet runs.
+ *
+ *   This is the question that removes the guess. The answer is read from the same block query validation already reads,
+ *   so nothing new is asked of the indexer, and it is best-effort by design: a chain that will not answer leaves the
+ *   wallet exactly where it was.
+ */
+
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { BlockHash } from '@midnightntwrk/wallet-sdk-indexer-client';
+import { HttpQueryClient } from '@midnightntwrk/wallet-sdk-indexer-client/effect';
+import { Data, Effect, Option, pipe } from 'effect';
+
+/**
+ * Asks the chain which protocol version it is currently on.
+ *
+ * @remarks
+ *   Promise-shaped rather than `Effect`-shaped because it is a wallet-configuration field, and an application supplying
+ *   its own — pointing at a cache, a node RPC, or a value it already holds — should not have to speak `Effect` to do
+ *   it. Every caller treats it as best-effort: a rejection, including a timeout, means "the chain did not say", never
+ *   "the wallet cannot start".
+ */
+export type ChainVersionProbe = () => Promise<ProtocolVersion.ProtocolVersion>;
+
+/** The indexer's answer to "what is the latest block", cut down to the one field a version probe reads. */
+export type LatestBlockAnswer = Readonly<{ block: Readonly<{ protocolVersion: number }> | null }>;
+
+/** Raised when the chain named no version, because it has produced no block for one to be reported under. */
+export class ChainVersionUnavailableError extends Data.TaggedError(
+  '@midnightntwrk/wallet-sdk-capabilities/chainVersion/chainVersionProbe/ChainVersionUnavailableError',
+)<{
+  readonly message: string;
+}> {}
+
+/**
+ * Reads the protocol version out of the indexer's answer for the latest block.
+ *
+ * @remarks
+ *   Absent rather than zero when there is no block. A chain that has produced nothing has not said which side of any
+ *   boundary it is on, and the bottom of the timeline is precisely the wrong guess — it is the one the probe exists to
+ *   replace.
+ * @param answer The indexer's answer for the latest block.
+ * @returns The version that block was reported under, or nothing when there is no block.
+ */
+export const chainVersionOf = (answer: LatestBlockAnswer): Option.Option<ProtocolVersion.ProtocolVersion> =>
+  pipe(
+    Option.fromNullable(answer.block),
+    Option.map((block) => ProtocolVersion.ProtocolVersion(BigInt(block.protocolVersion))),
+  );
+
+/**
+ * The chain's current protocol version, read through whichever query client is provided.
+ *
+ * @remarks
+ *   The same `BlockHash` query the default block-data fetcher runs, so a chain answers both with one selection set and
+ *   the two cannot disagree about what "the latest block" is.
+ */
+export const currentChainVersion = Effect.gen(function* () {
+  const query = yield* BlockHash;
+  return chainVersionOf(yield* query({ offset: null }));
+});
+
+/** What building the default {@link ChainVersionProbe} needs: somewhere to ask. */
+export type DefaultChainVersionProbeConfiguration = {
+  indexerClientConnection: {
+    indexerHttpUrl: string;
+  };
+};
+
+/**
+ * Builds a {@link ChainVersionProbe} that asks the indexer over HTTP for the latest block's protocol version.
+ *
+ * @remarks
+ *   Each call opens a short-lived query client and closes it again, as the default block-data fetcher does. It carries
+ *   no timeout of its own: the caller that blocks on it owns how long it is prepared to wait, and the wallet that
+ *   starts with one applies its own bound.
+ * @param config Where to ask.
+ * @returns The probe.
+ */
+export const makeIndexerChainVersionProbe =
+  (config: DefaultChainVersionProbeConfiguration): ChainVersionProbe =>
+  () =>
+    pipe(
+      currentChainVersion,
+      Effect.provide(HttpQueryClient.layer({ url: config.indexerClientConnection.indexerHttpUrl })),
+      Effect.scoped,
+      Effect.flatMap(
+        Option.match({
+          onNone: () =>
+            Effect.fail(
+              new ChainVersionUnavailableError({
+                message: 'The indexer reports no block, so the chain has named no protocol version.',
+              }),
+            ),
+          onSome: Effect.succeed,
+        }),
+      ),
+      Effect.runPromise,
+    );

--- a/packages/capabilities/src/chainVersion/index.ts
+++ b/packages/capabilities/src/chainVersion/index.ts
@@ -10,12 +10,4 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-export * from './balancer/index.js';
-export * from './chainVersion/index.js';
-export * from './codecs/index.js';
-export * from './pendingTransactions/index.js';
-export * from './proving/index.js';
-export * from './signatures/index.js';
-export * from './simulation/index.js';
-export * from './submission/index.js';
-export * from './validation/index.js';
+export * from './chainVersionProbe.js';

--- a/packages/capabilities/src/chainVersion/test/chainVersionProbe.test.ts
+++ b/packages/capabilities/src/chainVersion/test/chainVersionProbe.test.ts
@@ -33,9 +33,9 @@ const blockAt = (protocolVersion: number) => ({ block: { protocolVersion } });
  * An indexer that answers every query with one prepared result.
  *
  * @remarks
- *   A stub rather than a spy: what is asserted is the version the probe arrives at, not that a query was issued. The
- *   real {@link currentChainVersion} document is still the one executed — only the transport is replaced — so a
- *   selection set that stopped carrying `protocolVersion` would surface here.
+ *   A stub rather than a spy: what is asserted is the version the probe arrives at, not that a query was issued. The real
+ *   {@link currentChainVersion} document is still the one executed — only the transport is replaced — so a selection set
+ *   that stopped carrying `protocolVersion` would surface here.
  */
 const indexerAnswering = <T>(result: T): Layer.Layer<QueryClient> =>
   // Type cast required because: `QueryClient.query` is generic in the document it is handed, so its result type is

--- a/packages/capabilities/src/chainVersion/test/chainVersionProbe.test.ts
+++ b/packages/capabilities/src/chainVersion/test/chainVersionProbe.test.ts
@@ -1,0 +1,72 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * What the chain answers when asked which protocol version it is on.
+ *
+ * @remarks
+ *   The question exists because a wallet that spans a protocol boundary has to choose a variant before it has seen a
+ *   single event, and until it asks, its only guess is the bottom of the timeline. The answer is a property of the
+ *   chain, read from the same block query validation already reads.
+ */
+
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { QueryClient } from '@midnightntwrk/wallet-sdk-indexer-client/effect';
+import { Effect, Layer, Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { chainVersionOf, currentChainVersion } from '../chainVersionProbe.js';
+
+/** A block as the indexer serves it, cut down to the one field the probe reads. */
+const blockAt = (protocolVersion: number) => ({ block: { protocolVersion } });
+
+/**
+ * An indexer that answers every query with one prepared result.
+ *
+ * @remarks
+ *   A stub rather than a spy: what is asserted is the version the probe arrives at, not that a query was issued. The
+ *   real {@link currentChainVersion} document is still the one executed — only the transport is replaced — so a
+ *   selection set that stopped carrying `protocolVersion` would surface here.
+ */
+const indexerAnswering = <T>(result: T): Layer.Layer<QueryClient> =>
+  // Type cast required because: `QueryClient.query` is generic in the document it is handed, so its result type is
+  // computed from that document. A stub answering with one prepared value cannot express that relation; the pairing
+  // holds by construction here, since each caller hands in the shape the query it provokes asks for.
+  Layer.succeed(QueryClient, { query: () => Effect.succeed(result) } as QueryClient.Service);
+
+describe('reading the protocol version out of a block', () => {
+  it('takes the version the chain reported its latest block under', () => {
+    expect(chainVersionOf(blockAt(2_000_000))).toStrictEqual(Option.some(ProtocolVersion.ProtocolVersion(2_000_000n)));
+  });
+
+  it('reports nothing for a chain that has produced no block at all', () => {
+    // Not version zero: a chain with no blocks has not said which side of any boundary it is on, and answering with
+    // the bottom of the timeline is exactly the wrong guess the probe exists to remove.
+    expect(chainVersionOf({ block: null })).toStrictEqual(Option.none());
+  });
+});
+
+describe('asking the chain for its current protocol version', () => {
+  it('answers with the version the indexer reports for the latest block', async () =>
+    Effect.gen(function* () {
+      const version = yield* currentChainVersion;
+
+      expect(version).toStrictEqual(Option.some(ProtocolVersion.ProtocolVersion(2_000_000n)));
+    }).pipe(Effect.provide(indexerAnswering(blockAt(2_000_000))), Effect.runPromise));
+
+  it('answers with nothing when the indexer knows of no block', async () =>
+    Effect.gen(function* () {
+      const version = yield* currentChainVersion;
+
+      expect(version).toStrictEqual(Option.none());
+    }).pipe(Effect.provide(indexerAnswering({ block: null })), Effect.runPromise));
+});

--- a/packages/dust-wallet/src/DustWallet.ts
+++ b/packages/dust-wallet/src/DustWallet.ts
@@ -37,6 +37,7 @@ import {
   type VariantBuilder,
   type WalletLike,
 } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import { type BlockData as PricedBlockData } from '@midnightntwrk/wallet-sdk-capabilities/validation';
 import { type Clock, EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
 import { type Duration, Effect, Either, Option, Ref, type Scope } from 'effect';
@@ -346,6 +347,16 @@ export type DefaultDustConfiguration = {
    *   unchanged.
    */
   forkVersion: ProtocolVersion.ProtocolVersion;
+  /**
+   * How the wallet asks the chain which protocol version it is on, before it chooses a variant to start at.
+   *
+   * @remarks
+   *   Optional, and defaulted rather than absent: left unset, the wallet asks the indexer named by
+   *   {@link indexerClientConnection}, which it is about to synchronize from anyway. Supply one to ask something else —
+   *   a cache, a node RPC, a value the application already holds. The answer is best-effort wherever it comes from: a
+   *   chain that cannot be reached leaves the wallet starting exactly where it started before there was a probe.
+   */
+  chainVersionProbe?: ChainVersionProbe;
 };
 
 export interface CustomizedDustWalletClass<

--- a/packages/dust-wallet/src/ForkingDustWallet.ts
+++ b/packages/dust-wallet/src/ForkingDustWallet.ts
@@ -33,23 +33,27 @@ import {
   WalletTransaction,
 } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type DustAddress } from '@midnightntwrk/wallet-sdk-address-format';
+import {
+  type ChainVersionProbe,
+  makeIndexerChainVersionProbe,
+} from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import * as PreForkSignatures from '@midnightntwrk/wallet-sdk-capabilities/signatures';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
 import {
   StartMaterial,
-  type Variant,
+  Variant,
   type VariantBuilder,
   type WalletLike,
 } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type Clock, EitherOps, HList } from '@midnightntwrk/wallet-sdk-utilities';
-import { Effect, Either, Option, Ref, type Scope } from 'effect';
+import { Duration, Effect, Either, Option, Ref, type Scope, pipe } from 'effect';
 import * as rx from 'rxjs';
 import { type UnsupportedSnapshotVersionError, variantForSnapshot } from './Restore.js';
 import { type DefaultDustConfiguration, type DustWalletAPI, DustWalletState } from './DustWallet.js';
 import { type BlockData as PricedBlockData } from '@midnightntwrk/wallet-sdk-capabilities/validation';
 import { CoreWallet as PreForkCoreWallet, V1Builder, V1Tag, type V1Variant } from './v1/index.js';
 import { type WalletSyncUpdate as PreForkSyncUpdate } from './v1/Sync.js';
-import { type CoreWallet, Migration, V2Builder, V2Tag, type V2Variant } from './v2/index.js';
+import { CoreWallet, Migration, V2Builder, V2Tag, type V2Variant } from './v2/index.js';
 import { type WalletSyncUpdate as PostForkSyncUpdate } from './v2/SyncSchema.js';
 import { type NightUtxoSplitForDustRegistration } from './v2/Transacting.js';
 import { type UtxoWithMeta } from './v2/types/Dust.js';
@@ -122,6 +126,20 @@ export type ForkingDustConfiguration = {
   networkId: NetworkId;
   /** The protocol version at which the chain hands over from the pre-fork ledger version to the post-fork one. */
   forkVersion: ProtocolVersion.ProtocolVersion;
+  /**
+   * How the wallet asks the chain which protocol version it is on, before it chooses a variant to start at.
+   *
+   * @remarks
+   *   Optional, and best-effort where present: a wallet with no probe — or one whose probe does not answer in time —
+   *   starts on the pre-fork variant and learns the version from the first event it sees, which is what a wallet with
+   *   no history has always done. What a probe buys is the two things that guess costs: a hand-over per start on a
+   *   chain entirely past the boundary, and, on a chain that has shown this wallet no events at all, an epoch that
+   *   never gets corrected.
+   *
+   *   Nothing about it can make a start fail. A rejection, a timeout, a version no registered variant covers: each
+   *   leaves the wallet exactly where a wallet that never asked would be.
+   */
+  chainVersionProbe?: ChainVersionProbe;
 };
 
 /**
@@ -155,18 +173,23 @@ export interface ForkingDustWalletClass<
    * @remarks
    *   The only start that can follow the chain the whole way. The seed is the one piece of key material that crosses a
    *   protocol boundary — each variant derives its own `DustSecretKey` from it, and the two derive the same dust public
-   *   key — so a wallet built this way can synchronize on either side of the fork. It begins on the pre-fork variant
-   *   and is handed over when the chain reports a version the post-fork variant owns, which on a chain that has already
-   *   forked happens on the first batch it sees.
+   *   key — so a wallet built this way can synchronize on either side of the fork.
+   *
+   *   Asynchronous because choosing where to begin can mean asking the chain: with a
+   *   {@link ForkingDustConfiguration.chainVersionProbe} configured, the wallet starts at the variant that owns the
+   *   version the chain reports, which on a chain already past the boundary is the post-fork one from the first moment.
+   *   Without one, or when the question goes unanswered, it begins on the pre-fork variant and is handed over when the
+   *   chain reports a version the post-fork variant owns — on a chain that has already forked, the first batch it sees.
    * @param seed The seed to derive both ledger versions' dust keys from.
    * @param dustParameters The post-fork ledger version's dust parameters, which an empty post-fork state is valued
    *   against.
-   * @returns A wallet started on the pre-fork variant.
+   * @returns A wallet started at the variant the chain is on, or on the pre-fork variant when the chain was not asked
+   *   or did not say.
    */
   startWithSeed(
     seed: Uint8Array,
     dustParameters?: DustGenerationRates,
-  ): ForkingDustWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+  ): Promise<ForkingDustWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>>;
   /**
    * Builds a wallet from dust keys of both ledger versions.
    *
@@ -178,12 +201,13 @@ export interface ForkingDustWalletClass<
    *   same derivation done twice; a seed costs neither.
    * @param keys One ledger version's dust secret key per side of the boundary.
    * @param dustParameters The post-fork ledger version's dust parameters.
-   * @returns A wallet started on the pre-fork variant, which is where a wallet with no history belongs.
+   * @returns A wallet started at the variant the chain is on, or on the pre-fork variant — where a wallet with no
+   *   history belongs — when the chain was not asked or did not say.
    */
   startWithKeys(
     keys: DustKeysByEpoch,
     dustParameters?: DustGenerationRates,
-  ): ForkingDustWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+  ): Promise<ForkingDustWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>>;
   /**
    * Restores a wallet from a snapshot, into whichever registered variant wrote it.
    *
@@ -240,6 +264,24 @@ export type DustGenerationRates = Readonly<{
 
 export const asPreForkDustParameters = (parameters: DustGenerationRates): v8.DustParameters =>
   new v8.DustParameters(parameters.nightDustRatio, parameters.generationDecayRate, parameters.dustGracePeriodSeconds);
+
+/**
+ * The same dust rates, as the post-fork ledger version's parameters object.
+ *
+ * @remarks
+ *   The mirror of {@link asPreForkDustParameters}, and needed for the same reason: an empty state of either variant is
+ *   parameterised, and the rates a caller names are plain numbers rather than either ledger's object. Ordinarily the
+ *   post-fork side's empty state is the migration's business; a wallet that starts post-fork because the chain said so
+ *   has no migration to get one from, and builds its own here.
+ * @param parameters The rates to express.
+ * @returns The same generation and decay rates, as a post-fork `DustParameters`.
+ */
+export const asPostForkDustParameters = (parameters: DustGenerationRates): ledger.DustParameters =>
+  new ledger.DustParameters(
+    parameters.nightDustRatio,
+    parameters.generationDecayRate,
+    parameters.dustGracePeriodSeconds,
+  );
 
 /**
  * Builds a dust wallet class over a variant either side of a protocol boundary.
@@ -379,26 +421,120 @@ export function CustomForkingDustWallet<
   const postForkTx = <T>(handle: AnyTx): Effect.Effect<T, ProtocolVersionMismatchError> =>
     EitherOps.toEffect(WalletTransaction.unwrapWithin<T>(handle, postForkEpoch));
 
+  /**
+   * How long a start waits for the chain to say which version it is on.
+   *
+   * @remarks
+   *   Short, because what is being bought is small: the alternative to an answer is the hand-over this wallet has
+   *   always done, which costs one migration and no correctness on a chain that produces events. It is a ceiling
+   *   rather than a typical cost — an unreachable indexer refuses a connection long before this — and it exists so
+   *   that a probe which neither answers nor fails cannot hold a start open indefinitely.
+   */
+  const probeTimeout = Duration.seconds(5);
+
+  /** Where a start begins, when the chain answered for it. */
+  type ProbedStart = Readonly<{
+    version: ProtocolVersion.ProtocolVersion;
+    variant: HList.Each<Variants>;
+  }>;
+
+  /**
+   * The variant the chain's current version belongs to, or nothing.
+   *
+   * @remarks
+   *   Nothing covers every way the question can fail to produce an answer, and they are deliberately not distinguished:
+   *   no probe configured, a probe that rejected, a probe that outlived the wallet's patience, or a version no
+   *   registered variant claims. Each means the same thing to a caller — start where a wallet with no history starts —
+   *   and none of them is a reason to fail.
+   */
+  const probedStart: Effect.Effect<Option.Option<ProbedStart>> =
+    configuration.chainVersionProbe === undefined
+      ? Effect.succeedNone
+      : pipe(
+          Effect.tryPromise(configuration.chainVersionProbe),
+          Effect.timeout(probeTimeout),
+          Effect.map((version) =>
+            Option.map(BaseWallet.variantFor(version), (variant): ProbedStart => ({ version, variant })),
+          ),
+          Effect.orElseSucceed(() => Option.none<ProbedStart>()),
+        );
+
+  /**
+   * A fresh state of the variant a probed start begins at, recording the version the chain reported.
+   *
+   * @remarks
+   *   Built exactly as the head-variant boot path builds its own — an empty state of that variant, valued against that
+   *   ledger version's rebuild of the rates the caller named — and then annotated with the observed version, which is
+   *   what keeps a variant from starting outside its own activation range and signalling backwards on sight.
+   */
+  const freshStateAt = (
+    variant: HList.Each<Variants>,
+    keys: DustKeysByEpoch,
+    rates: DustGenerationRates,
+    version: ProtocolVersion.ProtocolVersion,
+  ): PreForkCoreWallet | CoreWallet =>
+    Variant.getVersionedVariantTag(variant) === V2Tag
+      ? CoreWallet.withProtocolVersion(
+          CoreWallet.initEmpty(asPostForkDustParameters(rates), keys.v9, configuration.networkId),
+          version,
+        )
+      : PreForkCoreWallet.withProtocolVersion(
+          PreForkCoreWallet.initEmpty(asPreForkDustParameters(rates), keys.v8, configuration.networkId),
+          version,
+        );
+
   return class ForkingDustWalletImplementation
     extends BaseWallet
     implements ForkingDustWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>
   {
     static readonly configuration: TConfiguration = configuration;
 
-    static startWithSeed(
+    /**
+     * Starts at the variant the chain says it is on, or at the head variant when it does not say.
+     *
+     * @remarks
+     *   The second branch is the whole of this wallet's previous behaviour, unchanged and reached whenever the chain was
+     *   not asked or did not answer: the pre-fork variant, an empty state valued against the pre-fork rebuild of the
+     *   rates the caller named, and a hand-over on the first batch that reports a version it does not own.
+     * @param keys One ledger version's dust key per side of the boundary, since either side may be the one that runs.
+     * @param rates The rates the caller named, which whichever empty state is built is valued against.
+     * @returns The started wallet.
+     */
+    static #startProbed(
+      keys: DustKeysByEpoch,
+      rates: DustGenerationRates,
+    ): Promise<ForkingDustWalletImplementation> {
+      return pipe(
+        probedStart,
+        Effect.map(
+          Option.match({
+            onNone: () =>
+              ForkingDustWalletImplementation.startFirst(
+                ForkingDustWalletImplementation,
+                // Valued against the same rates the caller named, rebuilt by the ledger version that owns this state —
+                // see {@link asPreForkDustParameters}.
+                PreForkCoreWallet.initEmpty(asPreForkDustParameters(rates), keys.v8, configuration.networkId),
+              ),
+            onSome: ({ version, variant }) =>
+              ForkingDustWalletImplementation.startAtVariant(
+                ForkingDustWalletImplementation,
+                variant,
+                freshStateAt(variant, keys, rates, version),
+              ),
+          }),
+        ),
+        Effect.runPromise,
+      );
+    }
+
+    static async startWithSeed(
       seed: Uint8Array,
       dustParameters: DustGenerationRates = defaultRates,
-    ): ForkingDustWalletImplementation {
+    ): Promise<ForkingDustWalletImplementation> {
       const derived = keysFromSeed(WalletSeed.WalletSeed(seed));
-      const wallet = ForkingDustWalletImplementation.startFirst(
-        ForkingDustWalletImplementation,
-        // Valued against the same rates the caller named, rebuilt by the ledger version that owns this state — see
-        // {@link asPreForkDustParameters}. The post-fork side's own empty state is the migration's business.
-        PreForkCoreWallet.initEmpty(
-          asPreForkDustParameters(dustParameters),
-          Option.getOrThrow(derived.preFork),
-          configuration.networkId,
-        ),
+      const wallet = await ForkingDustWalletImplementation.#startProbed(
+        { v8: Option.getOrThrow(derived.preFork), v9: Option.getOrThrow(derived.postFork) },
+        dustParameters,
       );
       // Both sides derived here and now, and the seed reference dropped with this frame: from this point the wallet
       // holds key objects only, which is strictly less than it held before and does the same work.
@@ -406,14 +542,11 @@ export function CustomForkingDustWallet<
       return wallet;
     }
 
-    static startWithKeys(
+    static async startWithKeys(
       keys: DustKeysByEpoch,
       dustParameters: DustGenerationRates = defaultRates,
-    ): ForkingDustWalletImplementation {
-      const wallet = ForkingDustWalletImplementation.startFirst(
-        ForkingDustWalletImplementation,
-        PreForkCoreWallet.initEmpty(asPreForkDustParameters(dustParameters), keys.v8, configuration.networkId),
-      );
+    ): Promise<ForkingDustWalletImplementation> {
+      const wallet = await ForkingDustWalletImplementation.#startProbed(keys, dustParameters);
       wallet.#retainKeys({ preFork: Option.some(keys.v8), postFork: Option.some(keys.v9) });
       return wallet;
     }
@@ -863,14 +996,24 @@ export type DustWalletClass = ForkingDustWalletClass<PreForkSyncUpdate, PostFork
  *
  *   **Fee-paying operations work on either side of the boundary**: the active variant answers with its own ledger's
  *   objects, and every result travels as a handle stamped with the epoch that built it.
+ *
+ *   **The chain is asked where it is before a variant is chosen.** The indexer this wallet already syncs from answers
+ *   which protocol version the chain is on, so a start on a chain past the boundary begins post-fork rather than
+ *   handing over immediately. An application that would rather ask something else — a cache, a value it already holds
+ *   — supplies its own `chainVersionProbe`; one whose chain cannot be reached loses nothing, because the answer is
+ *   best-effort and its absence is the behaviour this wallet had before.
  * @param configuration What the wallet and both its variants are built from, including where the boundary lies.
  * @returns The wallet class.
  */
 export function DustWallet(configuration: DefaultDustConfiguration): DustWalletClass {
   const dustParameters = configuration.dustParameters ?? ledger.LedgerParameters.initialParameters().dust;
+  const withProbe: DefaultDustConfiguration = {
+    ...configuration,
+    chainVersionProbe: configuration.chainVersionProbe ?? makeIndexerChainVersionProbe(configuration),
+  };
 
   return CustomForkingDustWallet(
-    configuration,
+    withProbe,
     {
       builder: new V1Builder().withDefaults(),
       // The one field that cannot be shared: `dustParameters` is a WASM object of whichever ledger module produced it,

--- a/packages/dust-wallet/src/ForkingDustWallet.ts
+++ b/packages/dust-wallet/src/ForkingDustWallet.ts
@@ -136,8 +136,8 @@ export type ForkingDustConfiguration = {
    *   chain entirely past the boundary, and, on a chain that has shown this wallet no events at all, an epoch that
    *   never gets corrected.
    *
-   *   Nothing about it can make a start fail. A rejection, a timeout, a version no registered variant covers: each
-   *   leaves the wallet exactly where a wallet that never asked would be.
+   *   Nothing about it can make a start fail. A rejection, a timeout, a version no registered variant covers: each leaves
+   *   the wallet exactly where a wallet that never asked would be.
    */
   chainVersionProbe?: ChainVersionProbe;
 };
@@ -179,7 +179,8 @@ export interface ForkingDustWalletClass<
    *   {@link ForkingDustConfiguration.chainVersionProbe} configured, the wallet starts at the variant that owns the
    *   version the chain reports, which on a chain already past the boundary is the post-fork one from the first moment.
    *   Without one, or when the question goes unanswered, it begins on the pre-fork variant and is handed over when the
-   *   chain reports a version the post-fork variant owns — on a chain that has already forked, the first batch it sees.
+   *   chain reports a version the post-fork variant owns — on a chain that has already forked, the first batch it
+   *   sees.
    * @param seed The seed to derive both ledger versions' dust keys from.
    * @param dustParameters The post-fork ledger version's dust parameters, which an empty post-fork state is valued
    *   against.
@@ -425,10 +426,10 @@ export function CustomForkingDustWallet<
    * How long a start waits for the chain to say which version it is on.
    *
    * @remarks
-   *   Short, because what is being bought is small: the alternative to an answer is the hand-over this wallet has
-   *   always done, which costs one migration and no correctness on a chain that produces events. It is a ceiling
-   *   rather than a typical cost — an unreachable indexer refuses a connection long before this — and it exists so
-   *   that a probe which neither answers nor fails cannot hold a start open indefinitely.
+   *   Short, because what is being bought is small: the alternative to an answer is the hand-over this wallet has always
+   *   done, which costs one migration and no correctness on a chain that produces events. It is a ceiling rather than a
+   *   typical cost — an unreachable indexer refuses a connection long before this — and it exists so that a probe which
+   *   neither answers nor fails cannot hold a start open indefinitely.
    */
   const probeTimeout = Duration.seconds(5);
 
@@ -500,10 +501,7 @@ export function CustomForkingDustWallet<
      * @param rates The rates the caller named, which whichever empty state is built is valued against.
      * @returns The started wallet.
      */
-    static #startProbed(
-      keys: DustKeysByEpoch,
-      rates: DustGenerationRates,
-    ): Promise<ForkingDustWalletImplementation> {
+    static #startProbed(keys: DustKeysByEpoch, rates: DustGenerationRates): Promise<ForkingDustWalletImplementation> {
       return pipe(
         probedStart,
         Effect.map(
@@ -999,8 +997,8 @@ export type DustWalletClass = ForkingDustWalletClass<PreForkSyncUpdate, PostFork
  *
  *   **The chain is asked where it is before a variant is chosen.** The indexer this wallet already syncs from answers
  *   which protocol version the chain is on, so a start on a chain past the boundary begins post-fork rather than
- *   handing over immediately. An application that would rather ask something else — a cache, a value it already holds
- *   — supplies its own `chainVersionProbe`; one whose chain cannot be reached loses nothing, because the answer is
+ *   handing over immediately. An application that would rather ask something else — a cache, a value it already holds —
+ *   supplies its own `chainVersionProbe`; one whose chain cannot be reached loses nothing, because the answer is
  *   best-effort and its absence is the behaviour this wallet had before.
  * @param configuration What the wallet and both its variants are built from, including where the boundary lies.
  * @returns The wallet class.

--- a/packages/dust-wallet/src/test/configuration.test.ts
+++ b/packages/dust-wallet/src/test/configuration.test.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 import { type DustParameters } from '@midnightntwrk/ledger-v9';
 import { type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import { type CanAssign, type Equal, type Expect } from '@midnightntwrk/wallet-sdk-utilities/types';
 import { type Duration } from 'effect';
 import { describe, it } from 'vitest';
@@ -34,6 +35,7 @@ describe('DefaultDustConfiguration', () => {
           indexerClientConnection: { indexerHttpUrl: string };
           transactionDetailsRetryWindow?: Duration.DurationInput;
           forkVersion: ProtocolVersion.ProtocolVersion;
+          chainVersionProbe?: ChainVersionProbe;
         }
       >
     >;
@@ -55,5 +57,10 @@ describe('DefaultDustConfiguration', () => {
     // `forkVersion` is the wallet layer's alone: neither variant knows there is another one.
     type _3 = Expect<Equal<'forkVersion' extends keyof DefaultV1Configuration ? true : false, false>>;
     type _4 = Expect<Equal<'forkVersion' extends keyof DefaultV2Configuration ? true : false, false>>;
+
+    // And so is the question of where to start, for the same reason: a variant that does not know there is another
+    // one has no use for the answer.
+    type _5 = Expect<Equal<'chainVersionProbe' extends keyof DefaultV1Configuration ? true : false, false>>;
+    type _6 = Expect<Equal<'chainVersionProbe' extends keyof DefaultV2Configuration ? true : false, false>>;
   });
 });

--- a/packages/dust-wallet/src/test/forkHarness.ts
+++ b/packages/dust-wallet/src/test/forkHarness.ts
@@ -46,6 +46,7 @@ import {
   LedgerParameters as PostForkLedgerParameters,
 } from '@midnightntwrk/ledger-v9';
 import { type NetworkId, type ProtocolState, type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { Deferred, Effect, FiberId, Option, Stream, pipe } from 'effect';
 import { CustomForkingDustWallet, type ForkingDustWallet } from '../ForkingDustWallet.js';
@@ -299,6 +300,13 @@ export type ForkWalletConfig = Readonly<{
   dustParameters: Readonly<{ preFork: PreForkParameters; postFork: PostForkParameters }>;
   /** The instant sync updates are valued at — at or after the last event's block time. */
   syncTime: Date;
+  /**
+   * How the wallet asks the chain which protocol version it is on before choosing a variant to start at.
+   *
+   * Absent means it does not ask, which is the behaviour of every wallet built without one: it starts at the head
+   * variant and learns the version from the first event it sees.
+   */
+  chainVersionProbe?: ChainVersionProbe;
 }>;
 
 /** A state emission, whichever variant produced it. */
@@ -334,12 +342,16 @@ export type ForkWallet = Readonly<{
 /**
  * Builds and starts the shipped forking dust wallet over an in-memory timeline that forks.
  *
- * @param config - The two sources, the boundary version, the network, the seed and the parameters each side values dust
- *   against.
+ * @remarks
+ *   Effectful because starting one is: a wallet that spans a boundary may ask the chain which version it is on before it
+ *   can choose a variant, and that question is answered over the network. A harness that hid it behind a synchronous
+ *   call would be hiding the very thing these proofs are about.
+ * @param config - The two sources, the boundary version, the network, the seed, the parameters each side values dust
+ *   against, and how the chain is asked its version.
  * @returns The running wallet and its observation channels.
  */
-export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
-  const { preFork, replayed, networkId, forkVersion, seed, dustParameters, syncTime } = config;
+export const makeForkWallet = (config: ForkWalletConfig): Effect.Effect<ForkWallet> => {
+  const { preFork, replayed, networkId, forkVersion, seed, dustParameters, syncTime, chainVersionProbe } = config;
 
   const preForkKey = PreForkSecretKey.fromSeed(seed);
   const postForkKey = PostForkSecretKey.fromSeed(seed);
@@ -370,7 +382,7 @@ export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
     .withMigration(() => capturingCrossLedgerMigration(dustParameters.postFork, captured));
 
   const WalletClass = CustomForkingDustWallet(
-    { networkId, forkVersion },
+    { networkId, forkVersion, ...(chainVersionProbe !== undefined ? { chainVersionProbe } : {}) },
     {
       builder: preForkBuilder,
       configuration: {
@@ -393,43 +405,46 @@ export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
     },
   );
 
-  const wallet = WalletClass.startWithSeed(seed, dustParameters.postFork);
-  const runtime = wallet.runtime;
+  return Effect.promise(() => WalletClass.startWithSeed(seed, dustParameters.postFork)).pipe(
+    Effect.map((wallet) => {
+      const runtime = wallet.runtime;
 
-  const currentState = pipe(runtime.stateChanges, Stream.take(1), Stream.runHead, Effect.map(Option.getOrThrow));
+      const currentState = pipe(runtime.stateChanges, Stream.take(1), Stream.runHead, Effect.map(Option.getOrThrow));
 
-  return {
-    dust: wallet,
+      return {
+        dust: wallet,
 
-    keys: { preFork: preForkKey, postFork: postForkKey },
+        keys: { preFork: preForkKey, postFork: postForkKey },
 
-    // The key handed over is the post-fork ledger version's, which is what the wallet's API speaks. The pre-fork
-    // variant running underneath is started from the seed the wallet retained instead — the seam a wallet crossing a
-    // boundary rests on.
-    start: Effect.promise(() => wallet.start(postForkKey)),
+        // The key handed over is the post-fork ledger version's, which is what the wallet's API speaks. The pre-fork
+        // variant running underneath is started from the seed the wallet retained instead — the seam a wallet crossing
+        // a boundary rests on.
+        start: Effect.promise(() => wallet.start(postForkKey)),
 
-    awaitMigration: Deferred.await(captured),
+        awaitMigration: Deferred.await(captured),
 
-    migration: Deferred.poll(captured).pipe(
-      Effect.flatMap(Option.match({ onNone: () => Effect.succeedNone, onSome: Effect.asSome })),
-    ),
+        migration: Deferred.poll(captured).pipe(
+          Effect.flatMap(Option.match({ onNone: () => Effect.succeedNone, onSome: Effect.asSome })),
+        ),
 
-    activeTag: pipe(
-      runtime.currentVariant,
-      Effect.map((current) => current.runningVariant.__polyTag__),
-    ),
+        activeTag: pipe(
+          runtime.currentVariant,
+          Effect.map((current) => current.runningVariant.__polyTag__),
+        ),
 
-    currentState,
+        currentState,
 
-    awaitState: (predicate) =>
-      pipe(
-        runtime.stateChanges,
-        Stream.filter(predicate),
-        Stream.take(1),
-        Stream.runHead,
-        Effect.map(Option.getOrThrow),
-      ),
+        awaitState: (predicate: (state: ForkedState) => boolean) =>
+          pipe(
+            runtime.stateChanges,
+            Stream.filter(predicate),
+            Stream.take(1),
+            Stream.runHead,
+            Effect.map(Option.getOrThrow),
+          ),
 
-    stop: Effect.promise(() => wallet.stop()),
-  };
+        stop: Effect.promise(() => wallet.stop()),
+      };
+    }),
+  );
 };

--- a/packages/dust-wallet/src/test/forkSimulation.test.ts
+++ b/packages/dust-wallet/src/test/forkSimulation.test.ts
@@ -205,7 +205,7 @@ describe('a dust wallet crossing a hard fork', () => {
         const wire = yield* Queue.unbounded<readonly TimelineEvent[]>();
         const replayed = yield* Deferred.make<readonly TimelineEvent[]>();
 
-        const wallet = makeForkWallet({
+        const wallet = yield* makeForkWallet({
           preFork: Stream.fromQueue(wire),
           replayed: Deferred.await(replayed),
           networkId,
@@ -303,7 +303,7 @@ describe('a dust wallet crossing a hard fork', () => {
         const wire = yield* Queue.unbounded<readonly TimelineEvent[]>();
         const replayed = yield* Deferred.make<readonly TimelineEvent[]>();
 
-        const wallet = makeForkWallet({
+        const wallet = yield* makeForkWallet({
           preFork: Stream.fromQueue(wire),
           replayed: Deferred.await(replayed),
           networkId,
@@ -349,7 +349,7 @@ describe('a dust wallet crossing a hard fork', () => {
         const replay = replayOf(chain.eventBytes);
         const wire = yield* Queue.unbounded<readonly TimelineEvent[]>();
 
-        const wallet = makeForkWallet({
+        const wallet = yield* makeForkWallet({
           preFork: Stream.fromQueue(wire),
           replayed: Effect.succeed(replay),
           networkId,

--- a/packages/dust-wallet/src/test/forkStart.test.ts
+++ b/packages/dust-wallet/src/test/forkStart.test.ts
@@ -19,12 +19,14 @@
  *   here are the other question — a wallet meeting a chain that is already on one side or the other, which is what
  *   every application start actually is.
  *
- *   A wallet always begins on the pre-fork variant, because that is the variant a wallet with no history belongs to. On a
- *   chain that has already forked it therefore hands over immediately, having applied nothing: one migration per start,
- *   paid on chains that are entirely past the boundary. That cost is accepted rather than hidden — removing it means
- *   asking the chain for its version before choosing a variant, which is a separate piece of work.
+ *   Where it begins turns on one question: whether it asked the chain. A wallet given a way to ask starts at the variant
+ *   that owns the version the chain reports, which on a chain past the boundary is the post-fork one from the first
+ *   moment — no hand-over, and the right epoch before a single event has arrived. A wallet with no way to ask, or one
+ *   whose question went unanswered, begins on the pre-fork variant, because that is where a wallet with no history
+ *   belongs, and hands over on the first batch it sees. Both are specified here: the second is not a fallback in name
+ *   only, it is what every offline-first application and every wallet built without a probe does.
  *
- *   Both starts assert the boundary by comparison with `forkVersion` and never by the number itself: which protocol
+ *   All of it asserts the boundary by comparison with `forkVersion` and never by the number itself: which protocol
  *   version a chain reports is a property of the chain, and the real fork's value is not final.
  */
 
@@ -39,6 +41,7 @@ import {
   type UnprovenTx,
   WalletTransaction,
 } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import { Cause, Deferred, Effect, Option, Queue, Runtime, type Scope, Stream } from 'effect';
 import { describe, expect, it, vi } from 'vitest';
 import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
@@ -80,13 +83,14 @@ const dustParameters = {
 const walletOnChainAt = (
   chain: DustChain,
   version: ProtocolVersion.ProtocolVersion,
+  chainVersionProbe?: ChainVersionProbe,
 ): Effect.Effect<ForkWallet, never, Scope.Scope> =>
   Effect.gen(function* () {
     const history: readonly TimelineEvent[] = numberedFrom(chain.eventBytes, 1, Number(version));
     const wire = yield* Queue.unbounded<readonly TimelineEvent[]>();
     const replayed = yield* Deferred.make<readonly TimelineEvent[]>();
 
-    const wallet = makeForkWallet({
+    const wallet = yield* makeForkWallet({
       preFork: Stream.fromQueue(wire),
       replayed: Deferred.await(replayed),
       networkId,
@@ -94,6 +98,7 @@ const walletOnChainAt = (
       seed: dustSeed(),
       dustParameters,
       syncTime: chain.syncTime,
+      ...(chainVersionProbe !== undefined ? { chainVersionProbe } : {}),
     });
     yield* Effect.addFinalizer(() => wallet.stop);
     yield* wallet.start;
@@ -106,6 +111,22 @@ const walletOnChainAt = (
 
     return wallet;
   });
+
+/** A probe answering as a chain on `version` would. */
+const chainReporting =
+  (version: ProtocolVersion.ProtocolVersion): ChainVersionProbe =>
+  () =>
+    Promise.resolve(version);
+
+/**
+ * A probe that never answers.
+ *
+ * @remarks
+ *   One shape stands in for every way the question can go unanswered — no indexer, no network, a request that outlives
+ *   the wallet's patience — because the wallet distinguishes none of them: it asked, it has no answer, it starts where
+ *   a wallet that never asked starts.
+ */
+const unreachableChain: ChainVersionProbe = () => Promise.reject(new Error('the indexer cannot be reached'));
 
 /**
  * The typed failure a wallet call rejected with.
@@ -218,9 +239,43 @@ const syncedPreForkWallet: Effect.Effect<ForkWallet, WalletRuntimeError, Scope.S
   return wallet;
 });
 
+describe('a dust wallet that asks the chain where it is starting', () => {
+  it('starts on the post-fork variant of a chain past the boundary, without a hand-over at all', async () =>
+    Effect.gen(function* () {
+      const chain = yield* Effect.promise(() => buildDustChain());
+      const wallet = yield* walletOnChainAt(chain, afterFork, chainReporting(afterFork));
+
+      // The post-fork variant does the syncing from the first event, and there is nothing to hand over because
+      // nothing was left behind. This is what the hand-over below costs a wallet that could not ask.
+      const synced = yield* wallet.awaitState((state) => dustCount(state.state) === DUST_EVENT_COUNT);
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+      expect(synced.state.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
+      expect(balanceAt(synced.state, chain.syncTime)).toBeGreaterThan(0n);
+
+      expect(yield* wallet.migration).toStrictEqual(Option.none());
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('starts on the pre-fork variant of a chain that has not forked, and stays there', async () =>
+    Effect.gen(function* () {
+      const chain = yield* Effect.promise(() => buildDustChain());
+      const wallet = yield* walletOnChainAt(chain, beforeFork, chainReporting(beforeFork));
+
+      // The answer sends it to the variant that owns the version, which below the boundary is the one it would have
+      // started on anyway. What the probe changes here is nothing at all, which is the claim.
+      const synced = yield* wallet.awaitState((state) => dustCount(state.state) === DUST_EVENT_COUNT);
+      expect(balanceAt(synced.state, chain.syncTime)).toBeGreaterThan(0n);
+      expect(synced.state.protocolVersion).toBeLessThan(forkVersion);
+
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+      expect(yield* wallet.migration).toStrictEqual(Option.none());
+    }).pipe(Effect.scoped, Effect.runPromise));
+});
+
 describe('a dust wallet starting on a chain that has already forked', () => {
   it('hands over on the first batch, having applied nothing, and syncs on the post-fork variant', async () =>
     Effect.gen(function* () {
+      // No probe: the shape of every wallet built without one, and of every application that would rather not have
+      // its start depend on reaching an indexer.
       const chain = yield* Effect.promise(() => buildDustChain());
       const wallet = yield* walletOnChainAt(chain, afterFork);
 
@@ -238,6 +293,21 @@ describe('a dust wallet starting on a chain that has already forked', () => {
       const synced = yield* wallet.awaitState((state) => dustCount(state.state) === DUST_EVENT_COUNT);
       expect(yield* wallet.activeTag).toBe(V2Tag);
       expect(synced.state.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
+      expect(balanceAt(synced.state, chain.syncTime)).toBeGreaterThan(0n);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('hands over the same way when it asked the chain and got no answer', async () =>
+    Effect.gen(function* () {
+      const chain = yield* Effect.promise(() => buildDustChain());
+      const wallet = yield* walletOnChainAt(chain, afterFork, unreachableChain);
+
+      // A question that cannot be answered leaves the wallet exactly where a wallet that never asked would be — and,
+      // above all, leaves it started. An unreachable chain is not a reason to fail to start.
+      const migration = yield* wallet.awaitMigration;
+      expect(migration.from.appliedIndex).toBe(0n);
+
+      const synced = yield* wallet.awaitState((state) => dustCount(state.state) === DUST_EVENT_COUNT);
+      expect(yield* wallet.activeTag).toBe(V2Tag);
       expect(balanceAt(synced.state, chain.syncTime)).toBeGreaterThan(0n);
     }).pipe(Effect.scoped, Effect.runPromise));
 });
@@ -371,6 +441,62 @@ describe('a dust wallet starting on a chain that has not forked', () => {
     }).pipe(Effect.scoped, Effect.runPromise));
 });
 
+/**
+ * A dust wallet on a chain past the boundary that has shown it nothing.
+ *
+ * @remarks
+ *   The hazard the probe closes, and the reason it is a correctness item rather than an optimization. A wallet learns
+ *   the chain's version from the events it observes, so one that has observed none holds the only version it can
+ *   assume: the bottom of the timeline. That is not a transient state on a chain whose dust timeline contains nothing
+ *   addressed to this wallet — it is where the wallet stays, for as long as it runs. And since transacting works on
+ *   either side of the boundary, the wallet does not refuse: it prices and builds with the wrong ledger version,
+ *   against a chain that will reject the result.
+ *
+ *   Modelled by a wire that never emits, which is exactly the observable position of a wallet whose source has nothing
+ *   to deliver. What is asserted is the epoch the wallet believes it is in, read through a call that enforces it.
+ */
+describe('a dust wallet on a chain that has shown it no events', () => {
+  const walletOnSilentChain = (chainVersionProbe?: ChainVersionProbe): Effect.Effect<ForkWallet, never, Scope.Scope> =>
+    Effect.gen(function* () {
+      const wire = yield* Queue.unbounded<readonly TimelineEvent[]>();
+      const replayed = yield* Deferred.make<readonly TimelineEvent[]>();
+
+      const wallet = yield* makeForkWallet({
+        preFork: Stream.fromQueue(wire),
+        replayed: Deferred.await(replayed),
+        networkId,
+        forkVersion,
+        seed: dustSeed(),
+        dustParameters,
+        syncTime: new Date(),
+        ...(chainVersionProbe !== undefined ? { chainVersionProbe } : {}),
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      return wallet;
+    });
+
+  it('believes it is pre-fork, and refuses the chain’s own transactions, when it never asked', async () =>
+    Effect.gen(function* () {
+      const wallet = yield* walletOnSilentChain();
+
+      const failure = Option.getOrThrow(yield* failureOf(wallet.dust.calculateFee([postForkTransaction()])));
+
+      // A transaction of the ledger version this chain actually runs, refused by a wallet sitting on the same chain.
+      expect(failure).toBeInstanceOf(ProtocolVersionMismatchError);
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('is in the epoch the chain is in, having asked it', async () =>
+    Effect.gen(function* () {
+      const wallet = yield* walletOnSilentChain(chainReporting(afterFork));
+
+      // Same wallet, same silent chain, one question asked: the transaction is now one this wallet can price, and the
+      // variant holding it is the one the chain is on.
+      expect(yield* failureOf(wallet.dust.calculateFee([postForkTransaction()]))).toStrictEqual(Option.none());
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+    }).pipe(Effect.scoped, Effect.runPromise));
+});
+
 describe('projections fast-sync and the two-variant wallet', () => {
   it('is a post-fork capability the pre-fork variant does not have and never will', () => {
     // The load-bearing fact behind the finding below, asserted rather than asserted-in-prose: the projections path
@@ -382,19 +508,22 @@ describe('projections fast-sync and the two-variant wallet', () => {
     expect('makeEventLessSyncCapability' in PreForkSync).toBe(false);
   });
 
-  it('is therefore reachable only through a single-variant composition', async () =>
+  it('is still reachable only through a single-variant composition, probe or no probe', async () =>
     Effect.gen(function* () {
-      // What the flip actually costs the fast-sync path: a two-variant wallet begins on the pre-fork variant no matter
-      // what the chain reports, so even on a chain entirely past the boundary it boots a variant that cannot fast-sync
-      // — and only reaches the post-fork one after a migration. A wallet that wants projections therefore composes a
-      // *single* post-fork variant (`CustomDustWallet` + `makeEventLessSyncService`, as `docs-snippets`'
-      // `dust-fast-sync.ts` does), which is unaffected by the flip.
+      // The finding survives the start probe, which changes where a wallet begins and not what it can sync with. A
+      // two-variant wallet has to be able to read a chain below the boundary, and below the boundary there is only the
+      // event path — so its post-fork variant is composed with the event sync too, and it is on the pre-fork variant
+      // whenever the chain has not forked, was not asked, or did not answer. A wallet that wants projections therefore
+      // still composes a *single* post-fork variant (`CustomDustWallet` + `makeEventLessSyncService`, as
+      // `docs-snippets`' `dust-fast-sync.ts` does).
       const chain = yield* Effect.promise(() => buildDustChain());
-      const wallet = yield* walletOnChainAt(chain, afterFork);
 
-      // It boots the events variant even though every event it will ever see is post-fork.
-      expect(yield* wallet.activeTag).toBe(V1Tag);
-      yield* wallet.awaitMigration;
-      expect(yield* wallet.activeTag).toBe(V2Tag);
+      const probed = yield* walletOnChainAt(chain, afterFork, chainReporting(afterFork));
+      expect(yield* probed.activeTag).toBe(V2Tag);
+
+      // The same class, the same registration, a chain that has not forked: the events variant, and no way for it to
+      // be anything else.
+      const belowBoundary = yield* walletOnChainAt(chain, beforeFork, chainReporting(beforeFork));
+      expect(yield* belowBoundary.activeTag).toBe(V1Tag);
     }).pipe(Effect.scoped, Effect.runPromise));
 });

--- a/packages/dust-wallet/src/test/forkStart.test.ts
+++ b/packages/dust-wallet/src/test/forkStart.test.ts
@@ -445,15 +445,15 @@ describe('a dust wallet starting on a chain that has not forked', () => {
  * A dust wallet on a chain past the boundary that has shown it nothing.
  *
  * @remarks
- *   The hazard the probe closes, and the reason it is a correctness item rather than an optimization. A wallet learns
- *   the chain's version from the events it observes, so one that has observed none holds the only version it can
- *   assume: the bottom of the timeline. That is not a transient state on a chain whose dust timeline contains nothing
- *   addressed to this wallet — it is where the wallet stays, for as long as it runs. And since transacting works on
- *   either side of the boundary, the wallet does not refuse: it prices and builds with the wrong ledger version,
- *   against a chain that will reject the result.
+ *   The hazard the probe closes, and the reason it is a correctness item rather than an optimization. A wallet learns the
+ *   chain's version from the events it observes, so one that has observed none holds the only version it can assume:
+ *   the bottom of the timeline. That is not a transient state on a chain whose dust timeline contains nothing addressed
+ *   to this wallet — it is where the wallet stays, for as long as it runs. And since transacting works on either side
+ *   of the boundary, the wallet does not refuse: it prices and builds with the wrong ledger version, against a chain
+ *   that will reject the result.
  *
- *   Modelled by a wire that never emits, which is exactly the observable position of a wallet whose source has nothing
- *   to deliver. What is asserted is the epoch the wallet believes it is in, read through a call that enforces it.
+ *   Modelled by a wire that never emits, which is exactly the observable position of a wallet whose source has nothing to
+ *   deliver. What is asserted is the epoch the wallet believes it is in, read through a call that enforces it.
  */
 describe('a dust wallet on a chain that has shown it no events', () => {
   const walletOnSilentChain = (chainVersionProbe?: ChainVersionProbe): Effect.Effect<ForkWallet, never, Scope.Scope> =>

--- a/packages/dust-wallet/src/test/tryRestore.test.ts
+++ b/packages/dust-wallet/src/test/tryRestore.test.ts
@@ -46,7 +46,10 @@ const seed = Buffer.alloc(32, 7);
 
 describe('a Dust wallet restored from a snapshot it can read', () => {
   it('comes back as a wallet, rather than as a reason it could not', async () => {
-    const source = DustWallet(configuration).startWithSeed(seed, ledger.LedgerParameters.initialParameters().dust);
+    const source = await DustWallet(configuration).startWithSeed(
+      seed,
+      ledger.LedgerParameters.initialParameters().dust,
+    );
     const written = await source.serializeState();
     await source.stop();
 

--- a/packages/e2e-tests/src/tests/emptyWallet.universal.test.ts
+++ b/packages/e2e-tests/src/tests/emptyWallet.universal.test.ts
@@ -67,9 +67,9 @@ describe('Fresh wallet with empty state', () => {
       ...walletConfig,
       txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
     });
-    shieldedWallet = Wallet.startWithSeed(utils.getShieldedSeed(walletSeed));
-    unshieldedWallet = Unshielded.startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore));
-    dustWallet = Dust.startWithSeed(utils.getDustSeed(walletSeed));
+    shieldedWallet = await Wallet.startWithSeed(utils.getShieldedSeed(walletSeed));
+    unshieldedWallet = await Unshielded.startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore));
+    dustWallet = await Dust.startWithSeed(utils.getDustSeed(walletSeed));
     await shieldedWallet.start(walletSecretKey);
     await unshieldedWallet.start();
     await dustWallet.start(dustSecretKey);
@@ -83,7 +83,7 @@ describe('Fresh wallet with empty state', () => {
     await dustWallet.stop();
   });
 
-  test('Valid Midnight wallet can be built from a BIP32 compatible mnemonic seed phrase', () => {
+  test('Valid Midnight wallet can be built from a BIP32 compatible mnemonic seed phrase', async () => {
     const mnemonics = [
       'result',
       'off',
@@ -113,7 +113,7 @@ describe('Fresh wallet with empty state', () => {
 
     const entropy = Buffer.from(KeyManagement.util.mnemonicWordsToEntropy(mnemonics), 'hex');
     try {
-      Wallet.startWithSeed(entropy);
+      await Wallet.startWithSeed(entropy);
       // If we reach here, no error was thrown
       expect(true).toBe(true);
     } catch (error) {
@@ -122,7 +122,7 @@ describe('Fresh wallet with empty state', () => {
     }
 
     try {
-      UnshieldedWallet({
+      await UnshieldedWallet({
         networkId: fixture.getNetworkId(),
         indexerClientConnection: {
           indexerHttpUrl: fixture.getIndexerUri(),
@@ -137,11 +137,14 @@ describe('Fresh wallet with empty state', () => {
     }
   });
 
-  test('Unable to start wallet with invalid seed', () => {
+  // Rejected rather than thrown: starting a wallet that spans a protocol boundary can mean asking the chain which
+  // version it is on, so the whole start is a promise — and a seed the SDK will not accept fails it before any
+  // question is asked.
+  test('Unable to start wallet with invalid seed', async () => {
     const shortSeed = Buffer.from('12345', 'hex');
-    expect(() => Wallet.startWithSeed(shortSeed)).toThrowError('Expected 32-byte seed');
+    await expect(Wallet.startWithSeed(shortSeed)).rejects.toThrowError('Expected 32-byte seed');
     const invalidSeed = Buffer.from('"000000000000000000000000000000000000000000000000000000000000009', 'hex');
-    expect(() => Wallet.startWithSeed(invalidSeed)).toThrowError('Expected 32-byte seed');
+    await expect(Wallet.startWithSeed(invalidSeed)).rejects.toThrowError('Expected 32-byte seed');
   });
 
   test(

--- a/packages/e2e-tests/src/tests/helpers/walletInit.ts
+++ b/packages/e2e-tests/src/tests/helpers/walletInit.ts
@@ -86,7 +86,7 @@ const restoreUnshieldedWallet = async (
     const serialized = await readIfExists(path);
     if (serialized) {
       const keyStore = createKeystore({ kind: 'schnorr', secret: getUnshieldedSeed(seed) }, fixture.getNetworkId());
-      const wallet = UnshieldedWallet({
+      const wallet = await UnshieldedWallet({
         networkId: fixture.getNetworkId(),
         indexerClientConnection: {
           indexerHttpUrl: fixture.getIndexerUri(),

--- a/packages/e2e-tests/src/tests/multipleWallets.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/multipleWallets.undeployed.test.ts
@@ -56,12 +56,12 @@ describe('Syncing', () => {
     async function buildWallets(seeds: Uint8Array<ArrayBufferLike>[]) {
       for (let i = 0; i < seeds.length; i++) {
         unshieldedKeystores[i] = createKeystore({ kind: 'schnorr', secret: seeds[i] }, fixture.getNetworkId());
-        shieldedWallets[i] = Wallet.startWithSeed(seeds[i]);
-        dustWallets[i] = Dust.startWithSeed(seeds[i], dustParameters);
+        shieldedWallets[i] = await Wallet.startWithSeed(seeds[i]);
+        dustWallets[i] = await Dust.startWithSeed(seeds[i], dustParameters);
       }
 
       for (let i = 0; i < seeds.length; i++) {
-        unshieldedWallets[i] = UnshieldedWallet({
+        unshieldedWallets[i] = await UnshieldedWallet({
           networkId: fixture.getNetworkId(),
           indexerClientConnection: {
             indexerHttpUrl: fixture.getIndexerUri(),

--- a/packages/e2e-tests/src/tests/smoke.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/smoke.undeployed.test.ts
@@ -244,7 +244,7 @@ describe('Smoke tests', () => {
         { kind: 'schnorr', secret: utils.getUnshieldedSeed(seedFunded) },
         fixture.getNetworkId(),
       );
-      const initialWallet = UnshieldedWallet({
+      const initialWallet = await UnshieldedWallet({
         networkId: fixture.getNetworkId(),
         indexerClientConnection: {
           indexerHttpUrl: fixture.getIndexerUri(),

--- a/packages/facade/test/orphanOnFork.test.ts
+++ b/packages/facade/test/orphanOnFork.test.ts
@@ -113,9 +113,9 @@ describe('A pending transaction the fork left behind', () => {
     const unshieldedSeed = getUnshieldedSeed(seed);
     const dustSeed = getDustSeed(seed);
     const unshieldedKeystore = createKeystore({ kind: 'schnorr', secret: unshieldedSeed }, configuration.networkId);
-    shielded = ShieldedWallet(configuration).startWithSeed(shieldedSeed);
-    unshielded = UnshieldedWallet(configuration).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore));
-    dust = DustWallet(configuration).startWithSeed(dustSeed, ledger.LedgerParameters.initialParameters().dust);
+    shielded = await ShieldedWallet(configuration).startWithSeed(shieldedSeed);
+    unshielded = await UnshieldedWallet(configuration).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore));
+    dust = await DustWallet(configuration).startWithSeed(dustSeed, ledger.LedgerParameters.initialParameters().dust);
     pending = new RecordingPendingTransactions();
 
     facade = await WalletFacade.init({

--- a/packages/facade/test/pendingTransactions.test.ts
+++ b/packages/facade/test/pendingTransactions.test.ts
@@ -63,9 +63,9 @@ describe('Wallet Facade handling pending transactions', () => {
     const unshieldedSeed = getUnshieldedSeed(seed);
     const dustSeed = getDustSeed(seed);
     const unshieldedKeystore = createKeystore({ kind: 'schnorr', secret: unshieldedSeed }, configuration.networkId);
-    shielded = ShieldedWallet(configuration).startWithSeed(shieldedSeed);
-    unshielded = UnshieldedWallet(configuration).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore));
-    dust = DustWallet(configuration).startWithSeed(dustSeed, ledger.LedgerParameters.initialParameters().dust);
+    shielded = await ShieldedWallet(configuration).startWithSeed(shieldedSeed);
+    unshielded = await UnshieldedWallet(configuration).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore));
+    dust = await DustWallet(configuration).startWithSeed(dustSeed, ledger.LedgerParameters.initialParameters().dust);
 
     facade = await WalletFacade.init({
       configuration,

--- a/packages/facade/test/submission.test.ts
+++ b/packages/facade/test/submission.test.ts
@@ -79,22 +79,22 @@ describe('Facade submission', () => {
     const facade: WalletFacade = await WalletFacade.init({
       configuration,
       submissionService: () => fakeSubmission,
-      shielded: (config) => {
-        const wallet = ShieldedWallet(config).startWithSeed(seed);
+      shielded: async (config) => {
+        const wallet = await ShieldedWallet(config).startWithSeed(seed);
         const mockedShielded = withRealState(vi.mockObject(wallet), wallet);
         mockedShielded.start.mockResolvedValue(undefined);
         return mockedShielded;
       },
-      unshielded: (config) => {
-        const wallet = UnshieldedWallet(config).startWithPublicKey(
+      unshielded: async (config) => {
+        const wallet = await UnshieldedWallet(config).startWithPublicKey(
           PublicKey.fromKeyStore(createKeystore({ kind: 'schnorr', secret: seed }, config.networkId)),
         );
         const mockedUnshielded = withRealState(vi.mockObject(wallet), wallet);
         mockedUnshielded.start.mockResolvedValue(undefined);
         return mockedUnshielded;
       },
-      dust: (config) => {
-        const wallet = DustWallet(config).startWithSeed(seed, ledger.LedgerParameters.initialParameters().dust);
+      dust: async (config) => {
+        const wallet = await DustWallet(config).startWithSeed(seed, ledger.LedgerParameters.initialParameters().dust);
         const mockedDust = withRealState(vi.mockObject(wallet), wallet);
         mockedDust.start.mockResolvedValue(undefined);
         return mockedDust;
@@ -123,11 +123,11 @@ describe('Facade submission', () => {
       txHistoryStorage,
     };
     const seed = crypto.randomBytes(32);
-    const shielded = ShieldedWallet(config).startWithSeed(seed);
-    const unshielded = UnshieldedWallet(config).startWithPublicKey(
+    const shielded = await ShieldedWallet(config).startWithSeed(seed);
+    const unshielded = await UnshieldedWallet(config).startWithPublicKey(
       PublicKey.fromKeyStore(createKeystore({ kind: 'schnorr', secret: seed }, config.networkId)),
     );
-    const dust = DustWallet(config).startWithSeed(seed, ledger.LedgerParameters.initialParameters().dust);
+    const dust = await DustWallet(config).startWithSeed(seed, ledger.LedgerParameters.initialParameters().dust);
     const fakeSubmission = new (class implements SubmissionService<ledger.FinalizedTransaction> {
       submitTransaction = () => Promise.reject(new Error('Submission failed'));
       close = () => Promise.resolve();
@@ -204,11 +204,11 @@ describe('Facade submission', () => {
       txHistoryStorage,
     };
     const seed = crypto.randomBytes(32);
-    const shielded = ShieldedWallet(config).startWithSeed(seed);
-    const unshielded = UnshieldedWallet(config).startWithPublicKey(
+    const shielded = await ShieldedWallet(config).startWithSeed(seed);
+    const unshielded = await UnshieldedWallet(config).startWithPublicKey(
       PublicKey.fromKeyStore(createKeystore({ kind: 'schnorr', secret: seed }, config.networkId)),
     );
-    const dust = DustWallet(config).startWithSeed(seed, ledger.LedgerParameters.initialParameters().dust);
+    const dust = await DustWallet(config).startWithSeed(seed, ledger.LedgerParameters.initialParameters().dust);
     const fakeSubmission = new (class implements SubmissionService<ledger.FinalizedTransaction> {
       submitTransaction = () => Promise.reject(new Error('Submission failed'));
       close = () => Promise.resolve();

--- a/packages/shielded-wallet/src/ForkingShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ForkingShieldedWallet.ts
@@ -138,8 +138,8 @@ export type ForkingShieldedConfiguration = {
    *   chain entirely past the boundary, and, on a chain that has shown this wallet no events at all, an epoch that
    *   never gets corrected.
    *
-   *   Nothing about it can make a start fail. A rejection, a timeout, a version no registered variant covers: each
-   *   leaves the wallet exactly where a wallet that never asked would be.
+   *   Nothing about it can make a start fail. A rejection, a timeout, a version no registered variant covers: each leaves
+   *   the wallet exactly where a wallet that never asked would be.
    */
   chainVersionProbe?: ChainVersionProbe;
 };
@@ -185,7 +185,8 @@ export interface ForkingShieldedWalletClass<
    *   {@link ForkingShieldedConfiguration.chainVersionProbe} configured, the wallet starts at the variant that owns the
    *   version the chain reports, which on a chain already past the boundary is the post-fork one from the first moment.
    *   Without one, or when the question goes unanswered, it begins on the pre-fork variant and is handed over when the
-   *   chain reports a version the post-fork variant owns — on a chain that has already forked, the first batch it sees.
+   *   chain reports a version the post-fork variant owns — on a chain that has already forked, the first batch it
+   *   sees.
    * @param seed The seed to derive both ledger versions' keys from.
    * @returns A wallet started at the variant the chain is on, or on the pre-fork variant when the chain was not asked
    *   or did not say.
@@ -374,10 +375,10 @@ export function CustomForkingShieldedWallet<
    * How long a start waits for the chain to say which version it is on.
    *
    * @remarks
-   *   Short, because what is being bought is small: the alternative to an answer is the hand-over this wallet has
-   *   always done, which costs one migration and no correctness on a chain that produces events. It is a ceiling
-   *   rather than a typical cost — an unreachable indexer refuses a connection long before this — and it exists so
-   *   that a probe which neither answers nor fails cannot hold a start open indefinitely.
+   *   Short, because what is being bought is small: the alternative to an answer is the hand-over this wallet has always
+   *   done, which costs one migration and no correctness on a chain that produces events. It is a ceiling rather than a
+   *   typical cost — an unreachable indexer refuses a connection long before this — and it exists so that a probe which
+   *   neither answers nor fails cannot hold a start open indefinitely.
    */
   const probeTimeout = Duration.seconds(5);
 
@@ -779,8 +780,8 @@ export type ShieldedWalletClass = ForkingShieldedWalletClass<
  *
  *   **The chain is asked where it is before a variant is chosen.** The indexer this wallet already syncs from answers
  *   which protocol version the chain is on, so a start on a chain past the boundary begins post-fork rather than
- *   handing over immediately. An application that would rather ask something else — a cache, a value it already holds
- *   — supplies its own `chainVersionProbe`; one whose chain cannot be reached loses nothing, because the answer is
+ *   handing over immediately. An application that would rather ask something else — a cache, a value it already holds —
+ *   supplies its own `chainVersionProbe`; one whose chain cannot be reached loses nothing, because the answer is
  *   best-effort and its absence is the behaviour this wallet had before.
  * @param configuration What the wallet and both its variants are built from, including where the boundary lies.
  * @returns The wallet class.

--- a/packages/shielded-wallet/src/ForkingShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ForkingShieldedWallet.ts
@@ -33,15 +33,19 @@ import {
   WalletTransaction,
 } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type ShieldedAddress } from '@midnightntwrk/wallet-sdk-address-format';
+import {
+  type ChainVersionProbe,
+  makeIndexerChainVersionProbe,
+} from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
 import {
   StartMaterial,
-  type Variant,
+  Variant,
   type VariantBuilder,
   type WalletLike,
 } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { EitherOps, HList } from '@midnightntwrk/wallet-sdk-utilities';
-import { Effect, Either, Option, Ref, type Scope } from 'effect';
+import { Duration, Effect, Either, Option, Ref, type Scope, pipe } from 'effect';
 import * as rx from 'rxjs';
 import { type UnsupportedSnapshotVersionError, variantForSnapshot } from './Restore.js';
 import {
@@ -52,7 +56,7 @@ import {
 } from './ShieldedWallet.js';
 import { CoreWallet as PreForkCoreWallet, V1Builder, V1Tag, type V1Variant } from './v1/index.js';
 import { type WalletSyncUpdate as PreForkSyncUpdate } from './v1/Sync.js';
-import { type CoreWallet, Migration, V2Builder, V2Tag, type V2Variant } from './v2/index.js';
+import { CoreWallet, Migration, V2Builder, V2Tag, type V2Variant } from './v2/index.js';
 import { type WalletSyncUpdate as PostForkSyncUpdate } from './v2/Sync.js';
 import { type TokenTransfer } from './v2/Transacting.js';
 import { type WalletError as PreForkWalletError } from './v1/WalletError.js';
@@ -124,6 +128,20 @@ export type ForkingShieldedConfiguration = {
   networkId: NetworkId.NetworkId;
   /** The protocol version at which the chain hands over from the pre-fork ledger version to the post-fork one. */
   forkVersion: ProtocolVersion.ProtocolVersion;
+  /**
+   * How the wallet asks the chain which protocol version it is on, before it chooses a variant to start at.
+   *
+   * @remarks
+   *   Optional, and best-effort where present: a wallet with no probe — or one whose probe does not answer in time —
+   *   starts on the pre-fork variant and learns the version from the first event it sees, which is what a wallet with
+   *   no history has always done. What a probe buys is the two things that guess costs: a hand-over per start on a
+   *   chain entirely past the boundary, and, on a chain that has shown this wallet no events at all, an epoch that
+   *   never gets corrected.
+   *
+   *   Nothing about it can make a start fail. A rejection, a timeout, a version no registered variant covers: each
+   *   leaves the wallet exactly where a wallet that never asked would be.
+   */
+  chainVersionProbe?: ChainVersionProbe;
 };
 
 /**
@@ -161,12 +179,18 @@ export interface ForkingShieldedWalletClass<
    * @remarks
    *   The only start that can follow the chain the whole way. The seed is the one piece of key material that crosses a
    *   protocol boundary — each variant derives its own from it — so a wallet built this way can synchronize on either
-   *   side of the fork. It begins on the pre-fork variant and is handed over when the chain reports a version the
-   *   post-fork variant owns, which on a chain that has already forked happens on the first batch it sees.
+   *   side of the fork.
+   *
+   *   Asynchronous because choosing where to begin can mean asking the chain: with a
+   *   {@link ForkingShieldedConfiguration.chainVersionProbe} configured, the wallet starts at the variant that owns the
+   *   version the chain reports, which on a chain already past the boundary is the post-fork one from the first moment.
+   *   Without one, or when the question goes unanswered, it begins on the pre-fork variant and is handed over when the
+   *   chain reports a version the post-fork variant owns — on a chain that has already forked, the first batch it sees.
    * @param seed The seed to derive both ledger versions' keys from.
-   * @returns A wallet started on the pre-fork variant.
+   * @returns A wallet started at the variant the chain is on, or on the pre-fork variant when the chain was not asked
+   *   or did not say.
    */
-  startWithSeed(seed: Uint8Array): ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+  startWithSeed(seed: Uint8Array): Promise<ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>>;
   /**
    * Builds a wallet from key objects of both ledger versions.
    *
@@ -176,9 +200,10 @@ export interface ForkingShieldedWalletClass<
    *   side of the chain — and a partial product here would be exactly the foot-gun the single-key start was. It costs
    *   the caller an import of both ledger packages and the same derivation done twice; a seed costs neither.
    * @param keys One ledger version's Zswap secret keys per side of the boundary.
-   * @returns A wallet started on the pre-fork variant, which is where a wallet with no history belongs.
+   * @returns A wallet started at the variant the chain is on, or on the pre-fork variant — where a wallet with no
+   *   history belongs — when the chain was not asked or did not say.
    */
-  startWithKeys(keys: ShieldedKeysByEpoch): ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+  startWithKeys(keys: ShieldedKeysByEpoch): Promise<ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>>;
   /**
    * Restores a wallet from a snapshot, into whichever registered variant wrote it.
    *
@@ -345,29 +370,113 @@ export function CustomForkingShieldedWallet<
   const sealPostFork = (result: ledger.UnprovenTransaction | undefined): ShieldedBalancingResult =>
     result === undefined ? undefined : WalletTransaction.adopt('Unproven', result, postForkStamp);
 
+  /**
+   * How long a start waits for the chain to say which version it is on.
+   *
+   * @remarks
+   *   Short, because what is being bought is small: the alternative to an answer is the hand-over this wallet has
+   *   always done, which costs one migration and no correctness on a chain that produces events. It is a ceiling
+   *   rather than a typical cost — an unreachable indexer refuses a connection long before this — and it exists so
+   *   that a probe which neither answers nor fails cannot hold a start open indefinitely.
+   */
+  const probeTimeout = Duration.seconds(5);
+
+  /** Where a start begins, when the chain answered for it. */
+  type ProbedStart = Readonly<{
+    version: ProtocolVersion.ProtocolVersion;
+    variant: HList.Each<Variants>;
+  }>;
+
+  /**
+   * The variant the chain's current version belongs to, or nothing.
+   *
+   * @remarks
+   *   Nothing covers every way the question can fail to produce an answer, and they are deliberately not distinguished:
+   *   no probe configured, a probe that rejected, a probe that outlived the wallet's patience, or a version no
+   *   registered variant claims. Each means the same thing to a caller — start where a wallet with no history starts —
+   *   and none of them is a reason to fail.
+   */
+  const probedStart: Effect.Effect<Option.Option<ProbedStart>> =
+    configuration.chainVersionProbe === undefined
+      ? Effect.succeedNone
+      : pipe(
+          Effect.tryPromise(configuration.chainVersionProbe),
+          Effect.timeout(probeTimeout),
+          Effect.map((version) =>
+            Option.map(BaseWallet.variantFor(version), (variant): ProbedStart => ({ version, variant })),
+          ),
+          Effect.orElseSucceed(() => Option.none<ProbedStart>()),
+        );
+
+  /**
+   * A fresh state of the variant a probed start begins at, recording the version the chain reported.
+   *
+   * @remarks
+   *   Built exactly as the head-variant boot path builds its own — an empty state of that variant, from that ledger
+   *   version's keys — and then annotated with the observed version, which is what keeps a variant from starting
+   *   outside its own activation range and signalling backwards on sight.
+   */
+  const freshStateAt = (
+    variant: HList.Each<Variants>,
+    keys: ShieldedKeysByEpoch,
+    version: ProtocolVersion.ProtocolVersion,
+  ): PreForkCoreWallet | CoreWallet =>
+    Variant.getVersionedVariantTag(variant) === V2Tag
+      ? CoreWallet.withProtocolVersion(CoreWallet.initEmpty(keys.v9, configuration.networkId), version)
+      : PreForkCoreWallet.withProtocolVersion(PreForkCoreWallet.initEmpty(keys.v8, configuration.networkId), version);
+
   return class ForkingShieldedWalletImplementation
     extends BaseWallet
     implements ForkingShieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>
   {
     static readonly configuration: TConfiguration = configuration;
 
-    static startWithSeed(seed: Uint8Array): ForkingShieldedWalletImplementation {
-      const derived = keysFromSeed(WalletSeed.WalletSeed(seed));
-      const wallet = ForkingShieldedWalletImplementation.startFirst(
-        ForkingShieldedWalletImplementation,
-        PreForkCoreWallet.initEmpty(Option.getOrThrow(derived.preFork), configuration.networkId),
+    /**
+     * Starts at the variant the chain says it is on, or at the head variant when it does not say.
+     *
+     * @remarks
+     *   The second branch is the whole of this wallet's previous behaviour, unchanged and reached whenever the chain was
+     *   not asked or did not answer: the pre-fork variant, an empty state, and a hand-over on the first batch that
+     *   reports a version it does not own.
+     * @param keys One ledger version's keys per side of the boundary, since either side may be the one that runs.
+     * @returns The started wallet.
+     */
+    static #startProbed(keys: ShieldedKeysByEpoch): Promise<ForkingShieldedWalletImplementation> {
+      return pipe(
+        probedStart,
+        Effect.map(
+          Option.match({
+            onNone: () =>
+              ForkingShieldedWalletImplementation.startFirst(
+                ForkingShieldedWalletImplementation,
+                PreForkCoreWallet.initEmpty(keys.v8, configuration.networkId),
+              ),
+            onSome: ({ version, variant }) =>
+              ForkingShieldedWalletImplementation.startAtVariant(
+                ForkingShieldedWalletImplementation,
+                variant,
+                freshStateAt(variant, keys, version),
+              ),
+          }),
+        ),
+        Effect.runPromise,
       );
+    }
+
+    static async startWithSeed(seed: Uint8Array): Promise<ForkingShieldedWalletImplementation> {
+      const derived = keysFromSeed(WalletSeed.WalletSeed(seed));
+      const wallet = await ForkingShieldedWalletImplementation.#startProbed({
+        v8: Option.getOrThrow(derived.preFork),
+        v9: Option.getOrThrow(derived.postFork),
+      });
       // Both sides derived here and now, and the seed reference dropped with this frame: from this point the wallet
       // holds key objects only, which is strictly less than it held before and does the same work.
       wallet.#retainKeys(derived);
       return wallet;
     }
 
-    static startWithKeys(keys: ShieldedKeysByEpoch): ForkingShieldedWalletImplementation {
-      const wallet = ForkingShieldedWalletImplementation.startFirst(
-        ForkingShieldedWalletImplementation,
-        PreForkCoreWallet.initEmpty(keys.v8, configuration.networkId),
-      );
+    static async startWithKeys(keys: ShieldedKeysByEpoch): Promise<ForkingShieldedWalletImplementation> {
+      const wallet = await ForkingShieldedWalletImplementation.#startProbed(keys);
       wallet.#retainKeys({ preFork: Option.some(keys.v8), postFork: Option.some(keys.v9) });
       return wallet;
     }
@@ -667,12 +776,22 @@ export type ShieldedWalletClass = ForkingShieldedWalletClass<
  *   **Transacting works on either side of the boundary**: the active variant builds with its own ledger and its own
  *   derived keys, and every result travels as a handle stamped with the epoch that built it. Proving a pre-fork
  *   transaction still requires a proving server registered below the boundary.
+ *
+ *   **The chain is asked where it is before a variant is chosen.** The indexer this wallet already syncs from answers
+ *   which protocol version the chain is on, so a start on a chain past the boundary begins post-fork rather than
+ *   handing over immediately. An application that would rather ask something else — a cache, a value it already holds
+ *   — supplies its own `chainVersionProbe`; one whose chain cannot be reached loses nothing, because the answer is
+ *   best-effort and its absence is the behaviour this wallet had before.
  * @param configuration What the wallet and both its variants are built from, including where the boundary lies.
  * @returns The wallet class.
  */
 export function ShieldedWallet(configuration: DefaultShieldedConfiguration): ShieldedWalletClass {
+  const withProbe: DefaultShieldedConfiguration = {
+    ...configuration,
+    chainVersionProbe: configuration.chainVersionProbe ?? makeIndexerChainVersionProbe(configuration),
+  };
   return CustomForkingShieldedWallet(
-    configuration,
+    withProbe,
     { builder: new V1Builder().withDefaults(), configuration },
     {
       builder: new V2Builder().withDefaults().withMigration(() => Migration.makeCrossLedgerMigration()),

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -52,6 +52,7 @@ import {
   type WalletLike,
 } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
+import type { ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import type { UnboundTransaction } from '@midnightntwrk/wallet-sdk-capabilities/proving';
 import { EitherOps, HList, Poly } from '@midnightntwrk/wallet-sdk-utilities';
 import { variantForSnapshot } from './Restore.js';
@@ -283,6 +284,16 @@ export type DefaultShieldedConfiguration = {
    *   will ship once it is, and this field keeps working unchanged.
    */
   forkVersion: ProtocolVersion.ProtocolVersion;
+  /**
+   * How the wallet asks the chain which protocol version it is on, before it chooses a variant to start at.
+   *
+   * @remarks
+   *   Optional, and defaulted rather than absent: left unset, the wallet asks the indexer named by
+   *   {@link indexerClientConnection}, which it is about to synchronize from anyway. Supply one to ask something else —
+   *   a cache, a node RPC, a value the application already holds. The answer is best-effort wherever it comes from: a
+   *   chain that cannot be reached leaves the wallet starting exactly where it started before there was a probe.
+   */
+  chainVersionProbe?: ChainVersionProbe;
 };
 
 export interface CustomizedShieldedWalletClass<

--- a/packages/shielded-wallet/src/test/configuration.test.ts
+++ b/packages/shielded-wallet/src/test/configuration.test.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { type NetworkId, type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import { type CanAssign, type Equal, type Expect } from '@midnightntwrk/wallet-sdk-utilities/types';
 import { type Duration } from 'effect';
 import { describe, it } from 'vitest';
@@ -34,6 +35,7 @@ describe('DefaultShieldedConfiguration', () => {
           txHistoryStorage: V2TransactionHistory.ShieldedHistoryStorage;
           transactionDetailsRetryWindow?: Duration.DurationInput;
           forkVersion: ProtocolVersion.ProtocolVersion;
+          chainVersionProbe?: ChainVersionProbe;
         }
       >
     >;
@@ -50,5 +52,10 @@ describe('DefaultShieldedConfiguration', () => {
     // `forkVersion` is the wallet layer's alone: neither variant knows there is another one.
     type _3 = Expect<Equal<'forkVersion' extends keyof DefaultV1Configuration ? true : false, false>>;
     type _4 = Expect<Equal<'forkVersion' extends keyof DefaultV2Configuration ? true : false, false>>;
+
+    // And so is the question of where to start, for the same reason: a variant that does not know there is another
+    // one has no use for the answer.
+    type _5 = Expect<Equal<'chainVersionProbe' extends keyof DefaultV1Configuration ? true : false, false>>;
+    type _6 = Expect<Equal<'chainVersionProbe' extends keyof DefaultV2Configuration ? true : false, false>>;
   });
 });

--- a/packages/shielded-wallet/src/test/forkHarness.ts
+++ b/packages/shielded-wallet/src/test/forkHarness.ts
@@ -267,7 +267,7 @@ export const makeForkWallet = (config: ForkWalletConfig): Effect.Effect<ForkWall
     .withMigration(() => capturingCrossLedgerMigration(captured));
 
   const WalletClass = CustomForkingShieldedWallet(
-    { networkId, forkVersion, chainVersionProbe },
+    { networkId, forkVersion, ...(chainVersionProbe !== undefined ? { chainVersionProbe } : {}) },
     { builder: preForkBuilder, configuration: { networkId, simulator: preFork } },
     { builder: postForkBuilder, configuration: { networkId, replayed } },
   );

--- a/packages/shielded-wallet/src/test/forkHarness.ts
+++ b/packages/shielded-wallet/src/test/forkHarness.ts
@@ -29,6 +29,7 @@
 import * as v8 from '@midnight-ntwrk/ledger-v8';
 import * as v9 from '@midnightntwrk/ledger-v9';
 import { type NetworkId, type ProtocolState, type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import { type Simulator, type V8 } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { Deferred, Effect, FiberId, Option, Stream, pipe } from 'effect';
@@ -185,6 +186,13 @@ export type ForkWalletConfig = Readonly<{
   forkVersion: ProtocolVersion.ProtocolVersion;
   /** The seed both variants derive their keys from. */
   seed: Uint8Array;
+  /**
+   * How the wallet asks the chain which protocol version it is on before choosing a variant to start at.
+   *
+   * Absent means it does not ask, which is the behaviour of every wallet built without one: it starts at the head
+   * variant and learns the version from the first event it sees.
+   */
+  chainVersionProbe?: ChainVersionProbe;
 }>;
 
 /** A state emission, whichever variant produced it. */
@@ -220,11 +228,15 @@ export type ForkWallet = Readonly<{
 /**
  * Builds and starts the shipped forking shielded wallet over two simulated chains.
  *
- * @param config - The two sources, the boundary version, the network and the seed.
+ * @remarks
+ *   Effectful because starting one is: a wallet that spans a boundary may ask the chain which version it is on before it
+ *   can choose a variant, and that question is answered over the network. A harness that hid it behind a synchronous
+ *   call would be hiding the very thing these proofs are about.
+ * @param config - The two sources, the boundary version, the network, the seed, and how the chain is asked its version.
  * @returns The running wallet and its observation channels.
  */
-export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
-  const { preFork, replayed, networkId, forkVersion, seed } = config;
+export const makeForkWallet = (config: ForkWalletConfig): Effect.Effect<ForkWallet> => {
+  const { preFork, replayed, networkId, forkVersion, seed, chainVersionProbe } = config;
 
   const preForkKeys = v8.ZswapSecretKeys.fromSeed(seed);
   const postForkKeys = v9.ZswapSecretKeys.fromSeed(seed);
@@ -255,48 +267,51 @@ export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
     .withMigration(() => capturingCrossLedgerMigration(captured));
 
   const WalletClass = CustomForkingShieldedWallet(
-    { networkId, forkVersion },
+    { networkId, forkVersion, chainVersionProbe },
     { builder: preForkBuilder, configuration: { networkId, simulator: preFork } },
     { builder: postForkBuilder, configuration: { networkId, replayed } },
   );
 
-  const wallet = WalletClass.startWithSeed(seed);
-  const runtime = wallet.runtime;
+  return Effect.promise(() => WalletClass.startWithSeed(seed)).pipe(
+    Effect.map((wallet) => {
+      const runtime = wallet.runtime;
 
-  const currentState = pipe(runtime.stateChanges, Stream.take(1), Stream.runHead, Effect.map(Option.getOrThrow));
+      const currentState = pipe(runtime.stateChanges, Stream.take(1), Stream.runHead, Effect.map(Option.getOrThrow));
 
-  return {
-    shielded: wallet,
+      return {
+        shielded: wallet,
 
-    keys: { preFork: preForkKeys, postFork: postForkKeys },
+        keys: { preFork: preForkKeys, postFork: postForkKeys },
 
-    // The keys handed over are the post-fork ledger version's, which is what the wallet's API speaks. The pre-fork
-    // variant running underneath is started from the seed the wallet retained instead — the seam a wallet crossing a
-    // boundary rests on.
-    start: Effect.promise(() => wallet.start(postForkKeys)),
+        // The keys handed over are the post-fork ledger version's, which is what the wallet's API speaks. The pre-fork
+        // variant running underneath is started from the seed the wallet retained instead — the seam a wallet crossing
+        // a boundary rests on.
+        start: Effect.promise(() => wallet.start(postForkKeys)),
 
-    awaitMigration: Deferred.await(captured),
+        awaitMigration: Deferred.await(captured),
 
-    migration: Deferred.poll(captured).pipe(
-      Effect.flatMap(Option.match({ onNone: () => Effect.succeedNone, onSome: Effect.asSome })),
-    ),
+        migration: Deferred.poll(captured).pipe(
+          Effect.flatMap(Option.match({ onNone: () => Effect.succeedNone, onSome: Effect.asSome })),
+        ),
 
-    activeTag: pipe(
-      runtime.currentVariant,
-      Effect.map((current) => current.runningVariant.__polyTag__),
-    ),
+        activeTag: pipe(
+          runtime.currentVariant,
+          Effect.map((current) => current.runningVariant.__polyTag__),
+        ),
 
-    currentState,
+        currentState,
 
-    awaitState: (predicate) =>
-      pipe(
-        runtime.stateChanges,
-        Stream.filter(predicate),
-        Stream.take(1),
-        Stream.runHead,
-        Effect.map(Option.getOrThrow),
-      ),
+        awaitState: (predicate: (state: ForkedState) => boolean) =>
+          pipe(
+            runtime.stateChanges,
+            Stream.filter(predicate),
+            Stream.take(1),
+            Stream.runHead,
+            Effect.map(Option.getOrThrow),
+          ),
 
-    stop: Effect.promise(() => wallet.stop()),
-  };
+        stop: Effect.promise(() => wallet.stop()),
+      };
+    }),
+  );
 };

--- a/packages/shielded-wallet/src/test/forkSimulation.integration.test.ts
+++ b/packages/shielded-wallet/src/test/forkSimulation.integration.test.ts
@@ -150,7 +150,7 @@ describe('a shielded wallet crossing a byte-faithful hard fork', () => {
       const fork = yield* ForkSimulator.init(baseConfig);
       const replayed = yield* Deferred.make<Simulator>();
 
-      const wallet = makeForkWallet({
+      const wallet = yield* makeForkWallet({
         preFork: fork.preFork,
         replayed: Deferred.await(replayed),
         networkId,

--- a/packages/shielded-wallet/src/test/forkSimulation.test.ts
+++ b/packages/shielded-wallet/src/test/forkSimulation.test.ts
@@ -172,7 +172,7 @@ describe('a shielded wallet crossing a hard fork', () => {
       const chain = yield* preForkChain(coins, forkVersion);
       const replayed = yield* Deferred.make<Simulator>();
 
-      const wallet = makeForkWallet({
+      const wallet = yield* makeForkWallet({
         preFork: chain,
         replayed: Deferred.await(replayed),
         networkId,
@@ -259,7 +259,7 @@ describe('a shielded wallet crossing a hard fork', () => {
       const chain = yield* preForkChain(coins, withinRangeVersion);
       const replayed = yield* Deferred.make<Simulator>();
 
-      const wallet = makeForkWallet({
+      const wallet = yield* makeForkWallet({
         preFork: chain,
         replayed: Deferred.await(replayed),
         networkId,
@@ -292,7 +292,7 @@ describe('a shielded wallet crossing a hard fork', () => {
       yield* driveTo(chain, forkBlock);
       const replayChain = yield* replayOf(coins, chain);
 
-      const wallet = makeForkWallet({
+      const wallet = yield* makeForkWallet({
         preFork: chain,
         replayed: Effect.succeed(replayChain),
         networkId,

--- a/packages/shielded-wallet/src/test/forkStart.test.ts
+++ b/packages/shielded-wallet/src/test/forkStart.test.ts
@@ -431,12 +431,12 @@ describe('a shielded wallet starting on a chain that has not forked', () => {
  * A wallet on a chain past the boundary that has shown it nothing.
  *
  * @remarks
- *   The hazard the probe closes, and the reason it is a correctness item rather than an optimization. A wallet learns
- *   the chain's version from the events it observes, so one that has observed none holds the only version it can
- *   assume: the bottom of the timeline. That is not a transient state on a chain whose shielded timeline contains
- *   nothing addressed to this wallet — it is where the wallet stays, for as long as it runs. And since transacting
- *   works on either side of the boundary, the wallet does not refuse: it builds with the wrong ledger version, against
- *   a chain that will reject the result.
+ *   The hazard the probe closes, and the reason it is a correctness item rather than an optimization. A wallet learns the
+ *   chain's version from the events it observes, so one that has observed none holds the only version it can assume:
+ *   the bottom of the timeline. That is not a transient state on a chain whose shielded timeline contains nothing
+ *   addressed to this wallet — it is where the wallet stays, for as long as it runs. And since transacting works on
+ *   either side of the boundary, the wallet does not refuse: it builds with the wrong ledger version, against a chain
+ *   that will reject the result.
  *
  *   Modelled by not starting synchronization, which is exactly the observable position of a wallet whose source has
  *   nothing to deliver: no event has been applied. What is asserted is the epoch the wallet believes it is in, read

--- a/packages/shielded-wallet/src/test/forkStart.test.ts
+++ b/packages/shielded-wallet/src/test/forkStart.test.ts
@@ -19,12 +19,14 @@
  *   are the other question — a wallet meeting a chain that is already on one side or the other, which is what every
  *   application start actually is.
  *
- *   A wallet always begins on the pre-fork variant, because that is the variant a wallet with no history belongs to. On a
- *   chain that has already forked it therefore hands over immediately, having applied nothing: one migration per start,
- *   paid on chains that are entirely past the boundary. That cost is accepted rather than hidden — removing it means
- *   asking the chain for its version before choosing a variant, which is a separate piece of work.
+ *   Where it begins turns on one question: whether it asked the chain. A wallet given a way to ask starts at the variant
+ *   that owns the version the chain reports, which on a chain past the boundary is the post-fork one from the first
+ *   moment — no hand-over, and the right epoch before a single event has arrived. A wallet with no way to ask, or one
+ *   whose question went unanswered, begins on the pre-fork variant, because that is where a wallet with no history
+ *   belongs, and hands over on the first batch it sees. Both are specified here: the second is not a fallback in name
+ *   only, it is what every offline-first application and every wallet built without a probe does.
  *
- *   Both starts assert the boundary by comparison with `forkVersion` and never by the number itself: which protocol
+ *   All of it asserts the boundary by comparison with `forkVersion` and never by the number itself: which protocol
  *   version a chain reports is a property of the chain, and the real fork's value is not final.
  */
 
@@ -42,6 +44,7 @@ import {
   ShieldedCoinPublicKey,
   ShieldedEncryptionPublicKey,
 } from '@midnightntwrk/wallet-sdk-address-format';
+import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import { V8, genesisStrictness, immediateBlockProducer } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type LedgerOps } from '@midnightntwrk/wallet-sdk-utilities';
@@ -159,6 +162,22 @@ const preForkTransaction = (): AnyTx =>
 const postForkTransaction = (): AnyTx =>
   WalletTransaction.adopt('Unproven', v9.Transaction.fromParts(networkId), forkVersion);
 
+/** A probe answering as a chain on `version` would. */
+const chainReporting =
+  (version: ProtocolVersion.ProtocolVersion): ChainVersionProbe =>
+  () =>
+    Promise.resolve(version);
+
+/**
+ * A probe that never answers.
+ *
+ * @remarks
+ *   One shape stands in for every way the question can go unanswered — no indexer, no network, a request that outlives
+ *   the wallet's patience — because the wallet distinguishes none of them: it asked, it has no answer, it starts where
+ *   a wallet that never asked starts.
+ */
+const unreachableChain: ChainVersionProbe = () => Promise.reject(new Error('the indexer cannot be reached'));
+
 /**
  * A wallet on a chain that has not forked, synchronized and holding its coins.
  *
@@ -172,7 +191,13 @@ const syncedPreForkWallet: Effect.Effect<ForkWallet, LedgerOps.LedgerError | Wal
     const chain = yield* chainAt(beforeFork, coins);
     const replayed = yield* replayOf(coins, chain);
 
-    const wallet = makeForkWallet({ preFork: chain, replayed: Effect.succeed(replayed), networkId, forkVersion, seed });
+    const wallet = yield* makeForkWallet({
+      preFork: chain,
+      replayed: Effect.succeed(replayed),
+      networkId,
+      forkVersion,
+      seed,
+    });
     yield* Effect.addFinalizer(() => wallet.stop);
     yield* wallet.start;
 
@@ -182,6 +207,67 @@ const syncedPreForkWallet: Effect.Effect<ForkWallet, LedgerOps.LedgerError | Wal
     return wallet;
   });
 
+describe('a shielded wallet that asks the chain where it is starting', () => {
+  it('starts on the post-fork variant of a chain past the boundary, without a hand-over at all', async () =>
+    Effect.gen(function* () {
+      const coins = chainCoins();
+      const chain = yield* chainAt(afterFork, coins);
+      const replayed = yield* replayOf(coins, chain);
+
+      const wallet = yield* makeForkWallet({
+        preFork: chain,
+        replayed: Effect.succeed(replayed),
+        networkId,
+        forkVersion,
+        seed,
+        chainVersionProbe: chainReporting(afterFork),
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+
+      // Before sync has been started, before any event exists to learn from: the variant is already the post-fork one.
+      // The pre-fork variant is not where this wallet began and then left — it never ran.
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+
+      yield* wallet.start;
+
+      const synced = yield* wallet.awaitState((state) => totalValue(state.state) === walletTotal);
+      expect(coinValues(synced.state)).toEqual([...walletValues]);
+      expect(synced.version).toBeGreaterThanOrEqual(forkVersion);
+
+      // Nothing was migrated, because nothing was left behind. This is the whole point: the hand-over below is a cost
+      // paid only by a wallet that could not ask.
+      expect(yield* wallet.migration).toStrictEqual(Option.none());
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('starts on the pre-fork variant of a chain that has not forked, and stays there', async () =>
+    Effect.gen(function* () {
+      const coins = chainCoins();
+      const chain = yield* chainAt(beforeFork, coins);
+      const replayed = yield* replayOf(coins, chain);
+
+      const wallet = yield* makeForkWallet({
+        preFork: chain,
+        replayed: Effect.succeed(replayed),
+        networkId,
+        forkVersion,
+        seed,
+        chainVersionProbe: chainReporting(beforeFork),
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      yield* wallet.start;
+
+      // The answer sends it to the variant that owns the version, which below the boundary is the one it would have
+      // started on anyway. What the probe changes here is nothing at all, which is the claim.
+      const synced = yield* wallet.awaitState((state) => totalValue(state.state) === walletTotal);
+      expect(coinValues(synced.state)).toEqual([...walletValues]);
+      expect(synced.state.protocolVersion).toBeLessThan(forkVersion);
+
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+      expect(yield* wallet.migration).toStrictEqual(Option.none());
+    }).pipe(Effect.scoped, Effect.runPromise));
+});
+
 describe('a shielded wallet starting on a chain that has already forked', () => {
   it('hands over on the first batch, having applied nothing, and syncs on the post-fork variant', async () =>
     Effect.gen(function* () {
@@ -189,7 +275,9 @@ describe('a shielded wallet starting on a chain that has already forked', () => 
       const chain = yield* chainAt(afterFork, coins);
       const replayed = yield* replayOf(coins, chain);
 
-      const wallet = makeForkWallet({
+      // No probe: the shape of every wallet built without one, and of every application that would rather not have
+      // its start depend on reaching an indexer.
+      const wallet = yield* makeForkWallet({
         preFork: chain,
         replayed: Effect.succeed(replayed),
         networkId,
@@ -215,6 +303,33 @@ describe('a shielded wallet starting on a chain that has already forked', () => 
       expect(synced.version).toBeGreaterThanOrEqual(forkVersion);
       expect(coinValues(synced.state)).toEqual([...walletValues]);
     }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('hands over the same way when it asked the chain and got no answer', async () =>
+    Effect.gen(function* () {
+      const coins = chainCoins();
+      const chain = yield* chainAt(afterFork, coins);
+      const replayed = yield* replayOf(coins, chain);
+
+      const wallet = yield* makeForkWallet({
+        preFork: chain,
+        replayed: Effect.succeed(replayed),
+        networkId,
+        forkVersion,
+        seed,
+        chainVersionProbe: unreachableChain,
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      yield* wallet.start;
+
+      // A question that cannot be answered leaves the wallet exactly where a wallet that never asked would be — and,
+      // above all, leaves it started. An unreachable chain is not a reason to fail to start.
+      const migration = yield* wallet.awaitMigration;
+      expect(migration.from.appliedIndex).toBe(0n);
+
+      const synced = yield* wallet.awaitState((state) => totalValue(state.state) === walletTotal);
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+      expect(coinValues(synced.state)).toEqual([...walletValues]);
+    }).pipe(Effect.scoped, Effect.runPromise));
 });
 
 describe('a shielded wallet starting on a chain that has not forked', () => {
@@ -225,7 +340,7 @@ describe('a shielded wallet starting on a chain that has not forked', () => {
       // The replay is never reached: a source the post-fork variant would consume if it ever ran.
       const replayed = yield* replayOf(coins, chain);
 
-      const wallet = makeForkWallet({
+      const wallet = yield* makeForkWallet({
         preFork: chain,
         replayed: Effect.succeed(replayed),
         networkId,
@@ -309,5 +424,60 @@ describe('a shielded wallet starting on a chain that has not forked', () => {
       const after = yield* wallet.currentState;
       expect(totalValue(after.state)).toBe(walletTotal);
       expect(yield* wallet.activeTag).toBe(V1Tag);
+    }).pipe(Effect.scoped, Effect.runPromise));
+});
+
+/**
+ * A wallet on a chain past the boundary that has shown it nothing.
+ *
+ * @remarks
+ *   The hazard the probe closes, and the reason it is a correctness item rather than an optimization. A wallet learns
+ *   the chain's version from the events it observes, so one that has observed none holds the only version it can
+ *   assume: the bottom of the timeline. That is not a transient state on a chain whose shielded timeline contains
+ *   nothing addressed to this wallet — it is where the wallet stays, for as long as it runs. And since transacting
+ *   works on either side of the boundary, the wallet does not refuse: it builds with the wrong ledger version, against
+ *   a chain that will reject the result.
+ *
+ *   Modelled by not starting synchronization, which is exactly the observable position of a wallet whose source has
+ *   nothing to deliver: no event has been applied. What is asserted is the epoch the wallet believes it is in, read
+ *   through the one call that enforces it.
+ */
+describe('a shielded wallet on a chain that has shown it no events', () => {
+  const walletOnSilentChain = (chainVersionProbe?: ChainVersionProbe) =>
+    Effect.gen(function* () {
+      const chain = yield* chainAt(afterFork, []);
+      const replayed = yield* replayOf([], chain);
+
+      const wallet = yield* makeForkWallet({
+        preFork: chain,
+        replayed: Effect.succeed(replayed),
+        networkId,
+        forkVersion,
+        seed,
+        chainVersionProbe,
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      return wallet;
+    });
+
+  it('believes it is pre-fork, and refuses the chain’s own transactions, when it never asked', async () =>
+    Effect.gen(function* () {
+      const wallet = yield* walletOnSilentChain();
+
+      const failure = Option.getOrThrow(yield* failureOf(wallet.shielded.balanceTransaction(postForkTransaction())));
+
+      // A transaction of the ledger version this chain actually runs, refused by a wallet sitting on the same chain.
+      expect(failure).toBeInstanceOf(ProtocolVersionMismatchError);
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('is in the epoch the chain is in, having asked it', async () =>
+    Effect.gen(function* () {
+      const wallet = yield* walletOnSilentChain(chainReporting(afterFork));
+
+      // Same wallet, same silent chain, one question asked: the transaction is now one this wallet can read, and the
+      // variant holding it is the one the chain is on.
+      expect(yield* failureOf(wallet.shielded.balanceTransaction(postForkTransaction()))).toStrictEqual(Option.none());
+      expect(yield* wallet.activeTag).toBe(V2Tag);
     }).pipe(Effect.scoped, Effect.runPromise));
 });

--- a/packages/shielded-wallet/src/test/forkStart.test.ts
+++ b/packages/shielded-wallet/src/test/forkStart.test.ts
@@ -454,7 +454,7 @@ describe('a shielded wallet on a chain that has shown it no events', () => {
         networkId,
         forkVersion,
         seed,
-        chainVersionProbe,
+        ...(chainVersionProbe !== undefined ? { chainVersionProbe } : {}),
       });
       yield* Effect.addFinalizer(() => wallet.stop);
       return wallet;

--- a/packages/shielded-wallet/src/test/tryRestore.test.ts
+++ b/packages/shielded-wallet/src/test/tryRestore.test.ts
@@ -52,7 +52,7 @@ const seed = Buffer.alloc(32, 7);
 
 describe('a shielded wallet restored from a snapshot it can read', () => {
   it('comes back as a wallet, rather than as a reason it could not', async () => {
-    const source = ShieldedWallet(configuration).startWithSeed(seed);
+    const source = await ShieldedWallet(configuration).startWithSeed(seed);
     const written = await source.serializeState();
     await source.stop();
 

--- a/packages/unshielded-wallet/src/ForkingUnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/ForkingUnshieldedWallet.ts
@@ -41,11 +41,15 @@ import {
   WalletTransaction,
 } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type UnshieldedAddress } from '@midnightntwrk/wallet-sdk-address-format';
+import {
+  type ChainVersionProbe,
+  makeIndexerChainVersionProbe,
+} from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import * as PreForkSignatures from '@midnightntwrk/wallet-sdk-capabilities/signatures';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
-import { type Variant, type VariantBuilder, type WalletLike } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { Variant, type VariantBuilder, type WalletLike } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { EitherOps, HList } from '@midnightntwrk/wallet-sdk-utilities';
-import { Effect, Either, Option, Ref, type Scope } from 'effect';
+import { Duration, Effect, Either, Option, Ref, type Scope, pipe } from 'effect';
 import * as rx from 'rxjs';
 import { type PublicKey } from './KeyStore.js';
 import { type UnsupportedSnapshotVersionError, variantForSnapshot } from './Restore.js';
@@ -122,6 +126,23 @@ export type ForkingUnshieldedConfiguration = {
   networkId: NetworkId.NetworkId;
   /** The protocol version at which the chain hands over from the pre-fork ledger version to the post-fork one. */
   forkVersion: ProtocolVersion.ProtocolVersion;
+  /**
+   * How the wallet asks the chain which protocol version it is on, before it chooses a variant to start at.
+   *
+   * @remarks
+   *   Optional, and best-effort where present: a wallet with no probe — or one whose probe does not answer in time —
+   *   starts on the pre-fork variant and learns the version from the first message it sees, which is what a wallet with
+   *   no history has always done. What a probe buys is the two things that guess costs: a hand-over per start on a
+   *   chain entirely past the boundary, and, on a chain that has shown this wallet no messages at all, an epoch that
+   *   never gets corrected.
+   *
+   *   It resolves where a wallet may start, never where it can: an identity only the post-fork ledger version can hold
+   *   starts there whatever the chain reports, because there is no decision left to inform.
+   *
+   *   Nothing about it can make a start fail. A rejection, a timeout, a version no registered variant covers: each
+   *   leaves the wallet exactly where a wallet that never asked would be.
+   */
+  chainVersionProbe?: ChainVersionProbe;
 };
 
 /** A running unshielded wallet that spans a protocol boundary. */
@@ -143,14 +164,20 @@ export interface ForkingUnshieldedWalletClass<
    * @remarks
    *   There is no secret here and none is wanted: an unshielded wallet reads public UTXO data addressed to an address
    *   anybody could compute, and signing is supplied per call by the caller. What the wallet does have to settle is
-   *   which variant can _hold_ the identity, and that turns on the signature scheme — see {@link asPreForkPublicKey}. A
-   *   schnorr identity begins on the pre-fork variant and follows the chain the whole way; an ecdsa one begins on the
-   *   post-fork variant, because the pre-fork ledger version has no way to express it.
+   *   which variant can _hold_ the identity, and that turns on the signature scheme — see {@link asPreForkPublicKey}. An
+   *   ecdsa identity begins on the post-fork variant, because the pre-fork ledger version has no way to express it.
+   *
+   *   A schnorr identity can be held by either, so for it the second question is where the chain is. Asynchronous
+   *   because answering that can mean asking: with a {@link ForkingUnshieldedConfiguration.chainVersionProbe}
+   *   configured, such a wallet starts at the variant that owns the version the chain reports, which on a chain
+   *   already past the boundary is the post-fork one from the first moment. Without one, or when the question goes
+   *   unanswered, it begins on the pre-fork variant and follows the chain across.
    * @param publicKey The identity to watch, in the post-fork ledger version's shape, which is the one this wallet's
    *   public API speaks.
-   * @returns A started wallet.
+   * @returns A started wallet, on the variant that can hold the identity and — where both can — the one the chain says
+   *   it is on.
    */
-  startWithPublicKey(publicKey: PublicKey): ForkingUnshieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>;
+  startWithPublicKey(publicKey: PublicKey): Promise<ForkingUnshieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>>;
   /**
    * Restores a wallet from a snapshot, into whichever registered variant wrote it.
    *
@@ -301,32 +328,115 @@ export function CustomForkingUnshieldedWallet<
         Either.getOrThrowWith(PreForkSignatures.lowerSignature(signature), (error) => error),
       );
 
+  /**
+   * How long a start waits for the chain to say which version it is on.
+   *
+   * @remarks
+   *   Short, because what is being bought is small: the alternative to an answer is the hand-over this wallet has
+   *   always done, which costs one migration and no correctness on a chain that produces messages. It is a ceiling
+   *   rather than a typical cost — an unreachable indexer refuses a connection long before this — and it exists so
+   *   that a probe which neither answers nor fails cannot hold a start open indefinitely.
+   */
+  const probeTimeout = Duration.seconds(5);
+
+  /** Where a start begins, when the chain answered for it. */
+  type ProbedStart = Readonly<{
+    version: ProtocolVersion.ProtocolVersion;
+    variant: HList.Each<Variants>;
+  }>;
+
+  /**
+   * The variant the chain's current version belongs to, or nothing.
+   *
+   * @remarks
+   *   Nothing covers every way the question can fail to produce an answer, and they are deliberately not distinguished:
+   *   no probe configured, a probe that rejected, a probe that outlived the wallet's patience, or a version no
+   *   registered variant claims. Each means the same thing to a caller — start where a wallet with no history starts —
+   *   and none of them is a reason to fail.
+   */
+  const probedStart: Effect.Effect<Option.Option<ProbedStart>> =
+    configuration.chainVersionProbe === undefined
+      ? Effect.succeedNone
+      : pipe(
+          Effect.tryPromise(configuration.chainVersionProbe),
+          Effect.timeout(probeTimeout),
+          Effect.map((version) =>
+            Option.map(BaseWallet.variantFor(version), (variant): ProbedStart => ({ version, variant })),
+          ),
+          Effect.orElseSucceed(() => Option.none<ProbedStart>()),
+        );
+
+  /**
+   * A fresh state of the variant a probed start begins at, recording the version the chain reported.
+   *
+   * @remarks
+   *   Built exactly as the head-variant boot path builds its own — the identity, in the shape that variant holds it —
+   *   and then annotated with the observed version, which is what keeps a variant from starting outside its own
+   *   activation range and signalling backwards on sight.
+   * @param variant The variant the chain's version resolved to.
+   * @param publicKey The identity in the shape this wallet's API speaks.
+   * @param preForkPublicKey The same identity as the pre-fork ledger version has it, which is only reached when that
+   *   variant is the one chosen — and only a schnorr identity ever gets here at all.
+   */
+  const freshStateAt = (
+    variant: HList.Each<Variants>,
+    publicKey: PublicKey,
+    preForkPublicKey: PreForkPublicKey,
+    version: ProtocolVersion.ProtocolVersion,
+  ): PreForkCoreWallet | CoreWallet =>
+    Variant.getVersionedVariantTag(variant) === V2Tag
+      ? CoreWallet.withProtocolVersion(CoreWallet.init(publicKey, configuration.networkId), version)
+      : PreForkCoreWallet.withProtocolVersion(
+          PreForkCoreWallet.init(preForkPublicKey, configuration.networkId),
+          version,
+        );
+
   return class ForkingUnshieldedWalletImplementation
     extends BaseWallet
     implements ForkingUnshieldedWallet<TPreForkSyncUpdate, TPostForkSyncUpdate>
   {
     static readonly configuration: TConfiguration = configuration;
 
-    static startWithPublicKey(publicKey: PublicKey): ForkingUnshieldedWalletImplementation {
+    static startWithPublicKey(publicKey: PublicKey): Promise<ForkingUnshieldedWalletImplementation> {
       return Option.match(asPreForkPublicKey(publicKey), {
-        // The identity both ledger versions can express: begin where a wallet with no history belongs, below the
-        // boundary, and let the runtime hand over when the chain says so.
+        // The identity both ledger versions can express, so where it begins is a question about the chain rather than
+        // about the key: at the variant that owns the version the chain reports, or — when the chain was not asked or
+        // did not answer — below the boundary, where a wallet with no history belongs, letting the runtime hand over
+        // when the chain says so.
         onSome: (preForkPublicKey) =>
-          ForkingUnshieldedWalletImplementation.startFirst(
-            ForkingUnshieldedWalletImplementation,
-            PreForkCoreWallet.init(preForkPublicKey, configuration.networkId),
+          pipe(
+            probedStart,
+            Effect.map(
+              Option.match({
+                onNone: () =>
+                  ForkingUnshieldedWalletImplementation.startFirst(
+                    ForkingUnshieldedWalletImplementation,
+                    PreForkCoreWallet.init(preForkPublicKey, configuration.networkId),
+                  ),
+                onSome: ({ version, variant }) =>
+                  ForkingUnshieldedWalletImplementation.startAtVariant(
+                    ForkingUnshieldedWalletImplementation,
+                    variant,
+                    freshStateAt(variant, publicKey, preForkPublicKey, version),
+                  ),
+              }),
+            ),
+            Effect.runPromise,
           ),
-        // An identity only the post-fork ledger version can express, so it starts on that variant and stays there.
-        // Stamped with the boundary version rather than left at the minimum: a variant that starts from a state
-        // outside its own activation range reports that on sight, which is how a stranded snapshot heals — and here
-        // there is no variant above this one to hand over to. The state does belong to this variant, so it says so.
+        // An identity only the post-fork ledger version can express, so it starts on that variant and stays there —
+        // and the chain is not asked, because there is nothing its answer could decide. Stamped with the boundary
+        // version rather than left at the minimum: a variant that starts from a state outside its own activation range
+        // reports that on sight, which is how a stranded snapshot heals — and here there is no variant above this one
+        // to hand over to. The state does belong to this variant, so it says so.
         onNone: () =>
-          ForkingUnshieldedWalletImplementation.startAtVariant(
-            ForkingUnshieldedWalletImplementation,
-            variants[V2Tag],
-            CoreWallet.withProtocolVersion(
-              CoreWallet.init(publicKey, configuration.networkId),
-              configuration.forkVersion,
+          Promise.resolve(
+            ForkingUnshieldedWalletImplementation.startAtVariant(
+              ForkingUnshieldedWalletImplementation,
+              variants[V2Tag],
+              CoreWallet.withProtocolVersion(
+                CoreWallet.init(publicKey, configuration.networkId),
+                configuration.forkVersion,
+              ),
             ),
           ),
       });
@@ -664,12 +774,22 @@ export type UnshieldedWalletClass = ForkingUnshieldedWalletClass<
  *
  *   Transacting, synchronization, balances, coins, addresses, serialization, restore and reverting all work on both
  *   sides: each variant builds with its own ledger version, and what it produces says which version built it.
+ *
+ *   **The chain is asked where it is before a variant is chosen.** The indexer this wallet already syncs from answers
+ *   which protocol version the chain is on, so a start on a chain past the boundary begins post-fork rather than
+ *   handing over immediately. An application that would rather ask something else — a cache, a value it already holds
+ *   — supplies its own `chainVersionProbe`; one whose chain cannot be reached loses nothing, because the answer is
+ *   best-effort and its absence is the behaviour this wallet had before.
  * @param configuration What the wallet and both its variants are built from, including where the boundary lies.
  * @returns The wallet class.
  */
 export function UnshieldedWallet(configuration: DefaultUnshieldedConfiguration): UnshieldedWalletClass {
+  const withProbe: DefaultUnshieldedConfiguration = {
+    ...configuration,
+    chainVersionProbe: configuration.chainVersionProbe ?? makeIndexerChainVersionProbe(configuration),
+  };
   return CustomForkingUnshieldedWallet(
-    configuration,
+    withProbe,
     { builder: new V1Builder().withDefaults(), configuration },
     {
       builder: new V2Builder().withDefaults().withMigration(() => Migration.makeCrossLedgerMigration()),

--- a/packages/unshielded-wallet/src/ForkingUnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/ForkingUnshieldedWallet.ts
@@ -139,8 +139,8 @@ export type ForkingUnshieldedConfiguration = {
    *   It resolves where a wallet may start, never where it can: an identity only the post-fork ledger version can hold
    *   starts there whatever the chain reports, because there is no decision left to inform.
    *
-   *   Nothing about it can make a start fail. A rejection, a timeout, a version no registered variant covers: each
-   *   leaves the wallet exactly where a wallet that never asked would be.
+   *   Nothing about it can make a start fail. A rejection, a timeout, a version no registered variant covers: each leaves
+   *   the wallet exactly where a wallet that never asked would be.
    */
   chainVersionProbe?: ChainVersionProbe;
 };
@@ -167,11 +167,11 @@ export interface ForkingUnshieldedWalletClass<
    *   which variant can _hold_ the identity, and that turns on the signature scheme — see {@link asPreForkPublicKey}. An
    *   ecdsa identity begins on the post-fork variant, because the pre-fork ledger version has no way to express it.
    *
-   *   A schnorr identity can be held by either, so for it the second question is where the chain is. Asynchronous
-   *   because answering that can mean asking: with a {@link ForkingUnshieldedConfiguration.chainVersionProbe}
-   *   configured, such a wallet starts at the variant that owns the version the chain reports, which on a chain
-   *   already past the boundary is the post-fork one from the first moment. Without one, or when the question goes
-   *   unanswered, it begins on the pre-fork variant and follows the chain across.
+   *   A schnorr identity can be held by either, so for it the second question is where the chain is. Asynchronous because
+   *   answering that can mean asking: with a {@link ForkingUnshieldedConfiguration.chainVersionProbe} configured, such a
+   *   wallet starts at the variant that owns the version the chain reports, which on a chain already past the boundary
+   *   is the post-fork one from the first moment. Without one, or when the question goes unanswered, it begins on the
+   *   pre-fork variant and follows the chain across.
    * @param publicKey The identity to watch, in the post-fork ledger version's shape, which is the one this wallet's
    *   public API speaks.
    * @returns A started wallet, on the variant that can hold the identity and — where both can — the one the chain says
@@ -332,10 +332,10 @@ export function CustomForkingUnshieldedWallet<
    * How long a start waits for the chain to say which version it is on.
    *
    * @remarks
-   *   Short, because what is being bought is small: the alternative to an answer is the hand-over this wallet has
-   *   always done, which costs one migration and no correctness on a chain that produces messages. It is a ceiling
-   *   rather than a typical cost — an unreachable indexer refuses a connection long before this — and it exists so
-   *   that a probe which neither answers nor fails cannot hold a start open indefinitely.
+   *   Short, because what is being bought is small: the alternative to an answer is the hand-over this wallet has always
+   *   done, which costs one migration and no correctness on a chain that produces messages. It is a ceiling rather than
+   *   a typical cost — an unreachable indexer refuses a connection long before this — and it exists so that a probe
+   *   which neither answers nor fails cannot hold a start open indefinitely.
    */
   const probeTimeout = Duration.seconds(5);
 
@@ -370,9 +370,9 @@ export function CustomForkingUnshieldedWallet<
    * A fresh state of the variant a probed start begins at, recording the version the chain reported.
    *
    * @remarks
-   *   Built exactly as the head-variant boot path builds its own — the identity, in the shape that variant holds it —
-   *   and then annotated with the observed version, which is what keeps a variant from starting outside its own
-   *   activation range and signalling backwards on sight.
+   *   Built exactly as the head-variant boot path builds its own — the identity, in the shape that variant holds it — and
+   *   then annotated with the observed version, which is what keeps a variant from starting outside its own activation
+   *   range and signalling backwards on sight.
    * @param variant The variant the chain's version resolved to.
    * @param publicKey The identity in the shape this wallet's API speaks.
    * @param preForkPublicKey The same identity as the pre-fork ledger version has it, which is only reached when that
@@ -777,8 +777,8 @@ export type UnshieldedWalletClass = ForkingUnshieldedWalletClass<
  *
  *   **The chain is asked where it is before a variant is chosen.** The indexer this wallet already syncs from answers
  *   which protocol version the chain is on, so a start on a chain past the boundary begins post-fork rather than
- *   handing over immediately. An application that would rather ask something else — a cache, a value it already holds
- *   — supplies its own `chainVersionProbe`; one whose chain cannot be reached loses nothing, because the answer is
+ *   handing over immediately. An application that would rather ask something else — a cache, a value it already holds —
+ *   supplies its own `chainVersionProbe`; one whose chain cannot be reached loses nothing, because the answer is
  *   best-effort and its absence is the behaviour this wallet had before.
  * @param configuration What the wallet and both its variants are built from, including where the boundary lies.
  * @returns The wallet class.

--- a/packages/unshielded-wallet/src/UnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/UnshieldedWallet.ts
@@ -48,6 +48,7 @@ import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
 import { type PublicKey } from './KeyStore.js';
 import { type SyncProgress } from './v2/SyncProgress.js';
 import { type UnshieldedAddress } from '@midnightntwrk/wallet-sdk-address-format';
+import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 
 /** The core state of whichever unshielded variant produced an emission. */
 export type UnshieldedCoreState = PreForkCoreWallet | CoreWallet;
@@ -187,6 +188,16 @@ export type DefaultUnshieldedConfiguration = {
    *   unchanged.
    */
   forkVersion: ProtocolVersion.ProtocolVersion;
+  /**
+   * How the wallet asks the chain which protocol version it is on, before it chooses a variant to start at.
+   *
+   * @remarks
+   *   Optional, and defaulted rather than absent: left unset, the wallet asks the indexer named by
+   *   {@link indexerClientConnection}, which it is about to synchronize from anyway. Supply one to ask something else —
+   *   a cache, a node RPC, a value the application already holds. The answer is best-effort wherever it comes from: a
+   *   chain that cannot be reached leaves the wallet starting exactly where it started before there was a probe.
+   */
+  chainVersionProbe?: ChainVersionProbe;
 };
 
 export type UnshieldedWalletAPI<TSerialized = string> = {

--- a/packages/unshielded-wallet/src/test/configuration.test.ts
+++ b/packages/unshielded-wallet/src/test/configuration.test.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { type NetworkId, type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import { type CanAssign, type Equal, type Expect } from '@midnightntwrk/wallet-sdk-utilities/types';
 import { describe, it } from 'vitest';
 import { type DefaultUnshieldedConfiguration } from '../UnshieldedWallet.js';
@@ -31,6 +32,7 @@ describe('DefaultUnshieldedConfiguration', () => {
           indexerClientConnection: V2Sync.IndexerClientConnection;
           txHistoryStorage: V2TransactionHistory.UnshieldedHistoryStorage;
           forkVersion: ProtocolVersion.ProtocolVersion;
+          chainVersionProbe?: ChainVersionProbe;
         }
       >
     >;
@@ -49,5 +51,10 @@ describe('DefaultUnshieldedConfiguration', () => {
     // `forkVersion` is the wallet layer's alone: neither variant knows there is another one.
     type _3 = Expect<Equal<'forkVersion' extends keyof DefaultV1Configuration ? true : false, false>>;
     type _4 = Expect<Equal<'forkVersion' extends keyof DefaultV2Configuration ? true : false, false>>;
+
+    // And so is the question of where to start, for the same reason: a variant that does not know there is another
+    // one has no use for the answer.
+    type _5 = Expect<Equal<'chainVersionProbe' extends keyof DefaultV1Configuration ? true : false, false>>;
+    type _6 = Expect<Equal<'chainVersionProbe' extends keyof DefaultV2Configuration ? true : false, false>>;
   });
 });

--- a/packages/unshielded-wallet/src/test/forkHarness.ts
+++ b/packages/unshielded-wallet/src/test/forkHarness.ts
@@ -29,6 +29,7 @@
  *   post-fork ledger version's {@link PublicKey}.
  */
 import { NetworkId, type ProtocolState, type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { Deferred, Effect, FiberId, HashMap, Option, Stream, pipe } from 'effect';
 import { CustomForkingUnshieldedWallet, type ForkingUnshieldedWallet } from '../ForkingUnshieldedWallet.js';
@@ -199,6 +200,13 @@ export type ForkWalletConfig = {
   /** The identity the wallet is started with, in the shape an application holds it: the post-fork ledger version's. */
   readonly publicKey: PublicKey;
   readonly networkId?: NetworkId.NetworkId;
+  /**
+   * How the wallet asks the chain which protocol version it is on before choosing a variant to start at.
+   *
+   * Absent means it does not ask, which is the behaviour of every wallet built without one: it starts at the head
+   * variant and learns the version from the first message it sees.
+   */
+  readonly chainVersionProbe?: ChainVersionProbe;
 };
 
 /** A state emission, whichever variant produced it. */
@@ -232,10 +240,14 @@ export type ForkWallet = {
 /**
  * Builds and starts the shipped forking unshielded wallet over an in-memory timeline that forks.
  *
- * @param config The timeline, the boundary version and the identity to start with.
+ * @remarks
+ *   Effectful because starting one is: a wallet that spans a boundary may ask the chain which version it is on before it
+ *   can choose a variant, and that question is answered over the network. A harness that hid it behind a synchronous
+ *   call would be hiding the very thing these proofs are about.
+ * @param config The timeline, the boundary version, the identity to start with, and how the chain is asked its version.
  * @returns The running wallet and its observation channels.
  */
-export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
+export const makeForkWallet = (config: ForkWalletConfig): Effect.Effect<ForkWallet> => {
   const networkId = config.networkId ?? NetworkId.NetworkId.Undeployed;
   const captured = Deferred.unsafeMake<CapturedMigration>(FiberId.none);
   const variantConfiguration: SourceConfiguration = { networkId, timeline: config.timeline };
@@ -280,41 +292,48 @@ export const makeForkWallet = (config: ForkWalletConfig): ForkWallet => {
     .withMigration(() => capturingCrossLedgerMigration(captured));
 
   const WalletClass = CustomForkingUnshieldedWallet(
-    { networkId, forkVersion: config.forkVersion },
+    {
+      networkId,
+      forkVersion: config.forkVersion,
+      ...(config.chainVersionProbe !== undefined ? { chainVersionProbe: config.chainVersionProbe } : {}),
+    },
     { builder: preForkBuilder, configuration: variantConfiguration },
     { builder: postForkBuilder, configuration: variantConfiguration },
   );
 
-  const wallet = WalletClass.startWithPublicKey(config.publicKey);
-  const runtime = wallet.runtime;
+  return Effect.promise(() => WalletClass.startWithPublicKey(config.publicKey)).pipe(
+    Effect.map((wallet) => {
+      const runtime = wallet.runtime;
 
-  return {
-    unshielded: wallet,
+      return {
+        unshielded: wallet,
 
-    start: Effect.promise(() => wallet.start()),
+        start: Effect.promise(() => wallet.start()),
 
-    awaitMigration: Deferred.await(captured),
+        awaitMigration: Deferred.await(captured),
 
-    migration: Deferred.poll(captured).pipe(
-      Effect.flatMap(Option.match({ onNone: () => Effect.succeedNone, onSome: Effect.asSome })),
-    ),
+        migration: Deferred.poll(captured).pipe(
+          Effect.flatMap(Option.match({ onNone: () => Effect.succeedNone, onSome: Effect.asSome })),
+        ),
 
-    activeTag: pipe(
-      runtime.currentVariant,
-      Effect.map((current) => current.runningVariant.__polyTag__),
-    ),
+        activeTag: pipe(
+          runtime.currentVariant,
+          Effect.map((current) => current.runningVariant.__polyTag__),
+        ),
 
-    currentState: pipe(runtime.stateChanges, Stream.take(1), Stream.runHead, Effect.map(Option.getOrThrow)),
+        currentState: pipe(runtime.stateChanges, Stream.take(1), Stream.runHead, Effect.map(Option.getOrThrow)),
 
-    awaitState: (predicate) =>
-      pipe(
-        runtime.stateChanges,
-        Stream.filter(predicate),
-        Stream.take(1),
-        Stream.runHead,
-        Effect.map(Option.getOrThrow),
-      ),
+        awaitState: (predicate: (state: ForkedState) => boolean) =>
+          pipe(
+            runtime.stateChanges,
+            Stream.filter(predicate),
+            Stream.take(1),
+            Stream.runHead,
+            Effect.map(Option.getOrThrow),
+          ),
 
-    stop: Effect.promise(() => wallet.stop()),
-  };
+        stop: Effect.promise(() => wallet.stop()),
+      };
+    }),
+  );
 };

--- a/packages/unshielded-wallet/src/test/forkSimulation.test.ts
+++ b/packages/unshielded-wallet/src/test/forkSimulation.test.ts
@@ -64,7 +64,7 @@ const valuesOf = (utxos: readonly CarriedUtxo[]): readonly bigint[] => utxos.map
 
 describe('unshielded hard-fork crossing', () => {
   it('carries every UTXO across and applies the boundary transaction exactly once, in the new variant', async () => {
-    const wallet = makeForkWallet({ timeline, forkVersion, publicKey: postFork });
+    const wallet = yield* makeForkWallet({ timeline, forkVersion, publicKey: postFork });
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
@@ -115,7 +115,7 @@ describe('unshielded hard-fork crossing', () => {
   });
 
   it('carries the pre-fork UTXOs field for field, not merely by count', async () => {
-    const wallet = makeForkWallet({ timeline, forkVersion, publicKey: postFork });
+    const wallet = yield* makeForkWallet({ timeline, forkVersion, publicKey: postFork });
 
     const { before, after } = await Effect.runPromise(
       Effect.gen(function* () {
@@ -151,7 +151,7 @@ describe('unshielded hard-fork crossing', () => {
       // 5 is still below the boundary of 7, so this must be applied, not deferred.
       timelineTransaction({ id: 2, protocolVersion: 5, owner: preFork.addressHex, value: 200n }),
     ];
-    const wallet = makeForkWallet({ timeline: withinRange, forkVersion, publicKey: postFork });
+    const wallet = yield* makeForkWallet({ timeline: withinRange, forkVersion, publicKey: postFork });
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
@@ -176,7 +176,7 @@ describe('unshielded hard-fork crossing', () => {
   it('reaches the same end state from a wallet whose first sync already contains the fork', async () => {
     // Scenario 2: a fresh wallet syncing a timeline that already straddles the boundary. It still syncs the pre-fork
     // prefix with the old variant, hands over, and consumes the rest — double work by design, correct by construction.
-    const wallet = makeForkWallet({ timeline, forkVersion, publicKey: postFork });
+    const wallet = yield* makeForkWallet({ timeline, forkVersion, publicKey: postFork });
 
     const final = await Effect.runPromise(
       Effect.gen(function* () {

--- a/packages/unshielded-wallet/src/test/forkSimulation.test.ts
+++ b/packages/unshielded-wallet/src/test/forkSimulation.test.ts
@@ -64,7 +64,7 @@ const valuesOf = (utxos: readonly CarriedUtxo[]): readonly bigint[] => utxos.map
 
 describe('unshielded hard-fork crossing', () => {
   it('carries every UTXO across and applies the boundary transaction exactly once, in the new variant', async () => {
-    const wallet = yield* makeForkWallet({ timeline, forkVersion, publicKey: postFork });
+    const wallet = await Effect.runPromise(makeForkWallet({ timeline, forkVersion, publicKey: postFork }));
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
@@ -115,7 +115,7 @@ describe('unshielded hard-fork crossing', () => {
   });
 
   it('carries the pre-fork UTXOs field for field, not merely by count', async () => {
-    const wallet = yield* makeForkWallet({ timeline, forkVersion, publicKey: postFork });
+    const wallet = await Effect.runPromise(makeForkWallet({ timeline, forkVersion, publicKey: postFork }));
 
     const { before, after } = await Effect.runPromise(
       Effect.gen(function* () {
@@ -151,7 +151,7 @@ describe('unshielded hard-fork crossing', () => {
       // 5 is still below the boundary of 7, so this must be applied, not deferred.
       timelineTransaction({ id: 2, protocolVersion: 5, owner: preFork.addressHex, value: 200n }),
     ];
-    const wallet = yield* makeForkWallet({ timeline: withinRange, forkVersion, publicKey: postFork });
+    const wallet = await Effect.runPromise(makeForkWallet({ timeline: withinRange, forkVersion, publicKey: postFork }));
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
@@ -176,7 +176,7 @@ describe('unshielded hard-fork crossing', () => {
   it('reaches the same end state from a wallet whose first sync already contains the fork', async () => {
     // Scenario 2: a fresh wallet syncing a timeline that already straddles the boundary. It still syncs the pre-fork
     // prefix with the old variant, hands over, and consumes the rest — double work by design, correct by construction.
-    const wallet = yield* makeForkWallet({ timeline, forkVersion, publicKey: postFork });
+    const wallet = await Effect.runPromise(makeForkWallet({ timeline, forkVersion, publicKey: postFork }));
 
     const final = await Effect.runPromise(
       Effect.gen(function* () {

--- a/packages/unshielded-wallet/src/test/forkStart.test.ts
+++ b/packages/unshielded-wallet/src/test/forkStart.test.ts
@@ -19,10 +19,13 @@
  *   here are the other question — a wallet meeting a chain that is already on one side or the other, which is what
  *   every application start actually is.
  *
- *   A wallet always begins on the pre-fork variant, because that is the variant a wallet with no history belongs to. On a
- *   chain that has already forked it therefore hands over immediately, having applied nothing: one migration per start,
- *   paid on chains that are entirely past the boundary. That cost is accepted rather than hidden — removing it means
- *   asking the chain for its version before choosing a variant, which is a separate piece of work.
+ *   Where it begins turns on one question: whether it asked the chain. A wallet given a way to ask starts at the variant
+ *   that owns the version the chain reports, which on a chain past the boundary is the post-fork one from the first
+ *   moment — no hand-over, and the right epoch before a single message has arrived. A wallet with no way to ask, or one
+ *   whose question went unanswered, begins on the pre-fork variant, because that is where a wallet with no history
+ *   belongs, and hands over on the first batch it sees. Both are specified here: the second is not a fallback in name
+ *   only, it is what every offline-first application and every wallet built without a probe does. An identity only the
+ *   post-fork ledger version can hold is the one start no question is asked for, because there is nothing to decide.
  *
  *   Unshielded's hand-over is a **structural carry** rather than a fresh state plus replay, so the "applied nothing"
  *   start is asserted for what a carry of nothing actually looks like: an empty carry, a cursor still at the start, and
@@ -42,6 +45,7 @@ import {
   ProtocolVersionMismatchError,
   WalletTransaction,
 } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import { Cause, Effect, Either, Fiber, Option, Runtime, type Scope } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { peekProtocolVersion } from '../Restore.js';
@@ -77,13 +81,35 @@ const valuesOf = (utxos: readonly CarriedUtxo[]): readonly bigint[] => utxos.map
 const walletOnChainAt = (
   protocolVersion: number,
   publicKey = postFork,
+  chainVersionProbe?: ChainVersionProbe,
 ): Effect.Effect<ForkWallet, never, Scope.Scope> =>
   Effect.gen(function* () {
-    const wallet = makeForkWallet({ timeline: chainAt(protocolVersion), forkVersion, publicKey });
+    const wallet = yield* makeForkWallet({
+      timeline: chainAt(protocolVersion),
+      forkVersion,
+      publicKey,
+      ...(chainVersionProbe !== undefined ? { chainVersionProbe } : {}),
+    });
     yield* Effect.addFinalizer(() => wallet.stop);
     yield* wallet.start;
     return wallet;
   });
+
+/** A probe answering as a chain on `version` would. */
+const chainReporting =
+  (version: number): ChainVersionProbe =>
+  () =>
+    Promise.resolve(ProtocolVersion.ProtocolVersion(BigInt(version)));
+
+/**
+ * A probe that never answers.
+ *
+ * @remarks
+ *   One shape stands in for every way the question can go unanswered — no indexer, no network, a request that outlives
+ *   the wallet's patience — because the wallet distinguishes none of them: it asked, it has no answer, it starts where
+ *   a wallet that never asked starts.
+ */
+const unreachableChain: ChainVersionProbe = () => Promise.reject(new Error('the indexer cannot be reached'));
 
 /** A wallet on a chain that has not forked, synchronized and holding its UTXOs. */
 const syncedPreForkWallet: Effect.Effect<ForkWallet, never, Scope.Scope> = Effect.gen(function* () {
@@ -187,10 +213,71 @@ const transactionBuildingCalls = (wallet: ForkWallet): readonly (readonly [strin
   ];
 };
 
+describe('an unshielded wallet that asks the chain where it is starting', () => {
+  it('starts on the post-fork variant of a chain past the boundary, without a hand-over at all', async () =>
+    Effect.gen(function* () {
+      const wallet = yield* makeForkWallet({
+        timeline: chainAt(afterFork),
+        forkVersion,
+        publicKey: postFork,
+        chainVersionProbe: chainReporting(afterFork),
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      // Before sync has been started, before any message exists to learn from: the variant is already the post-fork
+      // one. The pre-fork variant is not where this wallet began and then left — it never ran.
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+
+      const settled = yield* Effect.fork(
+        wallet.awaitState((state) => state.state.progress.appliedId === 2n).pipe(Effect.orDie),
+      );
+      yield* wallet.start;
+
+      const final = yield* Fiber.join(settled);
+      expect(valuesOf(utxosOf(final.state))).toEqual([100n, 200n]);
+      expect(final.state.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
+
+      // Nothing was carried, because nothing was left behind. This is what the hand-over below costs a wallet that
+      // could not ask.
+      expect(yield* wallet.migration).toStrictEqual(Option.none());
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('starts on the pre-fork variant of a chain that has not forked, and stays there', async () =>
+    Effect.gen(function* () {
+      const wallet = yield* walletOnChainAt(beforeFork, postFork, chainReporting(beforeFork));
+      yield* wallet.awaitState((state) => state.state.progress.appliedId === 2n).pipe(Effect.orDie);
+
+      // The answer sends it to the variant that owns the version, which below the boundary is the one it would have
+      // started on anyway. What the probe changes here is nothing at all, which is the claim.
+      const settled = yield* wallet.currentState;
+      expect(valuesOf(utxosOf(settled.state))).toEqual([100n, 200n]);
+      expect(settled.state.protocolVersion).toBeLessThan(forkVersion);
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+      expect(yield* wallet.migration).toStrictEqual(Option.none());
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('asks nothing for an identity only the post-fork ledger version can hold', async () =>
+    Effect.gen(function* () {
+      // A chain below the boundary, and an answer saying so, and the wallet still starts post-fork: an ecdsa identity
+      // has no pre-fork shape, so there is no decision for the chain to inform. The probe resolves where a wallet may
+      // start, never where it can.
+      const ecdsa = ecdsaIdentity(networkId);
+
+      const wallet = yield* walletOnChainAt(beforeFork, ecdsa, chainReporting(beforeFork));
+
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+      const state = yield* wallet.currentState;
+      expect(state.state.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
+      expect(yield* wallet.migration).toStrictEqual(Option.none());
+    }).pipe(Effect.scoped, Effect.runPromise));
+});
+
 describe('an unshielded wallet starting on a chain that has already forked', () => {
   it('hands over having applied nothing, carrying nothing, and syncs the whole chain on the post-fork variant', async () =>
     Effect.gen(function* () {
-      const wallet = makeForkWallet({ timeline: chainAt(afterFork), forkVersion, publicKey: postFork });
+      // No probe: the shape of every wallet built without one, and of every application that would rather not have
+      // its start depend on reaching an indexer.
+      const wallet = yield* makeForkWallet({ timeline: chainAt(afterFork), forkVersion, publicKey: postFork });
       yield* Effect.addFinalizer(() => wallet.stop);
       // Subscribed BEFORE starting: `stateChanges` does not replay, so a settled state reached while nobody was
       // listening would be missed and the wait would hang rather than fail.
@@ -222,6 +309,30 @@ describe('an unshielded wallet starting on a chain that has already forked', () 
       expect(valuesOf(utxosOf(final.state))).toEqual([100n, 200n]);
       expect(final.state.progress.appliedId).toBe(2n);
       expect(final.state.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('hands over the same way when it asked the chain and got no answer', async () =>
+    Effect.gen(function* () {
+      const wallet = yield* makeForkWallet({
+        timeline: chainAt(afterFork),
+        forkVersion,
+        publicKey: postFork,
+        chainVersionProbe: unreachableChain,
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      const settled = yield* Effect.fork(
+        wallet.awaitState((state) => state.state.progress.appliedId === 2n).pipe(Effect.orDie),
+      );
+      yield* wallet.start;
+
+      // A question that cannot be answered leaves the wallet exactly where a wallet that never asked would be — and,
+      // above all, leaves it started. An unreachable chain is not a reason to fail to start.
+      const migration = yield* wallet.awaitMigration;
+      expect(migration.from.appliedId).toBe(0n);
+
+      const final = yield* Fiber.join(settled);
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+      expect(valuesOf(utxosOf(final.state))).toEqual([100n, 200n]);
     }).pipe(Effect.scoped, Effect.runPromise));
 });
 
@@ -403,5 +514,58 @@ describe('an unshielded wallet whose identity the pre-fork ledger version cannot
       // itself outside its own activation range does not report that on sight and migrate away from itself.
       expect(state.state.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
       expect(yield* wallet.migration).toStrictEqual(Option.none());
+    }).pipe(Effect.scoped, Effect.runPromise));
+});
+
+/**
+ * An unshielded wallet on a chain past the boundary that has shown it nothing.
+ *
+ * @remarks
+ *   The hazard the probe closes, and the reason it is a correctness item rather than an optimization. A wallet learns
+ *   the chain's version from the messages it observes, so one that has observed none holds the only version it can
+ *   assume: the bottom of the timeline. That is not a transient state on a chain whose timeline contains nothing
+ *   addressed to this wallet — it is where the wallet stays, for as long as it runs. And since transacting works on
+ *   either side of the boundary, the wallet does not refuse: it builds with the wrong ledger version, against a chain
+ *   that will reject the result.
+ *
+ *   Modelled by an empty timeline, which is exactly that chain: sync runs, and there is nothing for it to deliver.
+ */
+describe('an unshielded wallet on a chain that has shown it no messages', () => {
+  const walletOnSilentChain = (chainVersionProbe?: ChainVersionProbe): Effect.Effect<ForkWallet, never, Scope.Scope> =>
+    Effect.gen(function* () {
+      const wallet = yield* makeForkWallet({
+        timeline: [],
+        forkVersion,
+        publicKey: postFork,
+        ...(chainVersionProbe !== undefined ? { chainVersionProbe } : {}),
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      yield* wallet.start;
+      return wallet;
+    });
+
+  it('believes it is pre-fork, and refuses the chain’s own transactions, when it never asked', async () =>
+    Effect.gen(function* () {
+      const wallet = yield* walletOnSilentChain();
+
+      const failure = Option.getOrThrow(
+        yield* failureOf(wallet.unshielded.balanceUnprovenTransaction(postForkTransaction())),
+      );
+
+      // A transaction of the ledger version this chain actually runs, refused by a wallet sitting on the same chain.
+      expect(failure).toBeInstanceOf(ProtocolVersionMismatchError);
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('is in the epoch the chain is in, having asked it', async () =>
+    Effect.gen(function* () {
+      const wallet = yield* walletOnSilentChain(chainReporting(afterFork));
+
+      // Same wallet, same silent chain, one question asked: the transaction is now one this wallet can read, and the
+      // variant holding it is the one the chain is on.
+      expect(yield* failureOf(wallet.unshielded.balanceUnprovenTransaction(postForkTransaction()))).toStrictEqual(
+        Option.none(),
+      );
+      expect(yield* wallet.activeTag).toBe(V2Tag);
     }).pipe(Effect.scoped, Effect.runPromise));
 });

--- a/packages/unshielded-wallet/src/test/forkStart.test.ts
+++ b/packages/unshielded-wallet/src/test/forkStart.test.ts
@@ -521,12 +521,12 @@ describe('an unshielded wallet whose identity the pre-fork ledger version cannot
  * An unshielded wallet on a chain past the boundary that has shown it nothing.
  *
  * @remarks
- *   The hazard the probe closes, and the reason it is a correctness item rather than an optimization. A wallet learns
- *   the chain's version from the messages it observes, so one that has observed none holds the only version it can
- *   assume: the bottom of the timeline. That is not a transient state on a chain whose timeline contains nothing
- *   addressed to this wallet — it is where the wallet stays, for as long as it runs. And since transacting works on
- *   either side of the boundary, the wallet does not refuse: it builds with the wrong ledger version, against a chain
- *   that will reject the result.
+ *   The hazard the probe closes, and the reason it is a correctness item rather than an optimization. A wallet learns the
+ *   chain's version from the messages it observes, so one that has observed none holds the only version it can assume:
+ *   the bottom of the timeline. That is not a transient state on a chain whose timeline contains nothing addressed to
+ *   this wallet — it is where the wallet stays, for as long as it runs. And since transacting works on either side of
+ *   the boundary, the wallet does not refuse: it builds with the wrong ledger version, against a chain that will reject
+ *   the result.
  *
  *   Modelled by an empty timeline, which is exactly that chain: sync runs, and there is nothing for it to deliver.
  */

--- a/packages/unshielded-wallet/src/test/tryRestore.test.ts
+++ b/packages/unshielded-wallet/src/test/tryRestore.test.ts
@@ -47,7 +47,7 @@ const identity = PublicKey.fromKeyStore(
 
 describe('an unshielded wallet restored from a snapshot it can read', () => {
   it('comes back as a wallet, rather than as a reason it could not', async () => {
-    const source = UnshieldedWallet(configuration).startWithPublicKey(identity);
+    const source = await UnshieldedWallet(configuration).startWithPublicKey(identity);
     const written = await source.serializeState();
     await source.stop();
 

--- a/packages/unshielded-wallet/test/UnshieldedWallet.integration.test.ts
+++ b/packages/unshielded-wallet/test/UnshieldedWallet.integration.test.ts
@@ -50,7 +50,7 @@ describe('UnshieldedWallet', () => {
     const config = createWalletConfig(indexerPort);
     const keystore = createKeystore({ kind: 'schnorr', secret: unshieldedSeed }, config.networkId);
 
-    const unshieldedWallet = UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(keystore));
+    const unshieldedWallet = await UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(keystore));
 
     await unshieldedWallet.start();
 
@@ -75,7 +75,7 @@ describe('UnshieldedWallet', () => {
       txHistoryStorage: new NoOpTransactionHistoryStorage(),
     });
     const keystore = createKeystore({ kind: 'schnorr', secret: unshieldedSeed }, initialConfig.networkId);
-    const initialWallet = UnshieldedWallet(initialConfig).startWithPublicKey(PublicKey.fromKeyStore(keystore));
+    const initialWallet = await UnshieldedWallet(initialConfig).startWithPublicKey(PublicKey.fromKeyStore(keystore));
 
     await initialWallet.start();
     await waitForCoins(initialWallet);
@@ -91,7 +91,7 @@ describe('UnshieldedWallet', () => {
   it('should restore from serialized state', async () => {
     const initialConfig = createWalletConfig(indexerPort);
     const keystore = createKeystore({ kind: 'schnorr', secret: unshieldedSeed }, initialConfig.networkId);
-    const initialWallet = UnshieldedWallet(initialConfig).startWithPublicKey(PublicKey.fromKeyStore(keystore));
+    const initialWallet = await UnshieldedWallet(initialConfig).startWithPublicKey(PublicKey.fromKeyStore(keystore));
 
     await initialWallet.start();
 

--- a/packages/wallet-integration-tests/test/serializationAndRestoration.integration.test.ts
+++ b/packages/wallet-integration-tests/test/serializationAndRestoration.integration.test.ts
@@ -90,7 +90,7 @@ describe('Wallet serialization and restoration', () => {
 
   it('allows to restore an non-empty wallet from the serialized state', async () => {
     const seed = getShieldedSeed('0000000000000000000000000000000000000000000000000000000000000002');
-    const wallet = Wallet.startWithSeed(seed);
+    const wallet = await Wallet.startWithSeed(seed);
     await wallet.start(ledger.ZswapSecretKeys.fromSeed(seed));
     try {
       const syncedState: ShieldedWalletState = await wallet.waitForSyncedState();
@@ -115,7 +115,7 @@ describe('Wallet serialization and restoration', () => {
 
   it('allows to restore an empty wallet from the serialized state', async () => {
     const seed = getShieldedSeed('0000000000000000000000000000000000000000000000000000000000000009');
-    const wallet = Wallet.startWithSeed(seed);
+    const wallet = await Wallet.startWithSeed(seed);
     await wallet.start(ledger.ZswapSecretKeys.fromSeed(seed));
     try {
       const syncedState: ShieldedWalletState = await wallet.waitForSyncedState();
@@ -140,7 +140,7 @@ describe('Wallet serialization and restoration', () => {
 
   it('should restore shielded wallet from serialized transaction history', async () => {
     const seed = getShieldedSeed('0000000000000000000000000000000000000000000000000000000000000002');
-    const wallet = ShieldedWallet(shieldedConfiguration).startWithSeed(seed);
+    const wallet = await ShieldedWallet(shieldedConfiguration).startWithSeed(seed);
     await wallet.start(ledger.ZswapSecretKeys.fromSeed(seed));
     try {
       await wallet.waitForSyncedState();
@@ -179,7 +179,7 @@ describe('Wallet serialization and restoration', () => {
     const unshieldedSeed = getUnshieldedSeed('0000000000000000000000000000000000000000000000000000000000000002');
     const keystore = createKeystore({ kind: 'schnorr', secret: unshieldedSeed }, unshieldedConfiguration.networkId);
 
-    const initialWallet = UnshieldedWallet(unshieldedConfiguration).startWithPublicKey(
+    const initialWallet = await UnshieldedWallet(unshieldedConfiguration).startWithPublicKey(
       PublicKey.fromKeyStore(keystore),
     );
     await initialWallet.start();

--- a/packages/wallet-sdk-testkit/src/wallet.ts
+++ b/packages/wallet-sdk-testkit/src/wallet.ts
@@ -99,7 +99,7 @@ const restoreUnshieldedWallet = async (
     const serialized = await readIfExists(path);
     if (serialized) {
       const keyStore = createKeystore({ kind: 'schnorr', secret: getUnshieldedSeed(seed) }, env.endpoints.networkId);
-      const wallet = UnshieldedWallet({
+      const wallet = await UnshieldedWallet({
         networkId: env.endpoints.networkId,
         indexerClientConnection: {
           indexerHttpUrl: env.endpoints.indexerHttpUrl,


### PR DESCRIPTION
Twelfth increment of the dual-ledger public API redesign — WP-8b, promoted from post-GA optimization to a GA correctness item. Stacked on #685.

## Why promoted

Two-variant wallets boot the head (pre-fork) variant and learn the chain's version only from observed events. That meant (a) every start on a v9-native chain paid a spurious v8-boot → migrate → v2-resync dance, and (b) — the sharper hazard #684 created — a wallet on a chain that has shown it **no events** stays in the pre-fork epoch and now silently *builds* ledger-v8 transactions against a v9 chain, failing only at the node. The probe pins the correct epoch from the first moment.

## What's here

- **`chainVersionProbe`** (`capabilities/chainVersion`): reuses the existing `BlockHash` query (which already selects `protocolVersion` — zero indexer-client changes), `Option`-shaped core (`absent`, not zero, for a chain with no block), 5-second ceiling, typed `ChainVersionUnavailableError`.
- **Wired into the three forking wallets' start paths** (`startWithSeed`/`startWithKeys`/`startWithPublicKey` — never `restore`, whose snapshot version is authoritative): probe → `variantFor` → `startAtVariant` on that variant's own fresh state, annotated inside its activation range (the same construction unshielded's ecdsa start already used). Default factories wire the probe from the config's existing `indexerClientConnection`; `CustomForking*` callers get an optional field — absent means today's behavior exactly.
- **Best-effort by design**: no probe, probe rejected, probe timed out, and unclaimed version all collapse — deliberately undistinguished — to the head-variant boot, pinned per wallet alongside the probed paths. Offline-first apps and simulators cannot newly fail to start.
- **The breaking part, framed honestly**: the forking classes' start methods return `Promise<Wallet>` — the variant must be settled before the runtime exists, so there is no synchronous way to achieve "the pre-fork variant never activated". Blast radius was small: wallet factories were already typed `MaybePromise`, so every `(config) => Wallet(config).startWithSeed(...)` closure is unchanged; direct callers gained `await`. Single-variant `Custom*` starts stay synchronous.
- **Not claimed**: the v8 WASM module still loads at import time (value import + eager both-epoch key derivation) — the probe removes the migration and the epoch error, not the load; making the load lazy is separate work.

## Pins (second sanctioned pin-flip of the line, mapped old → new in the report)

Per wallet: the old boot-v1 → migrate pin is **kept verbatim** under "no probe", joined by a probe-failed sibling asserting the identical fallback dance; new probed pins assert direct v2 start with **no hand-over at all**; pre-fork chains pin to v1; and the **empty-timeline pair** encodes the sharper hazard — an unprobed wallet believes it is pre-fork and refuses the chain's own transactions, a probed one is in the chain's epoch. Dust's fast-sync pin is *restated, not weakened*: still reachable only through a single-variant composition, probe or no probe. forkStart totals: shielded 13, dust 21, unshielded 22 (red-first confirmed: 13/20/22 failing before implementation).

## Gate

dist 17/17, typecheck 37/37, lint 58/58, unit 54/54 tasks (shielded 191 / dust 196 / unshielded 225 / capabilities 186 / facade 61), fork-simulation integration 3/3, effect-language-service 0 findings on all 30 changed files, format + changesets green. Live suites verified: configs already carry indexer connections, so they get the probe — and stop paying the spurious migration — for free. Changesets: three wallet majors (async starts + new default behavior + fallback semantics), capabilities minor.