### PR TITLE
docs(changesets,claude) + test: the wrap-up audit — release notes, debts, spec vectors

### DIFF
--- a/.changeset/dust-two-variant-fork-flip.md
+++ b/.changeset/dust-two-variant-fork-flip.md
@@ -8,9 +8,9 @@
 
 The shipped dust wallet now registers one variant either side of a protocol boundary — the pre-fork ledger version from
 the minimum supported version, the post-fork one from `configuration.forkVersion` — and follows the chain across it.
-The crossing itself is unchanged and still proven by `test/forkSimulation.test.ts`, which was rewired onto the shipped
+The crossing itself is unchanged and still proven by `src/test/forkSimulation.test.ts`, which was rewired onto the shipped
 factory with **no assertion changed**: the test-only two-variant builder it used to stand on has been dissolved into
-`test/forkHarness.ts`, which is now observation and simulated infrastructure around the real wallet.
+`src/test/forkHarness.ts`, which is now observation and simulated infrastructure around the real wallet.
 
 **`forkVersion` is required on `DefaultDustConfiguration`, without a default.** A wrong value does not degrade — it
 decides which ledger version reads the chain. `@midnightntwrk/wallet-sdk-shielded` publishes `V9_NATIVE_FORK_VERSION`
@@ -23,7 +23,9 @@ What else moved:
 - `DustWallet` retains **start material** rather than a raw key. A wallet started from a seed can start synchronization
   on either variant, because each derives its own `DustSecretKey` through a new per-variant `startAux` capability
   (`V1Builder`/`V2Builder` gained `withStartAux`/`withStartAuxDefaults`, and a hand-composed builder that never states
-  one is now refused at `build`). A wallet started from a key object answers only for the variant that key belongs to.
+  one is now refused at `build`). The single-key `startWithSecretKey`, which could only ever answer for one variant, is
+  **deleted** later in this same release rather than shipped; `startWithKeys({ v8, v9 })` replaces it — see *Wallets are
+  started from seeds*.
 - `DustWalletState` binds its projections to the variant that produced the emission (`DustWalletState.fromVariant`).
   Everything it projects is version-agnostic plain data; the version union surfaces on `state` alone. The
   `capabilities` and `services` members are **gone** — `splitNightUtxos` is now a method on the state, which is what
@@ -33,17 +35,21 @@ What else moved:
   `UnsupportedSnapshotVersionError`.
 - `CustomDustWallet` is unchanged and still single-variant.
 
-**A temporary seam, which must not survive to general availability.** While the wallet is on the pre-fork variant,
+**A seam that existed between this change and the next, and does not survive into this release.** Registering a
+pre-fork variant arrived before there was any way to prove what it built, so for as long as that was true,
 `createDustGenerationTransaction`, `attachDustRegistration`, `addDustGenerationSignature`,
-`addDustRegistrationSignature`, `calculateFee`, `estimateFee` and `balanceTransactions` fail with a typed
-`PreForkDustTransactingUnsupportedError`. Each of them takes or produces a transaction of the post-fork ledger version,
-which this release has no way to prove; the seam closes with version-routed proving. Everything else works on both
-sides: synchronization, the state observable and all its projections, `balance(date)`, dust generation estimates,
-`splitNightUtxosForDustRegistration`, `revertTransaction`, addresses, serialization, restore, and the migration.
+`addDustRegistrationSignature`, `calculateFee`, `estimateFee` and `balanceTransactions` were refused by name while the
+wallet was on the pre-fork variant. Version-routed proving and pre-fork transacting close it in this same release — see
+*Transact on either side of the protocol boundary* — and `PreForkDustTransactingUnsupportedError` is not part of the
+published surface. Everything else worked on both sides throughout: synchronization, the state observable and all its
+projections, `balance(date)`, dust generation estimates, `splitNightUtxosForDustRegistration`, `revertTransaction`,
+addresses, serialization, restore, and the migration.
 
-**Two consequences, both accepted and reported rather than hidden.** (1) Every start on a chain already past the
-boundary pays one spurious migration: the wallet begins on the pre-fork variant, applies nothing, and hands over on its
-first batch. (2) **The projections fast-sync path is unreachable through the shipped `DustWallet`.** It is a post-fork
+**Two consequences, one of them since removed.** (1) A wallet with no way to ask the chain where it is pays one spurious
+migration on a chain already past the boundary: it begins on the pre-fork variant, applies nothing, and hands over on
+its first batch. The start-version probe added later in this same release removes that for a default wallet, and leaves
+it as the fallback for a wallet whose question goes unanswered. (2) **The projections fast-sync path is unreachable
+through the shipped `DustWallet`.** It is a post-fork
 capability — it needs `DustLocalState` APIs no published pre-fork ledger version has, permanently — so a two-variant
 wallet always boots the event-replay variant and would only reach projections after migrating. Fast sync therefore
 stays a **single-variant** composition (`CustomDustWallet` + `makeEventLessSyncService`, as `docs-snippets`'

--- a/.changeset/dust-v1-v2-restructure.md
+++ b/.changeset/dust-v1-v2-restructure.md
@@ -45,5 +45,6 @@ the typed error channel instead of as a defect.
 re-exports the ledger-v9 one.
 
 Nothing changes at the root entry points: `DustWallet`, `DustWalletAPI`, and friends keep their names, the production
-wallet still registers only the ledger-v9 variant, and serialized wallet states round-trip unchanged — snapshots never
+wallet registered only the ledger-v9 variant at this point — it registers one either side of the boundary by the end of
+this release — and serialized wallet states round-trip unchanged — snapshots never
 embedded the variant naming. The testkit and facade updates are internal repoints to the renamed types.

--- a/.changeset/facade-owns-the-transactions-it-accepts.md
+++ b/.changeset/facade-owns-the-transactions-it-accepts.md
@@ -17,6 +17,7 @@ methods accept.
 **Ownership decision.** The facade names it, rather than dust promoting it to a documented public export, because the
 facade has a single entry point and was exporting nothing for a type in five of its public signatures, while dust's
 declaration sits under `v2/types/` with a v8 twin under `v1/types/` — variant-scoped, and not a type whose identity
-survives the fork. This is transitional: `WalletTransaction` handles replace these signatures, at which point the
-protocol version a transaction was authored for travels with it instead of being lost at this boundary, and the alias
-goes away with them.
+survives the fork. This was transitional, and the transition happens inside this same release: `WalletTransaction` handles replace these
+signatures, so the protocol version a transaction was authored for travels with it instead of being lost at this
+boundary. The name stays — `AnyTransaction` is an alias of `AnyTx` as released, so an annotation written against it
+keeps compiling — but what it aliases is the handle rather than a dust subpath's internal.

--- a/.changeset/hd-wallet-seeds.md
+++ b/.changeset/hd-wallet-seeds.md
@@ -13,6 +13,8 @@ for a wallet that will sign with ECDSA.
 It throws rather than returning a result: this sits at a boundary an application calls directly and its failures are
 programming errors, not ordinary states. `HDWallet` remains for a caller that would rather branch on a tagged result.
 
-The derivation is pinned by test against its current behaviour, not against a published specification: the
-spec-reference vectors cover the hop *after* this one and take the per-wallet seed as given, so nothing published states
-what a master seed derives to per role. What the vectors protect is that naming the walk changed nothing.
+The derivation is pinned against the specification rather than against itself. The Wallet Specification gains a
+**Per-wallet seeds** section naming which role each of the three seeds comes from, the spec reference implements that
+walk over BIP-32 independently of this package, and the vectors it generates (`seedDerivation.json`) are what these
+tests assert against. They reproduce the values this package already derived, which is what makes them a statement of
+what a Midnight wallet is rather than a record of what this package happened to do.

--- a/.changeset/orphan-pending-on-fork.md
+++ b/.changeset/orphan-pending-on-fork.md
@@ -34,5 +34,7 @@ is never orphaned — not knowing what a transaction was authored for is not evi
 - A custom `PendingTransactionsService` must implement `orphanBeyond(chainNow)`.
 - `facade.revert` / `facade.revertTransaction` take an optional trailing `reason`. Existing calls are unaffected.
 
-`FacadeState.pending` keeps its shape; orphaned entries appear on it as items whose `result.status` is
-`'ORPHANED_BY_FORK'`.
+Underneath, an orphaned entry is one whose `result.status` is `'ORPHANED_BY_FORK'`. `FacadeState.pending` kept the
+pending set's own shape at this point and does not by the end of this release: it is `readonly PendingTransaction[]`
+with a tagged `PendingStatus` whose `Orphaned` arm carries `authoredFor` and `chainNow`, which is where an application
+reads this (see *`FacadeState.pending` is now `readonly PendingTransaction[]`*).

--- a/.changeset/shielded-fork-boundary-wiring.md
+++ b/.changeset/shielded-fork-boundary-wiring.md
@@ -47,5 +47,5 @@ state until the restart reconnects it.
 variant a migration activates; `stop` releases them. Previously a migration left the wallet with no running sync, and no
 keys to restart it with.
 
-The shielded wallet still registers a single ledger-v9 variant, so nothing about a live wallet's behaviour changes
-today.
+The shielded wallet registered a single ledger-v9 variant when this landed, so on its own it changed nothing about a
+live wallet's behaviour. It is the wiring the two-variant wallet in this same release runs on.

--- a/.changeset/shielded-required-fork-version.md
+++ b/.changeset/shielded-required-fork-version.md
@@ -45,5 +45,5 @@ Reaching further than the shielded package:
 `DefaultV1Configuration` and `DefaultV2Configuration` are unchanged and deliberately do **not** gain the field: neither
 variant knows there is another one, and `forkVersion` is the wallet layer's alone.
 
-Registration is still single-variant in this release, so nothing changes behaviourally: this is the configuration
-contract landing ahead of the two-variant wallet that consumes it.
+Registration was still single-variant when this landed, so it changed nothing behaviourally on its own: it is the
+configuration contract arriving ahead of the two-variant wallet that consumes it, which is in this same release.

--- a/.changeset/shielded-retained-start-material.md
+++ b/.changeset/shielded-retained-start-material.md
@@ -10,10 +10,13 @@ variant on the other side of a protocol boundary has nothing to start with, and 
 would sync it into nonsense. A wallet started from a seed cannot reach it at all.
 
 The shielded wallet class now retains `StartMaterial` rather than the start-aux it was handed, and resolves per
-activating variant through that variant's own `startAux` derivation. `startWithSeed` retains the seed, so a wallet built
-from one can start synchronization on any variant it is later migrated to. `start(keys)` accumulates key objects per
-variant tag — the same product a caller holding keys for both protocol versions would supply at once — and a retained
-seed supersedes them, being strictly more capable.
+activating variant through that variant's own `startAux` derivation. A seed-accepting start can therefore serve any
+variant the wallet is later migrated to, and a start given key objects accumulates them per variant tag — the same
+product a caller holding keys for both protocol versions would supply at once.
 
-Behaviour-preserving for a wallet registered over a single variant, which is every shielded wallet this release builds:
-the retention and post-migration restart tests pass unmodified.
+Two things this note said of the wallet layer change hand: by the end of this release `startWithSeed` derives both
+epochs' key objects eagerly and drops the seed with the calling frame, so what a shielded wallet retains is key
+objects for both sides rather than a seed (see *Wallets are started from seeds*); and the shielded wallet is registered
+over **two** variants rather than one (see *`ShieldedWallet(configuration)` now registers a variant either side of the
+protocol boundary*). At the point of this change it was still single-variant and therefore behaviour-preserving: the
+retention and post-migration restart tests passed unmodified.

--- a/.changeset/shielded-two-variant-wallet.md
+++ b/.changeset/shielded-two-variant-wallet.md
@@ -11,21 +11,23 @@ and takes over from there, with the cross-ledger migration that carries identity
 boundary is one number in one place: the version at which the runtime hands over is the version at which each variant
 stops applying.
 
-**Nothing an application calls changes shape.** `startWithSeed`, `restore`, `start(keys)`, the `state` observable and
-everything it projects, `waitForSyncedState`, `serializeState` and `getAddress` keep their signatures and meaning, and
-existing calls compile unchanged. What changes is what runs underneath, and three things worth knowing:
+**Registering two variants alters nothing an application calls.** The `state` observable and everything it projects,
+`waitForSyncedState`, `restore`, `serializeState` and `getAddress` keep their signatures and meaning. The start and
+transacting methods do change in this release, but for other reasons and in other notes — see *Wallets are started from
+seeds*, *Transact on either side of the protocol boundary* and *asks the chain where it is starting*. What registering
+two variants changes is what runs underneath, and three things worth knowing:
 
-- **A wallet starts on the pre-fork variant.** On a chain that has already forked it hands over on the first batch it
-  sees, having applied nothing — one migration per start, paid on chains that are entirely past the boundary. It is
-  accepted rather than hidden: removing it means asking the chain for its version before choosing a variant, which is
-  separate work. On a chain that has not forked, the wallet stays on the pre-fork variant until the chain reports a
-  version the post-fork one owns.
-- **`startWithSeed` is the only start that can follow the chain the whole way.** The seed is the one piece of key
-  material that crosses a boundary — each variant derives its own from it. `start(keys)` keeps working: the keys are
-  the post-fork ledger version's, so they are retained against that variant, and a wallet still on the pre-fork variant
-  is started from the seed it retained. A wallet built with `startWithSecretKeys` therefore starts **on the post-fork
-  variant** and stays there, because key objects belong to one ledger version's runtime and there is nothing to
-  convert; it cannot read a chain that is still pre-fork.
+- **A wallet with no way to ask the chain starts on the pre-fork variant.** On a chain that has already forked it hands
+  over on the first batch it sees, having applied nothing — one migration per start. As released this is the fallback
+  rather than the rule: the start-version probe added later in this same release asks the chain first, so a default
+  wallet on a chain past the boundary starts on the post-fork variant with no hand-over at all. Without a probe, or
+  when the question goes unanswered, the hand-over is what happens. On a chain that has not forked, the wallet stays on
+  the pre-fork variant until the chain reports a version the post-fork one owns.
+- **A seed is the only key material that can follow the chain the whole way.** Each variant derives its own from it, so
+  a wallet built from a seed can synchronize on either side of the boundary; key objects belong to one ledger version's
+  runtime and there is nothing to convert. The single-key `startWithSecretKeys` this change would have pinned to the
+  post-fork variant is **deleted** later in this same release rather than shipped — what replaces it is
+  `startWithKeys({ v8, v9 })`, which requires both sides for exactly this reason.
 - **Restoring routes on the snapshot's declared protocol version**, into whichever of the two variants wrote it. The
   serialized format is unchanged, and snapshots written by this release round-trip: a wallet that has synced past the
   boundary declares a version the post-fork variant owns, and one that has not was written by the pre-fork variant in
@@ -34,16 +36,14 @@ existing calls compile unchanged. What changes is what runs underneath, and thre
   anything, declaring `0` — it now routes to the pre-fork variant and fails to deserialize. Start such a wallet from
   its seed instead; it has no state to lose.
 
-**Temporary: building a transaction is refused while the wallet is on the pre-fork variant**, with the typed
-`PreForkTransactingUnsupportedError` naming the operation (`balanceTransaction`, `transferTransaction`, `initSwap`).
-**This seam must not survive to general availability** — mainnet is pre-fork until the fork happens, so a wallet that
-cannot transact pre-fork cannot be the wallet that ships. It closes with the version-routed proving increment, which
-routes a recipe to the prover that speaks the protocol version it was built at; until then the only proving path this
-SDK has speaks the post-fork ledger version, and there is nothing honest for the pre-fork branch to return.
-Synchronization, the state observable and everything it projects, balances, coins, addresses, serialization, restoring
-and the migration itself all work on **both** sides of the boundary. `revertTransaction` is deliberately not part of the
-seam: it builds nothing, needs no proving, and on the pre-fork variant releases nothing, because that variant cannot
-have produced the transaction being reverted.
+**A seam that existed between this change and the next, and does not survive into this release.** Registering a
+pre-fork variant arrived before there was any way to prove what it built, so for as long as that was true, building a
+transaction on the pre-fork variant was refused by name (`balanceTransaction`, `transferTransaction`, `initSwap`).
+Version-routed proving and pre-fork transacting close it in this same release — see *Transact on either side of the
+protocol boundary* — and `PreForkTransactingUnsupportedError` is not part of the published surface. No version of this
+package that an application can install refuses to transact pre-fork. Synchronization, the state observable and
+everything it projects, balances, coins, addresses, serialization, restoring and the migration itself worked on
+**both** sides of the boundary throughout.
 
 **New entry points.** `CustomForkingShieldedWallet(configuration, preFork, postFork)` builds the same shape over
 variants of your choosing, each with **its own configuration** — two variants either side of a boundary can mean

--- a/.changeset/shielded-v1-v2-restructure.md
+++ b/.changeset/shielded-v1-v2-restructure.md
@@ -24,6 +24,7 @@ ledger-v8 simulator twin only, where it previously re-exported the whole simulat
 subpath re-exports the ledger-v9 one.
 
 Nothing changes at the root entry points: `ShieldedWallet`, `ShieldedWalletAPI`, and friends keep their names, the
-production wallet still registers only the ledger-v9 variant, and serialized wallet states round-trip unchanged —
+production wallet registered only the ledger-v9 variant at this point — it registers one either side of the boundary by
+the end of this release — and serialized wallet states round-trip unchanged —
 snapshots never embedded the variant naming. The testkit and facade updates are internal repoints to the renamed
 types.

--- a/.changeset/unshielded-two-variant-fork-flip.md
+++ b/.changeset/unshielded-two-variant-fork-flip.md
@@ -7,9 +7,9 @@
 
 The shipped unshielded wallet now registers one variant either side of a protocol boundary — the pre-fork ledger version
 from the minimum supported version, the post-fork one from `configuration.forkVersion` — and follows the chain across
-it. The crossing itself is unchanged and still proven by `test/forkSimulation.test.ts`, which was rewired onto the
+it. The crossing itself is unchanged and still proven by `src/test/forkSimulation.test.ts`, which was rewired onto the
 shipped factory with **no assertion changed**: the test-only two-variant builder it used to stand on has been dissolved
-into `test/forkHarness.ts`, which is now observation and simulated infrastructure around the real wallet.
+into `src/test/forkHarness.ts`, which is now observation and simulated infrastructure around the real wallet.
 
 Unshielded's crossing is a **structural carry**, not a fresh state plus replay. Its UTXOs are public ledger data the
 wallet holds as plain records, so every one of them crosses field for field, along with the identity, the network and
@@ -46,21 +46,23 @@ What else moved:
   so it does not collide with the other wallets' same-named classes in the umbrella barrel.
 - `CustomUnshieldedWallet` is unchanged and still single-variant.
 
-**A temporary seam, which must not survive to general availability.** While the wallet is on the pre-fork variant,
+**A seam that existed between this change and the next, and does not survive into this release.** Registering a
+pre-fork variant arrived before there was any way to prove what it built, so for as long as that was true,
 `balanceFinalizedTransaction`, `balanceUnboundTransaction`, `balanceUnprovenTransaction`, `transferTransaction`,
-`rotateUtxos`, `initSwap`, `signUnprovenTransaction` and `signUnboundTransaction` fail with a typed
-`PreForkUnshieldedTransactingUnsupportedError`. Each of them takes or produces a transaction of the post-fork ledger
-version, which the pre-fork variant cannot even hold and which this release has no way to prove; the seam closes with
-version-routed proving. Everything else works on both sides: synchronization, the state observable and all its
-projections, balances, coins, the address, `revertTransaction`, serialization, restore, and the migration.
-`revertTransaction` is deliberately outside the seam — the pre-fork variant cannot have built the transaction being
+`rotateUtxos`, `initSwap`, `signUnprovenTransaction` and `signUnboundTransaction` were refused by name while the wallet
+was on the pre-fork variant. Version-routed proving and pre-fork transacting close it in this same release — see
+*Transact on either side of the protocol boundary* — and `PreForkUnshieldedTransactingUnsupportedError` is not part of
+the published surface. Everything else worked on both sides throughout: synchronization, the state observable and all
+its projections, balances, coins, the address, `revertTransaction`, serialization, restore, and the migration.
+`revertTransaction` was deliberately outside the seam — the pre-fork variant cannot have built the transaction being
 reverted so it has booked nothing to release, and the facade reverts all three wallets together when a submission
 fails.
 
-**One consequence, accepted and reported rather than hidden.** Every start on a chain already past the boundary pays one
-spurious migration: the wallet begins on the pre-fork variant, applies nothing, and hands over on the first message it
-sees. For unshielded that carries nothing across and leaves the cursor at the start, so the post-fork variant simply
-syncs the chain itself.
+**One consequence, since removed.** A wallet with no way to ask the chain where it is pays one spurious migration on a
+chain already past the boundary: it begins on the pre-fork variant, applies nothing, and hands over on the first message
+it sees. For unshielded that carries nothing across and leaves the cursor at the start, so the post-fork variant simply
+syncs the chain itself. The start-version probe added later in this same release removes that for a default wallet, and
+leaves it as the fallback for a wallet whose question goes unanswered.
 
 BREAKING CHANGE — `DefaultUnshieldedConfiguration` requires `forkVersion`. `UnshieldedWalletState.capabilities` and
 `UnshieldedWalletState.services` are removed, along with the `UnshieldedWalletCapabilities` and

--- a/.changeset/unshielded-v1-v2-restructure.md
+++ b/.changeset/unshielded-v1-v2-restructure.md
@@ -57,5 +57,6 @@ to the async signer.
 `unshielded/v2` subpath re-exports the ledger-v9 one.
 
 Nothing changes at the root entry points: `UnshieldedWallet`, `UnshieldedWalletAPI` and friends keep their names, the
-production wallet still registers only the ledger-v9 variant, and serialized wallet states round-trip unchanged —
+production wallet registered only the ledger-v9 variant at this point — it registers one either side of the boundary by
+the end of this release — and serialized wallet states round-trip unchanged —
 snapshots never embedded the variant naming. The facade update is an internal repoint to the renamed types.

--- a/.changeset/validation-at-the-authored-version.md
+++ b/.changeset/validation-at-the-authored-version.md
@@ -27,7 +27,9 @@ gained type parameters for the ledger version they speak, each defaulting to the
 annotation keeps naming exactly what it named before, and `makeDefaultValidationService(Effect)` is unchanged in
 signature and behaviour — this release is additive.
 
-Not yet wired: nothing registers the pre-fork validator, because the default block-data fetcher's codec registry is
-open-ended from the minimum supported version and holds only the current ledger's codec, so the block data reaching
-validation is always current-ledger parameters. Routing the block-data fetch on the version a block reports is what
-closes that.
+Nothing registered the pre-fork validator at this point, because the default block-data fetcher's codec registry was
+open-ended from the minimum supported version and held only the current ledger's codec, so the block data reaching
+validation was always current-ledger parameters. Routing the block-data fetch on the version a block reports is what
+closed that, later in this same release: `makeDefaultValidationServices` and `makeDefaultVersionedValidationService`
+now register a validator either side of the boundary, and the shipped pre-fork validator is reachable rather than
+merely constructible (see *Validate a transaction at the version it was authored for*).

--- a/.changeset/version-keyed-proving.md
+++ b/.changeset/version-keyed-proving.md
@@ -30,9 +30,10 @@ refusal.
   says out loud what an unversioned service was implicitly claiming.
 - `BalancingRecipe` has a required `protocolVersion`. Recipes the facade builds carry it already; only code that
   constructs a recipe by hand has to say which version it was built for.
-- `facade.finalizeTransaction(tx)` gains an optional second argument, the version the transaction was built for. Pass
-  it whenever it is known — without it the version the wallets have reached is used, which is the best available
-  answer for a transaction that never recorded what it was built for, not a correct one.
+- `facade.finalizeTransaction(tx)` briefly took an optional second argument naming the version the transaction was
+  built for. As released it takes none: a transaction crosses the facade as a `WalletTransaction` handle carrying its
+  own stamp, which is authoritative, so there is nothing left to pass and no fallback to the version the wallets have
+  reached (see *The facade speaks transaction handles*).
 - `makeDefaultProvingService` / `makeDefaultProvingServiceEffect` take a `ServerProvingConfiguration` (required URL).
   `makeDefaultVersionedProvingService` is the version-routed equivalent and returns an `Either`.
 - `ProvingService<TProven>` is now `ProvingService<TProven, TUnproven = ledger.UnprovenTransaction>`. Existing

--- a/.changeset/version-routed-ledger-parameters.md
+++ b/.changeset/version-routed-ledger-parameters.md
@@ -29,5 +29,8 @@ always been on `Block` in the indexer schema.
   which ledger to use has to be read before the parameters are decoded, the same reason the shielded event payload
   keeps its `raw`. `BlockDataSchema` is now the default-codec instance of `makeBlockDataSchema(codecs)`; pass your own
   registry to bound a variant to the range it is active over.
-- `makeDefaultBlockDataFetcher` and dust's `makeDefaultSyncService` accept an optional `ledgerParametersCodecs`. Both
-  default to claiming every protocol version, so a single-variant wallet is unaffected.
+- `makeDefaultBlockDataFetcher` and dust's `makeDefaultSyncService` accept an optional `ledgerParametersCodecs`. Dust's
+  defaults to claiming every protocol version, so a single-variant wallet is unaffected. The block-data fetcher's
+  configuration also gains a **required** `forkVersion` by the end of this release, and its default registry is split at
+  it rather than claiming everything: `defaultLedgerParametersCodecs` becomes a function of the fork version (see
+  *Validate a transaction at the version it was authored for, on a chain with a protocol boundary*).

--- a/.changeset/wallet-transaction-handle.md
+++ b/.changeset/wallet-transaction-handle.md
@@ -29,5 +29,7 @@ either one names a ledger version, and breaks when the chain moves on.
   because choosing a ledger version is the caller's to make and hardcoding one here would be the very thing the handle
   removes.
 
-Nothing routes through the handle yet — the wallets and the facade still name ledger types in their own signatures.
-This is the type they will be stated in terms of.
+This is the type the wallets and the facade are stated in terms of. Nothing routed through it at the point this landed;
+by the end of this release everything does — every public method that took or returned a ledger transaction takes or
+returns a handle instead (see *The facade speaks transaction handles* and *Transact on either side of the protocol
+boundary*).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Key documents:
 
 ### API Usage Examples
 
-**Package:** `packages/docs-snippets`
+**Package:** `packages/docs-snippets` (the snippets themselves are in `packages/docs-snippets/src/snippets/`)
 
 Contains working code examples for common wallet operations:
 
@@ -83,7 +83,14 @@ Contains working code examples for common wallet operations:
 - `swap.ts` - Token swap (intent creation)
 - `balancing.ts` - Transaction balancing
 - `initialization.ts` - Wallet initialization
+- `ecdsa-initialization.ts` - Wallet initialization with an ECDSA unshielded identity
 - `dust-fast-sync.ts` - Wallet initialization with projections-based dust fast sync
+- `designation.ts` / `redesignation.ts` / `deregistration.ts` - Registering Night for dust generation, and undoing it
+- `dust-sponsorship.ts` - Paying another party's fees
+- `wasm-prover.ts` - In-process proving
+- `well-formed-validation.ts` - Validating a transaction before submission
+- `terms-and-conditions.ts` - Fetching terms and conditions
+- `addresses.no-net.ts` / `hd.no-net.ts` - Address formatting and HD derivation (no network needed)
 
 **IMPORTANT:** Always refer to docs-snippets for API usage patterns when implementing new features.
 
@@ -289,6 +296,30 @@ Each variant follows a Services + Capabilities pattern:
 
 Capabilities operate on state synchronously; services provide data that capabilities process.
 
+### The v1/v2 Twin Convention
+
+Each of the three wallet packages holds **two variants of the same wallet**, one per ledger version, in sibling
+directories under `src/`:
+
+- **`src/v1`** - the **pre-fork** variant, on `@midnight-ntwrk/ledger-v8`. Active below the chain's `forkVersion`.
+- **`src/v2`** - the **current** variant, on `@midnightntwrk/ledger-v9`. Active from `forkVersion` upwards.
+
+The two trees are near-identical modulo the ledger import: same file names, same exports with `V1`/`V2` in their names.
+
+**Working rule: edit `v2`, then mirror the change into `v1` with the ledger swapped.** `v2` is where a change belongs
+first, because it is what the chain will be running. A change that lands in only one twin is a bug that shows up as a
+wallet that misbehaves on one side of the fork.
+
+**Justified `v9`-only exclusions.** A few things are deliberately absent from `v1` because no published ledger-v8 has
+the API they need — the largest is dust's projections-based fast sync (`makeEventLessSyncService`), which rests on
+`DustLocalState` members that exist only in v9 and cannot be back-ported. These are permanent, not gaps to be closed;
+each is documented where it is excluded. Do not "fix" a missing `v1` counterpart without checking whether it is one of
+them.
+
+**The wallet layer above the twins is single.** `ShieldedWallet` / `DustWallet` / `UnshieldedWallet` each register both
+variants and hand over at `configuration.forkVersion`; the package's own `Default*Configuration` is declared by the
+package, not aliased to either variant's. `Custom*Wallet(configuration, builder)` is the single-variant composition.
+
 ### State Management
 
 Uses Effect library with `SubscriptionRef` for BLoC-like state management:
@@ -308,7 +339,15 @@ Uses Effect library with `SubscriptionRef` for BLoC-like state management:
     is configured in tsconfig.base.json as a TypeScript plugin.
 - **RxJS** (`rxjs`) - Observable streams for reactive state
   - Only in APIs exposed to the users of the SDK
-- **@midnight-ntwrk/ledger-v8** - Core ledger types and ZK proof types
+- **Two ledgers, side by side** - the SDK runs the pre-fork ledger below the protocol boundary and the current one from
+  it, so both are installed and both are real:
+  - **`@midnight-ntwrk/ledger-v8`** - the pre-fork ledger (`v1` variants)
+  - **`@midnightntwrk/ledger-v9`** - the current ledger (`v2` variants)
+  - **Watch the scope.** `@midnight-ntwrk` (hyphenated) and `@midnightntwrk` (not) are **two different npm orgs**, and
+    the two ledgers are published under different ones. One character decides which package you import; getting it wrong
+    yields a module-not-found for a package that plainly exists. Copy the specifier, do not type it.
+  - Never hardcode a ledger version in SDK code that a wallet runs. Version travels as `ProtocolVersion` data;
+    `packages/abstractions/src/WalletTransaction.ts` is how a transaction carries the version that built it.
 
 ## Testing
 
@@ -511,7 +550,7 @@ const ProtocolVersion = Brand.nominal<ProtocolVersion>();
 
 **Canonical examples:**
 
-- `packages/dapp-connector-reference/src/parsing.ts` - `parseTokenType`, `parseShieldedAddress`
+- `packages/abstractions/src/TokenType.ts` - `parseTokenType` returns `Either<TokenType, InvalidTokenTypeError>`
 - `packages/abstractions/src/ProtocolVersion.ts` - Branded type with `Brand.nominal`
 - `packages/address-format/src/index.ts` - Bech32m parsing returns typed addresses
 
@@ -1055,19 +1094,25 @@ When implementing new features, refer to these exemplary files:
 | Tagged enum ADT                      | `packages/runtime/src/abstractions/StateChange.ts`                            |
 | Service/Capability separation        | `packages/capabilities/src/pendingTransactions/pendingTransactionsService.ts` |
 | Pure state transformations           | `packages/unshielded-wallet/src/v1/UnshieldedState.ts`                        |
-| Parse don't validate                 | `packages/dapp-connector-reference/src/parsing.ts`                            |
+| Parse don't validate                 | `packages/abstractions/src/TokenType.ts`                                      |
 | Branded types                        | `packages/abstractions/src/ProtocolVersion.ts`                                |
 
 ## Transaction Inspection
 
-When working with transactions (especially in tests), use the ledger types from `@midnight-ntwrk/ledger-v7`.
+When working with transactions (especially in tests), use the ledger types of the version that produced them. There are
+two, and which one applies is decided by the transaction's own protocol version, not by which one is easier to import:
+`@midnightntwrk/ledger-v9` from the protocol boundary, `@midnight-ntwrk/ledger-v8` below it (mind the scope hyphen — see
+Key Dependencies). A `WalletTransaction` handle carries that version as data;
+`WalletTransaction.unwrapWithin(handle, range)` is how a test gets at the transaction inside, and it refuses a stamp
+outside the range rather than handing bytes to a ledger that would misread them.
 
 ### Key References
 
 **Ledger TypeScript Types:**
 
-- `node_modules/@midnight-ntwrk/ledger-v7/ledger-v7.d.ts` - Full type definitions for Transaction, Intent, ZswapOffer,
-  DustActions, etc.
+- `node_modules/@midnightntwrk/ledger-v9/ledger-v9.d.ts` - Full type definitions for Transaction, Intent, ZswapOffer,
+  DustActions, etc. (current ledger)
+- `node_modules/@midnight-ntwrk/ledger-v8/ledger-v8.d.ts` - The same, for the pre-fork ledger
 
 **Ledger Specification (midnight-ledger repo):**
 
@@ -1078,15 +1123,16 @@ When working with transactions (especially in tests), use the ledger types from 
 
 **Wallet SDK Examples:**
 
-- `packages/unshielded-wallet/src/v1/Transacting.ts` - Transaction building patterns
-- `packages/unshielded-wallet/src/v1/test/transacting.test.ts` - Transaction test examples
-- `packages/docs-snippets/` - API usage examples for transfers, swaps, balancing
+- `packages/unshielded-wallet/src/v2/Transacting.ts` - Transaction building patterns (`v1` is its pre-fork twin)
+- `packages/unshielded-wallet/src/v2/test/transacting.test.ts` - Transaction test examples
+- `packages/docs-snippets/src/snippets/` - API usage examples for transfers, swaps, balancing
 
-**DApp Connector Reference Tests:**
+**Transaction inspection in tests:**
 
-- `packages/dapp-connector-reference/src/test/transfer.test.ts` - Transaction inspection helpers (deserialize, check
-  balance, count outputs, verify DustSpend)
-- `packages/dapp-connector-reference/src/test/intent.test.ts` - Intent imbalance verification helpers
+- `packages/dust-wallet/src/v2/test/transacting.test.ts` - Reading `intent.dustActions` registrations and spends off a
+  built transaction
+- `packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts` - Checking a transaction's imbalances per segment
+- `packages/shielded-wallet/src/v2/test/transacting.test.ts` - Inspecting offers, inputs and outputs
 
 ### Key Concepts
 

--- a/docs/spec/Specification.md
+++ b/docs/spec/Specification.md
@@ -48,6 +48,7 @@ This document comprises a couple of sections:
     - [Summary](#summary)
   - [Key management](#key-management)
     - [HD Wallet structure](#hd-wallet-structure)
+    - [Per-wallet seeds](#per-wallet-seeds)
     - [Night and unshielded tokens keys](#night-and-unshielded-tokens-keys)
     - [Dust keys](#dust-keys)
     - [Shielded token (Zswap) keys](#shielded-token-zswap-keys)
@@ -280,6 +281,42 @@ Where:
 > Generally treating keys as uniform bitstrings should not be done, though in this particular case, where secp256k1 base
 > field is so close in size to 2^256, it is found that impact on security is negligible, which makes this approach
 > acceptable.
+
+### Per-wallet seeds
+
+Sections below describe what each of a wallet's keys is generated from - a seed, treated as uniform bytes. This section
+describes where those seeds come from, since a wallet holds one master seed and needs three: one for unshielded tokens,
+one for Dust and one for shielded tokens.
+
+All three are secret keys derived from the master seed in the tree described above, at the same account and address
+index, differing only in the role:
+
+| Seed       | Role                                  | Value | Path                                     |
+| ---------- | ------------------------------------- | ----- | ---------------------------------------- |
+| Unshielded | Unshielded (and Night) External chain | 0     | `m / 44' / 2400' / account' / 0 / index` |
+| Dust       | Dust                                  | 2     | `m / 44' / 2400' / account' / 2 / index` |
+| Shielded   | Shielded                              | 3     | `m / 44' / 2400' / account' / 3 / index` |
+
+Where `account` and `index` follow BIP-44 recommendations, and a wallet with no reason to choose otherwise uses `0` for
+both. In a TS pseudocode:
+
+```ts
+type WalletSeeds = { unshielded: Buffer; dust: Buffer; shielded: Buffer };
+function walletSeeds(masterSeed: Buffer, account: number, index: number): WalletSeeds {
+  const seedAt = (role: number) => privateKeyAt(masterSeed, `m/44'/${2400}'/${account}'/${role}/${index}`);
+  return { unshielded: seedAt(0), dust: seedAt(2), shielded: seedAt(3) };
+}
+```
+
+What is taken at each path is the 32 bytes of the private key itself, and not an extended key: chain code and depth
+belong to the derivation and not to what the seed is used for. This is what makes a seed portable between
+implementations - two wallets given the same master seed, account and index arrive at the same keys and the same
+addresses, without agreeing on anything but the path.
+
+> [!NOTE] The role is what keeps the three apart, so no seed derived for one of them is ever the seed of another. For
+> the same reason, a wallet signing unshielded transactions with a signature scheme other than the one role 0 is used
+> with takes its unshielded seed from the role that scheme is assigned, rather than reusing role 0's secret scalar under
+> a second algorithm. Its Dust and shielded seeds are unaffected.
 
 ### Night and unshielded tokens keys
 

--- a/packages/dust-wallet/src/test/forkHarness.ts
+++ b/packages/dust-wallet/src/test/forkHarness.ts
@@ -49,11 +49,7 @@ import { type NetworkId, type ProtocolState, type ProtocolVersion } from '@midni
 import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { Deferred, Effect, FiberId, Option, Stream, pipe } from 'effect';
-import {
-  CustomForkingDustWallet,
-  type ForkingDustWallet,
-  type ForkingDustWalletClass,
-} from '../ForkingDustWallet.js';
+import { CustomForkingDustWallet, type ForkingDustWallet, type ForkingDustWalletClass } from '../ForkingDustWallet.js';
 import { type CoreWallet as PreForkWallet } from '../v1/CoreWallet.js';
 import * as PreForkSync from '../v1/Sync.js';
 import { V1Builder } from '../v1/V1Builder.js';
@@ -324,8 +320,8 @@ export type ForkWallet = Readonly<{
    * The class the wallet was started from, so a snapshot can be restored through the same registration that wrote it.
    *
    * @remarks
-   *   Restoring is a class-level entry point, not an instance one — it is how an application gets a wallet in the
-   *   first place — so a proof about restoring needs the class and not merely the running wallet.
+   *   Restoring is a class-level entry point, not an instance one — it is how an application gets a wallet in the first
+   *   place — so a proof about restoring needs the class and not merely the running wallet.
    */
   walletClass: ForkingDustWalletClass<PreForkSync.WalletSyncUpdate, PostForkUpdate>;
   /** A dust key of each ledger version, derived from the same seed. */

--- a/packages/dust-wallet/src/test/forkHarness.ts
+++ b/packages/dust-wallet/src/test/forkHarness.ts
@@ -49,7 +49,11 @@ import { type NetworkId, type ProtocolState, type ProtocolVersion } from '@midni
 import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { Deferred, Effect, FiberId, Option, Stream, pipe } from 'effect';
-import { CustomForkingDustWallet, type ForkingDustWallet } from '../ForkingDustWallet.js';
+import {
+  CustomForkingDustWallet,
+  type ForkingDustWallet,
+  type ForkingDustWalletClass,
+} from '../ForkingDustWallet.js';
 import { type CoreWallet as PreForkWallet } from '../v1/CoreWallet.js';
 import * as PreForkSync from '../v1/Sync.js';
 import { V1Builder } from '../v1/V1Builder.js';
@@ -316,6 +320,14 @@ export type ForkedState = ProtocolState.ProtocolState<PreForkWallet | PostForkWa
 export type ForkWallet = Readonly<{
   /** The wallet itself, exactly as an application would hold it. */
   dust: ForkingDustWallet<PreForkSync.WalletSyncUpdate, PostForkUpdate>;
+  /**
+   * The class the wallet was started from, so a snapshot can be restored through the same registration that wrote it.
+   *
+   * @remarks
+   *   Restoring is a class-level entry point, not an instance one — it is how an application gets a wallet in the
+   *   first place — so a proof about restoring needs the class and not merely the running wallet.
+   */
+  walletClass: ForkingDustWalletClass<PreForkSync.WalletSyncUpdate, PostForkUpdate>;
   /** A dust key of each ledger version, derived from the same seed. */
   keys: Readonly<{ preFork: PreForkSecretKey; postFork: PostForkSecretKey }>;
   /** Starts background sync through the wallet's own API, which resolves the key material each variant can use. */
@@ -413,6 +425,8 @@ export const makeForkWallet = (config: ForkWalletConfig): Effect.Effect<ForkWall
 
       return {
         dust: wallet,
+
+        walletClass: WalletClass,
 
         keys: { preFork: preForkKey, postFork: postForkKey },
 

--- a/packages/dust-wallet/src/test/forkRestore.test.ts
+++ b/packages/dust-wallet/src/test/forkRestore.test.ts
@@ -1,0 +1,159 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Restoring a snapshot into the variant that wrote it, through the wallet class an application holds.
+ *
+ * @remarks
+ *   `tryRestore.test.ts` pins what a snapshot the wallet cannot read does, and the runtime pins `startAtVariant` over
+ *   synthetic variants. Neither says that the pieces meet correctly in a shipped forking wallet, which is the
+ *   composition an application actually calls: peek at the snapshot, resolve the variant that owns the version it
+ *   declares, deserialize with *that* variant's deserializer, and start there.
+ *
+ *   Both epochs are pinned in one file on purpose. A router that always answered with the head variant would pass the
+ *   pre-fork half and fail the post-fork one; a router that always answered with the last registration would do the
+ *   reverse. Only routing on the snapshot's own declared version passes both.
+ *
+ *   The snapshots are the suite's own: each is written by a running wallet through `serializeState()`, so what is
+ *   restored is what this package actually produces rather than a fixture that could drift from it.
+ */
+
+import { LedgerParameters as PreForkLedgerParameters } from '@midnight-ntwrk/ledger-v8';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
+import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { Deferred, Effect, Option, Queue, type Scope, Stream, pipe } from 'effect';
+import * as rx from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+import { peekProtocolVersion } from '../Restore.js';
+import { V1Tag } from '../v1/RunningV1Variant.js';
+import { DUST_EVENT_COUNT, type DustChain, buildDustChain, dustSeed } from '../v1/test/dustEvents.js';
+import { V2Tag } from '../v2/RunningV2Variant.js';
+import { dustParameters as postForkDustParameters } from '../v2/test/dustEvents.js';
+import { type ForkWallet, makeForkWallet } from './forkHarness.js';
+import { type TimelineEvent, numberedFrom } from './forkReplay.js';
+import { balanceAt, dustCount } from './forkWalletAssertions.js';
+
+// Building a real dust chain (rewards + registrations through WASM) does not fit vitest's 5s default on a CI runner.
+vi.setConfig({ testTimeout: 60_000 });
+
+const networkId = NetworkId.NetworkId.Undeployed;
+
+/** Where the wallet registers its post-fork variant. */
+const forkVersion = ProtocolVersion.ProtocolVersion(7n);
+/** A chain that has already forked — past the boundary rather than exactly at it. */
+const afterFork = ProtocolVersion.ProtocolVersion(9n);
+/** A chain that has not — a version the pre-fork variant owns. */
+const beforeFork = ProtocolVersion.ProtocolVersion(5n);
+
+const dustParameters = {
+  preFork: PreForkLedgerParameters.initialParameters().dust,
+  postFork: postForkDustParameters(),
+};
+
+/** A wallet pointed at a timeline every event of which is reported at `version`. */
+const walletOnChainAt = (
+  chain: DustChain,
+  version: ProtocolVersion.ProtocolVersion,
+  chainVersionProbe: ChainVersionProbe,
+): Effect.Effect<ForkWallet, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const history: readonly TimelineEvent[] = numberedFrom(chain.eventBytes, 1, Number(version));
+    const wire = yield* Queue.unbounded<readonly TimelineEvent[]>();
+    const replayed = yield* Deferred.make<readonly TimelineEvent[]>();
+
+    const wallet = yield* makeForkWallet({
+      preFork: Stream.fromQueue(wire),
+      replayed: Deferred.await(replayed),
+      networkId,
+      forkVersion,
+      seed: dustSeed(),
+      dustParameters,
+      syncTime: chain.syncTime,
+      chainVersionProbe,
+    });
+    yield* Effect.addFinalizer(() => wallet.stop);
+    yield* wallet.start;
+
+    yield* Queue.offer(wire, history);
+    yield* Deferred.succeed(replayed, history);
+
+    return wallet;
+  });
+
+/** A probe answering as a chain on `version` would. */
+const chainReporting =
+  (version: ProtocolVersion.ProtocolVersion): ChainVersionProbe =>
+  () =>
+    Promise.resolve(version);
+
+/** The tag of the variant a wallet is running, read the way the harness reads it of the wallet it started. */
+const runningTag = (wallet: ForkWallet['dust']): Effect.Effect<string | symbol> =>
+  pipe(
+    wallet.runtime.currentVariant,
+    Effect.map((current) => current.runningVariant.__polyTag__),
+  );
+
+/** The first state a restored wallet publishes, which is the one it was restored onto. */
+const restoredState = (wallet: ForkWallet['dust']) => Effect.promise(() => rx.firstValueFrom(wallet.state));
+
+describe('a dust wallet restoring a snapshot through the class it was started from', () => {
+  it('restores a snapshot written below the boundary onto the pre-fork variant, with what it held', async () =>
+    Effect.gen(function* () {
+      const chain = yield* Effect.promise(() => buildDustChain());
+      const wallet = yield* walletOnChainAt(chain, beforeFork, chainReporting(beforeFork));
+
+      const synced = yield* wallet.awaitState((state) => dustCount(state.state) === DUST_EVENT_COUNT);
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+
+      const snapshot = yield* Effect.promise(() => wallet.dust.serializeState());
+      // The snapshot names the epoch that wrote it, which is the only thing the restore has to go on.
+      expect(Option.getOrThrow(peekProtocolVersion(snapshot))).toBe(synced.state.protocolVersion);
+      expect(synced.state.protocolVersion).toBeLessThan(forkVersion);
+
+      const restored = wallet.walletClass.restore(snapshot);
+      yield* Effect.addFinalizer(() => Effect.promise(() => restored.stop()));
+
+      expect(yield* runningTag(restored)).toBe(V1Tag);
+
+      const state = yield* restoredState(restored);
+      expect(state.protocolVersion).toBeLessThan(forkVersion);
+      expect(dustCount(state.state)).toBe(DUST_EVENT_COUNT);
+      expect(balanceAt(state.state, chain.syncTime)).toBe(balanceAt(synced.state, chain.syncTime));
+      expect(state.state.publicKey.publicKey).toBe(synced.state.publicKey.publicKey);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('restores a snapshot written at or past the boundary onto the post-fork variant, with what it held', async () =>
+    Effect.gen(function* () {
+      const chain = yield* Effect.promise(() => buildDustChain());
+      const wallet = yield* walletOnChainAt(chain, afterFork, chainReporting(afterFork));
+
+      const synced = yield* wallet.awaitState((state) => dustCount(state.state) === DUST_EVENT_COUNT);
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+
+      const snapshot = yield* Effect.promise(() => wallet.dust.serializeState());
+      expect(Option.getOrThrow(peekProtocolVersion(snapshot))).toBe(synced.state.protocolVersion);
+      expect(synced.state.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
+
+      const restored = wallet.walletClass.restore(snapshot);
+      yield* Effect.addFinalizer(() => Effect.promise(() => restored.stop()));
+
+      expect(yield* runningTag(restored)).toBe(V2Tag);
+
+      const state = yield* restoredState(restored);
+      expect(state.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
+      expect(dustCount(state.state)).toBe(DUST_EVENT_COUNT);
+      expect(balanceAt(state.state, chain.syncTime)).toBe(balanceAt(synced.state, chain.syncTime));
+      expect(state.state.publicKey.publicKey).toBe(synced.state.publicKey.publicKey);
+    }).pipe(Effect.scoped, Effect.runPromise));
+});

--- a/packages/dust-wallet/src/test/forkRestore.test.ts
+++ b/packages/dust-wallet/src/test/forkRestore.test.ts
@@ -18,7 +18,7 @@
  *   `tryRestore.test.ts` pins what a snapshot the wallet cannot read does, and the runtime pins `startAtVariant` over
  *   synthetic variants. Neither says that the pieces meet correctly in a shipped forking wallet, which is the
  *   composition an application actually calls: peek at the snapshot, resolve the variant that owns the version it
- *   declares, deserialize with *that* variant's deserializer, and start there.
+ *   declares, deserialize with _that_ variant's deserializer, and start there.
  *
  *   Both epochs are pinned in one file on purpose. A router that always answered with the head variant would pass the
  *   pre-fork half and fail the post-fork one; a router that always answered with the last registration would do the

--- a/packages/dust-wallet/src/test/forkRestore.test.ts
+++ b/packages/dust-wallet/src/test/forkRestore.test.ts
@@ -31,7 +31,6 @@
 import { LedgerParameters as PreForkLedgerParameters } from '@midnight-ntwrk/ledger-v8';
 import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
-import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { Deferred, Effect, Option, Queue, type Scope, Stream, pipe } from 'effect';
 import * as rx from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';

--- a/packages/facade/test/protocolPhaseWiring.test.ts
+++ b/packages/facade/test/protocolPhaseWiring.test.ts
@@ -1,0 +1,276 @@
+/*
+ * This file is part of MIDNIGHT-WALLET-SDK.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * What the facade makes of three wallets that disagree about which side of the protocol boundary the chain is on.
+ *
+ * @remarks
+ *   `protocolPhase.test.ts` pins `protocolPhaseOf` itself, over versions handed to it directly. This is the other half:
+ *   that the three wallets' own state streams reach it, each in its own slot, and that the answer follows them as they
+ *   cross. `orphanOnFork.test.ts` reads `protocol` too, but only of three wallets that have never synchronized — which
+ *   is the `Settled` arm and cannot be anything else.
+ *
+ *   Real disagreement is manufactured rather than simulated. Driving three wallets across a real fork means three
+ *   simulated chains, a replay and a cross-ledger migration inside one facade suite, which proves the wallets rather
+ *   than the wiring. What is under test here is a `combineLatest` and three property reads, so the three states are the
+ *   wallets' own — taken from real, shipped, unstarted wallets — restated at the versions a crossing would put them at.
+ *
+ *   The versions are deliberately all different where they can be, so a wiring that read one wallet's version three
+ *   times, or paired the wrong wallet with the wrong slot, fails rather than coincidentally passes.
+ */
+
+import * as ledger from '@midnightntwrk/ledger-v9';
+import {
+  InMemoryTransactionHistoryStorage,
+  NetworkId,
+  ProtocolVersion,
+  type FinalizedTx,
+} from '@midnightntwrk/wallet-sdk-abstractions';
+import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
+import type { PendingTransactionsService } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
+import { DustWallet, DustWalletState } from '@midnightntwrk/wallet-sdk-dust-wallet';
+import { ShieldedWallet, ShieldedWalletState, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import {
+  createKeystore,
+  PublicKey,
+  UnshieldedWallet,
+  UnshieldedWalletState,
+} from '@midnightntwrk/wallet-sdk-unshielded-wallet';
+import { Option } from 'effect';
+import * as rx from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type DefaultConfiguration, WalletEntrySchema, WalletFacade, mergeWalletEntries } from '../src/index.js';
+
+import { createPreForkMockProvingService, getDustSeed, getShieldedSeed, getUnshieldedSeed } from './utils/index.js';
+
+/** The boundary the facade reads `protocol` against. */
+const forkVersion = V9_NATIVE_FORK_VERSION;
+
+/** Three versions below the boundary, all different: ordinary drift within one epoch. */
+const beforeFork = {
+  shielded: ProtocolVersion.ProtocolVersion(3n),
+  unshielded: ProtocolVersion.ProtocolVersion(1n),
+  dust: ProtocolVersion.ProtocolVersion(2n),
+} as const;
+
+/** Two versions at or past it, different again: a wallet that has crossed need not be at the boundary exactly. */
+const afterFork = {
+  shielded: ProtocolVersion.ProtocolVersion(forkVersion + 5n),
+  dust: forkVersion,
+} as const;
+
+/** A pending service that answers and records, so the facade's own orphaning subscription has somewhere to go. */
+class SilentPendingTransactions implements PendingTransactionsService<FinalizedTx> {
+  readonly states = new rx.BehaviorSubject<PendingTransactions.PendingTransactions<FinalizedTx>>(
+    PendingTransactions.empty(),
+  );
+
+  start(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  stop(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  state(): rx.Observable<PendingTransactions.PendingTransactions<FinalizedTx>> {
+    return this.states.asObservable();
+  }
+
+  addPendingTransaction(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  clear(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  orphanBeyond(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/**
+ * The same wallet state, restated at another protocol version.
+ *
+ * @remarks
+ *   Everything but the version is the wallet's own: the core state it published and its own projections, delegated
+ *   through. Only what a crossing would change is changed, so what reaches the facade is a state of exactly the shape
+ *   the wallet publishes.
+ */
+const shieldedAt = (state: ShieldedWalletState, version: ProtocolVersion.ProtocolVersion): ShieldedWalletState =>
+  new ShieldedWalletState(version, state.state, {
+    balances: () => state.balances,
+    totalCoins: () => state.totalCoins,
+    availableCoins: () => state.availableCoins,
+    pendingCoins: () => state.pendingCoins,
+    coinPublicKey: () => state.coinPublicKey,
+    encryptionPublicKey: () => state.encryptionPublicKey,
+    address: () => state.address,
+    serialize: () => state.serialize(),
+  });
+
+const unshieldedAt = (state: UnshieldedWalletState, version: ProtocolVersion.ProtocolVersion): UnshieldedWalletState =>
+  new UnshieldedWalletState(version, state.state, {
+    balances: () => state.balances,
+    totalCoins: () => state.totalCoins,
+    availableCoins: () => state.availableCoins,
+    pendingCoins: () => state.pendingCoins,
+    address: () => state.address,
+    serialize: () => state.serialize(),
+  });
+
+const dustAt = (state: DustWalletState, version: ProtocolVersion.ProtocolVersion): DustWalletState =>
+  new DustWalletState(version, state.state, {
+    totalCoins: () => state.totalCoins,
+    availableCoins: () => state.availableCoins,
+    pendingCoins: () => state.pendingCoins,
+    publicKey: () => state.publicKey,
+    address: () => state.address,
+    balance: (time) => state.balance(time),
+    estimateDustGeneration: (utxos, time) => state.estimateDustGeneration(utxos, time),
+    splitNightUtxos: (utxos) => state.splitNightUtxos(utxos),
+    serialize: () => state.serialize(),
+  });
+
+/** Replaces a wallet's state stream with one this suite drives, leaving everything else about the wallet real. */
+const drivenBy = <TWallet extends object, TState>(
+  wallet: TWallet,
+  states: rx.Observable<TState>,
+): rx.Observable<TState> => {
+  Object.defineProperty(wallet, 'state', { value: states, configurable: true });
+  return states;
+};
+
+describe('three wallets that disagree about which side of the boundary the chain is on', () => {
+  let facade: WalletFacade;
+  let shieldedStates: rx.BehaviorSubject<ShieldedWalletState>;
+  let unshieldedStates: rx.BehaviorSubject<UnshieldedWalletState>;
+  let dustStates: rx.BehaviorSubject<DustWalletState>;
+
+  beforeEach(async () => {
+    const configuration: DefaultConfiguration = {
+      networkId: NetworkId.NetworkId.Undeployed,
+      forkVersion,
+      relayURL: new URL('http://localhost:9944'),
+      indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
+      provingServerUrl: new URL('http://localhost:6300'),
+      costParameters: { feeBlocksMargin: 0 },
+      txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
+    };
+    const seed = '0000000000000000000000000000000000000000000000000000000000000002';
+    const keystore = createKeystore({ kind: 'schnorr', secret: getUnshieldedSeed(seed) }, configuration.networkId);
+
+    // Real, shipped wallets, deliberately never started: this suite supplies their state stream, and starting them
+    // would open indexer subscriptions it has no indexer for.
+    const shielded = await ShieldedWallet(configuration).startWithSeed(getShieldedSeed(seed));
+    const unshielded = await UnshieldedWallet(configuration).startWithPublicKey(PublicKey.fromKeyStore(keystore));
+    const dust = await DustWallet(configuration).startWithSeed(
+      getDustSeed(seed),
+      ledger.LedgerParameters.initialParameters().dust,
+    );
+
+    shieldedStates = new rx.BehaviorSubject(
+      shieldedAt(await rx.firstValueFrom(shielded.state), beforeFork.shielded),
+    );
+    unshieldedStates = new rx.BehaviorSubject(
+      unshieldedAt(await rx.firstValueFrom(unshielded.state), beforeFork.unshielded),
+    );
+    dustStates = new rx.BehaviorSubject(dustAt(await rx.firstValueFrom(dust.state), beforeFork.dust));
+
+    drivenBy(shielded, shieldedStates);
+    drivenBy(unshielded, unshieldedStates);
+    drivenBy(dust, dustStates);
+
+    facade = await WalletFacade.init({
+      configuration,
+      shielded: () => shielded,
+      unshielded: () => unshielded,
+      dust: () => dust,
+      provingService: () => createPreForkMockProvingService(),
+      pendingTransactionsService: () => new SilentPendingTransactions(),
+    });
+  });
+
+  afterEach(async () => {
+    await facade?.stop();
+  });
+
+  it('reports each wallet in its own slot, and calls a chain none of them has left settled', async () => {
+    const observed = await rx.firstValueFrom(facade.state());
+
+    // Three different versions, so a wiring that read one wallet three times cannot pass this.
+    expect(observed.protocolVersion).toStrictEqual(beforeFork);
+    expect(observed.activeProtocolVersion).toBe(beforeFork.unshielded);
+    // Differing versions within one epoch are ordinary synchronization, not a crossing.
+    expect(observed.protocol).toStrictEqual({ _tag: 'Settled', version: beforeFork.unshielded });
+  });
+
+  it('calls the chain crossing while one wallet is still on the near side, and names it', async () => {
+    shieldedStates.next(shieldedAt(shieldedStates.value, afterFork.shielded));
+    dustStates.next(dustAt(dustStates.value, afterFork.dust));
+
+    const observed = await rx.firstValueFrom(facade.state());
+
+    expect(observed.protocol).toStrictEqual({
+      _tag: 'Crossing',
+      from: beforeFork.unshielded,
+      to: afterFork.shielded,
+      behind: ['unshielded'],
+    });
+    // What the facade stays bound to meanwhile is what it acts at: the wallet still behind bounds all three.
+    expect(observed.activeProtocolVersion).toBe(beforeFork.unshielded);
+  });
+
+  it('names every wallet still on the near side, in a fixed order', async () => {
+    shieldedStates.next(shieldedAt(shieldedStates.value, afterFork.shielded));
+
+    const observed = await rx.firstValueFrom(facade.state());
+
+    expect(observed.protocol).toStrictEqual({
+      _tag: 'Crossing',
+      from: beforeFork.unshielded,
+      to: afterFork.shielded,
+      behind: ['unshielded', 'dust'],
+    });
+  });
+
+  it('settles again once the last wallet has crossed, at the version they all now report', async () => {
+    shieldedStates.next(shieldedAt(shieldedStates.value, afterFork.shielded));
+    dustStates.next(dustAt(dustStates.value, afterFork.dust));
+    expect((await rx.firstValueFrom(facade.state())).protocol._tag).toBe('Crossing');
+
+    unshieldedStates.next(unshieldedAt(unshieldedStates.value, forkVersion));
+
+    const observed = await rx.firstValueFrom(facade.state());
+
+    // The phase follows the streams rather than the moment the facade was built, which is the whole of the wiring.
+    expect(observed.protocol).toStrictEqual({ _tag: 'Settled', version: forkVersion });
+    expect(observed.activeProtocolVersion).toBe(forkVersion);
+  });
+
+  it('keeps the phase readable while a pending transaction is stamped at the version it acts at', async () => {
+    shieldedStates.next(shieldedAt(shieldedStates.value, afterFork.shielded));
+    dustStates.next(dustAt(dustStates.value, afterFork.dust));
+
+    const observed = await rx.firstValueFrom(facade.state());
+
+    // `from` is not a second opinion: it is the version the facade acts at, which is what anything built during the
+    // crossing window is stamped with.
+    expect(observed.protocol._tag === 'Crossing' ? Option.some(observed.protocol.from) : Option.none()).toStrictEqual(
+      Option.some(observed.activeProtocolVersion),
+    );
+  });
+});

--- a/packages/facade/test/protocolPhaseWiring.test.ts
+++ b/packages/facade/test/protocolPhaseWiring.test.ts
@@ -25,7 +25,8 @@
  *   Real disagreement is manufactured rather than simulated. Driving three wallets across a real fork means three
  *   simulated chains, a replay and a cross-ledger migration inside one facade suite, which proves the wallets rather
  *   than the wiring. What is under test here is a `combineLatest` and three property reads, so the three states are the
- *   wallets' own — taken from real, shipped, unstarted wallets — restated at the versions a crossing would put them at.
+ *   wallets' own — taken from real, shipped, unstarted wallets — restated at the versions a crossing would put them
+ *   at.
  *
  *   The versions are deliberately all different where they can be, so a wiring that read one wallet's version three
  *   times, or paired the wrong wallet with the wrong slot, fails rather than coincidentally passes.
@@ -182,9 +183,7 @@ describe('three wallets that disagree about which side of the boundary the chain
       ledger.LedgerParameters.initialParameters().dust,
     );
 
-    shieldedStates = new rx.BehaviorSubject(
-      shieldedAt(await rx.firstValueFrom(shielded.state), beforeFork.shielded),
-    );
+    shieldedStates = new rx.BehaviorSubject(shieldedAt(await rx.firstValueFrom(shielded.state), beforeFork.shielded));
     unshieldedStates = new rx.BehaviorSubject(
       unshieldedAt(await rx.firstValueFrom(unshielded.state), beforeFork.unshielded),
     );

--- a/packages/hd/test/seedDerivation.json
+++ b/packages/hd/test/seedDerivation.json
@@ -1,0 +1,770 @@
+[
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000001",
+    "account": 0,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/0",
+        "seed": "22b8e577b3f638b2b361f36fd62d7138ed489d9afe3da5f7c325e2d0a95ae043"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/0",
+        "seed": "34d1c3ed1486d0ac6293f915e525ea7717800c4589c7929ddcbe0d1bd2d2818c"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/0",
+        "seed": "b9b76cce66828aa6bd798abbb15b012331a6aa1e5f99e678724c37463b5775a1"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/0",
+        "seed": "9690d4013e42e6739d9496f836b2cbd4339451c02a00624b86e9fb15cc4197a8"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/0",
+        "seed": "559cbe772a3c6fc8e4e8999cd3962bcee4bbc1580281e488fec2c3f78016f88f"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "22b8e577b3f638b2b361f36fd62d7138ed489d9afe3da5f7c325e2d0a95ae043",
+      "dust": "b9b76cce66828aa6bd798abbb15b012331a6aa1e5f99e678724c37463b5775a1",
+      "shielded": "9690d4013e42e6739d9496f836b2cbd4339451c02a00624b86e9fb15cc4197a8"
+    }
+  },
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000001",
+    "account": 0,
+    "addressIndex": 1,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/1",
+        "seed": "abc72cdcd6d6b9b40f275710a3a9b5185040683c83e8d5dabb10b2ec100eb5a0"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/1",
+        "seed": "75f046c16f01068dcbd2890cfe0517ef643863749e9828bd8b849ddf11fd8fdb"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/1",
+        "seed": "3d840c135edb955f6fb8c508e479b83772c227a492a3602496d437a1517eed3a"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/1",
+        "seed": "8655e62d761c746faf6dba1e29b46336061901a66fada04bfd1f897526c4695e"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/1",
+        "seed": "14bacf3a7e93d1f119f372a0b2a5ec8829241e55ee671b853ded4c99252518d8"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "abc72cdcd6d6b9b40f275710a3a9b5185040683c83e8d5dabb10b2ec100eb5a0",
+      "dust": "3d840c135edb955f6fb8c508e479b83772c227a492a3602496d437a1517eed3a",
+      "shielded": "8655e62d761c746faf6dba1e29b46336061901a66fada04bfd1f897526c4695e"
+    }
+  },
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000001",
+    "account": 1,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/1'/0/0",
+        "seed": "69a8e4a2fb369257cee62135a12685c133ac2f8aca76008287e4f6807ef1373e"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/1'/1/0",
+        "seed": "31c43910e2f1a3dc6ffefa14a640481f62c00f69a714bbf2195eccc08d3852d1"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/1'/2/0",
+        "seed": "6b0aa53d5e8afabaed15e8cf3863978b6b866dff0683957af6c594f496f38d04"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/1'/3/0",
+        "seed": "a8096953e10dab792d0f305417a7a7167849482a1cfdd880f689c42d62d2dc74"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/1'/4/0",
+        "seed": "e5d0c01a04a207dc404b768bccc36fe0c8e96007b04a43b4608e31e56327ed3e"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "69a8e4a2fb369257cee62135a12685c133ac2f8aca76008287e4f6807ef1373e",
+      "dust": "6b0aa53d5e8afabaed15e8cf3863978b6b866dff0683957af6c594f496f38d04",
+      "shielded": "a8096953e10dab792d0f305417a7a7167849482a1cfdd880f689c42d62d2dc74"
+    }
+  },
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000001",
+    "account": 2,
+    "addressIndex": 5,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/2'/0/5",
+        "seed": "e1d398885ec1682b6da76679ea275d751fe6baf0cd296a884ca275c9b1acb504"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/2'/1/5",
+        "seed": "0b8165bef36b486031c0ccfd7fba40e45c6ccaf101658db217ab86cdd626f8f5"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/2'/2/5",
+        "seed": "cab7b2f91fa2c399f180fe42c2b5feaa40afbf925818d40ddcb59d6cff072921"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/2'/3/5",
+        "seed": "7dfa747a1b6466ddc9381175edcf6e819c99205f03da807c65898442561ce3f8"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/2'/4/5",
+        "seed": "d042639e2f74c29fa414d5c45fde36a2381cd5906170164628c48732b22105b8"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "e1d398885ec1682b6da76679ea275d751fe6baf0cd296a884ca275c9b1acb504",
+      "dust": "cab7b2f91fa2c399f180fe42c2b5feaa40afbf925818d40ddcb59d6cff072921",
+      "shielded": "7dfa747a1b6466ddc9381175edcf6e819c99205f03da807c65898442561ce3f8"
+    }
+  },
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000000",
+    "account": 0,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/0",
+        "seed": "b76bd8d92eb76098e938051af9d6bf2c81d8bf47ead2aa5442ca60c04346378b"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/0",
+        "seed": "2fba2e9bbf3c62f8e6b4aae1eaab9c0c5227f819490abea9b7e46a9c40278ece"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/0",
+        "seed": "cab391b2eaaf459bd7ef54c461e7fc4e2377afb12fbdd532b0d63b0f48803534"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/0",
+        "seed": "a33865674c03ca1f6c4eb3f6b56625dce0accc96d2ca52114876a58773f5ecab"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/0",
+        "seed": "00d3da0c17f1e51f2c74b75fc0f91d4cdda07d71e6d3ca33c5e5a6b543a3c046"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "b76bd8d92eb76098e938051af9d6bf2c81d8bf47ead2aa5442ca60c04346378b",
+      "dust": "cab391b2eaaf459bd7ef54c461e7fc4e2377afb12fbdd532b0d63b0f48803534",
+      "shielded": "a33865674c03ca1f6c4eb3f6b56625dce0accc96d2ca52114876a58773f5ecab"
+    }
+  },
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000000",
+    "account": 0,
+    "addressIndex": 1,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/1",
+        "seed": "0f65dea026704aa610aa873457cb5dff4c76c722aae1e2378793234b999bfe76"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/1",
+        "seed": "eb4b1b039f91b17210f8564214d7d90a193890ad81888bd001830a0b890608ad"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/1",
+        "seed": "a40611d36a47c6c2449b5b8cf69e191ec2c91e3cbcdc1ef54cc95663d0a3080a"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/1",
+        "seed": "9b0cf4f31c1a9c43d4b7487bfa29506337f2b66387afc9824a5eada827aeaff4"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/1",
+        "seed": "e70f7fed1c80062291c3f26a7181f455cc76adf42a94ebf9337f9162d3e18893"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "0f65dea026704aa610aa873457cb5dff4c76c722aae1e2378793234b999bfe76",
+      "dust": "a40611d36a47c6c2449b5b8cf69e191ec2c91e3cbcdc1ef54cc95663d0a3080a",
+      "shielded": "9b0cf4f31c1a9c43d4b7487bfa29506337f2b66387afc9824a5eada827aeaff4"
+    }
+  },
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000000",
+    "account": 1,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/1'/0/0",
+        "seed": "a400ff335801080272ae0ecc6b76798783e9a4012077ba233ee871a5db291b0a"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/1'/1/0",
+        "seed": "ac22230b45686b3bf32e379036980f1257aec1481dbedbefec2475af6a4c2e9d"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/1'/2/0",
+        "seed": "9ec00f2a6ef7bb54499933a2ea704a972128237cdaa6e0f7511d35d1929a0856"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/1'/3/0",
+        "seed": "e26f8087e3c7dad0ee81447e9ea5ab29793d826a171b53d52a0941fadc43a66d"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/1'/4/0",
+        "seed": "0618f8150285a3624c8030c57e1122a513906459084abe57014d211bd90b1665"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "a400ff335801080272ae0ecc6b76798783e9a4012077ba233ee871a5db291b0a",
+      "dust": "9ec00f2a6ef7bb54499933a2ea704a972128237cdaa6e0f7511d35d1929a0856",
+      "shielded": "e26f8087e3c7dad0ee81447e9ea5ab29793d826a171b53d52a0941fadc43a66d"
+    }
+  },
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000000",
+    "account": 2,
+    "addressIndex": 5,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/2'/0/5",
+        "seed": "925cdded461bcd37257703be12403bb381e158f0e83fc2c1a73c7e80364efc5f"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/2'/1/5",
+        "seed": "ca7e9bda54573c3c7aeaf6c6f3109077d68fba0a51cd9964cc3e9975097ef449"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/2'/2/5",
+        "seed": "b9cd5182c1dd2fc9dfe831dfbc9dfa1182fc0e24b220be511784105b83f0aa30"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/2'/3/5",
+        "seed": "327ba5e946799ea0578ae9b5a3600ec1e3399a66fe89bd81759d1b7b4d9ef26e"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/2'/4/5",
+        "seed": "d623fdb3366a5743e033eca7a331e9b3a9d92e339f9849b8632534f5d703b6a5"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "925cdded461bcd37257703be12403bb381e158f0e83fc2c1a73c7e80364efc5f",
+      "dust": "b9cd5182c1dd2fc9dfe831dfbc9dfa1182fc0e24b220be511784105b83f0aa30",
+      "shielded": "327ba5e946799ea0578ae9b5a3600ec1e3399a66fe89bd81759d1b7b4d9ef26e"
+    }
+  },
+  {
+    "masterSeed": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "account": 0,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/0",
+        "seed": "b39bd35a1f2ab12434fe89502245c4d49e955e623152ffb108d3eab7577588b0"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/0",
+        "seed": "ab2fef59e2bf8805409c97cdd458ea5d42b9e580a5369375ba322b291166f042"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/0",
+        "seed": "535ca6755d051baaaacbcbcdb6247271d176b0de7ad56bdd644c18bd27903685"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/0",
+        "seed": "8e9d2e7244f986a6b9b86847b6188b0fd62a588a19995e2fe1bd37c6fa0d6a71"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/0",
+        "seed": "4f060696cf8d72649046fb3877101c8b333ab94c70d33b886c68f39777b4a1ab"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "b39bd35a1f2ab12434fe89502245c4d49e955e623152ffb108d3eab7577588b0",
+      "dust": "535ca6755d051baaaacbcbcdb6247271d176b0de7ad56bdd644c18bd27903685",
+      "shielded": "8e9d2e7244f986a6b9b86847b6188b0fd62a588a19995e2fe1bd37c6fa0d6a71"
+    }
+  },
+  {
+    "masterSeed": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "account": 0,
+    "addressIndex": 1,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/1",
+        "seed": "31b21c0c10dbb7ae3ca5b34f709b5c2e240ec21d1ed106d7ec33a9e8bd69e74a"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/1",
+        "seed": "9da86ef0e8c9e84c893990c8b757e8941688cf2aaf212e82453e8748e971e17e"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/1",
+        "seed": "cf1f2c42ac691cd2a71ad31734f4e05f162016ff8df3da4b46fc7133fb366654"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/1",
+        "seed": "100aae03f97fecc671da82cc957b907b7ccf9769e1553a389c14edcb805a4226"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/1",
+        "seed": "e1af1898bdcf5ecd0d9ca40e5c2f001a016387041961437bdebc17c7777f0757"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "31b21c0c10dbb7ae3ca5b34f709b5c2e240ec21d1ed106d7ec33a9e8bd69e74a",
+      "dust": "cf1f2c42ac691cd2a71ad31734f4e05f162016ff8df3da4b46fc7133fb366654",
+      "shielded": "100aae03f97fecc671da82cc957b907b7ccf9769e1553a389c14edcb805a4226"
+    }
+  },
+  {
+    "masterSeed": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "account": 1,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/1'/0/0",
+        "seed": "b41158ea0e64b6beb74e230f2e1a808389dc2d183c6614b37ce9b3ca0c4388ba"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/1'/1/0",
+        "seed": "8d5bb992612b5be5e1c5671338eeb84ab846a549ea1f1306723d5e51d3e9d44f"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/1'/2/0",
+        "seed": "30709aa981b4df091398d1964d315690fc2145d27c0e58714b72767133f97047"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/1'/3/0",
+        "seed": "d37c306ff7566d9469511433cf56a4b669f64af8d195291a0090220d0c22d6d6"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/1'/4/0",
+        "seed": "510801315fe04ee08641259aab81f6b21b9391b24941ad9ff616b8f0b7d0b62b"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "b41158ea0e64b6beb74e230f2e1a808389dc2d183c6614b37ce9b3ca0c4388ba",
+      "dust": "30709aa981b4df091398d1964d315690fc2145d27c0e58714b72767133f97047",
+      "shielded": "d37c306ff7566d9469511433cf56a4b669f64af8d195291a0090220d0c22d6d6"
+    }
+  },
+  {
+    "masterSeed": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "account": 2,
+    "addressIndex": 5,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/2'/0/5",
+        "seed": "a8f3adef15d7a32b03f7288100c1709f46c6abe3747e87f2c421c3f166e6b92b"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/2'/1/5",
+        "seed": "5152ce7cb2d62ec8f733db87b33bbc43fa316402f1f444e97b6dea7b018bdf67"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/2'/2/5",
+        "seed": "4389f771021fb03fcb3cea80bd222f222029def5c8c3332c68deda2852e44b96"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/2'/3/5",
+        "seed": "e03174bb7308e4767958ea6fd71309a423f80824642bc15669bf7391e87f6c6e"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/2'/4/5",
+        "seed": "08a0282c7ac6aefc1cbc7297c66e186e321c3486e402d54c29dd8625973144ac"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "a8f3adef15d7a32b03f7288100c1709f46c6abe3747e87f2c421c3f166e6b92b",
+      "dust": "4389f771021fb03fcb3cea80bd222f222029def5c8c3332c68deda2852e44b96",
+      "shielded": "e03174bb7308e4767958ea6fd71309a423f80824642bc15669bf7391e87f6c6e"
+    }
+  },
+  {
+    "masterSeed": "b49408db310c043ab736fb57a98e15c8cedbed4c38450df3755ac9726ee14d0c",
+    "account": 0,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/0",
+        "seed": "543110874819c43470602a2710579b006de9d29788cd0f2e6d611d9994f40a81"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/0",
+        "seed": "906c7139f23883dc4c8fcef83c42ac25487a047df04b93042cdc6379c1557a4c"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/0",
+        "seed": "2852902e81dbc84d6ed459c2b977995cd8aa18f35a016db139749bdef167f811"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/0",
+        "seed": "641e75883e350a65dd3e93dd52229949be18456d5d17ea5484d5c1f73c4d57ce"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/0",
+        "seed": "1a05518eee536737ebaf43b7c54ce85bf7e57dc108e5eda1ed9b5e7a2864c81b"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "543110874819c43470602a2710579b006de9d29788cd0f2e6d611d9994f40a81",
+      "dust": "2852902e81dbc84d6ed459c2b977995cd8aa18f35a016db139749bdef167f811",
+      "shielded": "641e75883e350a65dd3e93dd52229949be18456d5d17ea5484d5c1f73c4d57ce"
+    }
+  },
+  {
+    "masterSeed": "b49408db310c043ab736fb57a98e15c8cedbed4c38450df3755ac9726ee14d0c",
+    "account": 0,
+    "addressIndex": 1,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/1",
+        "seed": "d39703a6a0594ff62ea443b011033c5239aa276f4d72ec139b5c59746e91ccd4"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/1",
+        "seed": "4735f9cba78b612eca5e492b2e20710f79d38fe5c311f808328515928de0c282"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/1",
+        "seed": "1b72f521ce10e097449417eea627732ce262052e5a2170a7623e3f16c173f7b7"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/1",
+        "seed": "518026ff30ca7ab23d227ffc93232b5c78d0f7a02b6ced9dd686a54dd0311c14"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/1",
+        "seed": "4893a7677b9c83be37d163d4da9a068016c667fbfff31bf6625c36561ae9ff7a"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "d39703a6a0594ff62ea443b011033c5239aa276f4d72ec139b5c59746e91ccd4",
+      "dust": "1b72f521ce10e097449417eea627732ce262052e5a2170a7623e3f16c173f7b7",
+      "shielded": "518026ff30ca7ab23d227ffc93232b5c78d0f7a02b6ced9dd686a54dd0311c14"
+    }
+  },
+  {
+    "masterSeed": "b49408db310c043ab736fb57a98e15c8cedbed4c38450df3755ac9726ee14d0c",
+    "account": 1,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/1'/0/0",
+        "seed": "1e2c3b62cf396e5e7bfbe7b04ce5c25cd5318e7013ba1dcbd22ed3b0bb15d3de"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/1'/1/0",
+        "seed": "42a8467bac1f96fd8b08d22b1fdac3eacfdb34a714bb32f5029cc2e0c5bf3996"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/1'/2/0",
+        "seed": "dedf271548ebb6cef6934bbe777a69207e043e93360dc82caaf49fc605a15fcb"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/1'/3/0",
+        "seed": "825a4ad95f7f79c682c7d2819e013a22fd8a8b0842e4058e4ac47de768829d0a"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/1'/4/0",
+        "seed": "7dc293936c4eba0054371604e143fad3333b144e6cf0abce3f81ad4cce68bfd5"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "1e2c3b62cf396e5e7bfbe7b04ce5c25cd5318e7013ba1dcbd22ed3b0bb15d3de",
+      "dust": "dedf271548ebb6cef6934bbe777a69207e043e93360dc82caaf49fc605a15fcb",
+      "shielded": "825a4ad95f7f79c682c7d2819e013a22fd8a8b0842e4058e4ac47de768829d0a"
+    }
+  },
+  {
+    "masterSeed": "b49408db310c043ab736fb57a98e15c8cedbed4c38450df3755ac9726ee14d0c",
+    "account": 2,
+    "addressIndex": 5,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/2'/0/5",
+        "seed": "4b3164138c3ae13d9c908eb8f3c3dfdb1beb2562101dd4a9d3cca549554a7a89"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/2'/1/5",
+        "seed": "348360f27d5fb4abb0f9800d04e1bfb1c6107b85e44bcd3d847af2a6247e82f6"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/2'/2/5",
+        "seed": "f58bca92919ecead3c6a1e9aab720cdded2de531f8b5a15ba0696f667ff7a1d4"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/2'/3/5",
+        "seed": "a763cd6036c238fb7cfd552b6f980598647fa79274533b95f474d104c7dd6d36"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/2'/4/5",
+        "seed": "09763387dbf1bdbde5b07043ccb444f5697f429c5cded1fc23b2d59a1d737dc1"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "4b3164138c3ae13d9c908eb8f3c3dfdb1beb2562101dd4a9d3cca549554a7a89",
+      "dust": "f58bca92919ecead3c6a1e9aab720cdded2de531f8b5a15ba0696f667ff7a1d4",
+      "shielded": "a763cd6036c238fb7cfd552b6f980598647fa79274533b95f474d104c7dd6d36"
+    }
+  },
+  {
+    "masterSeed": "06004625b6cb2ccead21b15fee2a940c404365702b697b4721bfeecfc6b1b15e",
+    "account": 0,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/0",
+        "seed": "6f150d871e61d80b32a9f4c6cd29ef4522d84fec7b37030de98786a88383a385"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/0",
+        "seed": "f94f4551032b7db233c82fbf84ed7857480d6b833c6cffd08cd875146a80b77c"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/0",
+        "seed": "0995ea2747cbafa26e81f39130e5f4d8c0cd23ee61ab882a9a434d544176b364"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/0",
+        "seed": "8f46aae4617acdbd7dd705af463940f6e3dbb47a970fefdf51fcff027266bac2"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/0",
+        "seed": "45e2f26e5f222a2411553bd25fda633e77c7b363285113fc4e0c3b5911b23953"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "6f150d871e61d80b32a9f4c6cd29ef4522d84fec7b37030de98786a88383a385",
+      "dust": "0995ea2747cbafa26e81f39130e5f4d8c0cd23ee61ab882a9a434d544176b364",
+      "shielded": "8f46aae4617acdbd7dd705af463940f6e3dbb47a970fefdf51fcff027266bac2"
+    }
+  },
+  {
+    "masterSeed": "06004625b6cb2ccead21b15fee2a940c404365702b697b4721bfeecfc6b1b15e",
+    "account": 0,
+    "addressIndex": 1,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/1",
+        "seed": "76dd2e80c6aa21675261343d1c0bc6538c815e25b0a8efbf68e9fb0a0c13225a"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/1",
+        "seed": "d8b1ba5b615156cd0520228c4366de0e2793c5da345c780f8c81c47d19ae3286"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/1",
+        "seed": "3efa843345220076bb8baefc507faf981748b52d191674f986160bc3b4cbcc1a"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/1",
+        "seed": "1c60eeb6e2aa0f9a4c5ee3273fba31b14318f60e159b3b9c329f55294d0c0637"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/1",
+        "seed": "0e5bcd3b75775d600e601a9ede0aac5d057596a990f24dc6b2fcac10aa05b403"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "76dd2e80c6aa21675261343d1c0bc6538c815e25b0a8efbf68e9fb0a0c13225a",
+      "dust": "3efa843345220076bb8baefc507faf981748b52d191674f986160bc3b4cbcc1a",
+      "shielded": "1c60eeb6e2aa0f9a4c5ee3273fba31b14318f60e159b3b9c329f55294d0c0637"
+    }
+  },
+  {
+    "masterSeed": "06004625b6cb2ccead21b15fee2a940c404365702b697b4721bfeecfc6b1b15e",
+    "account": 1,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/1'/0/0",
+        "seed": "114a5c2de771db642ddce57efbddc5017bfb6344b6d3acb23ab31960375ee86b"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/1'/1/0",
+        "seed": "9af7f1a320cd99e9b4d82259334f01681a7d14691c206ef026f0b65aee0a4fac"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/1'/2/0",
+        "seed": "5fd7cf92b0f560eb5b6c1ce40fa2561ac42decddf353558671f12e9fcb747489"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/1'/3/0",
+        "seed": "bc9169d8de5abc104274b7180ba50fddc37cc22a0c74473cbb797e98ec925b4d"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/1'/4/0",
+        "seed": "213001539aa750d9468c11a8ca5ce52c61aed78fa7fd72dba7ee53f4f2a30fbc"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "114a5c2de771db642ddce57efbddc5017bfb6344b6d3acb23ab31960375ee86b",
+      "dust": "5fd7cf92b0f560eb5b6c1ce40fa2561ac42decddf353558671f12e9fcb747489",
+      "shielded": "bc9169d8de5abc104274b7180ba50fddc37cc22a0c74473cbb797e98ec925b4d"
+    }
+  },
+  {
+    "masterSeed": "06004625b6cb2ccead21b15fee2a940c404365702b697b4721bfeecfc6b1b15e",
+    "account": 2,
+    "addressIndex": 5,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/2'/0/5",
+        "seed": "3a1e8312288701835d9742a88c7eb2d2bd7e8346acc2bc7e8b742cf4192f986e"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/2'/1/5",
+        "seed": "d93a563d418f4782672860dfd79d149f3dedcb72c24524f08cd034351912bff8"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/2'/2/5",
+        "seed": "d7d169173f5377e6235f6f95be708cd5ac7fe6bb7fbcd06b7971dfaf5e833fe3"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/2'/3/5",
+        "seed": "474e1ec5df872034a1e7fe5f774827707bf505ae531c5f1509c09312009d567c"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/2'/4/5",
+        "seed": "30ff89b32aba96cbabca4ad2013e2965887dbf3470fdf68181c6d02409d7a531"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "3a1e8312288701835d9742a88c7eb2d2bd7e8346acc2bc7e8b742cf4192f986e",
+      "dust": "d7d169173f5377e6235f6f95be708cd5ac7fe6bb7fbcd06b7971dfaf5e833fe3",
+      "shielded": "474e1ec5df872034a1e7fe5f774827707bf505ae531c5f1509c09312009d567c"
+    }
+  },
+  {
+    "masterSeed": "215ca8a6923ec73f241c92ef702ccfc277aa5856bc94f59afa7e82ec94547850",
+    "account": 0,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/0",
+        "seed": "f7ea70204ad7c72bde05b667584160d4feecf435863ab1c902a107852b7a5531"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/0",
+        "seed": "7e3883b2d3ef17df5b89099328f44672947ab7aca8a885e0f9c34d1ef8764e5d"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/0",
+        "seed": "683a154ce937a0d7a1b23f90ffcc04c1cfab66fcac4aaf130a8264a79891e841"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/0",
+        "seed": "ed5c4fd2223106c727e1dac1de67e5c7073ec25f0e6a0f5926cea3cc758bb1b2"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/0",
+        "seed": "6a18bf1e28789a1cf167588d45febfbfd79b2d973ad001b95c3c284a3b1e92f9"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "f7ea70204ad7c72bde05b667584160d4feecf435863ab1c902a107852b7a5531",
+      "dust": "683a154ce937a0d7a1b23f90ffcc04c1cfab66fcac4aaf130a8264a79891e841",
+      "shielded": "ed5c4fd2223106c727e1dac1de67e5c7073ec25f0e6a0f5926cea3cc758bb1b2"
+    }
+  },
+  {
+    "masterSeed": "215ca8a6923ec73f241c92ef702ccfc277aa5856bc94f59afa7e82ec94547850",
+    "account": 0,
+    "addressIndex": 1,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/1",
+        "seed": "585792f27ee4444b87147a53a2d4607028fddc09389fba74c5246423d4acc0f7"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/1",
+        "seed": "24792d21cd1d5e9720ab94a26684833f07adf32eb7347cce0892ca753eac28aa"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/1",
+        "seed": "fd48f9dd2b24eea2ca1c3ab1fc8fb88380b198590c5fa680bd74970462741bfa"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/1",
+        "seed": "5beed28f0c24cd188cb4b85ad27a2c0f914183312ad11c93fc3bcb436cc3d81c"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/1",
+        "seed": "5e52a43fa8efa4d8010e489be6a2a3d830936b1c84cdb62d68743eaa465da7eb"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "585792f27ee4444b87147a53a2d4607028fddc09389fba74c5246423d4acc0f7",
+      "dust": "fd48f9dd2b24eea2ca1c3ab1fc8fb88380b198590c5fa680bd74970462741bfa",
+      "shielded": "5beed28f0c24cd188cb4b85ad27a2c0f914183312ad11c93fc3bcb436cc3d81c"
+    }
+  },
+  {
+    "masterSeed": "215ca8a6923ec73f241c92ef702ccfc277aa5856bc94f59afa7e82ec94547850",
+    "account": 1,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/1'/0/0",
+        "seed": "9f32da89d21a3c791a6b79aa92e4fa36b039d090bb65c278d69501ac343bcd8c"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/1'/1/0",
+        "seed": "e3e70eb3b0ca7221b508f7337d4a731274439999427046965dc4bbb5111c408c"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/1'/2/0",
+        "seed": "42098698a8e18bc7f5a7b80439fa788c119e5b6700805e3a4ad2f5657ba388ca"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/1'/3/0",
+        "seed": "9ef53cd2917ce0f6765b2cfb5838425eef885a8ce220365fdcc3e28b60146af0"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/1'/4/0",
+        "seed": "1f222309012ca80a3b89ed4e2d7d2dbf8e1caa3288ebea78b9f4a3122e701430"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "9f32da89d21a3c791a6b79aa92e4fa36b039d090bb65c278d69501ac343bcd8c",
+      "dust": "42098698a8e18bc7f5a7b80439fa788c119e5b6700805e3a4ad2f5657ba388ca",
+      "shielded": "9ef53cd2917ce0f6765b2cfb5838425eef885a8ce220365fdcc3e28b60146af0"
+    }
+  },
+  {
+    "masterSeed": "215ca8a6923ec73f241c92ef702ccfc277aa5856bc94f59afa7e82ec94547850",
+    "account": 2,
+    "addressIndex": 5,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/2'/0/5",
+        "seed": "cc2b3cd31eb6024fd2090aa808e7b068a4750d5b27b16a1386f905eb08ff02da"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/2'/1/5",
+        "seed": "0d4dada167211c18c75b42dec7e3d3e5b6a5a9a9e8a640076ffce7680e62c1df"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/2'/2/5",
+        "seed": "06372c5c82554e0f4d7b82060d9738bc4fc5a313617b2ed1e1e85ca1901fc493"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/2'/3/5",
+        "seed": "9faa3469993828db58e2ff44c17137bb3c16a9b65a2d549a5be9c99c0eb8f98b"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/2'/4/5",
+        "seed": "29af866ab0ba8657dce351939bdbfe9b274b1be3b2b45fe15eedff1a5dcd1b83"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "cc2b3cd31eb6024fd2090aa808e7b068a4750d5b27b16a1386f905eb08ff02da",
+      "dust": "06372c5c82554e0f4d7b82060d9738bc4fc5a313617b2ed1e1e85ca1901fc493",
+      "shielded": "9faa3469993828db58e2ff44c17137bb3c16a9b65a2d549a5be9c99c0eb8f98b"
+    }
+  }
+]

--- a/packages/hd/test/walletSeeds.test.ts
+++ b/packages/hd/test/walletSeeds.test.ts
@@ -19,17 +19,27 @@
  *   derivation, six near-identical copies of the same walk down the same tree, each one silently discarding the failure
  *   branches. The walk is what `packages/hd` is for; naming it is what was missing.
  *
- *   The values below are pinned against the derivation as it stands today, not against a published specification. The
- *   spec-reference test vectors cover the hop _after_ this one — a per-wallet seed to keys and addresses — and take the
- *   per-wallet seed as given. Nothing published states what a master seed derives to per role, so what these vectors
- *   protect is that the naming changed nothing.
+ *   The values are now pinned against a published specification rather than against themselves. The [Per-wallet
+ *   seeds](../../../docs/spec/Specification.md#per-wallet-seeds) section states which role each of the three seeds
+ *   comes from, the [spec reference](../../spec-reference) implements that walk independently, and
+ *   `seedDerivation.json` is the vector file it generates — a byte-identical copy of
+ *   `packages/spec-reference/test-vectors/seedDerivation.json`, the same arrangement `packages/address-format` uses for
+ *   its own vectors. The hexadecimal below is therefore a claim about what a Midnight wallet is, not a record of what
+ *   this package happened to do.
  */
 import { describe, expect, it } from 'vitest';
 import { HDWallet, Roles, WalletSeeds } from '../src/index.js';
+import vectors from './seedDerivation.json' with { type: 'json' };
 
 const hex = (bytes: Uint8Array): string => Buffer.from(bytes).toString('hex');
 
-const masterSeed = Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex');
+const masterSeedOf = (vector: (typeof vectors)[number]): Buffer => Buffer.from(vector.masterSeed, 'hex');
+
+/** The first address of the first account, which is what a wallet with no reason to choose otherwise uses. */
+const firstAddress = vectors.find((vector) => vector.account === 0 && vector.addressIndex === 0);
+if (firstAddress === undefined) throw new Error('the vectors no longer cover the first address');
+
+const masterSeed = masterSeedOf(firstAddress);
 
 /** The walk every consumer in this repository has been writing out by hand. */
 const byHand = (role: (typeof Roles)[keyof typeof Roles], account = 0, index = 0): string => {
@@ -41,7 +51,51 @@ const byHand = (role: (typeof Roles)[keyof typeof Roles], account = 0, index = 0
 };
 
 describe('the seeds one master seed derives to', () => {
-  it('gives each wallet the seed that wallet has always been given', () => {
+  it.each(vectors)(
+    'derives the specified seeds from $masterSeed at account $account, address index $addressIndex',
+    (vector) => {
+      const seeds = WalletSeeds.fromMasterSeed(masterSeedOf(vector), {
+        account: vector.account,
+        addressIndex: vector.addressIndex,
+      });
+
+      expect({
+        unshielded: hex(seeds.unshielded),
+        dust: hex(seeds.dust),
+        shielded: hex(seeds.shielded),
+      }).toStrictEqual(vector.walletSeeds);
+    },
+  );
+
+  it.each(vectors)(
+    'derives the specified ECDSA unshielded seed from $masterSeed at account $account, address index $addressIndex',
+    (vector) => {
+      const seeds = WalletSeeds.fromMasterSeed(masterSeedOf(vector), {
+        account: vector.account,
+        addressIndex: vector.addressIndex,
+        unshieldedRole: Roles.EcdsaUnshielded,
+      });
+
+      expect(hex(seeds.unshielded)).toBe(vector.seedsByRole.EcdsaUnshielded.seed);
+      // The other two are the same wallet whichever way its unshielded side signs.
+      expect(hex(seeds.dust)).toBe(vector.walletSeeds.dust);
+      expect(hex(seeds.shielded)).toBe(vector.walletSeeds.shielded);
+    },
+  );
+
+  it('places each seed at the role the specification assigns it', () => {
+    // Read the other way round: the vectors state a path per role, and this is the claim that the three seeds are
+    // taken from roles 0, 2 and 3 of that path rather than merely being three different values.
+    expect(firstAddress.seedsByRole.UnshieldedExternal.path).toBe(`m/44'/2400'/0'/${Roles.NightExternal}/0`);
+    expect(firstAddress.seedsByRole.Dust.path).toBe(`m/44'/2400'/0'/${Roles.Dust}/0`);
+    expect(firstAddress.seedsByRole.Shielded.path).toBe(`m/44'/2400'/0'/${Roles.Zswap}/0`);
+    expect(firstAddress.seedsByRole.EcdsaUnshielded.path).toBe(`m/44'/2400'/0'/${Roles.EcdsaUnshielded}/0`);
+  });
+
+  it('agrees with the tree this package already exposed, so the two entry points cannot drift apart', () => {
+    // Kept beside the vectors rather than replaced by them: the vectors anchor `WalletSeeds` to the specification, and
+    // `tests.test.ts` anchors `HDWallet` to an independent BIP-32 implementation. This is the seam between the two,
+    // which neither of those covers.
     const seeds = WalletSeeds.fromMasterSeed(masterSeed);
 
     expect(hex(seeds.shielded)).toBe(byHand(Roles.Zswap));
@@ -49,37 +103,14 @@ describe('the seeds one master seed derives to', () => {
     expect(hex(seeds.dust)).toBe(byHand(Roles.Dust));
   });
 
-  it('derives the values it derives today, so naming the walk changed nothing', () => {
-    const seeds = WalletSeeds.fromMasterSeed(masterSeed);
-
-    expect(hex(seeds.shielded)).toBe('9690d4013e42e6739d9496f836b2cbd4339451c02a00624b86e9fb15cc4197a8');
-    expect(hex(seeds.unshielded)).toBe('22b8e577b3f638b2b361f36fd62d7138ed489d9afe3da5f7c325e2d0a95ae043');
-    expect(hex(seeds.dust)).toBe('b9b76cce66828aa6bd798abbb15b012331a6aa1e5f99e678724c37463b5775a1');
-  });
-
-  it('follows the account and address index it is asked for', () => {
-    const seeds = WalletSeeds.fromMasterSeed(masterSeed, { account: 2, addressIndex: 5 });
-
-    expect(hex(seeds.shielded)).toBe(byHand(Roles.Zswap, 2, 5));
-    expect(hex(seeds.unshielded)).toBe(byHand(Roles.NightExternal, 2, 5));
-    expect(hex(seeds.dust)).toBe(byHand(Roles.Dust, 2, 5));
-  });
-
-  it('derives the unshielded seed from whichever signing scheme the wallet will use', () => {
-    const ecdsa = WalletSeeds.fromMasterSeed(masterSeed, { unshieldedRole: Roles.EcdsaUnshielded });
-
-    expect(hex(ecdsa.unshielded)).toBe(byHand(Roles.EcdsaUnshielded));
-    // The other two are the same wallet whichever way its unshielded side signs.
-    expect(hex(ecdsa.shielded)).toBe(byHand(Roles.Zswap));
-    expect(hex(ecdsa.dust)).toBe(byHand(Roles.Dust));
-  });
-
   it('does not hold the master seed open once it has what it needs', () => {
     // The private material inside the BIP32 tree is wiped before this returns; an application that reads the master
     // seed afterwards is reading its own buffer, which is the only copy the SDK never controlled.
+    const before = hex(masterSeed);
+
     const seeds = WalletSeeds.fromMasterSeed(masterSeed);
 
-    expect(hex(masterSeed)).toBe('0000000000000000000000000000000000000000000000000000000000000001');
+    expect(hex(masterSeed)).toBe(before);
     expect(seeds.shielded).not.toBe(masterSeed);
   });
 });

--- a/packages/shielded-wallet/src/test/forkHarness.ts
+++ b/packages/shielded-wallet/src/test/forkHarness.ts
@@ -210,8 +210,8 @@ export type ForkWallet = Readonly<{
    * The class the wallet was started from, so a snapshot can be restored through the same registration that wrote it.
    *
    * @remarks
-   *   Restoring is a class-level entry point, not an instance one — it is how an application gets a wallet in the
-   *   first place — so a proof about restoring needs the class and not merely the running wallet.
+   *   Restoring is a class-level entry point, not an instance one — it is how an application gets a wallet in the first
+   *   place — so a proof about restoring needs the class and not merely the running wallet.
    */
   walletClass: ForkingShieldedWalletClass<V1.Sync.SimulatorSyncUpdate, V2.Sync.SimulatorSyncUpdate>;
   /** Keys of each ledger version, derived from the same seed. */

--- a/packages/shielded-wallet/src/test/forkHarness.ts
+++ b/packages/shielded-wallet/src/test/forkHarness.ts
@@ -33,7 +33,11 @@ import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/c
 import { type Simulator, type V8 } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
 import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { Deferred, Effect, FiberId, Option, Stream, pipe } from 'effect';
-import { CustomForkingShieldedWallet, type ForkingShieldedWallet } from '../ForkingShieldedWallet.js';
+import {
+  CustomForkingShieldedWallet,
+  type ForkingShieldedWallet,
+  type ForkingShieldedWalletClass,
+} from '../ForkingShieldedWallet.js';
 import * as V1 from '../v1/index.js';
 import * as V2 from '../v2/index.js';
 
@@ -202,6 +206,14 @@ export type ForkedState = ProtocolState.ProtocolState<V1.CoreWallet | V2.CoreWal
 export type ForkWallet = Readonly<{
   /** The wallet itself, exactly as an application would hold it. */
   shielded: ForkingShieldedWallet<V1.Sync.SimulatorSyncUpdate, V2.Sync.SimulatorSyncUpdate>;
+  /**
+   * The class the wallet was started from, so a snapshot can be restored through the same registration that wrote it.
+   *
+   * @remarks
+   *   Restoring is a class-level entry point, not an instance one — it is how an application gets a wallet in the
+   *   first place — so a proof about restoring needs the class and not merely the running wallet.
+   */
+  walletClass: ForkingShieldedWalletClass<V1.Sync.SimulatorSyncUpdate, V2.Sync.SimulatorSyncUpdate>;
   /** Keys of each ledger version, derived from the same seed. */
   keys: Readonly<{ preFork: v8.ZswapSecretKeys; postFork: v9.ZswapSecretKeys }>;
   /** Starts background sync through the wallet's own API, which resolves the key material each variant can use. */
@@ -280,6 +292,8 @@ export const makeForkWallet = (config: ForkWalletConfig): Effect.Effect<ForkWall
 
       return {
         shielded: wallet,
+
+        walletClass: WalletClass,
 
         keys: { preFork: preForkKeys, postFork: postForkKeys },
 

--- a/packages/shielded-wallet/src/test/forkRestore.test.ts
+++ b/packages/shielded-wallet/src/test/forkRestore.test.ts
@@ -1,0 +1,184 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Restoring a snapshot into the variant that wrote it, through the wallet class an application holds.
+ *
+ * @remarks
+ *   `restore.test.ts` pins the routing helpers on hand-built envelopes, and the runtime pins `startAtVariant` over
+ *   synthetic variants. Neither says that the two meet correctly in a shipped forking wallet, which is the composition
+ *   an application actually calls: peek at the snapshot, resolve the variant that owns the version it declares,
+ *   deserialize with *that* variant's deserializer, and start there.
+ *
+ *   Both epochs are pinned in one file on purpose. A router that always answered with the head variant would pass the
+ *   pre-fork half and fail the post-fork one; a router that always answered with the last registration would do the
+ *   reverse. Only routing on the snapshot's own declared version passes both.
+ *
+ *   The snapshots are the suite's own: each is written by a running wallet through `serializeState()`, so what is
+ *   restored is what this package actually produces rather than a fixture that could drift from it.
+ */
+
+import * as v8 from '@midnight-ntwrk/ledger-v8';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
+import { V8, genesisStrictness, immediateBlockProducer } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { Effect, Option, pipe } from 'effect';
+import * as rx from 'rxjs';
+import { describe, expect, it } from 'vitest';
+import { peekProtocolVersion } from '../Restore.js';
+import { V1Tag } from '../v1/index.js';
+import { V2Tag } from '../v2/index.js';
+import { type ForkWallet, makeForkWallet } from './forkHarness.js';
+import { type ReplayedCoin, makeReplayChain, mintable, preForkPayment } from './forkReplay.js';
+import { coinValues, totalValue } from './forkWalletAssertions.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+
+/** Where the wallet registers its post-fork variant. */
+const forkVersion = ProtocolVersion.ProtocolVersion(7n);
+/** A chain that has already forked — past the boundary rather than exactly at it. */
+const afterFork = ProtocolVersion.ProtocolVersion(9n);
+/** A chain that has not — a version the pre-fork variant owns. */
+const beforeFork = ProtocolVersion.ProtocolVersion(5n);
+
+const forkBlock = 4n;
+
+const seed = Buffer.alloc(32, 42);
+
+const walletValues = [100n, 200n] as const;
+const walletTotal = walletValues.reduce((sum, value) => sum + value, 0n);
+
+const walletRecipient = () => {
+  const keys = v8.ZswapSecretKeys.fromSeed(seed);
+  return { coinPublicKey: keys.coinPublicKey, encryptionPublicKey: keys.encryptionPublicKey };
+};
+
+const chainCoins = (): readonly ReplayedCoin[] =>
+  walletValues.map((value) => mintable(v8.shieldedToken().raw, value, walletRecipient()));
+
+/** A ledger-v8 chain stamped with `version` from its genesis block, paying the wallet one coin per block. */
+const chainAt = (version: ProtocolVersion.ProtocolVersion, coins: readonly ReplayedCoin[]) =>
+  Effect.gen(function* () {
+    const chain = yield* V8.Simulator.init({
+      networkId,
+      protocolVersion: version,
+      blockProducer: V8.immediateBlockProducer(undefined, V8.genesisStrictness),
+    });
+    yield* Effect.forEach(coins, (coin) => chain.submitTransaction(preForkPayment(networkId, coin)), {
+      discard: true,
+    });
+    return chain;
+  });
+
+/** The post-fork source: the same coins, re-announced by the post-fork ledger version. */
+const replayOf = (coins: readonly ReplayedCoin[], chain: V8.Simulator) =>
+  Effect.gen(function* () {
+    const genesisTime = yield* chain.query((state) => state.currentTime);
+    return yield* makeReplayChain({
+      networkId,
+      protocolVersion: afterFork,
+      genesisBlockNumber: forkBlock,
+      genesisTime,
+      blockProducer: immediateBlockProducer(undefined, genesisStrictness),
+      coins,
+    });
+  });
+
+/** A probe answering as a chain on `version` would. */
+const chainReporting =
+  (version: ProtocolVersion.ProtocolVersion): ChainVersionProbe =>
+  () =>
+    Promise.resolve(version);
+
+/** The tag of the variant a wallet is running, read the way the harness reads it of the wallet it started. */
+const runningTag = (wallet: ForkWallet['shielded']): Effect.Effect<string | symbol> =>
+  pipe(
+    wallet.runtime.currentVariant,
+    Effect.map((current) => current.runningVariant.__polyTag__),
+  );
+
+/** The first state a restored wallet publishes, which is the one it was restored onto. */
+const restoredState = (wallet: ForkWallet['shielded']) => Effect.promise(() => rx.firstValueFrom(wallet.state));
+
+describe('a shielded wallet restoring a snapshot through the class it was started from', () => {
+  it('restores a snapshot written below the boundary onto the pre-fork variant, with what it held', async () =>
+    Effect.gen(function* () {
+      const coins = chainCoins();
+      const chain = yield* chainAt(beforeFork, coins);
+      const replayed = yield* replayOf(coins, chain);
+
+      const wallet = yield* makeForkWallet({
+        preFork: chain,
+        replayed: Effect.succeed(replayed),
+        networkId,
+        forkVersion,
+        seed,
+        chainVersionProbe: chainReporting(beforeFork),
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      yield* wallet.start;
+
+      const synced = yield* wallet.awaitState((state) => totalValue(state.state) === walletTotal);
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+
+      const snapshot = yield* Effect.promise(() => wallet.shielded.serializeState());
+      // The snapshot names the epoch that wrote it, which is the only thing the restore has to go on.
+      expect(Option.getOrThrow(peekProtocolVersion(snapshot))).toBe(synced.state.protocolVersion);
+      expect(synced.state.protocolVersion).toBeLessThan(forkVersion);
+
+      const restored = wallet.walletClass.restore(snapshot);
+      yield* Effect.addFinalizer(() => Effect.promise(() => restored.stop()));
+
+      expect(yield* runningTag(restored)).toBe(V1Tag);
+
+      const state = yield* restoredState(restored);
+      expect(state.protocolVersion).toBeLessThan(forkVersion);
+      expect(coinValues(state.state)).toEqual([...walletValues]);
+      expect(state.state.publicKeys).toStrictEqual(synced.state.publicKeys);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('restores a snapshot written at or past the boundary onto the post-fork variant, with what it held', async () =>
+    Effect.gen(function* () {
+      const coins = chainCoins();
+      const chain = yield* chainAt(afterFork, coins);
+      const replayed = yield* replayOf(coins, chain);
+
+      const wallet = yield* makeForkWallet({
+        preFork: chain,
+        replayed: Effect.succeed(replayed),
+        networkId,
+        forkVersion,
+        seed,
+        chainVersionProbe: chainReporting(afterFork),
+      });
+      yield* Effect.addFinalizer(() => wallet.stop);
+      yield* wallet.start;
+
+      const synced = yield* wallet.awaitState((state) => totalValue(state.state) === walletTotal);
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+
+      const snapshot = yield* Effect.promise(() => wallet.shielded.serializeState());
+      expect(Option.getOrThrow(peekProtocolVersion(snapshot))).toBe(synced.state.protocolVersion);
+      expect(synced.state.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
+
+      const restored = wallet.walletClass.restore(snapshot);
+      yield* Effect.addFinalizer(() => Effect.promise(() => restored.stop()));
+
+      expect(yield* runningTag(restored)).toBe(V2Tag);
+
+      const state = yield* restoredState(restored);
+      expect(state.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
+      expect(coinValues(state.state)).toEqual([...walletValues]);
+      expect(state.state.publicKeys).toStrictEqual(synced.state.publicKeys);
+    }).pipe(Effect.scoped, Effect.runPromise));
+});

--- a/packages/shielded-wallet/src/test/forkRestore.test.ts
+++ b/packages/shielded-wallet/src/test/forkRestore.test.ts
@@ -18,7 +18,7 @@
  *   `restore.test.ts` pins the routing helpers on hand-built envelopes, and the runtime pins `startAtVariant` over
  *   synthetic variants. Neither says that the two meet correctly in a shipped forking wallet, which is the composition
  *   an application actually calls: peek at the snapshot, resolve the variant that owns the version it declares,
- *   deserialize with *that* variant's deserializer, and start there.
+ *   deserialize with _that_ variant's deserializer, and start there.
  *
  *   Both epochs are pinned in one file on purpose. A router that always answered with the head variant would pass the
  *   pre-fork half and fail the post-fork one; a router that always answered with the last registration would do the

--- a/packages/spec-reference/README.md
+++ b/packages/spec-reference/README.md
@@ -1,5 +1,20 @@
 # @midnight-ntwrk/wallet-sdk-spec-reference
 
-Reference implementation of Midnight wallet key derivation and address formatting, used to generate and verify the test
-vectors in [`test-vectors/`](./test-vectors). It optimizes for readability and parity with the
+Reference implementation of Midnight wallet seed derivation, key derivation and address formatting, used to generate and
+verify the test vectors in [`test-vectors/`](./test-vectors). It optimizes for readability and parity with the
 [Wallet Specification](../../docs/spec/Specification.md) rather than performance or security.
+
+| Vector file                                                 | Specification section                                                 | Covers                                                        |
+| ----------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------- |
+| [`seedDerivation.json`](./test-vectors/seedDerivation.json) | [Per-wallet seeds](../../docs/spec/Specification.md#per-wallet-seeds) | one master seed to the three per-wallet seeds, by BIP-32 path |
+| [`keyDerivation.json`](./test-vectors/keyDerivation.json)   | [Key management](../../docs/spec/Specification.md#key-management)     | a per-wallet seed to that wallet's keys                       |
+| [`addresses.json`](./test-vectors/addresses.json)           | [Address format](../../docs/spec/Specification.md#address-format)     | those keys to their hexadecimal and Bech32m forms             |
+
+Regenerate with `yarn workspace @midnightntwrk/wallet-sdk-spec-reference run gen`; the file name of each vector set is
+the name of its entry in `TestVectors`, so a new generator produces a new file and a new verification case with no other
+wiring. Verification is `yarn test:unit --filter=@midnightntwrk/wallet-sdk-spec-reference`, which regenerates in memory
+and compares against what is committed.
+
+Two packages hold byte-identical copies of a vector file so their own suites can read it without depending on this
+private package — `packages/address-format/test/addresses.json` and `packages/hd/test/seedDerivation.json`. Both are
+copied by hand, so regenerating here means copying there.

--- a/packages/spec-reference/package.json
+++ b/packages/spec-reference/package.json
@@ -14,6 +14,7 @@
     "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@noble/curves": "^1.8.1",
     "@scure/base": "^2.0.0",
+    "@scure/bip32": "^2.0.1",
     "@subsquid/scale-codec": "^4.0.1",
     "commander": "^14.0.0"
   },
@@ -28,6 +29,7 @@
     "format:check": "prettier --check \"**/*.{ts,js,json,yaml,yml,md}\"",
     "gen": "tsx ./src/cli.ts gen --dir ./test-vectors",
     "find-seeds-esk": "tsx ./src/cli.ts find-seeds --key shield-esk",
-    "find-seeds-dust": "tsx ./src/cli.ts find-seeds --key dust-pk --number 3"
+    "find-seeds-dust": "tsx ./src/cli.ts find-seeds --key dust-pk --number 3",
+    "test:unit": "vitest run"
   }
 }

--- a/packages/spec-reference/src/index.test.ts
+++ b/packages/spec-reference/src/index.test.ts
@@ -11,7 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as crypto from 'node:crypto';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
+
+// The parity and roundtrip cases run the spec's pure-JS cryptography against the WASM ledger; on CI runners several of
+// them take 7-14 s, past vitest's 5 s default. First observed the first time this file ran in CI at all.
+vi.setConfig({ testTimeout: 30_000 });
 import {
   Bech32m,
   type Bech32mCodec,

--- a/packages/spec-reference/src/seed-derivation-reference.ts
+++ b/packages/spec-reference/src/seed-derivation-reference.ts
@@ -1,0 +1,83 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Reference for the "Per-wallet seeds" section of the specification: the walk from one master seed down to the seed
+// each of the three wallets is generated from. Everything else in this package takes such a seed as given.
+//
+// BIP-32 itself is delegated to @scure/bip32, exactly as the specification delegates it to BIP-32: what is stated here
+// is the wallet-specific part, which is the path and which role each seed comes from.
+
+import { HDKey } from '@scure/bip32';
+
+/** Path components the specification fixes for every Midnight wallet. */
+export const PURPOSE = 44;
+export const COIN_TYPE = 2400;
+
+/** The role level of the path. Which role each seed comes from is the whole of this reference. */
+export const Roles = {
+  UnshieldedExternal: 0,
+  UnshieldedInternal: 1,
+  Dust: 2,
+  Shielded: 3,
+  /**
+   * The role an unshielded seed comes from when the wallet signs with ECDSA rather than the scheme role 0 is used with,
+   * so the secret scalar is never shared between two algorithms.
+   */
+  EcdsaUnshielded: 4,
+} as const;
+
+export type Role = (typeof Roles)[keyof typeof Roles];
+
+/** Where the three seeds an application holds sit, for a wallet that has a reason not to use the first address. */
+export type WalletSeedsOptions = {
+  account?: number;
+  index?: number;
+  /** Which role the unshielded seed comes from — role 0 unless the wallet signs with a different scheme. */
+  unshieldedRole?: Role;
+};
+
+/** The three seeds every other derivation in this package takes as its input. */
+export type WalletSeeds = {
+  unshielded: Buffer;
+  dust: Buffer;
+  shielded: Buffer;
+};
+
+/** `m / purpose' / coin_type' / account' / role / index`, written the way BIP-32 writes it. */
+export function derivationPath(account: number, role: Role, index: number): string {
+  return `m/${PURPOSE}'/${COIN_TYPE}'/${account}'/${role}/${index}`;
+}
+
+/**
+ * The private key at a path, which is what the specification means by a seed.
+ *
+ * The 32 bytes of the key itself, and not an extended key: chain code and depth belong to the derivation rather than to
+ * what the seed is used for.
+ */
+export function seedAt(masterSeed: Buffer, path: string): Buffer {
+  const derived = HDKey.fromMasterSeed(masterSeed).derive(path);
+  if (derived.privateKey === null) {
+    throw new Error(`No private key exists at ${path}`);
+  }
+  return Buffer.from(derived.privateKey);
+}
+
+/** The walk from one master seed down to the seed each of the three wallets is generated from. */
+export function walletSeeds(masterSeed: Buffer, options: WalletSeedsOptions = {}): WalletSeeds {
+  const { account = 0, index = 0, unshieldedRole = Roles.UnshieldedExternal } = options;
+  return {
+    unshielded: seedAt(masterSeed, derivationPath(account, unshieldedRole, index)),
+    dust: seedAt(masterSeed, derivationPath(account, Roles.Dust, index)),
+    shielded: seedAt(masterSeed, derivationPath(account, Roles.Shielded, index)),
+  };
+}

--- a/packages/spec-reference/src/test-vectors.ts
+++ b/packages/spec-reference/src/test-vectors.ts
@@ -27,6 +27,7 @@ import {
   unshieldedKeyPairFromUniformBytes,
   dustKeys,
 } from './key-derivation-reference.js';
+import { Roles, derivationPath, seedAt, walletSeeds } from './seed-derivation-reference.js';
 import * as ledger from '@midnight-ntwrk/ledger-v8';
 import * as crypto from 'node:crypto';
 
@@ -51,9 +52,24 @@ export type AddressVector = {
   shieldedCPK: AddressEntry;
 };
 
+/** One master seed placed at one account and address index, and every seed the tree yields there. */
+export type SeedDerivationVector = {
+  masterSeed: string;
+  account: number;
+  addressIndex: number;
+  /**
+   * The seed at every role of the path, so an implementation taking its unshielded seed from a role other than the
+   * default can be checked against the same file.
+   */
+  seedsByRole: Record<keyof typeof Roles, { path: string; seed: string }>;
+  /** The three seeds an application holds: the default roles, which is what the specification's table states. */
+  walletSeeds: { unshielded: string; dust: string; shielded: string };
+};
+
 export type TestVectors = {
   keyDerivation: KeyDerivationVector[];
   addresses: AddressVector[];
+  seedDerivation: SeedDerivationVector[];
 };
 
 export const networkIds = [null, 'my-private-net', 'devnet', 'testnet', 'my-private-net-5']; //null stands for mainnet
@@ -165,9 +181,59 @@ export function generateAddressFormattingTestVectors(seeds: Buffer[]): AddressVe
   });
 }
 
+/**
+ * The master seeds the per-wallet seed derivation is stated over.
+ *
+ * Kept apart from `seeds` above deliberately: those are per-wallet seeds, the input to every other derivation in this
+ * package, and this walk produces them rather than consuming them. The first entry is the one
+ * `@midnightntwrk/wallet-sdk-hd` pins its own tests against, so the two cannot come to disagree about the same master
+ * seed.
+ */
+export const masterSeeds = [
+  Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex'),
+  Buffer.alloc(32, 0),
+  Buffer.alloc(32, 255),
+  Buffer.from('b49408db310c043ab736fb57a98e15c8cedbed4c38450df3755ac9726ee14d0c', 'hex'), //random
+  Buffer.from('06004625b6cb2ccead21b15fee2a940c404365702b697b4721bfeecfc6b1b15e', 'hex'), //random
+  Buffer.from('215ca8a6923ec73f241c92ef702ccfc277aa5856bc94f59afa7e82ec94547850', 'hex'), //random
+];
+
+/** Where in the tree the seeds are taken from — the first address, and enough others to pin both levels. */
+export const seedPlacements = [
+  { account: 0, addressIndex: 0 },
+  { account: 0, addressIndex: 1 },
+  { account: 1, addressIndex: 0 },
+  { account: 2, addressIndex: 5 },
+];
+
+export function generateSeedDerivationTestVectors(masterSeeds: Buffer[]): SeedDerivationVector[] {
+  const placed = masterSeeds.flatMap((masterSeed) => seedPlacements.map((placement) => ({ masterSeed, ...placement })));
+  return placed.map(({ masterSeed, account, addressIndex }) => {
+    const seedsByRole = Object.fromEntries(
+      Object.entries(Roles).map(([name, role]) => {
+        const path = derivationPath(account, role, addressIndex);
+        return [name, { path, seed: seedAt(masterSeed, path).toString('hex') }];
+      }),
+    ) as SeedDerivationVector['seedsByRole'];
+    const wallet = walletSeeds(masterSeed, { account, index: addressIndex });
+    return {
+      masterSeed: masterSeed.toString('hex'),
+      account,
+      addressIndex,
+      seedsByRole,
+      walletSeeds: {
+        unshielded: wallet.unshielded.toString('hex'),
+        dust: wallet.dust.toString('hex'),
+        shielded: wallet.shielded.toString('hex'),
+      },
+    };
+  });
+}
+
 export function generateTestVectors(seeds: Buffer[]): TestVectors {
   return {
     keyDerivation: generateKeyDerivationTestVectors(seeds),
     addresses: generateAddressFormattingTestVectors(seeds),
+    seedDerivation: generateSeedDerivationTestVectors(masterSeeds),
   };
 }

--- a/packages/spec-reference/test-vectors/seedDerivation.json
+++ b/packages/spec-reference/test-vectors/seedDerivation.json
@@ -1,0 +1,770 @@
+[
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000001",
+    "account": 0,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/0",
+        "seed": "22b8e577b3f638b2b361f36fd62d7138ed489d9afe3da5f7c325e2d0a95ae043"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/0",
+        "seed": "34d1c3ed1486d0ac6293f915e525ea7717800c4589c7929ddcbe0d1bd2d2818c"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/0",
+        "seed": "b9b76cce66828aa6bd798abbb15b012331a6aa1e5f99e678724c37463b5775a1"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/0",
+        "seed": "9690d4013e42e6739d9496f836b2cbd4339451c02a00624b86e9fb15cc4197a8"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/0",
+        "seed": "559cbe772a3c6fc8e4e8999cd3962bcee4bbc1580281e488fec2c3f78016f88f"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "22b8e577b3f638b2b361f36fd62d7138ed489d9afe3da5f7c325e2d0a95ae043",
+      "dust": "b9b76cce66828aa6bd798abbb15b012331a6aa1e5f99e678724c37463b5775a1",
+      "shielded": "9690d4013e42e6739d9496f836b2cbd4339451c02a00624b86e9fb15cc4197a8"
+    }
+  },
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000001",
+    "account": 0,
+    "addressIndex": 1,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/1",
+        "seed": "abc72cdcd6d6b9b40f275710a3a9b5185040683c83e8d5dabb10b2ec100eb5a0"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/1",
+        "seed": "75f046c16f01068dcbd2890cfe0517ef643863749e9828bd8b849ddf11fd8fdb"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/1",
+        "seed": "3d840c135edb955f6fb8c508e479b83772c227a492a3602496d437a1517eed3a"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/1",
+        "seed": "8655e62d761c746faf6dba1e29b46336061901a66fada04bfd1f897526c4695e"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/1",
+        "seed": "14bacf3a7e93d1f119f372a0b2a5ec8829241e55ee671b853ded4c99252518d8"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "abc72cdcd6d6b9b40f275710a3a9b5185040683c83e8d5dabb10b2ec100eb5a0",
+      "dust": "3d840c135edb955f6fb8c508e479b83772c227a492a3602496d437a1517eed3a",
+      "shielded": "8655e62d761c746faf6dba1e29b46336061901a66fada04bfd1f897526c4695e"
+    }
+  },
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000001",
+    "account": 1,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/1'/0/0",
+        "seed": "69a8e4a2fb369257cee62135a12685c133ac2f8aca76008287e4f6807ef1373e"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/1'/1/0",
+        "seed": "31c43910e2f1a3dc6ffefa14a640481f62c00f69a714bbf2195eccc08d3852d1"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/1'/2/0",
+        "seed": "6b0aa53d5e8afabaed15e8cf3863978b6b866dff0683957af6c594f496f38d04"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/1'/3/0",
+        "seed": "a8096953e10dab792d0f305417a7a7167849482a1cfdd880f689c42d62d2dc74"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/1'/4/0",
+        "seed": "e5d0c01a04a207dc404b768bccc36fe0c8e96007b04a43b4608e31e56327ed3e"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "69a8e4a2fb369257cee62135a12685c133ac2f8aca76008287e4f6807ef1373e",
+      "dust": "6b0aa53d5e8afabaed15e8cf3863978b6b866dff0683957af6c594f496f38d04",
+      "shielded": "a8096953e10dab792d0f305417a7a7167849482a1cfdd880f689c42d62d2dc74"
+    }
+  },
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000001",
+    "account": 2,
+    "addressIndex": 5,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/2'/0/5",
+        "seed": "e1d398885ec1682b6da76679ea275d751fe6baf0cd296a884ca275c9b1acb504"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/2'/1/5",
+        "seed": "0b8165bef36b486031c0ccfd7fba40e45c6ccaf101658db217ab86cdd626f8f5"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/2'/2/5",
+        "seed": "cab7b2f91fa2c399f180fe42c2b5feaa40afbf925818d40ddcb59d6cff072921"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/2'/3/5",
+        "seed": "7dfa747a1b6466ddc9381175edcf6e819c99205f03da807c65898442561ce3f8"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/2'/4/5",
+        "seed": "d042639e2f74c29fa414d5c45fde36a2381cd5906170164628c48732b22105b8"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "e1d398885ec1682b6da76679ea275d751fe6baf0cd296a884ca275c9b1acb504",
+      "dust": "cab7b2f91fa2c399f180fe42c2b5feaa40afbf925818d40ddcb59d6cff072921",
+      "shielded": "7dfa747a1b6466ddc9381175edcf6e819c99205f03da807c65898442561ce3f8"
+    }
+  },
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000000",
+    "account": 0,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/0",
+        "seed": "b76bd8d92eb76098e938051af9d6bf2c81d8bf47ead2aa5442ca60c04346378b"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/0",
+        "seed": "2fba2e9bbf3c62f8e6b4aae1eaab9c0c5227f819490abea9b7e46a9c40278ece"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/0",
+        "seed": "cab391b2eaaf459bd7ef54c461e7fc4e2377afb12fbdd532b0d63b0f48803534"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/0",
+        "seed": "a33865674c03ca1f6c4eb3f6b56625dce0accc96d2ca52114876a58773f5ecab"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/0",
+        "seed": "00d3da0c17f1e51f2c74b75fc0f91d4cdda07d71e6d3ca33c5e5a6b543a3c046"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "b76bd8d92eb76098e938051af9d6bf2c81d8bf47ead2aa5442ca60c04346378b",
+      "dust": "cab391b2eaaf459bd7ef54c461e7fc4e2377afb12fbdd532b0d63b0f48803534",
+      "shielded": "a33865674c03ca1f6c4eb3f6b56625dce0accc96d2ca52114876a58773f5ecab"
+    }
+  },
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000000",
+    "account": 0,
+    "addressIndex": 1,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/1",
+        "seed": "0f65dea026704aa610aa873457cb5dff4c76c722aae1e2378793234b999bfe76"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/1",
+        "seed": "eb4b1b039f91b17210f8564214d7d90a193890ad81888bd001830a0b890608ad"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/1",
+        "seed": "a40611d36a47c6c2449b5b8cf69e191ec2c91e3cbcdc1ef54cc95663d0a3080a"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/1",
+        "seed": "9b0cf4f31c1a9c43d4b7487bfa29506337f2b66387afc9824a5eada827aeaff4"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/1",
+        "seed": "e70f7fed1c80062291c3f26a7181f455cc76adf42a94ebf9337f9162d3e18893"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "0f65dea026704aa610aa873457cb5dff4c76c722aae1e2378793234b999bfe76",
+      "dust": "a40611d36a47c6c2449b5b8cf69e191ec2c91e3cbcdc1ef54cc95663d0a3080a",
+      "shielded": "9b0cf4f31c1a9c43d4b7487bfa29506337f2b66387afc9824a5eada827aeaff4"
+    }
+  },
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000000",
+    "account": 1,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/1'/0/0",
+        "seed": "a400ff335801080272ae0ecc6b76798783e9a4012077ba233ee871a5db291b0a"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/1'/1/0",
+        "seed": "ac22230b45686b3bf32e379036980f1257aec1481dbedbefec2475af6a4c2e9d"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/1'/2/0",
+        "seed": "9ec00f2a6ef7bb54499933a2ea704a972128237cdaa6e0f7511d35d1929a0856"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/1'/3/0",
+        "seed": "e26f8087e3c7dad0ee81447e9ea5ab29793d826a171b53d52a0941fadc43a66d"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/1'/4/0",
+        "seed": "0618f8150285a3624c8030c57e1122a513906459084abe57014d211bd90b1665"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "a400ff335801080272ae0ecc6b76798783e9a4012077ba233ee871a5db291b0a",
+      "dust": "9ec00f2a6ef7bb54499933a2ea704a972128237cdaa6e0f7511d35d1929a0856",
+      "shielded": "e26f8087e3c7dad0ee81447e9ea5ab29793d826a171b53d52a0941fadc43a66d"
+    }
+  },
+  {
+    "masterSeed": "0000000000000000000000000000000000000000000000000000000000000000",
+    "account": 2,
+    "addressIndex": 5,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/2'/0/5",
+        "seed": "925cdded461bcd37257703be12403bb381e158f0e83fc2c1a73c7e80364efc5f"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/2'/1/5",
+        "seed": "ca7e9bda54573c3c7aeaf6c6f3109077d68fba0a51cd9964cc3e9975097ef449"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/2'/2/5",
+        "seed": "b9cd5182c1dd2fc9dfe831dfbc9dfa1182fc0e24b220be511784105b83f0aa30"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/2'/3/5",
+        "seed": "327ba5e946799ea0578ae9b5a3600ec1e3399a66fe89bd81759d1b7b4d9ef26e"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/2'/4/5",
+        "seed": "d623fdb3366a5743e033eca7a331e9b3a9d92e339f9849b8632534f5d703b6a5"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "925cdded461bcd37257703be12403bb381e158f0e83fc2c1a73c7e80364efc5f",
+      "dust": "b9cd5182c1dd2fc9dfe831dfbc9dfa1182fc0e24b220be511784105b83f0aa30",
+      "shielded": "327ba5e946799ea0578ae9b5a3600ec1e3399a66fe89bd81759d1b7b4d9ef26e"
+    }
+  },
+  {
+    "masterSeed": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "account": 0,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/0",
+        "seed": "b39bd35a1f2ab12434fe89502245c4d49e955e623152ffb108d3eab7577588b0"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/0",
+        "seed": "ab2fef59e2bf8805409c97cdd458ea5d42b9e580a5369375ba322b291166f042"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/0",
+        "seed": "535ca6755d051baaaacbcbcdb6247271d176b0de7ad56bdd644c18bd27903685"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/0",
+        "seed": "8e9d2e7244f986a6b9b86847b6188b0fd62a588a19995e2fe1bd37c6fa0d6a71"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/0",
+        "seed": "4f060696cf8d72649046fb3877101c8b333ab94c70d33b886c68f39777b4a1ab"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "b39bd35a1f2ab12434fe89502245c4d49e955e623152ffb108d3eab7577588b0",
+      "dust": "535ca6755d051baaaacbcbcdb6247271d176b0de7ad56bdd644c18bd27903685",
+      "shielded": "8e9d2e7244f986a6b9b86847b6188b0fd62a588a19995e2fe1bd37c6fa0d6a71"
+    }
+  },
+  {
+    "masterSeed": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "account": 0,
+    "addressIndex": 1,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/1",
+        "seed": "31b21c0c10dbb7ae3ca5b34f709b5c2e240ec21d1ed106d7ec33a9e8bd69e74a"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/1",
+        "seed": "9da86ef0e8c9e84c893990c8b757e8941688cf2aaf212e82453e8748e971e17e"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/1",
+        "seed": "cf1f2c42ac691cd2a71ad31734f4e05f162016ff8df3da4b46fc7133fb366654"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/1",
+        "seed": "100aae03f97fecc671da82cc957b907b7ccf9769e1553a389c14edcb805a4226"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/1",
+        "seed": "e1af1898bdcf5ecd0d9ca40e5c2f001a016387041961437bdebc17c7777f0757"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "31b21c0c10dbb7ae3ca5b34f709b5c2e240ec21d1ed106d7ec33a9e8bd69e74a",
+      "dust": "cf1f2c42ac691cd2a71ad31734f4e05f162016ff8df3da4b46fc7133fb366654",
+      "shielded": "100aae03f97fecc671da82cc957b907b7ccf9769e1553a389c14edcb805a4226"
+    }
+  },
+  {
+    "masterSeed": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "account": 1,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/1'/0/0",
+        "seed": "b41158ea0e64b6beb74e230f2e1a808389dc2d183c6614b37ce9b3ca0c4388ba"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/1'/1/0",
+        "seed": "8d5bb992612b5be5e1c5671338eeb84ab846a549ea1f1306723d5e51d3e9d44f"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/1'/2/0",
+        "seed": "30709aa981b4df091398d1964d315690fc2145d27c0e58714b72767133f97047"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/1'/3/0",
+        "seed": "d37c306ff7566d9469511433cf56a4b669f64af8d195291a0090220d0c22d6d6"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/1'/4/0",
+        "seed": "510801315fe04ee08641259aab81f6b21b9391b24941ad9ff616b8f0b7d0b62b"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "b41158ea0e64b6beb74e230f2e1a808389dc2d183c6614b37ce9b3ca0c4388ba",
+      "dust": "30709aa981b4df091398d1964d315690fc2145d27c0e58714b72767133f97047",
+      "shielded": "d37c306ff7566d9469511433cf56a4b669f64af8d195291a0090220d0c22d6d6"
+    }
+  },
+  {
+    "masterSeed": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "account": 2,
+    "addressIndex": 5,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/2'/0/5",
+        "seed": "a8f3adef15d7a32b03f7288100c1709f46c6abe3747e87f2c421c3f166e6b92b"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/2'/1/5",
+        "seed": "5152ce7cb2d62ec8f733db87b33bbc43fa316402f1f444e97b6dea7b018bdf67"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/2'/2/5",
+        "seed": "4389f771021fb03fcb3cea80bd222f222029def5c8c3332c68deda2852e44b96"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/2'/3/5",
+        "seed": "e03174bb7308e4767958ea6fd71309a423f80824642bc15669bf7391e87f6c6e"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/2'/4/5",
+        "seed": "08a0282c7ac6aefc1cbc7297c66e186e321c3486e402d54c29dd8625973144ac"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "a8f3adef15d7a32b03f7288100c1709f46c6abe3747e87f2c421c3f166e6b92b",
+      "dust": "4389f771021fb03fcb3cea80bd222f222029def5c8c3332c68deda2852e44b96",
+      "shielded": "e03174bb7308e4767958ea6fd71309a423f80824642bc15669bf7391e87f6c6e"
+    }
+  },
+  {
+    "masterSeed": "b49408db310c043ab736fb57a98e15c8cedbed4c38450df3755ac9726ee14d0c",
+    "account": 0,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/0",
+        "seed": "543110874819c43470602a2710579b006de9d29788cd0f2e6d611d9994f40a81"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/0",
+        "seed": "906c7139f23883dc4c8fcef83c42ac25487a047df04b93042cdc6379c1557a4c"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/0",
+        "seed": "2852902e81dbc84d6ed459c2b977995cd8aa18f35a016db139749bdef167f811"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/0",
+        "seed": "641e75883e350a65dd3e93dd52229949be18456d5d17ea5484d5c1f73c4d57ce"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/0",
+        "seed": "1a05518eee536737ebaf43b7c54ce85bf7e57dc108e5eda1ed9b5e7a2864c81b"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "543110874819c43470602a2710579b006de9d29788cd0f2e6d611d9994f40a81",
+      "dust": "2852902e81dbc84d6ed459c2b977995cd8aa18f35a016db139749bdef167f811",
+      "shielded": "641e75883e350a65dd3e93dd52229949be18456d5d17ea5484d5c1f73c4d57ce"
+    }
+  },
+  {
+    "masterSeed": "b49408db310c043ab736fb57a98e15c8cedbed4c38450df3755ac9726ee14d0c",
+    "account": 0,
+    "addressIndex": 1,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/1",
+        "seed": "d39703a6a0594ff62ea443b011033c5239aa276f4d72ec139b5c59746e91ccd4"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/1",
+        "seed": "4735f9cba78b612eca5e492b2e20710f79d38fe5c311f808328515928de0c282"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/1",
+        "seed": "1b72f521ce10e097449417eea627732ce262052e5a2170a7623e3f16c173f7b7"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/1",
+        "seed": "518026ff30ca7ab23d227ffc93232b5c78d0f7a02b6ced9dd686a54dd0311c14"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/1",
+        "seed": "4893a7677b9c83be37d163d4da9a068016c667fbfff31bf6625c36561ae9ff7a"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "d39703a6a0594ff62ea443b011033c5239aa276f4d72ec139b5c59746e91ccd4",
+      "dust": "1b72f521ce10e097449417eea627732ce262052e5a2170a7623e3f16c173f7b7",
+      "shielded": "518026ff30ca7ab23d227ffc93232b5c78d0f7a02b6ced9dd686a54dd0311c14"
+    }
+  },
+  {
+    "masterSeed": "b49408db310c043ab736fb57a98e15c8cedbed4c38450df3755ac9726ee14d0c",
+    "account": 1,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/1'/0/0",
+        "seed": "1e2c3b62cf396e5e7bfbe7b04ce5c25cd5318e7013ba1dcbd22ed3b0bb15d3de"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/1'/1/0",
+        "seed": "42a8467bac1f96fd8b08d22b1fdac3eacfdb34a714bb32f5029cc2e0c5bf3996"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/1'/2/0",
+        "seed": "dedf271548ebb6cef6934bbe777a69207e043e93360dc82caaf49fc605a15fcb"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/1'/3/0",
+        "seed": "825a4ad95f7f79c682c7d2819e013a22fd8a8b0842e4058e4ac47de768829d0a"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/1'/4/0",
+        "seed": "7dc293936c4eba0054371604e143fad3333b144e6cf0abce3f81ad4cce68bfd5"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "1e2c3b62cf396e5e7bfbe7b04ce5c25cd5318e7013ba1dcbd22ed3b0bb15d3de",
+      "dust": "dedf271548ebb6cef6934bbe777a69207e043e93360dc82caaf49fc605a15fcb",
+      "shielded": "825a4ad95f7f79c682c7d2819e013a22fd8a8b0842e4058e4ac47de768829d0a"
+    }
+  },
+  {
+    "masterSeed": "b49408db310c043ab736fb57a98e15c8cedbed4c38450df3755ac9726ee14d0c",
+    "account": 2,
+    "addressIndex": 5,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/2'/0/5",
+        "seed": "4b3164138c3ae13d9c908eb8f3c3dfdb1beb2562101dd4a9d3cca549554a7a89"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/2'/1/5",
+        "seed": "348360f27d5fb4abb0f9800d04e1bfb1c6107b85e44bcd3d847af2a6247e82f6"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/2'/2/5",
+        "seed": "f58bca92919ecead3c6a1e9aab720cdded2de531f8b5a15ba0696f667ff7a1d4"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/2'/3/5",
+        "seed": "a763cd6036c238fb7cfd552b6f980598647fa79274533b95f474d104c7dd6d36"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/2'/4/5",
+        "seed": "09763387dbf1bdbde5b07043ccb444f5697f429c5cded1fc23b2d59a1d737dc1"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "4b3164138c3ae13d9c908eb8f3c3dfdb1beb2562101dd4a9d3cca549554a7a89",
+      "dust": "f58bca92919ecead3c6a1e9aab720cdded2de531f8b5a15ba0696f667ff7a1d4",
+      "shielded": "a763cd6036c238fb7cfd552b6f980598647fa79274533b95f474d104c7dd6d36"
+    }
+  },
+  {
+    "masterSeed": "06004625b6cb2ccead21b15fee2a940c404365702b697b4721bfeecfc6b1b15e",
+    "account": 0,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/0",
+        "seed": "6f150d871e61d80b32a9f4c6cd29ef4522d84fec7b37030de98786a88383a385"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/0",
+        "seed": "f94f4551032b7db233c82fbf84ed7857480d6b833c6cffd08cd875146a80b77c"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/0",
+        "seed": "0995ea2747cbafa26e81f39130e5f4d8c0cd23ee61ab882a9a434d544176b364"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/0",
+        "seed": "8f46aae4617acdbd7dd705af463940f6e3dbb47a970fefdf51fcff027266bac2"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/0",
+        "seed": "45e2f26e5f222a2411553bd25fda633e77c7b363285113fc4e0c3b5911b23953"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "6f150d871e61d80b32a9f4c6cd29ef4522d84fec7b37030de98786a88383a385",
+      "dust": "0995ea2747cbafa26e81f39130e5f4d8c0cd23ee61ab882a9a434d544176b364",
+      "shielded": "8f46aae4617acdbd7dd705af463940f6e3dbb47a970fefdf51fcff027266bac2"
+    }
+  },
+  {
+    "masterSeed": "06004625b6cb2ccead21b15fee2a940c404365702b697b4721bfeecfc6b1b15e",
+    "account": 0,
+    "addressIndex": 1,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/1",
+        "seed": "76dd2e80c6aa21675261343d1c0bc6538c815e25b0a8efbf68e9fb0a0c13225a"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/1",
+        "seed": "d8b1ba5b615156cd0520228c4366de0e2793c5da345c780f8c81c47d19ae3286"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/1",
+        "seed": "3efa843345220076bb8baefc507faf981748b52d191674f986160bc3b4cbcc1a"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/1",
+        "seed": "1c60eeb6e2aa0f9a4c5ee3273fba31b14318f60e159b3b9c329f55294d0c0637"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/1",
+        "seed": "0e5bcd3b75775d600e601a9ede0aac5d057596a990f24dc6b2fcac10aa05b403"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "76dd2e80c6aa21675261343d1c0bc6538c815e25b0a8efbf68e9fb0a0c13225a",
+      "dust": "3efa843345220076bb8baefc507faf981748b52d191674f986160bc3b4cbcc1a",
+      "shielded": "1c60eeb6e2aa0f9a4c5ee3273fba31b14318f60e159b3b9c329f55294d0c0637"
+    }
+  },
+  {
+    "masterSeed": "06004625b6cb2ccead21b15fee2a940c404365702b697b4721bfeecfc6b1b15e",
+    "account": 1,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/1'/0/0",
+        "seed": "114a5c2de771db642ddce57efbddc5017bfb6344b6d3acb23ab31960375ee86b"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/1'/1/0",
+        "seed": "9af7f1a320cd99e9b4d82259334f01681a7d14691c206ef026f0b65aee0a4fac"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/1'/2/0",
+        "seed": "5fd7cf92b0f560eb5b6c1ce40fa2561ac42decddf353558671f12e9fcb747489"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/1'/3/0",
+        "seed": "bc9169d8de5abc104274b7180ba50fddc37cc22a0c74473cbb797e98ec925b4d"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/1'/4/0",
+        "seed": "213001539aa750d9468c11a8ca5ce52c61aed78fa7fd72dba7ee53f4f2a30fbc"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "114a5c2de771db642ddce57efbddc5017bfb6344b6d3acb23ab31960375ee86b",
+      "dust": "5fd7cf92b0f560eb5b6c1ce40fa2561ac42decddf353558671f12e9fcb747489",
+      "shielded": "bc9169d8de5abc104274b7180ba50fddc37cc22a0c74473cbb797e98ec925b4d"
+    }
+  },
+  {
+    "masterSeed": "06004625b6cb2ccead21b15fee2a940c404365702b697b4721bfeecfc6b1b15e",
+    "account": 2,
+    "addressIndex": 5,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/2'/0/5",
+        "seed": "3a1e8312288701835d9742a88c7eb2d2bd7e8346acc2bc7e8b742cf4192f986e"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/2'/1/5",
+        "seed": "d93a563d418f4782672860dfd79d149f3dedcb72c24524f08cd034351912bff8"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/2'/2/5",
+        "seed": "d7d169173f5377e6235f6f95be708cd5ac7fe6bb7fbcd06b7971dfaf5e833fe3"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/2'/3/5",
+        "seed": "474e1ec5df872034a1e7fe5f774827707bf505ae531c5f1509c09312009d567c"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/2'/4/5",
+        "seed": "30ff89b32aba96cbabca4ad2013e2965887dbf3470fdf68181c6d02409d7a531"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "3a1e8312288701835d9742a88c7eb2d2bd7e8346acc2bc7e8b742cf4192f986e",
+      "dust": "d7d169173f5377e6235f6f95be708cd5ac7fe6bb7fbcd06b7971dfaf5e833fe3",
+      "shielded": "474e1ec5df872034a1e7fe5f774827707bf505ae531c5f1509c09312009d567c"
+    }
+  },
+  {
+    "masterSeed": "215ca8a6923ec73f241c92ef702ccfc277aa5856bc94f59afa7e82ec94547850",
+    "account": 0,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/0",
+        "seed": "f7ea70204ad7c72bde05b667584160d4feecf435863ab1c902a107852b7a5531"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/0",
+        "seed": "7e3883b2d3ef17df5b89099328f44672947ab7aca8a885e0f9c34d1ef8764e5d"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/0",
+        "seed": "683a154ce937a0d7a1b23f90ffcc04c1cfab66fcac4aaf130a8264a79891e841"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/0",
+        "seed": "ed5c4fd2223106c727e1dac1de67e5c7073ec25f0e6a0f5926cea3cc758bb1b2"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/0",
+        "seed": "6a18bf1e28789a1cf167588d45febfbfd79b2d973ad001b95c3c284a3b1e92f9"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "f7ea70204ad7c72bde05b667584160d4feecf435863ab1c902a107852b7a5531",
+      "dust": "683a154ce937a0d7a1b23f90ffcc04c1cfab66fcac4aaf130a8264a79891e841",
+      "shielded": "ed5c4fd2223106c727e1dac1de67e5c7073ec25f0e6a0f5926cea3cc758bb1b2"
+    }
+  },
+  {
+    "masterSeed": "215ca8a6923ec73f241c92ef702ccfc277aa5856bc94f59afa7e82ec94547850",
+    "account": 0,
+    "addressIndex": 1,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/0'/0/1",
+        "seed": "585792f27ee4444b87147a53a2d4607028fddc09389fba74c5246423d4acc0f7"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/0'/1/1",
+        "seed": "24792d21cd1d5e9720ab94a26684833f07adf32eb7347cce0892ca753eac28aa"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/0'/2/1",
+        "seed": "fd48f9dd2b24eea2ca1c3ab1fc8fb88380b198590c5fa680bd74970462741bfa"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/0'/3/1",
+        "seed": "5beed28f0c24cd188cb4b85ad27a2c0f914183312ad11c93fc3bcb436cc3d81c"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/0'/4/1",
+        "seed": "5e52a43fa8efa4d8010e489be6a2a3d830936b1c84cdb62d68743eaa465da7eb"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "585792f27ee4444b87147a53a2d4607028fddc09389fba74c5246423d4acc0f7",
+      "dust": "fd48f9dd2b24eea2ca1c3ab1fc8fb88380b198590c5fa680bd74970462741bfa",
+      "shielded": "5beed28f0c24cd188cb4b85ad27a2c0f914183312ad11c93fc3bcb436cc3d81c"
+    }
+  },
+  {
+    "masterSeed": "215ca8a6923ec73f241c92ef702ccfc277aa5856bc94f59afa7e82ec94547850",
+    "account": 1,
+    "addressIndex": 0,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/1'/0/0",
+        "seed": "9f32da89d21a3c791a6b79aa92e4fa36b039d090bb65c278d69501ac343bcd8c"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/1'/1/0",
+        "seed": "e3e70eb3b0ca7221b508f7337d4a731274439999427046965dc4bbb5111c408c"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/1'/2/0",
+        "seed": "42098698a8e18bc7f5a7b80439fa788c119e5b6700805e3a4ad2f5657ba388ca"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/1'/3/0",
+        "seed": "9ef53cd2917ce0f6765b2cfb5838425eef885a8ce220365fdcc3e28b60146af0"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/1'/4/0",
+        "seed": "1f222309012ca80a3b89ed4e2d7d2dbf8e1caa3288ebea78b9f4a3122e701430"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "9f32da89d21a3c791a6b79aa92e4fa36b039d090bb65c278d69501ac343bcd8c",
+      "dust": "42098698a8e18bc7f5a7b80439fa788c119e5b6700805e3a4ad2f5657ba388ca",
+      "shielded": "9ef53cd2917ce0f6765b2cfb5838425eef885a8ce220365fdcc3e28b60146af0"
+    }
+  },
+  {
+    "masterSeed": "215ca8a6923ec73f241c92ef702ccfc277aa5856bc94f59afa7e82ec94547850",
+    "account": 2,
+    "addressIndex": 5,
+    "seedsByRole": {
+      "UnshieldedExternal": {
+        "path": "m/44'/2400'/2'/0/5",
+        "seed": "cc2b3cd31eb6024fd2090aa808e7b068a4750d5b27b16a1386f905eb08ff02da"
+      },
+      "UnshieldedInternal": {
+        "path": "m/44'/2400'/2'/1/5",
+        "seed": "0d4dada167211c18c75b42dec7e3d3e5b6a5a9a9e8a640076ffce7680e62c1df"
+      },
+      "Dust": {
+        "path": "m/44'/2400'/2'/2/5",
+        "seed": "06372c5c82554e0f4d7b82060d9738bc4fc5a313617b2ed1e1e85ca1901fc493"
+      },
+      "Shielded": {
+        "path": "m/44'/2400'/2'/3/5",
+        "seed": "9faa3469993828db58e2ff44c17137bb3c16a9b65a2d549a5be9c99c0eb8f98b"
+      },
+      "EcdsaUnshielded": {
+        "path": "m/44'/2400'/2'/4/5",
+        "seed": "29af866ab0ba8657dce351939bdbfe9b274b1be3b2b45fe15eedff1a5dcd1b83"
+      }
+    },
+    "walletSeeds": {
+      "unshielded": "cc2b3cd31eb6024fd2090aa808e7b068a4750d5b27b16a1386f905eb08ff02da",
+      "dust": "06372c5c82554e0f4d7b82060d9738bc4fc5a313617b2ed1e1e85ca1901fc493",
+      "shielded": "9faa3469993828db58e2ff44c17137bb3c16a9b65a2d549a5be9c99c0eb8f98b"
+    }
+  }
+]

--- a/packages/unshielded-wallet/src/test/forkHarness.ts
+++ b/packages/unshielded-wallet/src/test/forkHarness.ts
@@ -224,8 +224,8 @@ export type ForkWallet = {
    * The class the wallet was started from, so a snapshot can be restored through the same registration that wrote it.
    *
    * @remarks
-   *   Restoring is a class-level entry point, not an instance one — it is how an application gets a wallet in the
-   *   first place — so a proof about restoring needs the class and not merely the running wallet.
+   *   Restoring is a class-level entry point, not an instance one — it is how an application gets a wallet in the first
+   *   place — so a proof about restoring needs the class and not merely the running wallet.
    */
   readonly walletClass: ForkingUnshieldedWalletClass<PreForkUpdate, PostForkUpdate>;
   /** Starts background synchronization through the wallet's own API. */

--- a/packages/unshielded-wallet/src/test/forkHarness.ts
+++ b/packages/unshielded-wallet/src/test/forkHarness.ts
@@ -32,7 +32,11 @@ import { NetworkId, type ProtocolState, type ProtocolVersion } from '@midnightnt
 import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
 import { type WalletRuntimeError } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { Deferred, Effect, FiberId, HashMap, Option, Stream, pipe } from 'effect';
-import { CustomForkingUnshieldedWallet, type ForkingUnshieldedWallet } from '../ForkingUnshieldedWallet.js';
+import {
+  CustomForkingUnshieldedWallet,
+  type ForkingUnshieldedWallet,
+  type ForkingUnshieldedWalletClass,
+} from '../ForkingUnshieldedWallet.js';
 import { type PublicKey } from '../KeyStore.js';
 import { type CoreWallet as PreForkWallet } from '../v1/CoreWallet.js';
 import * as PreForkMigration from '../v1/Migration.js';
@@ -216,6 +220,14 @@ export type ForkedState = ProtocolState.ProtocolState<PreForkWallet | PostForkWa
 export type ForkWallet = {
   /** The wallet itself, exactly as an application would hold it. */
   readonly unshielded: ForkingUnshieldedWallet<PreForkUpdate, PostForkUpdate>;
+  /**
+   * The class the wallet was started from, so a snapshot can be restored through the same registration that wrote it.
+   *
+   * @remarks
+   *   Restoring is a class-level entry point, not an instance one — it is how an application gets a wallet in the
+   *   first place — so a proof about restoring needs the class and not merely the running wallet.
+   */
+  readonly walletClass: ForkingUnshieldedWalletClass<PreForkUpdate, PostForkUpdate>;
   /** Starts background synchronization through the wallet's own API. */
   readonly start: Effect.Effect<void>;
   /** Resolves when the hand-over happens, with both ends of it. */
@@ -307,6 +319,8 @@ export const makeForkWallet = (config: ForkWalletConfig): Effect.Effect<ForkWall
 
       return {
         unshielded: wallet,
+
+        walletClass: WalletClass,
 
         start: Effect.promise(() => wallet.start()),
 

--- a/packages/unshielded-wallet/src/test/forkRestore.test.ts
+++ b/packages/unshielded-wallet/src/test/forkRestore.test.ts
@@ -1,0 +1,135 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Restoring a snapshot into the variant that wrote it, through the wallet class an application holds.
+ *
+ * @remarks
+ *   `restore.test.ts` pins the routing helpers on hand-built envelopes, and the runtime pins `startAtVariant` over
+ *   synthetic variants. Neither says that the two meet correctly in a shipped forking wallet, which is the composition
+ *   an application actually calls: peek at the snapshot, resolve the variant that owns the version it declares,
+ *   deserialize with *that* variant's deserializer, and start there.
+ *
+ *   Both epochs are pinned in one file on purpose. A router that always answered with the head variant would pass the
+ *   pre-fork half and fail the post-fork one; a router that always answered with the last registration would do the
+ *   reverse. Only routing on the snapshot's own declared version passes both.
+ *
+ *   The snapshots are the suite's own: each is written by a running wallet through `serializeState()`, so what is
+ *   restored is what this package actually produces rather than a fixture that could drift from it.
+ */
+
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type ChainVersionProbe } from '@midnightntwrk/wallet-sdk-capabilities/chainVersion';
+import { Effect, Option, type Scope, pipe } from 'effect';
+import * as rx from 'rxjs';
+import { describe, expect, it } from 'vitest';
+import { peekProtocolVersion } from '../Restore.js';
+import { V1Tag } from '../v1/RunningV1Variant.js';
+import { V2Tag } from '../v2/RunningV2Variant.js';
+import { type CarriedUtxo, type ForkWallet, makeForkWallet, utxosOf } from './forkHarness.js';
+import { postForkIdentity, timelineTransaction } from './forkTimeline.js';
+
+const networkId = NetworkId.NetworkId.Undeployed;
+
+/** Where the wallet registers its post-fork variant. */
+const forkVersion = ProtocolVersion.ProtocolVersion(7n);
+/** A chain that has already forked — past the boundary rather than exactly at it. */
+const afterFork = 9;
+/** A chain that has not — a version the pre-fork variant owns. */
+const beforeFork = 5;
+
+const postFork = postForkIdentity(networkId);
+
+/** The whole history of a chain sitting on one side of the boundary: every message reported at the same version. */
+const chainAt = (protocolVersion: number) => [
+  timelineTransaction({ id: 1, protocolVersion, owner: postFork.addressHex, value: 100n }),
+  timelineTransaction({ id: 2, protocolVersion, owner: postFork.addressHex, value: 200n }),
+];
+
+const valuesOf = (utxos: readonly CarriedUtxo[]): readonly bigint[] => utxos.map((u) => u.value);
+
+/** A probe answering as a chain on `version` would. */
+const chainReporting =
+  (version: number): ChainVersionProbe =>
+  () =>
+    Promise.resolve(ProtocolVersion.ProtocolVersion(BigInt(version)));
+
+/** A started wallet that has consumed the whole of a chain reported at `protocolVersion`. */
+const syncedWalletOnChainAt = (protocolVersion: number): Effect.Effect<ForkWallet, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const wallet = yield* makeForkWallet({
+      timeline: chainAt(protocolVersion),
+      forkVersion,
+      publicKey: postFork,
+      chainVersionProbe: chainReporting(protocolVersion),
+    });
+    yield* Effect.addFinalizer(() => wallet.stop);
+    yield* wallet.start;
+    yield* wallet.awaitState((state) => state.state.progress.appliedId === 2n).pipe(Effect.orDie);
+    return wallet;
+  });
+
+/** The tag of the variant a wallet is running, read the way the harness reads it of the wallet it started. */
+const runningTag = (wallet: ForkWallet['unshielded']): Effect.Effect<string | symbol> =>
+  pipe(
+    wallet.runtime.currentVariant,
+    Effect.map((current) => current.runningVariant.__polyTag__),
+  );
+
+/** The first state a restored wallet publishes, which is the one it was restored onto. */
+const restoredState = (wallet: ForkWallet['unshielded']) => Effect.promise(() => rx.firstValueFrom(wallet.state));
+
+describe('an unshielded wallet restoring a snapshot through the class it was started from', () => {
+  it('restores a snapshot written below the boundary onto the pre-fork variant, with what it held', async () =>
+    Effect.gen(function* () {
+      const wallet = yield* syncedWalletOnChainAt(beforeFork);
+      expect(yield* wallet.activeTag).toBe(V1Tag);
+
+      const snapshot = yield* Effect.promise(() => wallet.unshielded.serializeState());
+      // The snapshot names the epoch that wrote it, which is the only thing the restore has to go on.
+      expect(peekProtocolVersion(snapshot)).toStrictEqual(
+        Option.some(ProtocolVersion.ProtocolVersion(BigInt(beforeFork))),
+      );
+
+      const restored = wallet.walletClass.restore(snapshot);
+      yield* Effect.addFinalizer(() => Effect.promise(() => restored.stop()));
+
+      expect(yield* runningTag(restored)).toBe(V1Tag);
+
+      const state = yield* restoredState(restored);
+      expect(state.protocolVersion).toBeLessThan(forkVersion);
+      expect(valuesOf(utxosOf(state.state))).toEqual([100n, 200n]);
+      expect(state.state.publicKey.address).toBe(postFork.addressHex);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('restores a snapshot written at or past the boundary onto the post-fork variant, with what it held', async () =>
+    Effect.gen(function* () {
+      const wallet = yield* syncedWalletOnChainAt(afterFork);
+      expect(yield* wallet.activeTag).toBe(V2Tag);
+
+      const snapshot = yield* Effect.promise(() => wallet.unshielded.serializeState());
+      expect(peekProtocolVersion(snapshot)).toStrictEqual(
+        Option.some(ProtocolVersion.ProtocolVersion(BigInt(afterFork))),
+      );
+
+      const restored = wallet.walletClass.restore(snapshot);
+      yield* Effect.addFinalizer(() => Effect.promise(() => restored.stop()));
+
+      expect(yield* runningTag(restored)).toBe(V2Tag);
+
+      const state = yield* restoredState(restored);
+      expect(state.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
+      expect(valuesOf(utxosOf(state.state))).toEqual([100n, 200n]);
+      expect(state.state.publicKey.address).toBe(postFork.addressHex);
+    }).pipe(Effect.scoped, Effect.runPromise));
+});

--- a/packages/unshielded-wallet/src/test/forkRestore.test.ts
+++ b/packages/unshielded-wallet/src/test/forkRestore.test.ts
@@ -18,7 +18,7 @@
  *   `restore.test.ts` pins the routing helpers on hand-built envelopes, and the runtime pins `startAtVariant` over
  *   synthetic variants. Neither says that the two meet correctly in a shipped forking wallet, which is the composition
  *   an application actually calls: peek at the snapshot, resolve the variant that owns the version it declares,
- *   deserialize with *that* variant's deserializer, and start there.
+ *   deserialize with _that_ variant's deserializer, and start there.
  *
  *   Both epochs are pinned in one file on purpose. A router that always answered with the head variant would pass the
  *   pre-fork half and fail the post-fork one; a router that always answered with the last registration would do the

--- a/packages/unshielded-wallet/src/test/forkRestore.test.ts
+++ b/packages/unshielded-wallet/src/test/forkRestore.test.ts
@@ -94,6 +94,7 @@ describe('an unshielded wallet restoring a snapshot through the class it was sta
     Effect.gen(function* () {
       const wallet = yield* syncedWalletOnChainAt(beforeFork);
       expect(yield* wallet.activeTag).toBe(V1Tag);
+      const synced = yield* wallet.currentState;
 
       const snapshot = yield* Effect.promise(() => wallet.unshielded.serializeState());
       // The snapshot names the epoch that wrote it, which is the only thing the restore has to go on.
@@ -109,13 +110,14 @@ describe('an unshielded wallet restoring a snapshot through the class it was sta
       const state = yield* restoredState(restored);
       expect(state.protocolVersion).toBeLessThan(forkVersion);
       expect(valuesOf(utxosOf(state.state))).toEqual([100n, 200n]);
-      expect(state.state.publicKey.address).toBe(postFork.addressHex);
+      expect(state.state.publicKey.address).toBe(synced.state.publicKey.address);
     }).pipe(Effect.scoped, Effect.runPromise));
 
   it('restores a snapshot written at or past the boundary onto the post-fork variant, with what it held', async () =>
     Effect.gen(function* () {
       const wallet = yield* syncedWalletOnChainAt(afterFork);
       expect(yield* wallet.activeTag).toBe(V2Tag);
+      const synced = yield* wallet.currentState;
 
       const snapshot = yield* Effect.promise(() => wallet.unshielded.serializeState());
       expect(peekProtocolVersion(snapshot)).toStrictEqual(
@@ -130,6 +132,6 @@ describe('an unshielded wallet restoring a snapshot through the class it was sta
       const state = yield* restoredState(restored);
       expect(state.protocolVersion).toBeGreaterThanOrEqual(forkVersion);
       expect(valuesOf(utxosOf(state.state))).toEqual([100n, 200n]);
-      expect(state.state.publicKey.address).toBe(postFork.addressHex);
+      expect(state.state.publicKey.address).toBe(synced.state.publicKey.address);
     }).pipe(Effect.scoped, Effect.runPromise));
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2723,6 +2723,7 @@ __metadata:
     "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@noble/curves": "npm:^1.8.1"
     "@scure/base": "npm:^2.0.0"
+    "@scure/bip32": "npm:^2.0.1"
     "@subsquid/scale-codec": "npm:^4.0.1"
     commander: "npm:^14.0.0"
     tsx: "npm:4.22.4"


### PR DESCRIPTION
Thirteenth and final increment of the dual-ledger public API redesign — the WP-16/17 wrap-up audit over the complete line (#675–#686). Stacked on #686.

## Changesets as release notes (14 corrections)

Nothing from this beta line has been released, so the pending changesets must read correctly in aggregate at the next cut. Fourteen described superseded states in the present tense — each corrected to carry the release's real arc: the temporary transacting seams are introduced AND closed within this release (no `PreForkTransactingUnsupportedError` exists in the published surface — verified zero occurrences); `startWithSecretKeys` guidance no longer tells readers to migrate onto something the same release deleted; the spurious start migration is the *fallback*, not the default, now the probe exists; `FacadeState.pending`'s shape, `finalizeTransaction`'s arity, the wired v8 validator, and the fork-split codec defaults all state what actually ships. One release-policy flag for reviewers (deliberately unchanged): two `minor` bumps technically break *constructors* of `ProtocolState`/`VariantContext` — consistently reasoned house-rule ("consumers read, don't construct"), loudly documented, but worth a deliberate eye.

## The three debts, closed

- **Forking `restore` composition pins** (×3 wallets, `forkRestore.test.ts`): a snapshot from each epoch restores through the *shipped forking class* onto the correct running variant, with the held value surviving — both epochs in one file, so a router that always answers head (or always last) fails half. Survey confirmed this closed a real gap: nothing anywhere asserted the composed round trip.
- **`ProtocolPhase` Crossing wiring pin** (facade, 5 tests): real shipped wallets with injected state streams through the real `WalletFacade.init` — pins per-slot version reads (three *different* versions, so slot mix-ups fail), within-epoch drift = `Settled`, one/two laggards in fixed `behind` order, live transitions, and `Crossing.from === activeProtocolVersion`. Discrimination verified empirically by mutating a slot read and watching exactly the right tests fail.
- **The spec now owns `WalletSeeds.fromMasterSeed`**: a new "Per-wallet seeds" section in `docs/spec/Specification.md` (filling a gap the document itself left — it twice said seeds derive "at certain path" without saying which), a reference implementation in `packages/spec-reference` over `@scure/bip32`, and a new `seedDerivation.json` vector file (24 entries). **The substantive result: the reference implementation — sharing zero code with the SDK — reproduces `packages/hd`'s hand-written golden hex exactly**, and the existing key/address vector files are byte-identical after regeneration. `hd`'s tests now pin against the vectors (53 tests); the golden-hex pin retired as subsumed.

## A CI gap found and fixed

`packages/spec-reference` was the only package defining `test` but not `test:unit` — so **its vector verification never ran in CI** (the workflow runs `yarn test:unit`; nothing invokes bare `test`). The script is added; the spec vectors are now part of the gate (29 tests).

## CLAUDE.md (WP-17, corrections only — every referenced path verified)

The stale `ledger-v7` references become the dual-ledger reality (both `.d.ts` paths, the handle's `unwrapWithin`, version-travels-as-data); the scope-hyphen footgun is documented at first mention (`@midnight-ntwrk` vs `@midnightntwrk` — one character, two npm orgs); the three dead `dapp-connector-reference` paths point at real current exemplars (`parseTokenType` for parse-don't-validate; three real transaction-inspection test files); a new "v1/v2 Twin Convention" section states the twins discipline and its one permanent exclusion; the docs-snippets list gains its 10 missing files.

## For reviewers, not covered by any changeset

- **Spec drift, deliberately left to the spec owner**: the spec's role table calls role 4 "Metadata"; `packages/hd` repurposed it as `Roles.EcdsaUnshielded` (released). The new section describes roles 0/2/3 by name and states the different-scheme principle without asserting role 4's meaning, keeping the document internally consistent; the vectors cover role 4 by path, so nothing is unpinned.
- Vector files remain hand-copied into consuming packages (`addresses.json` precedent, now `seedDerivation.json` too) — documented in spec-reference's README with a vector→section table; still a manual step.
- One genuinely new diagnostics hit on the line (`LedgerTranslation.ts:27` `deterministicKeys`) follows the repo-wide short-tag convention every other error uses; left consistent, reported.

## Gate

dist 17/17 · typecheck 37/37 · lint 58/58 · unit **55/55 tasks, 147 files, 1246 tests** (the known dust parallel-load flake surfaced once during independent verification and passed clean on re-run) · fork-simulation integration 3/3 · spec-reference 29 vector tests now gating · effect-language-service swept across all 350 line-changed files with only the accepted pre-existing hits · format + changesets green. Regression nets untouched and passing: all six fork suites, facade orphan/submission, runtime.