### PR TITLE
fix(unshielded-wallet)!: stop a leaked booking duplicating a utxo and doubling the balance

### DIFF
--- a/.changeset/fix-unshielded-utxo-duplication.md
+++ b/.changeset/fix-unshielded-utxo-duplication.md
@@ -1,0 +1,36 @@
+---
+'@midnightntwrk/wallet-sdk-unshielded-wallet': major
+'@midnightntwrk/wallet-sdk-capabilities': minor
+'@midnightntwrk/wallet-sdk-facade': minor
+---
+
+fix(unshielded-wallet): stop a leaked booking duplicating a UTxO and doubling the balance
+
+`availableUtxos` and `pendingUtxos` are disjoint by construction, and every balance accessor sums them independently, so
+a UTxO present in both is counted twice. Two defects combined to produce exactly that: the indexer sync path re-admitted
+a created UTxO that was still booked, and nothing released a booking taken while balancing when the transaction was
+abandoned before submission. Persisted, the result survived every restart.
+
+- `applyUpdate` no longer admits a created UTxO that is currently booked, the guard the simulator path already had, and
+  loading a snapshot holding one coin in both maps keeps it on the pending side only. State already corrupted in the
+  field repairs itself on the next start.
+- A booked coin now carries the TTL of the transaction it was booked for, and both sync capabilities release expired
+  bookings on every applied update. Past that instant the ledger rejects the transaction, so the booking cannot still be
+  valid. A pending entry restored from a snapshot written before this change is released by the first sweep.
+- A transaction that has been balanced but not yet proven is recorded as a reservation in the pending-transactions
+  service: its identifiers, the ids of the coins it booked, and its TTL, never the transaction itself, which carries key
+  material. The record persists, so a booking held for a counterparty that has not answered yet survives a restart. The
+  service's existing poll marks a reservation whose TTL has passed, and the facade then releases its coins.
+- Bookings restored from a snapshot are released once sync reaches the chain tip, unless a reservation still accounts
+  for them, returning an abandoned coin in seconds rather than at its transaction's TTL.
+- `UnshieldedWallet.revertUtxos(ids)` releases booked coins without the transaction that booked them, for a caller
+  holding only a record of the ids.
+
+BREAKING CHANGE: `UnshieldedState.spend`, `UnshieldedState.spendByUtxo`, `CoreWallet.spend` and `CoreWallet.spendUtxos`
+take the TTL of the transaction the coins are booked for as a required last argument. `UnshieldedState.restore` and
+`toArrays` exchange pending entries as `{ utxo, ttl, restored }` rather than bare UTxOs, and `TransactingCapability`
+gains `revertUtxos` and `releaseRestoredPending`, so a custom implementation of that interface must add them. The public
+coin accessors are unchanged: `pendingCoins`, `availableCoins` and `balances` still report UTxOs.
+
+The pending-transactions store gains a new format version carrying reservations. A store written before this change
+still loads; one written after it cannot be read by an earlier version of `@midnightntwrk/wallet-sdk-capabilities`.

--- a/.changeset/fix-unshielded-utxo-duplication.md
+++ b/.changeset/fix-unshielded-utxo-duplication.md
@@ -15,14 +15,19 @@ abandoned before submission. Persisted, the result survived every restart.
   loading a snapshot holding one coin in both maps keeps it on the pending side only. State already corrupted in the
   field repairs itself on the next start.
 - A booked coin now carries the TTL of the transaction it was booked for, and both sync capabilities release expired
-  bookings on every applied update. Past that instant the ledger rejects the transaction, so the booking cannot still be
-  valid. A pending entry restored from a snapshot written before this change is released by the first sweep.
+  bookings as updates arrive. This is the only thing that releases a booking, so two sweeps on different clocks cannot
+  free the same coin twice. It runs only once sync has caught up with the chain, because a replay from an earlier cursor
+  can still be carrying the transaction that spent a booked coin, and it releases strictly after the TTL rather than at
+  it, because the ledger accepts an intent while its TTL is at or after the block's timestamp.
 - A transaction that has been balanced but not yet proven is recorded as a reservation in the pending-transactions
   service: its identifiers, the ids of the coins it booked, and its TTL, never the transaction itself, which carries key
-  material. The record persists, so a booking held for a counterparty that has not answered yet survives a restart. The
-  service's existing poll marks a reservation whose TTL has passed, and the facade then releases its coins.
-- Bookings restored from a snapshot are released once sync reaches the chain tip, unless a reservation still accounts
-  for them, returning an abandoned coin in seconds rather than at its transaction's TTL.
+  material. In-place balancing records only the coins the wallet moved onto the pending side, not inputs the caller had
+  already put in the transaction. A reservation is dropped wherever its booking is reverted, and when its TTL passes.
+- Bookings restored from a snapshot are released once sync reaches the chain tip, unless a reservation or a transaction
+  being tracked still accounts for the spend, returning an abandoned coin in seconds rather than at its transaction's
+  TTL.
+- Balancing a transaction in place now books the coins it selects, so two balance calls can no longer select the same
+  coin.
 - `UnshieldedWallet.revertUtxos(ids)` releases booked coins without the transaction that booked them, for a caller
   holding only a record of the ids.
 
@@ -32,5 +37,7 @@ take the TTL of the transaction the coins are booked for as a required last argu
 gains `revertUtxos` and `releaseRestoredPending`, so a custom implementation of that interface must add them. The public
 coin accessors are unchanged: `pendingCoins`, `availableCoins` and `balances` still report UTxOs.
 
-The pending-transactions store gains a new format version carrying reservations. A store written before this change
-still loads; one written after it cannot be read by an earlier version of `@midnightntwrk/wallet-sdk-capabilities`.
+Both stored formats gained an optional member rather than a new version, so a store written by this release is still
+readable by an earlier one: the unshielded snapshot carries each booking's expiry, and the pending-transactions store
+carries its reservations. A pending entry restored from a snapshot that predates expiries is granted a full transaction
+lifetime from the moment it is loaded.

--- a/docs/decisions/0008-unshielded-bookings-persist-and-expire.md
+++ b/docs/decisions/0008-unshielded-bookings-persist-and-expire.md
@@ -56,29 +56,47 @@ the pending side only, so state already corrupted in the field repairs itself on
 duplicate forward.
 
 **2. A booking carries the TTL of the transaction it was taken for**, and both sync capabilities release expired
-bookings on every applied update — the indexer path against wall time, the simulator path against simulator time. Past
-that instant the ledger rejects the transaction, so the reservation cannot still be valid. This bounds the damage of any
-abandoned transaction to that transaction's own lifetime, with no help from the caller, and it is the floor for a wallet
-used without the facade. A snapshot written before bookings carried a TTL decodes at the epoch, so the first sweep
-releases it — which is the repair such a snapshot needs.
+bookings on every applied update — the indexer path against wall time, the simulator path against simulator time. Once
+that instant has passed the ledger rejects the transaction, so the reservation cannot still be valid. This bounds the
+damage of any abandoned transaction to that transaction's own lifetime, with no help from the caller, and it is the
+floor for a wallet used without the facade. It is also the only thing that releases a booking: everything below decides
+what to hold, never what to free, so one mechanism owns release and two sweeps on different clocks cannot free the same
+coin twice.
+
+Two details decide whether this is safe. It sweeps only once sync has caught up with the chain: while a replay from an
+earlier cursor is running, a coin can be booked here and already spent by a transaction the replay has not delivered,
+and releasing it then offers a coin that is gone. And a booking expires strictly after its TTL rather than at it,
+because the ledger accepts an intent while its TTL is at or after the block's timestamp. A snapshot written before
+bookings carried a TTL says nothing about when its coins were booked, so each is granted a full transaction lifetime
+from the moment it is loaded rather than being treated as already expired.
 
 **3. A balanced transaction is recorded as a reservation** in the pending-transactions service: the identifiers of the
 transaction, the intent hashes, the ids of the coins it booked, and the TTL. It never holds the transaction itself.
 Between balancing and submission nothing else recorded that those coins were spoken for, and this is that record. It
 persists, so it survives the restart that the swap case turns on. Registering or clearing the real transaction drops the
-reservation standing in for it, and the service's existing poll marks one whose TTL has passed so the facade can release
-its coins.
+reservation standing in for it, and the service's existing poll marks one whose TTL has passed, which retires the record
+alone — the coins it named are the wallet's own sweep to release, on the wallet's own clock.
 
 **4. Bookings restored from a snapshot are reconciled once sync reaches the chain tip.** At that point every transaction
 the address is party to has been applied, so a coin still booked was never spent by the process that booked it — unless
-a reservation says its transaction is still out there. Uncovered coins are released in seconds instead of waiting out a
-TTL that defaults to an hour; covered ones stay booked.
+something still accounts for the spend. Uncovered coins are released in seconds instead of waiting out a TTL that
+defaults to an hour; covered ones stay booked.
 
 The last mechanism is the one that has to be stated carefully, because both of its simpler forms are wrong. Releasing
 restored bookings once sync completes, unguarded, would invalidate a swap whose counterpart has not answered. Never
-releasing them leaves a coin stuck for up to an hour after sync has already proved nothing holds it. The reservation is
-what makes the difference visible to the wallet, and the guard is one sentence: **release a restored booking when sync
-is strictly complete, unless a reservation accounts for it.**
+releasing them leaves a coin stuck for up to an hour after sync has already proved nothing holds it. The guard is one
+sentence: **release a restored booking when sync is strictly complete, unless a reservation or a transaction being
+tracked accounts for it.**
+
+Both halves of that guard are load-bearing, and for the same reason mechanism 3 exists. A reservation covers a
+transaction that was balanced and never submitted. Registering the real transaction drops that reservation, so from
+submission onwards the tracked transaction is the only thing saying its coins are spoken for — and a transaction sitting
+in the mempool when the tip is reached is exactly the case that must not be released.
+
+The guard can only see what the services were given. The facade's default pending-transactions service starts empty, so
+a consumer that restores the wallet's snapshot but not the pending store reaches the tip with nothing accounting for the
+spends its previous process submitted. Restoring both is what makes this mechanism safe across a restart; restoring
+neither leaves mechanism 2 as the only rule, which is where this started.
 
 ### Positive Consequences
 
@@ -95,8 +113,12 @@ is strictly complete, unless a reservation accounts for it.**
 
 - A pending coin's stored shape gained a field, and `spend` gained a required argument, so this is a breaking change for
   anyone driving the wallet's state functions directly.
-- The pending-transactions store gained a new format version. A snapshot written before this change still loads, but a
-  snapshot written after it cannot be read by an earlier version of the package.
+- Both stored formats gained an optional member rather than a version: the pending coin its expiry, the
+  pending-transactions store its reservations. A snapshot written before this change still loads, and one written after
+  it is still readable by an earlier version of the package, which simply does not see the new member.
+- A booking is held for longer in two places than the first cut of this decision held it: through a replay, and at the
+  TTL instant itself. Both are the conservative direction — a coin unavailable slightly longer, rather than offered
+  while a transaction may still spend it.
 - A consumer that balances through its own code rather than the facade gets no reservation, so its bookings are
   protected by the TTL alone. That is the same protection they had before, not a regression.
 - The facade's trigger for the fourth mechanism has no automated test: the simulator never reports a chain tip, so the

--- a/docs/decisions/0008-unshielded-bookings-persist-and-expire.md
+++ b/docs/decisions/0008-unshielded-bookings-persist-and-expire.md
@@ -1,0 +1,173 @@
+# Unshielded bookings persist, expire at their transaction's TTL, and are reconciled against a durable record
+
+- Status: proposed
+- Deciders: Ian Gregson, Agron Murtezi, Andrzej Kopeć
+- Date: 2026-09-11
+
+Technical Story: [#697](https://github.com/midnightntwrk/midnight-wallet/issues/697) — a leaked unshielded booking gets
+duplicated into both UTxO maps, and the balance doubles.
+
+## Context and Problem Statement
+
+The unshielded wallet holds its coins in two maps, `availableUtxos` and `pendingUtxos`. Balancing a transaction moves a
+coin from the first to the second — a **booking** — so coin selection cannot hand the same coin to a second transaction.
+The maps are disjoint by construction, and every balance accessor sums them independently, so a coin present in both is
+counted twice.
+
+Two defects combined to produce exactly that. The indexer sync path re-admitted a created coin without checking whether
+it was still booked, so a resync from a cursor predating the creating transaction put the coin back into
+`availableUtxos` while it was also pending. And a booking was released only through the submit path, so a transaction
+abandoned between balancing and submission — a proof server on a mismatched ledger version, in the reported case — left
+its coins booked forever. Persisted, that state survived every restart: the wallet reported twice its on-chain balance,
+reported the same coin as both spendable and booked, and deleting the cache was the only recovery.
+
+The immediate guard is obvious and was never in dispute. The question this ADR answers is what a booking _is_: process
+state belonging to the caller that took it, or a durable record of something the wallet has released into the world.
+
+## Decision Drivers
+
+- A coin can be booked for a transaction that legitimately takes a long time — a swap counterpart sitting in an external
+  system, waiting on someone else — and a restart must not invalidate it.
+- Nothing may release a coin that a live transaction is still spending; coin selection would then hand it out twice.
+- A booking taken while proving is in flight looks exactly like a leaked one: the indexer reports the input unspent and
+  no transaction is being tracked yet.
+- Corrupted persisted state was unrecoverable without deleting the cache — the worst failure mode for a wallet.
+- An unproven transaction carries key material and must never be written to storage.
+- Whatever is built here should be a model the shielded and dust wallets can adopt, since they have the same gap.
+
+## Considered Options
+
+- Keep bookings persisted, expire them at the transaction's TTL, and reconcile what comes back from a snapshot against a
+  durable record of the transaction that took it.
+- Keep bookings persisted, and shorten their life with a lease renewed while the caller is actively proving.
+- Do not persist bookings. Hold them in process state and re-derive, after a restart, the exclusions that must survive.
+
+## Decision Outcome
+
+Chosen option: **keep bookings persisted, expire them at the transaction's TTL, and reconcile against a durable
+record**, because a booking is not the caller's private intent. It reflects something the wallet has already released
+into the world, and a wallet that forgets it on restart can invalidate a transaction that is still perfectly valid.
+
+Four mechanisms, smallest first. Each is useful without the ones after it.
+
+**1. The invariant is enforced where it was broken.** The indexer sync path no longer re-admits a created coin that is
+still booked, the guard the simulator path already had. Loading a snapshot that holds one coin in both maps keeps it on
+the pending side only, so state already corrupted in the field repairs itself on the next start rather than carrying the
+duplicate forward.
+
+**2. A booking carries the TTL of the transaction it was taken for**, and both sync capabilities release expired
+bookings on every applied update — the indexer path against wall time, the simulator path against simulator time. Past
+that instant the ledger rejects the transaction, so the reservation cannot still be valid. This bounds the damage of any
+abandoned transaction to that transaction's own lifetime, with no help from the caller, and it is the floor for a wallet
+used without the facade. A snapshot written before bookings carried a TTL decodes at the epoch, so the first sweep
+releases it — which is the repair such a snapshot needs.
+
+**3. A balanced transaction is recorded as a reservation** in the pending-transactions service: the identifiers of the
+transaction, the intent hashes, the ids of the coins it booked, and the TTL. It never holds the transaction itself.
+Between balancing and submission nothing else recorded that those coins were spoken for, and this is that record. It
+persists, so it survives the restart that the swap case turns on. Registering or clearing the real transaction drops the
+reservation standing in for it, and the service's existing poll marks one whose TTL has passed so the facade can release
+its coins.
+
+**4. Bookings restored from a snapshot are reconciled once sync reaches the chain tip.** At that point every transaction
+the address is party to has been applied, so a coin still booked was never spent by the process that booked it — unless
+a reservation says its transaction is still out there. Uncovered coins are released in seconds instead of waiting out a
+TTL that defaults to an hour; covered ones stay booked.
+
+The last mechanism is the one that has to be stated carefully, because both of its simpler forms are wrong. Releasing
+restored bookings once sync completes, unguarded, would invalidate a swap whose counterpart has not answered. Never
+releasing them leaves a coin stuck for up to an hour after sync has already proved nothing holds it. The reservation is
+what makes the difference visible to the wallet, and the guard is one sentence: **release a restored booking when sync
+is strictly complete, unless a reservation accounts for it.**
+
+### Positive Consequences
+
+- The reported defect is closed at its source, and an already-corrupted snapshot repairs itself on load.
+- A booking can no longer outlive its transaction. The worst case shrinks from "permanently wrong balance, recoverable
+  only by deleting the cache" to "one coin unavailable until its transaction's TTL".
+- A booking survives a restart, so a transaction waiting on someone else is not invalidated by one.
+- The coins a transaction reserved are recorded before it is proven, which closes the window where an abandoned
+  transaction left nothing behind to explain the missing balance.
+- The TTL is the common expiry language across the three wallets, and the reservation's per-wallet `inputs` section is
+  shaped for shielded and dust to add their own without a format change.
+
+### Negative Consequences
+
+- A pending coin's stored shape gained a field, and `spend` gained a required argument, so this is a breaking change for
+  anyone driving the wallet's state functions directly.
+- The pending-transactions store gained a new format version. A snapshot written before this change still loads, but a
+  snapshot written after it cannot be read by an earlier version of the package.
+- A consumer that balances through its own code rather than the facade gets no reservation, so its bookings are
+  protected by the TTL alone. That is the same protection they had before, not a regression.
+- The facade's trigger for the fourth mechanism has no automated test: the simulator never reports a chain tip, so the
+  condition cannot be reached in the simulator harness. The wallet behaviour behind it is covered against a real
+  indexer; the one-line subscription that calls it is not.
+
+## Pros and Cons of the Options
+
+### Persist, expire at the TTL, reconcile against a durable record
+
+- Good, because a booking that reflects a live transaction survives a restart, which is the case a wallet cannot get
+  wrong without invalidating real transactions.
+- Good, because it matches the model the ledger designed for the other two wallets — `pendingSpends` with an optional
+  expiry for shielded, `pendingDust` with `processTtls` for dust — keeping one mental model across all three.
+- Good, because the reservation gives the proving window an answer: a transaction being proved is registered before
+  proving starts, so a reconciler can tell it apart from an abandoned one.
+- Bad, because the invariant that broke is still maintained by call sites rather than by the type. Every future writer
+  of the two maps has to remember the guard.
+- Bad, because correctness now leans on the facade registering a reservation at every booking site, and there are six.
+
+### Shorten the life with a renewed lease
+
+- Good, because it bounds the stuck window to the lease rather than to the caller's TTL, with no consumer changes.
+- Bad, because the lease is invented by the SDK rather than derived from the transaction, so a caller that legitimately
+  proves later than the lease — offline signing, batching — loses a reservation that was still meaningful.
+- Bad, because renewal introduces a heartbeat into a state machine that otherwise advances only on sync updates.
+
+### Do not persist bookings
+
+- Good, because the defect class disappears: no persisted booking means none to collide with replayed sync data, and the
+  invariant can be expressed in the type rather than maintained by call sites.
+- Good, because it deletes more code than it adds.
+- Bad, and decisive: a booking is not only process state. It also reflects reality the wallet has left behind. A wallet
+  that issues a swap counterpart which then sits in an external system for an unspecified time, and is restarted in the
+  meantime, loses the booking and may invalidate that swap.
+- Bad, because it makes correct behaviour depend on every consumer registering every submission, and silently degrades
+  for one that submits through its own service.
+
+## Relationship to the shielded and dust wallets
+
+All three wallets reserve coins while balancing, and all three have to decide when a reservation is no longer valid. The
+ledger owns that state for shielded and dust; the SDK owns it for unshielded.
+
+| Concept            | Unshielded                      | Shielded                                  | Dust                         |
+| ------------------ | ------------------------------- | ----------------------------------------- | ---------------------------- |
+| Coins owned        | `availableUtxos` + `pending`    | `state.coins`                             | `state.coins`                |
+| Reservations held  | `pendingUtxos`                  | `pendingSpends` (ledger)                  | `pendingDust` (SDK) + ledger |
+| Reservation expiry | `ttl`, required                 | `Date \| undefined`, never set by the SDK | ledger's `processTtls`       |
+| Reaped by          | the wallet, on each sync update | nothing — `clearPending` is a no-op       | the ledger                   |
+
+Shielded has the same leak and cannot use the same fix directly: `pendingSpends` is the ledger's own field, serialized
+with its state, and the ledger's expiry endpoint is documented as non-functional. That is tracked separately. What
+transfers is the shape rather than the code: the TTL as the expiry language, and the reservation record, whose `inputs`
+is split per wallet precisely so shielded can add its own ids without another format change.
+
+**One trap worth stating plainly**, because no rename fixes it: `pendingCoins` means different things on two wallets. On
+the unshielded wallet it is coins reserved by an outgoing spend; on the shielded wallet it is coins _expected to
+arrive_. Both accessors predate this decision.
+
+## Follow-ups
+
+- **Shielded reservations** have no expiry and nothing sweeps them, so the same leak exists there. The issue tracking it
+  describes a facade accessor this decision did not build; the reservation list is the equivalent, and that issue's
+  wording should be corrected to match.
+- **Transaction history.** Tracking booked coins and tracking transaction history are closely related, and a reservation
+  is arguably the first moment a transaction becomes worth recording. History is still written from submission onwards,
+  and moving that earlier is a visible behaviour change for consumers, so it was left alone.
+
+## Links
+
+- Refines [ADR-0001](0001-bloc-wallet-state.md) — state lives in refs and is transformed by pure functions; this ADR
+  changes what the unshielded wallet's state records, not how it is held or published.
+- Constrained by [ADR-0006](0006-structure-for-flexibility-and-robustness.md) — the state shape belongs to a variant, so
+  the change is scoped to `v1` of the unshielded wallet and its capabilities.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -22,6 +22,8 @@ You can install the required package globally by running "npm install -g adr-log
   Builders and Facades
 - [ADR-0007](0007-npmjs-trusted-publishing-and-scope-rename.md) - npmjs Trusted Publishing and scope rename to
   `@midnightntwrk`
+- [ADR-0008](0008-unshielded-bookings-persist-and-expire.md) - Unshielded bookings persist, expire at their
+  transaction's TTL, and are reconciled against a durable record
 
 <!-- adrlogstop -->
 

--- a/packages/capabilities/src/pendingTransactions/pendingTransactions.ts
+++ b/packages/capabilities/src/pendingTransactions/pendingTransactions.ts
@@ -238,10 +238,50 @@ export const SerializedSchema = <TTransaction>(
   });
 };
 
+const ReservationSchema = Schema.Struct({
+  identifiers: Schema.Array(Schema.String),
+  intentHashes: Schema.Array(Schema.String),
+  inputs: Schema.Struct({ unshielded: Schema.Array(Schema.String) }),
+  ttl: Schema.Date,
+  createdAt: Schema.DateTimeUtc,
+  expired: Schema.Boolean,
+});
+
+/** `v1` plus the reservations. Written by every `serialize`; `v1` is still read, and decodes to no reservations. */
+type SerializedV2<TTransaction> = Readonly<{
+  version: 'v2';
+  transactions: readonly PendingItem<TTransaction>[];
+  reservations: readonly Reservation[];
+}>;
+
+export const SerializedV2Schema = <TTransaction>(
+  txTrait: TransactionTrait<TTransaction>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- as above, the encoded side is plain JSON
+): Schema.Schema<SerializedV2<TTransaction>, any> => {
+  const TxSchema = Schema.declare<TTransaction>((tx: unknown): tx is TTransaction => txTrait.isTx(tx));
+  const TxFromHex: Schema.Schema<TTransaction, string> = Schema.transform(Schema.Uint8ArrayFromHex, TxSchema, {
+    encode: (tx): Uint8Array => txTrait.serialize(tx),
+    decode: (bytes) => txTrait.deserialize(bytes),
+  });
+
+  return Schema.Struct({
+    version: Schema.Literal('v2'),
+    transactions: Schema.Array(Schema.Struct({ tx: TxFromHex, creationTime: Schema.DateTimeUtc })),
+    reservations: Schema.Array(ReservationSchema),
+  });
+};
+
+/** Every format this module can read. A snapshot written by a newer version is refused rather than half-read. */
+const AnySerializedSchema = <TTransaction>(
+  txTrait: TransactionTrait<TTransaction>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- as above
+): Schema.Schema<SerializedV2<TTransaction> | Serialized<TTransaction>, any> =>
+  Schema.Union(SerializedV2Schema(txTrait), SerializedSchema(txTrait));
+
 export const serialize = <TTransaction>(
   state: PendingTransactions<TTransaction>,
   txTrait: TransactionTrait<TTransaction>,
-): string => pipe(state, toSerialized, Schema.encodeSync(SerializedSchema(txTrait)), JSON.stringify);
+): string => pipe(state, toSerialized, Schema.encodeSync(SerializedV2Schema(txTrait)), JSON.stringify);
 
 export const deserialize = <TTransaction>(
   serialized: string,
@@ -249,25 +289,27 @@ export const deserialize = <TTransaction>(
 ): Either.Either<PendingTransactions<TTransaction>, ParseResult.ParseError> => {
   return pipe(
     serialized,
-    Schema.decodeUnknownEither(Schema.parseJson(SerializedSchema<TTransaction>(txTrait))),
+    Schema.decodeUnknownEither(Schema.parseJson(AnySerializedSchema<TTransaction>(txTrait))),
     Either.map((data) => fromSerialized<TTransaction>(data)),
   );
 };
 
 export const toSerialized = <TTransaction>(
   pendingTransactions: PendingTransactions<TTransaction>,
-): Serialized<TTransaction> => {
+): SerializedV2<TTransaction> => {
   return {
-    version: 'v1',
+    version: 'v2',
     transactions: pendingTransactions.all,
+    reservations: pendingTransactions.reservations,
   };
 };
 
 export const fromSerialized = <TTransaction>(
-  serialized: Serialized<TTransaction>,
+  serialized: SerializedV2<TTransaction> | Serialized<TTransaction>,
 ): PendingTransactions<TTransaction> => {
   return {
     all: serialized.transactions,
-    reservations: [],
+    // A snapshot written before reservations existed records none, which is the truth about what it knew.
+    reservations: serialized.version === 'v2' ? serialized.reservations : [],
   };
 };

--- a/packages/capabilities/src/pendingTransactions/pendingTransactions.ts
+++ b/packages/capabilities/src/pendingTransactions/pendingTransactions.ts
@@ -80,7 +80,16 @@ export type PendingTransactions<TTransaction> = Readonly<{
 const sharesIdentifier = (reservation: Reservation, identifiers: readonly string[]): boolean =>
   reservation.identifiers.some((id) => identifiers.includes(id));
 
-/** Records a balanced transaction, replacing any earlier reservation for the same spend. */
+/**
+ * Records a balanced transaction, replacing any earlier reservation for the same spend.
+ *
+ * @example
+ *   const held = addReservation(state, { identifiers: tx.identifiers(), inputs: { unshielded: ids }, ttl });
+ *
+ * @param state - The pending transactions to add to
+ * @param reservation - The record of what the balanced transaction booked
+ * @returns The state with that reservation held, and any it replaces gone
+ */
 export const addReservation = <TTransaction>(
   state: PendingTransactions<TTransaction>,
   reservation: Reservation,
@@ -92,7 +101,16 @@ export const addReservation = <TTransaction>(
   ),
 });
 
-/** Forgets every reservation holding one of `identifiers`. */
+/**
+ * Forgets every reservation holding one of `identifiers`.
+ *
+ * @example
+ *   const cleared = clearReservation(state, [...tx.identifiers()]);
+ *
+ * @param state - The pending transactions to clear from
+ * @param identifiers - Identifiers of the spend whose record is finished with
+ * @returns The state with those reservations gone; identifiers no reservation holds are ignored
+ */
 export const clearReservation = <TTransaction>(
   state: PendingTransactions<TTransaction>,
   identifiers: readonly string[],
@@ -102,20 +120,64 @@ export const clearReservation = <TTransaction>(
 });
 
 /**
- * Marks every reservation whose TTL `now` has reached. Marked rather than removed, mirroring how a failed transaction
- * is kept until a caller has acted on it: the coins still have to be released before the record is dropped.
+ * Marks every reservation whose TTL `now` has passed. Marked rather than removed, mirroring how a failed transaction is
+ * kept until a caller has acted on it: the coins still have to be released before the record is dropped.
+ *
+ * Passed, not reached: the ledger accepts an intent while its TTL is at or after the block's timestamp, so a
+ * transaction is still perfectly valid at the instant its TTL names.
+ *
+ * Returns the state it was given when nothing reaches its expiry. This runs on a timer, so most visits change nothing,
+ * and handing back the same value is what lets a caller publish only when something actually moved.
+ *
+ * @example
+ *   const swept = expireReservations(state, DateTime.unsafeNow());
+ *
+ * @param state - The pending transactions to sweep
+ * @param now - The instant to expire against
+ * @returns The state with newly expired reservations marked, or the same state when none is
  */
 export const expireReservations = <TTransaction>(
   state: PendingTransactions<TTransaction>,
   now: DateTime.Utc,
-): PendingTransactions<TTransaction> => ({
-  ...state,
-  reservations: Arr.map(state.reservations, (reservation) =>
-    reservation.expired || reservation.ttl.getTime() > DateTime.toEpochMillis(now)
-      ? reservation
-      : { ...reservation, expired: true },
-  ),
-});
+): PendingTransactions<TTransaction> => {
+  const hasExpiry = (reservation: Reservation): boolean =>
+    !reservation.expired && reservation.ttl.getTime() < DateTime.toEpochMillis(now);
+
+  return Arr.some(state.reservations, hasExpiry)
+    ? {
+        ...state,
+        reservations: Arr.map(state.reservations, (reservation) =>
+          hasExpiry(reservation) ? { ...reservation, expired: true } : reservation,
+        ),
+      }
+    : state;
+};
+
+/**
+ * The unshielded coin ids some spend still accounts for.
+ *
+ * Every reservation's inputs, plus the inputs of every transaction being tracked. Both halves are needed: a reservation
+ * covers a transaction that was balanced and never submitted, and registering a transaction drops the reservation
+ * standing in for it, so from submission onwards only the tracked transaction says the coins are spoken for.
+ *
+ * @example
+ *   const spokenFor = coveredUnshieldedIds(pending, (tx) => ownInputIdsOf(tx));
+ *
+ * @param state - The reservations and tracked transactions to read
+ * @param unshieldedInputsOf - How to name the unshielded coins a tracked transaction spends
+ * @returns Every such coin id, without repeats
+ */
+export const coveredUnshieldedIds = <TTransaction>(
+  state: PendingTransactions<TTransaction>,
+  unshieldedInputsOf: (tx: TTransaction) => readonly string[],
+): readonly string[] =>
+  pipe(
+    Arr.appendAll(
+      Arr.flatMap(state.reservations, (reservation) => reservation.inputs.unshielded),
+      Arr.flatMap(state.all, (item) => unshieldedInputsOf(item.tx)),
+    ),
+    Arr.dedupe,
+  );
 
 /** The reservations whose transactions can no longer be accepted, and whose coins are therefore free. */
 export const allExpiredReservations = <TTransaction>(
@@ -212,10 +274,26 @@ export const saveResult = <TTransaction>(
   };
 };
 
-//It has to stay immutable in the code now. Any changes made should be separate schemas with fallbacks/conversions
+const ReservationSchema = Schema.Struct({
+  identifiers: Schema.Array(Schema.String),
+  intentHashes: Schema.Array(Schema.String),
+  inputs: Schema.Struct({ unshielded: Schema.Array(Schema.String) }),
+  ttl: Schema.Date,
+  createdAt: Schema.DateTimeUtc,
+  expired: Schema.Boolean,
+});
+
+/**
+ * The stored shape. Reservations arrived after the format was already in the field, so they are an optional member of
+ * the version that was already there rather than a version of their own: a reader that predates them sees the version
+ * it knows and ignores the member it does not, which is what keeps a store written here readable by an older package.
+ *
+ * A snapshot that omits them records no reservations, which is the truth about what the writer knew.
+ */
 type Serialized<TTransaction> = Readonly<{
   version: 'v1';
   transactions: readonly PendingItem<TTransaction>[];
+  reservations: readonly Reservation[];
 }>;
 
 export const SerializedSchema = <TTransaction>(
@@ -235,53 +313,14 @@ export const SerializedSchema = <TTransaction>(
   return Schema.Struct({
     version: Schema.Literal('v1'),
     transactions: Schema.Array(TxItemSchema),
+    reservations: Schema.optionalWith(Schema.Array(ReservationSchema), { default: () => [] }),
   });
 };
-
-const ReservationSchema = Schema.Struct({
-  identifiers: Schema.Array(Schema.String),
-  intentHashes: Schema.Array(Schema.String),
-  inputs: Schema.Struct({ unshielded: Schema.Array(Schema.String) }),
-  ttl: Schema.Date,
-  createdAt: Schema.DateTimeUtc,
-  expired: Schema.Boolean,
-});
-
-/** `v1` plus the reservations. Written by every `serialize`; `v1` is still read, and decodes to no reservations. */
-type SerializedV2<TTransaction> = Readonly<{
-  version: 'v2';
-  transactions: readonly PendingItem<TTransaction>[];
-  reservations: readonly Reservation[];
-}>;
-
-export const SerializedV2Schema = <TTransaction>(
-  txTrait: TransactionTrait<TTransaction>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- as above, the encoded side is plain JSON
-): Schema.Schema<SerializedV2<TTransaction>, any> => {
-  const TxSchema = Schema.declare<TTransaction>((tx: unknown): tx is TTransaction => txTrait.isTx(tx));
-  const TxFromHex: Schema.Schema<TTransaction, string> = Schema.transform(Schema.Uint8ArrayFromHex, TxSchema, {
-    encode: (tx): Uint8Array => txTrait.serialize(tx),
-    decode: (bytes) => txTrait.deserialize(bytes),
-  });
-
-  return Schema.Struct({
-    version: Schema.Literal('v2'),
-    transactions: Schema.Array(Schema.Struct({ tx: TxFromHex, creationTime: Schema.DateTimeUtc })),
-    reservations: Schema.Array(ReservationSchema),
-  });
-};
-
-/** Every format this module can read. A snapshot written by a newer version is refused rather than half-read. */
-const AnySerializedSchema = <TTransaction>(
-  txTrait: TransactionTrait<TTransaction>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- as above
-): Schema.Schema<SerializedV2<TTransaction> | Serialized<TTransaction>, any> =>
-  Schema.Union(SerializedV2Schema(txTrait), SerializedSchema(txTrait));
 
 export const serialize = <TTransaction>(
   state: PendingTransactions<TTransaction>,
   txTrait: TransactionTrait<TTransaction>,
-): string => pipe(state, toSerialized, Schema.encodeSync(SerializedV2Schema(txTrait)), JSON.stringify);
+): string => pipe(state, toSerialized, Schema.encodeSync(SerializedSchema(txTrait)), JSON.stringify);
 
 export const deserialize = <TTransaction>(
   serialized: string,
@@ -289,27 +328,26 @@ export const deserialize = <TTransaction>(
 ): Either.Either<PendingTransactions<TTransaction>, ParseResult.ParseError> => {
   return pipe(
     serialized,
-    Schema.decodeUnknownEither(Schema.parseJson(AnySerializedSchema<TTransaction>(txTrait))),
+    Schema.decodeUnknownEither(Schema.parseJson(SerializedSchema<TTransaction>(txTrait))),
     Either.map((data) => fromSerialized<TTransaction>(data)),
   );
 };
 
 export const toSerialized = <TTransaction>(
   pendingTransactions: PendingTransactions<TTransaction>,
-): SerializedV2<TTransaction> => {
+): Serialized<TTransaction> => {
   return {
-    version: 'v2',
+    version: 'v1',
     transactions: pendingTransactions.all,
     reservations: pendingTransactions.reservations,
   };
 };
 
 export const fromSerialized = <TTransaction>(
-  serialized: SerializedV2<TTransaction> | Serialized<TTransaction>,
+  serialized: Serialized<TTransaction>,
 ): PendingTransactions<TTransaction> => {
   return {
     all: serialized.transactions,
-    // A snapshot written before reservations existed records none, which is the truth about what it knew.
-    reservations: serialized.version === 'v2' ? serialized.reservations : [],
+    reservations: serialized.reservations,
   };
 };

--- a/packages/capabilities/src/pendingTransactions/pendingTransactions.ts
+++ b/packages/capabilities/src/pendingTransactions/pendingTransactions.ts
@@ -179,7 +179,18 @@ export const coveredUnshieldedIds = <TTransaction>(
     Arr.dedupe,
   );
 
-/** The reservations whose transactions can no longer be accepted, and whose coins are therefore free. */
+/**
+ * The reservations whose transactions can no longer be accepted, and whose coins are therefore free.
+ *
+ * Expiry marks a reservation rather than removing it, so this is what a caller reads to find the records it still has
+ * to act on before dropping them.
+ *
+ * @example
+ *   const finished = allExpiredReservations(state);
+ *
+ * @param state - The pending transactions to read
+ * @returns The marked reservations, in the order they were added; empty when none has expired
+ */
 export const allExpiredReservations = <TTransaction>(
   state: PendingTransactions<TTransaction>,
 ): ReadonlyArray<Reservation> => Arr.filter(state.reservations, (reservation) => reservation.expired);

--- a/packages/capabilities/src/pendingTransactions/pendingTransactions.ts
+++ b/packages/capabilities/src/pendingTransactions/pendingTransactions.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Array as Arr, type DateTime, Either, Order, type ParseResult, pipe, Schema } from 'effect';
+import { Array as Arr, DateTime, Either, Order, type ParseResult, pipe, Schema } from 'effect';
 
 export type TransactionTrait<TTransaction> = {
   ids: (tx: TTransaction) => readonly string[];
@@ -48,9 +48,79 @@ export type FailedTransactionItem<TTransaction> = PendingTransactionsItem<TTrans
   result: FailedTransactionResult;
 };
 
+/**
+ * A transaction that has been balanced but not yet proven or submitted.
+ *
+ * Balancing reserves the coins a transaction will spend, and until the transaction is submitted nothing else records
+ * that those coins are spoken for — so a transaction abandoned in between strands them. A reservation is that missing
+ * record. It never holds the transaction itself: an unproven transaction carries key material and must not be
+ * persisted.
+ *
+ * `identifiers` is what ties a reservation to the transaction that later arrives, and it is stable: proving and binding
+ * both leave a transaction's identifiers unchanged. `intentHashes` is kept alongside because it is the value the ledger
+ * stamps on the coins the transaction creates.
+ */
+export type Reservation = Readonly<{
+  identifiers: readonly string[];
+  intentHashes: readonly string[];
+  /** Ids of the coins this transaction reserved, per wallet, so each wallet can release its own. */
+  inputs: Readonly<{ unshielded: readonly string[] }>;
+  /** The transaction's TTL: from this instant the ledger rejects it, so the reservation cannot still be valid. */
+  ttl: Date;
+  createdAt: DateTime.Utc;
+  expired: boolean;
+}>;
+
 export type PendingTransactions<TTransaction> = Readonly<{
   all: ReadonlyArray<PendingTransactionsItem<TTransaction>>;
+  reservations: ReadonlyArray<Reservation>;
 }>;
+
+/** Two reservations, or a reservation and a transaction, are the same spend if they share any identifier. */
+const sharesIdentifier = (reservation: Reservation, identifiers: readonly string[]): boolean =>
+  reservation.identifiers.some((id) => identifiers.includes(id));
+
+/** Records a balanced transaction, replacing any earlier reservation for the same spend. */
+export const addReservation = <TTransaction>(
+  state: PendingTransactions<TTransaction>,
+  reservation: Reservation,
+): PendingTransactions<TTransaction> => ({
+  ...state,
+  reservations: Arr.append(
+    Arr.filter(state.reservations, (existing) => !sharesIdentifier(existing, reservation.identifiers)),
+    reservation,
+  ),
+});
+
+/** Forgets every reservation holding one of `identifiers`. */
+export const clearReservation = <TTransaction>(
+  state: PendingTransactions<TTransaction>,
+  identifiers: readonly string[],
+): PendingTransactions<TTransaction> => ({
+  ...state,
+  reservations: Arr.filter(state.reservations, (reservation) => !sharesIdentifier(reservation, identifiers)),
+});
+
+/**
+ * Marks every reservation whose TTL `now` has reached. Marked rather than removed, mirroring how a failed transaction
+ * is kept until a caller has acted on it: the coins still have to be released before the record is dropped.
+ */
+export const expireReservations = <TTransaction>(
+  state: PendingTransactions<TTransaction>,
+  now: DateTime.Utc,
+): PendingTransactions<TTransaction> => ({
+  ...state,
+  reservations: Arr.map(state.reservations, (reservation) =>
+    reservation.expired || reservation.ttl.getTime() > DateTime.toEpochMillis(now)
+      ? reservation
+      : { ...reservation, expired: true },
+  ),
+});
+
+/** The reservations whose transactions can no longer be accepted, and whose coins are therefore free. */
+export const allExpiredReservations = <TTransaction>(
+  state: PendingTransactions<TTransaction>,
+): ReadonlyArray<Reservation> => Arr.filter(state.reservations, (reservation) => reservation.expired);
 
 export const has = <TTransaction>(
   transactions: PendingTransactions<TTransaction>,
@@ -84,6 +154,7 @@ export const allPending = <TTransaction>(
 export const empty = <TTransaction>(): PendingTransactions<TTransaction> => {
   return {
     all: [],
+    reservations: [],
   };
 };
 
@@ -109,6 +180,8 @@ export const addPendingTransaction = <TTransaction>(
   return {
     ...state,
     all: Arr.append(rest, theBiggestMatchingTx),
+    // The transaction now stands for the spend its reservation was holding open, and carries the same identifiers.
+    reservations: Arr.filter(state.reservations, (reservation) => !sharesIdentifier(reservation, txTrait.ids(tx))),
   };
 };
 
@@ -120,6 +193,8 @@ export const clear = <TTransaction>(
   return {
     ...state,
     all: Arr.filter(state.all, (item) => !txTrait.areAllTxIdsIncluded(item.tx, txTrait.ids(tx))),
+    // Whatever stopped tracking the transaction — a revert, or a spend that confirmed — also ends the reservation.
+    reservations: Arr.filter(state.reservations, (reservation) => !sharesIdentifier(reservation, txTrait.ids(tx))),
   };
 };
 
@@ -193,5 +268,6 @@ export const fromSerialized = <TTransaction>(
 ): PendingTransactions<TTransaction> => {
   return {
     all: serialized.transactions,
+    reservations: [],
   };
 };

--- a/packages/capabilities/src/pendingTransactions/pendingTransactionsService.ts
+++ b/packages/capabilities/src/pendingTransactions/pendingTransactionsService.ts
@@ -41,6 +41,10 @@ export type PendingTransactionsService<TTransaction> = {
   state: () => rx.Observable<PendingTransactions.PendingTransactions<TTransaction>>;
   addPendingTransaction: (tx: TTransaction) => Promise<void>;
   clear: (tx: TTransaction) => Promise<void>;
+  /** Records that a balanced transaction has coins reserved, before it is proven or submitted. */
+  addReservation: (reservation: PendingTransactions.Reservation) => Promise<void>;
+  /** Forgets the reservation holding any of `identifiers`, once its coins have been released. */
+  clearReservation: (identifiers: readonly string[]) => Promise<void>;
 };
 
 export type IndexerClientConnection = {
@@ -116,6 +120,14 @@ export class PendingTransactionsServiceImpl<TTransaction> implements PendingTran
     return this.#effectService.clear(tx).pipe(Effect.runPromise);
   }
 
+  addReservation(reservation: PendingTransactions.Reservation): Promise<void> {
+    return this.#effectService.addReservation(reservation).pipe(Effect.runPromise);
+  }
+
+  clearReservation(identifiers: readonly string[]): Promise<void> {
+    return this.#effectService.clearReservation(identifiers).pipe(Effect.runPromise);
+  }
+
   start(): Promise<void> {
     return this.#effectService.startPolling(Stream.tick(Duration.seconds(1))).pipe(
       Effect.provide(
@@ -144,6 +156,8 @@ export type PendingTransactionsServiceEffect<TTransaction> = {
   state: () => Stream.Stream<PendingTransactions.PendingTransactions<TTransaction>>;
   addPendingTransaction: (tx: TTransaction) => Effect.Effect<void, never, never>;
   clear: (tx: TTransaction) => Effect.Effect<void, never, never>;
+  addReservation: (reservation: PendingTransactions.Reservation) => Effect.Effect<void, never, never>;
+  clearReservation: (identifiers: readonly string[]) => Effect.Effect<void, never, never>;
 };
 
 export class PendingTransactionsServiceEffectImpl<
@@ -180,6 +194,9 @@ export class PendingTransactionsServiceEffectImpl<
 
   startPolling(ticks: Stream.Stream<unknown>): Effect.Effect<void, Error, QueryClient | Scope.Scope> {
     return ticks.pipe(
+      // A reservation stands in for a transaction that was never submitted, so no indexer query can settle it. The
+      // only thing that can is its TTL, checked on the same beat that reaps the transactions.
+      Stream.tap(() => this.expireReservations()),
       Stream.mapEffect(() => SubscriptionRef.get(this.#state)),
       Stream.mapConcat(PendingTransactions.allPending),
       Stream.mapConcatEffect((item) => {
@@ -225,6 +242,21 @@ export class PendingTransactionsServiceEffectImpl<
         Effect.andThen((now) => PendingTransactions.addPendingTransaction(state, tx, now, this.#txTrait)),
       );
     });
+  }
+
+  addReservation(reservation: PendingTransactions.Reservation): Effect.Effect<void> {
+    return SubscriptionRef.update(this.#state, (state) => PendingTransactions.addReservation(state, reservation));
+  }
+
+  clearReservation(identifiers: readonly string[]): Effect.Effect<void> {
+    return SubscriptionRef.update(this.#state, (state) => PendingTransactions.clearReservation(state, identifiers));
+  }
+
+  /** Marks the reservations whose transactions the ledger would no longer accept. Runs on every poll. */
+  private expireReservations(): Effect.Effect<void> {
+    return SubscriptionRef.updateEffect(this.#state, (state) =>
+      DateTime.now.pipe(Effect.map((now) => PendingTransactions.expireReservations(state, now))),
+    );
   }
 
   clear(tx: TTransaction): Effect.Effect<void> {

--- a/packages/capabilities/src/pendingTransactions/pendingTransactionsService.ts
+++ b/packages/capabilities/src/pendingTransactions/pendingTransactionsService.ts
@@ -188,8 +188,15 @@ export class PendingTransactionsServiceEffectImpl<
     ).pipe(Effect.runSync); // Should not be here, but otherwise initialization would be too involved
   }
 
+  /**
+   * The state, published when it moves. The poll writes the ref on every tick whether or not anything expired, and a
+   * write publishes regardless, so consecutive identical values are dropped here. Every real change builds a new value,
+   * so comparing by identity keeps a change from being mistaken for a repeat.
+   */
   state(): Stream.Stream<PendingTransactions.PendingTransactions<TTransaction>> {
-    return Stream.concat(Stream.fromEffect(SubscriptionRef.get(this.#state)), this.#state.changes);
+    return Stream.concat(Stream.fromEffect(SubscriptionRef.get(this.#state)), this.#state.changes).pipe(
+      Stream.changesWith((a, b) => a === b),
+    );
   }
 
   startPolling(ticks: Stream.Stream<unknown>): Effect.Effect<void, Error, QueryClient | Scope.Scope> {

--- a/packages/capabilities/src/pendingTransactions/pendingTransactionsService.ts
+++ b/packages/capabilities/src/pendingTransactions/pendingTransactionsService.ts
@@ -41,9 +41,32 @@ export type PendingTransactionsService<TTransaction> = {
   state: () => rx.Observable<PendingTransactions.PendingTransactions<TTransaction>>;
   addPendingTransaction: (tx: TTransaction) => Promise<void>;
   clear: (tx: TTransaction) => Promise<void>;
-  /** Records that a balanced transaction has coins reserved, before it is proven or submitted. */
+  /**
+   * Records that a balanced transaction has coins reserved, before it is proven or submitted.
+   *
+   * Between balancing and submission nothing else says those coins are spoken for, so this is the only durable record
+   * of them. Any earlier reservation sharing an identifier is replaced, so re-balancing the same spend does not
+   * accumulate records.
+   *
+   * @example
+   *   await service.addReservation({ identifiers: tx.identifiers(), inputs: { unshielded: ids }, ttl, ... });
+   *
+   * @param reservation - What the balanced transaction booked, and when the ledger stops accepting it
+   * @returns A promise that resolves once the record is held
+   */
   addReservation: (reservation: PendingTransactions.Reservation) => Promise<void>;
-  /** Forgets the reservation holding any of `identifiers`, once its coins have been released. */
+  /**
+   * Forgets the reservation holding any of `identifiers`, once its coins have been released.
+   *
+   * Call it wherever the booking it stands for ends: the transaction is registered and tracked on its own, the booking
+   * is reverted, or the record has expired. A record left behind outlives the coins it named.
+   *
+   * @example
+   *   await service.clearReservation([...tx.identifiers()]);
+   *
+   * @param identifiers - Identifiers of the spend whose record is finished with; unknown ones are ignored
+   * @returns A promise that resolves once the record is gone
+   */
   clearReservation: (identifiers: readonly string[]) => Promise<void>;
 };
 

--- a/packages/capabilities/src/pendingTransactions/test/pendingTransactions.test.ts
+++ b/packages/capabilities/src/pendingTransactions/test/pendingTransactions.test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { DateTime, HashSet, Order, pipe } from 'effect';
+import { DateTime, Either, HashSet, Order, pipe } from 'effect';
 import { describe, expect, it } from 'vitest';
 import * as PendingTransactions from '../pendingTransactions.js';
 
@@ -179,6 +179,53 @@ describe('Reservations', () => {
       const cleared = PendingTransactions.clear(state, { ids: ['id-a'] }, txTrait);
 
       expect(cleared.reservations).toEqual([]);
+    });
+  });
+
+  describe('persistence', () => {
+    const withOneOfEach = pipe(
+      PendingTransactions.addPendingTransaction(empty, { ids: ['id-tx'] }, CREATED_AT, txTrait),
+      (s) => PendingTransactions.addReservation(s, reservation({ identifiers: ['id-reserved'] })),
+    );
+
+    const roundTrip = (state: PendingTransactions.PendingTransactions<FakeTransaction>) =>
+      PendingTransactions.deserialize<FakeTransaction>(PendingTransactions.serialize(state, txTrait), txTrait);
+
+    it('brings a reservation back with every field it was stored with', () => {
+      // A reservation is the only record that a coin is spoken for, so losing one on restart strands that coin.
+      const restored = roundTrip(withOneOfEach);
+
+      expect(Either.getOrThrow(restored).reservations).toEqual([reservation({ identifiers: ['id-reserved'] })]);
+    });
+
+    it('still brings back the tracked transactions', () => {
+      const restored = Either.getOrThrow(roundTrip(withOneOfEach));
+
+      expect(restored.all.map((item) => item.tx)).toEqual([{ ids: ['id-tx'] }]);
+    });
+
+    it('reads a snapshot written before reservations existed, with none of them', () => {
+      // Such a snapshot records transactions only; a wallet restoring it has no reservations to speak of.
+      const v1 = JSON.stringify({
+        version: 'v1',
+        transactions: [
+          {
+            tx: Buffer.from(JSON.stringify({ ids: ['id-old'] }), 'utf-8').toString('hex'),
+            creationTime: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      });
+
+      const restored = Either.getOrThrow(PendingTransactions.deserialize<FakeTransaction>(v1, txTrait));
+
+      expect(restored.all.map((item) => item.tx)).toEqual([{ ids: ['id-old'] }]);
+      expect(restored.reservations).toEqual([]);
+    });
+
+    it('refuses a snapshot whose version it does not know', () => {
+      const unknown = JSON.stringify({ version: 'v99', transactions: [] });
+
+      expect(Either.isLeft(PendingTransactions.deserialize<FakeTransaction>(unknown, txTrait))).toBe(true);
     });
   });
 });

--- a/packages/capabilities/src/pendingTransactions/test/pendingTransactions.test.ts
+++ b/packages/capabilities/src/pendingTransactions/test/pendingTransactions.test.ts
@@ -1,0 +1,184 @@
+/*
+ * This file is part of MIDNIGHT-WALLET-SDK.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DateTime, HashSet, Order, pipe } from 'effect';
+import { describe, expect, it } from 'vitest';
+import * as PendingTransactions from '../pendingTransactions.js';
+
+type FakeTransaction = Readonly<{ ids: readonly string[] }>;
+
+const txTrait: PendingTransactions.TransactionTrait<FakeTransaction> = {
+  isTx: (data): data is FakeTransaction => typeof data === 'object' && data !== null && 'ids' in data,
+  serialize: (tx) => Buffer.from(JSON.stringify(tx), 'utf-8'),
+  deserialize: (bytes) => JSON.parse(Buffer.from(bytes).toString('utf-8')) as FakeTransaction,
+  ids: (tx) => tx.ids,
+  firstId: (tx) => tx.ids[0],
+  areAllTxIdsIncluded: (tx, ids) => tx.ids.every((id) => ids.includes(id)),
+  isOneIncludedInOther: (tx, otherTx) => {
+    const a = HashSet.fromIterable(tx.ids);
+    const b = HashSet.fromIterable(otherTx.ids);
+    const smaller = Order.min(Order.number)(HashSet.size(a), HashSet.size(b));
+    return HashSet.size(HashSet.intersection(a, b)) === smaller;
+  },
+  hasTTLExpired: () => false,
+};
+
+const at = (iso: string): DateTime.Utc => DateTime.unsafeMake(iso);
+
+const TTL = new Date('2026-01-01T01:00:00.000Z');
+const CREATED_AT = at('2026-01-01T00:00:00.000Z');
+
+const reservation = (overrides: Partial<PendingTransactions.Reservation> = {}): PendingTransactions.Reservation => ({
+  identifiers: ['id-a'],
+  intentHashes: ['intent-a'],
+  inputs: { unshielded: ['4b0f#0'] },
+  ttl: TTL,
+  createdAt: CREATED_AT,
+  expired: false,
+  ...overrides,
+});
+
+describe('Reservations', () => {
+  // A reservation records a transaction that has been balanced but not yet proven: its identifiers, the coins it
+  // booked, and when the ledger stops accepting it. It never holds the transaction itself, which carries key material.
+  const empty = PendingTransactions.empty<FakeTransaction>();
+
+  describe('adding and clearing', () => {
+    it('starts with none', () => {
+      expect(empty.reservations).toEqual([]);
+    });
+
+    it('keeps a reservation without touching the tracked transactions', () => {
+      const state = PendingTransactions.addReservation(empty, reservation());
+
+      expect(state.reservations).toEqual([reservation()]);
+      expect(state.all).toEqual([]);
+    });
+
+    it('replaces one that shares an identifier, so re-balancing does not double up', () => {
+      const first = reservation({ inputs: { unshielded: ['4b0f#0'] } });
+      const second = reservation({ inputs: { unshielded: ['4b0f#1'] } });
+
+      const state = pipe(PendingTransactions.addReservation(empty, first), (s) =>
+        PendingTransactions.addReservation(s, second),
+      );
+
+      expect(state.reservations).toEqual([second]);
+    });
+
+    it('keeps reservations that share no identifier', () => {
+      const mine = reservation({ identifiers: ['id-a'] });
+      const other = reservation({ identifiers: ['id-b'] });
+
+      const state = pipe(PendingTransactions.addReservation(empty, mine), (s) =>
+        PendingTransactions.addReservation(s, other),
+      );
+
+      expect(state.reservations).toEqual([mine, other]);
+    });
+
+    it('clears the reservation holding a given identifier', () => {
+      const mine = reservation({ identifiers: ['id-a'] });
+      const other = reservation({ identifiers: ['id-b'] });
+      const state = pipe(PendingTransactions.addReservation(empty, mine), (s) =>
+        PendingTransactions.addReservation(s, other),
+      );
+
+      const cleared = PendingTransactions.clearReservation(state, ['id-a']);
+
+      expect(cleared.reservations).toEqual([other]);
+    });
+
+    it('ignores an identifier no reservation holds', () => {
+      const state = PendingTransactions.addReservation(empty, reservation());
+
+      expect(PendingTransactions.clearReservation(state, ['id-unknown']).reservations).toEqual([reservation()]);
+    });
+  });
+
+  describe('expiry', () => {
+    it('marks a reservation the ledger would no longer accept', () => {
+      const state = PendingTransactions.addReservation(empty, reservation());
+
+      const expired = PendingTransactions.expireReservations(state, at('2026-01-01T01:00:00.001Z'));
+
+      expect(expired.reservations).toEqual([reservation({ expired: true })]);
+    });
+
+    it('marks one at exactly its expiry, since the ledger rejects it from that instant', () => {
+      const state = PendingTransactions.addReservation(empty, reservation());
+
+      const expired = PendingTransactions.expireReservations(state, at('2026-01-01T01:00:00.000Z'));
+
+      expect(expired.reservations).toEqual([reservation({ expired: true })]);
+    });
+
+    it('leaves one a millisecond short of its expiry', () => {
+      const state = PendingTransactions.addReservation(empty, reservation());
+
+      const swept = PendingTransactions.expireReservations(state, at('2026-01-01T00:59:59.999Z'));
+
+      expect(swept.reservations).toEqual([reservation({ expired: false })]);
+    });
+
+    it('reports only the expired ones, which is what a caller releases coins for', () => {
+      const stale = reservation({ identifiers: ['id-stale'], ttl: new Date('2026-01-01T00:30:00.000Z') });
+      const live = reservation({ identifiers: ['id-live'], ttl: new Date('2026-01-01T02:00:00.000Z') });
+      const state = pipe(PendingTransactions.addReservation(empty, stale), (s) =>
+        PendingTransactions.addReservation(s, live),
+      );
+
+      const swept = PendingTransactions.expireReservations(state, at('2026-01-01T01:00:00.000Z'));
+
+      expect(PendingTransactions.allExpiredReservations(swept)).toEqual([{ ...stale, expired: true }]);
+    });
+  });
+
+  describe('giving way to the transaction itself', () => {
+    // Once the full transaction is tracked, the reservation standing in for it is redundant: the transaction carries
+    // the same identifiers and its own expiry, and the release paths already act on it.
+    it('drops a reservation when a transaction sharing an identifier is added', () => {
+      const state = PendingTransactions.addReservation(empty, reservation({ identifiers: ['id-a'] }));
+
+      const withTx = PendingTransactions.addPendingTransaction(
+        state,
+        { ids: ['id-a', 'id-extra'] },
+        CREATED_AT,
+        txTrait,
+      );
+
+      expect(withTx.reservations).toEqual([]);
+      expect(withTx.all).toHaveLength(1);
+    });
+
+    it('leaves a reservation the transaction has nothing to do with', () => {
+      const mine = reservation({ identifiers: ['id-a'] });
+      const state = PendingTransactions.addReservation(empty, mine);
+
+      const withTx = PendingTransactions.addPendingTransaction(state, { ids: ['id-other'] }, CREATED_AT, txTrait);
+
+      expect(withTx.reservations).toEqual([mine]);
+    });
+
+    it('drops a reservation when the transaction sharing its identifier is cleared', () => {
+      // Clearing happens on an explicit revert and on a confirmed spend; either way the coins are no longer reserved.
+      const state = PendingTransactions.addReservation(empty, reservation({ identifiers: ['id-a'] }));
+
+      const cleared = PendingTransactions.clear(state, { ids: ['id-a'] }, txTrait);
+
+      expect(cleared.reservations).toEqual([]);
+    });
+  });
+});

--- a/packages/capabilities/src/pendingTransactions/test/pendingTransactions.test.ts
+++ b/packages/capabilities/src/pendingTransactions/test/pendingTransactions.test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { DateTime, Either, HashSet, Order, pipe } from 'effect';
+import { DateTime, Either, HashSet, Order, pipe, Schema } from 'effect';
 import { describe, expect, it } from 'vitest';
 import * as PendingTransactions from '../pendingTransactions.js';
 
@@ -117,12 +117,12 @@ describe('Reservations', () => {
       expect(expired.reservations).toEqual([reservation({ expired: true })]);
     });
 
-    it('marks one at exactly its expiry, since the ledger rejects it from that instant', () => {
+    it('leaves one at exactly its expiry, since a block stamped with that instant still accepts it', () => {
       const state = PendingTransactions.addReservation(empty, reservation());
 
-      const expired = PendingTransactions.expireReservations(state, at('2026-01-01T01:00:00.000Z'));
+      const swept = PendingTransactions.expireReservations(state, at('2026-01-01T01:00:00.000Z'));
 
-      expect(expired.reservations).toEqual([reservation({ expired: true })]);
+      expect(swept.reservations).toEqual([reservation()]);
     });
 
     it('leaves one a millisecond short of its expiry', () => {
@@ -227,5 +227,108 @@ describe('Reservations', () => {
 
       expect(Either.isLeft(PendingTransactions.deserialize<FakeTransaction>(unknown, txTrait))).toBe(true);
     });
+  });
+});
+
+describe('Coins a spend still accounts for', () => {
+  // Restored bookings are released once sync reaches the tip, and this is the set that survives that release. A
+  // reservation covers a transaction that was never submitted; a tracked transaction covers one that was, because
+  // registering it drops the reservation standing in for it. Either alone leaves half the window open.
+  const empty = PendingTransactions.empty<FakeTransaction>();
+  const unshieldedInputsOf = (tx: FakeTransaction): readonly string[] => tx.ids.map((id) => `${id}#0`);
+
+  it('covers the coins of a reservation, for a transaction never submitted', () => {
+    const state = PendingTransactions.addReservation(empty, reservation({ inputs: { unshielded: ['4b0f#0'] } }));
+
+    expect(PendingTransactions.coveredUnshieldedIds(state, unshieldedInputsOf)).toEqual(['4b0f#0']);
+  });
+
+  it('covers the coins of a tracked transaction, whose reservation registering it dropped', () => {
+    const submitted: FakeTransaction = { ids: ['4b0f'] };
+    const state = PendingTransactions.addPendingTransaction(empty, submitted, CREATED_AT, txTrait);
+
+    expect(state.reservations).toEqual([]);
+    expect(PendingTransactions.coveredUnshieldedIds(state, unshieldedInputsOf)).toEqual(['4b0f#0']);
+  });
+
+  it('covers both at once, without repeating a coin two of them name', () => {
+    const shared = PendingTransactions.addReservation(
+      empty,
+      reservation({ identifiers: ['other'], inputs: { unshielded: ['4b0f#0', 'aa11#0'] } }),
+    );
+    const state = PendingTransactions.addPendingTransaction(shared, { ids: ['4b0f'] }, CREATED_AT, txTrait);
+
+    expect([...PendingTransactions.coveredUnshieldedIds(state, unshieldedInputsOf)].toSorted()).toEqual([
+      '4b0f#0',
+      'aa11#0',
+    ]);
+  });
+
+  it('covers nothing when nothing is tracked and nothing is reserved', () => {
+    expect(PendingTransactions.coveredUnshieldedIds(empty, unshieldedInputsOf)).toEqual([]);
+  });
+});
+
+describe('Staying readable by an older reader', () => {
+  // Reservations were added to a format that was already in the field. Adding them as an optional member of the same
+  // version, rather than a new one, keeps a store written here readable by a package version that predates them: it
+  // sees the version it knows and ignores the member it does not.
+  const empty = PendingTransactions.empty<FakeTransaction>();
+
+  /** The schema as it stood before reservations existed, which is what an older reader applies. */
+  const olderReaderSchema = Schema.Struct({
+    version: Schema.Literal('v1'),
+    transactions: Schema.Array(Schema.Struct({ tx: Schema.Uint8ArrayFromHex, creationTime: Schema.DateTimeUtc })),
+  });
+
+  it('writes a snapshot an older reader still accepts', () => {
+    const state = pipe(PendingTransactions.addPendingTransaction(empty, { ids: ['id-a'] }, CREATED_AT, txTrait), (s) =>
+      PendingTransactions.addReservation(s, reservation()),
+    );
+
+    const written: unknown = JSON.parse(PendingTransactions.serialize(state, txTrait));
+
+    expect(Either.isRight(Schema.decodeUnknownEither(olderReaderSchema)(written))).toBe(true);
+  });
+
+  it('round-trips the reservations for a reader that does know them', () => {
+    const state = PendingTransactions.addReservation(empty, reservation());
+
+    const restored = Either.getOrThrow(
+      PendingTransactions.deserialize<FakeTransaction>(PendingTransactions.serialize(state, txTrait), txTrait),
+    );
+
+    expect(restored.reservations).toEqual([reservation()]);
+  });
+});
+
+describe('Sweeping when nothing has changed', () => {
+  // The sweep runs on a timer, so it visits a state where nothing has expired far more often than one where something
+  // has. Handing back the state it was given, rather than a rebuilt copy, is what lets a caller tell the two apart.
+  const empty = PendingTransactions.empty<FakeTransaction>();
+
+  it('hands back the very same state when no reservation reaches its expiry', () => {
+    const state = PendingTransactions.addReservation(empty, reservation());
+
+    expect(PendingTransactions.expireReservations(state, at('2026-01-01T00:30:00.000Z'))).toBe(state);
+  });
+
+  it('hands back the very same state when every reservation is already expired', () => {
+    const state = PendingTransactions.addReservation(empty, reservation({ expired: true }));
+
+    expect(PendingTransactions.expireReservations(state, at('2026-01-01T02:00:00.000Z'))).toBe(state);
+  });
+
+  it('hands back the very same state when there are no reservations at all', () => {
+    expect(PendingTransactions.expireReservations(empty, at('2026-01-01T02:00:00.000Z'))).toBe(empty);
+  });
+
+  it('builds a new state when a reservation does reach its expiry', () => {
+    const state = PendingTransactions.addReservation(empty, reservation());
+
+    const swept = PendingTransactions.expireReservations(state, at('2026-01-01T01:00:00.001Z'));
+
+    expect(swept).not.toBe(state);
+    expect(swept.reservations).toEqual([reservation({ expired: true })]);
   });
 });

--- a/packages/capabilities/src/pendingTransactions/test/pendingTransactionsService.test.ts
+++ b/packages/capabilities/src/pendingTransactions/test/pendingTransactionsService.test.ts
@@ -19,6 +19,7 @@ import {
   Chunk,
   DateTime,
   Deferred,
+  Duration,
   Effect,
   Equal,
   Exit,
@@ -666,4 +667,75 @@ describe('Pending Transactions Service (Effect)', () => {
       }),
     );
   });
+});
+
+describe('PendingTransactionsService reservations', () => {
+  const reservation = (overrides: Partial<PendingTransactions.Reservation> = {}): PendingTransactions.Reservation => ({
+    identifiers: ['id-a'],
+    intentHashes: ['intent-a'],
+    inputs: { unshielded: ['4b0f#0'] },
+    ttl: new Date('2026-01-01T01:00:00.000Z'),
+    createdAt: DateTime.unsafeMake('2026-01-01T00:00:00.000Z'),
+    expired: false,
+    ...overrides,
+  });
+
+  const currentState = (service: PendingTransactionsServiceEffectImpl<FakeTransaction>) =>
+    pipe(service.state(), Stream.runHead, Effect.map(Option.getOrThrow));
+
+  it('holds a reservation a caller registers, and lets it be cleared again', () =>
+    Effect.gen(function* () {
+      const service = new PendingTransactionsServiceEffectImpl(FakeTransaction.txTrait);
+
+      yield* service.addReservation(reservation());
+      expect((yield* currentState(service)).reservations).toEqual([reservation()]);
+
+      yield* service.clearReservation(['id-a']);
+      expect((yield* currentState(service)).reservations).toEqual([]);
+    }).pipe(Effect.provide(TestContext.TestContext), Effect.scoped, Effect.runPromise));
+
+  it('marks a reservation expired once its TTL passes, on the same poll that reaps transactions', () =>
+    // Nothing else notices that a balanced transaction was abandoned, so the poll is what turns a stale
+    // reservation into something a caller can act on.
+    Effect.gen(function* () {
+      const fakeTxStatus = new FakeTransactionStatus();
+      const service = new PendingTransactionsServiceEffectImpl(FakeTransaction.txTrait);
+
+      yield* TestClock.setTime(new Date('2026-01-01T02:00:00.000Z').getTime());
+      yield* service.addReservation(reservation());
+
+      yield* service
+        .startPolling(Stream.make(undefined))
+        .pipe(
+          Effect.provideService(TransactionStatus.tag, fakeTxStatus.runQuery),
+          Effect.provideService(QueryClient, {} as unknown as QueryClient.Service),
+          Effect.forkScoped,
+        );
+      yield* TestClock.adjust(Duration.seconds(1));
+
+      const state = yield* currentState(service);
+      expect(PendingTransactions.allExpiredReservations(state)).toEqual([reservation({ expired: true })]);
+    }).pipe(Effect.provide(TestContext.TestContext), Effect.scoped, Effect.runPromise));
+
+  it('leaves a reservation alone while its TTL is still ahead', () =>
+    Effect.gen(function* () {
+      const fakeTxStatus = new FakeTransactionStatus();
+      const service = new PendingTransactionsServiceEffectImpl(FakeTransaction.txTrait);
+
+      yield* TestClock.setTime(new Date('2026-01-01T00:30:00.000Z').getTime());
+      yield* service.addReservation(reservation());
+
+      yield* service
+        .startPolling(Stream.make(undefined))
+        .pipe(
+          Effect.provideService(TransactionStatus.tag, fakeTxStatus.runQuery),
+          Effect.provideService(QueryClient, {} as unknown as QueryClient.Service),
+          Effect.forkScoped,
+        );
+      yield* TestClock.adjust(Duration.seconds(1));
+
+      const state = yield* currentState(service);
+      expect(PendingTransactions.allExpiredReservations(state)).toEqual([]);
+      expect(state.reservations).toEqual([reservation()]);
+    }).pipe(Effect.provide(TestContext.TestContext), Effect.scoped, Effect.runPromise));
 });

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -308,6 +308,10 @@ export class FacadeState {
 
 const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1 hour
 
+/** How a coin is named wherever it is referred to without being carried: in a reservation, and in a release by id. */
+const coinIdsOf = (utxos: readonly { intentHash: string; outputNo: number }[]): readonly string[] =>
+  utxos.map((utxo) => `${utxo.intentHash}#${utxo.outputNo}`);
+
 /**
  * Clock abstraction for obtaining the current time. By default, the facade uses the system clock
  * ({@link Clock.systemClock}); for testing with a simulator, inject a custom clock (e.g. one backed by the simulator's
@@ -573,22 +577,30 @@ export class WalletFacade {
       )
       .subscribe();
 
-    // A reservation past its TTL stands for a transaction the ledger will not accept, so the coins it holds are
-    // free. There is no transaction to revert here — only the ids the reservation recorded.
+    // A reservation past its TTL stands for a transaction the ledger will not accept, so the record has done its job
+    // and is dropped. It does not release the coins: the wallet books each one with the same TTL and sweeps them
+    // itself, so one mechanism owns release.
+    //
+    // Releasing from here as well would be a second sweep on a different clock, and a coin the wallet has already
+    // freed can be booked again for another transaction before this one fires. The ids a reservation holds say
+    // nothing about which booking currently holds them, so that release would free the wrong one.
     this.#expiredReservationSubscription = this.pendingTransactionsService
       .state()
       .pipe(
         concatMap((pending) => PendingTransactions.allExpiredReservations(pending)),
-        concatMap(async (reservation) => {
-          await this.unshielded.revertUtxos(reservation.inputs.unshielded);
-          await this.pendingTransactionsService.clearReservation(reservation.identifiers);
-        }),
+        concatMap((reservation) => this.pendingTransactionsService.clearReservation(reservation.identifiers)),
       )
       .subscribe();
 
     // Coins a previous process left booked would otherwise sit until their transactions' TTLs, which can be an hour.
     // Once sync reaches the tip, every transaction this address is party to has been applied, so a coin still booked
-    // was never spent — unless a reservation says a transaction for it is still out there, waiting on someone else.
+    // was never spent — unless a reservation or a transaction being tracked says the spend is still out there. Both
+    // halves matter: registering a transaction drops the reservation standing in for it, so from submission onwards
+    // the tracked transaction is the only thing saying its coins are spoken for.
+    //
+    // This only sees what the services were given. A pending-transactions service restored from storage covers the
+    // spends a previous process submitted; one started empty covers none of them, and a restored booking whose
+    // transaction is still in the mempool is released here.
     this.#restoredBookingSubscription = this.unshielded.state
       .pipe(
         filter((unshielded) => unshielded.state.progress.isStrictlyComplete()),
@@ -597,8 +609,12 @@ export class WalletFacade {
         // feeding itself: releasing publishes new state, which would otherwise satisfy this same condition again.
         take(1),
         concatMap(async () => {
-          const stillSpokenFor = (await firstValueFrom(this.pendingTransactionsService.state())).reservations.flatMap(
-            (reservation) => reservation.inputs.unshielded,
+          const { publicKey } = (await firstValueFrom(this.unshielded.state)).state;
+          const pending = await firstValueFrom(this.pendingTransactionsService.state());
+          const stillSpokenFor = PendingTransactions.coveredUnshieldedIds(pending, (tx) =>
+            UnshieldedTransactionOps.extractOwnInputs(tx, publicKey.publicKey).map(
+              (utxo) => `${utxo.intentHash}#${utxo.outputNo}`,
+            ),
           );
           await this.unshielded.releaseRestoredPending(stillSpokenFor);
         }),
@@ -627,18 +643,69 @@ export class WalletFacade {
     const { publicKey } = (await firstValueFrom(this.unshielded.state)).state;
     const bookedCoins = UnshieldedTransactionOps.extractOwnInputs(unshieldedTx, publicKey.publicKey);
 
-    if (bookedCoins.length === 0) {
+    await this.#reserveIds(unshieldedTx, coinIdsOf(bookedCoins), ttl);
+  }
+
+  /** Records `bookedIds` against `unshieldedTx`, or nothing at all when the transaction booked no coins. */
+  async #reserveIds(
+    unshieldedTx: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>,
+    bookedIds: readonly string[],
+    ttl: Date,
+  ): Promise<void> {
+    if (bookedIds.length === 0) {
       return;
     }
 
     await this.pendingTransactionsService.addReservation({
       identifiers: unshieldedTx.identifiers(),
       intentHashes: [...(unshieldedTx.intents?.entries() ?? [])].map(([segment, intent]) => intent.intentHash(segment)),
-      inputs: { unshielded: bookedCoins.map((utxo) => `${utxo.intentHash}#${utxo.outputNo}`) },
+      inputs: { unshielded: bookedIds },
       ttl,
       createdAt: DateTime.unsafeFromDate(this.clock.now()),
       expired: false,
     });
+  }
+
+  /** The coins currently booked, by id. */
+  async #bookedCoinIds(): Promise<readonly string[]> {
+    return coinIdsOf((await firstValueFrom(this.unshielded.state)).pendingCoins.map((coin) => coin.utxo));
+  }
+
+  /**
+   * Balances a transaction in place and records only the coins the wallet itself booked doing so.
+   *
+   * In-place balancing hands back the caller's own transaction with the wallet's inputs added, so the result names
+   * coins from two sources: the ones coin selection just took, and any the caller had already put there. Only the first
+   * are this wallet's booking, and they are exactly the ones that moved onto the pending side.
+   */
+  async #balanceInPlaceAndReserve<
+    T extends ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish> | undefined,
+  >(balance: () => Promise<T>, ttl: Date): Promise<T> {
+    const bookedBefore = new Set(await this.#bookedCoinIds());
+    const balanced = await balance();
+
+    if (balanced === undefined) {
+      return balanced;
+    }
+
+    const newlyBooked = (await this.#bookedCoinIds()).filter((id) => !bookedBefore.has(id));
+    await this.#reserveIds(balanced, newlyBooked, ttl);
+
+    return balanced;
+  }
+
+  /**
+   * Undoes a booking taken while balancing, together with the record that stood for it.
+   *
+   * The two always go together. A record left behind outlives the coins it named, and until its TTL passes it tells
+   * anything that reads it that a spend is still out there — holding coins at the next reconciliation that nothing is
+   * actually holding.
+   */
+  async #revertUnshieldedBooking(
+    tx: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>,
+  ): Promise<void> {
+    await this.unshielded.revertTransaction(tx);
+    await this.pendingTransactionsService.clearReservation([...tx.identifiers()]);
   }
 
   private defaultTtl(): Date {
@@ -767,7 +834,7 @@ export class WalletFacade {
         split.feePayment,
       );
     } catch (error) {
-      await this.unshielded.revertTransaction(txWithOffers);
+      await this.#revertUnshieldedBooking(txWithOffers);
       throw error;
     }
 
@@ -780,7 +847,7 @@ export class WalletFacade {
     if (isRegistration && hasUnregisteredGuaranteed) {
       const fee = await this.dust.calculateFee([txWithDustActions]);
       if (split.feePayment < fee) {
-        await this.unshielded.revertTransaction(txWithOffers);
+        await this.#revertUnshieldedBooking(txWithOffers);
         throw Error(
           `Insufficient generated dust to cover registration fee (have ${split.feePayment}, need ${fee}). ` +
             `Use WalletFacade.waitForGeneratedDust(utxos, ${fee}) before retrying.`,
@@ -800,7 +867,7 @@ export class WalletFacade {
       }
       return signedRecipe.transaction;
     } catch (error) {
-      await this.unshielded.revertTransaction(txWithOffers);
+      await this.#revertUnshieldedBooking(txWithOffers);
       throw error;
     }
   }
@@ -956,9 +1023,8 @@ export class WalletFacade {
 
     // For unbound transactions, unshielded balancing happens in place not with a balancing transaction
     const balancedUnshieldedTx = shouldBalanceUnshielded
-      ? await this.unshielded.balanceUnboundTransaction(tx)
+      ? await this.#balanceInPlaceAndReserve(() => this.unshielded.balanceUnboundTransaction(tx), ttl)
       : undefined;
-    await this.#reserve(balancedUnshieldedTx, ttl);
 
     // Step 2: Unbound unshielded tx are balanced in place, use it as base tx if present
     const baseTx = balancedUnshieldedTx ?? tx;
@@ -1025,9 +1091,8 @@ export class WalletFacade {
 
     // For unproven transactions, unshielded balancing happens in place
     const balancedUnshieldedTx = shouldBalanceUnshielded
-      ? await this.unshielded.balanceUnprovenTransaction(tx)
+      ? await this.#balanceInPlaceAndReserve(() => this.unshielded.balanceUnprovenTransaction(tx), ttl)
       : undefined;
-    await this.#reserve(balancedUnshieldedTx, ttl);
 
     // Step 2: Use the balanced unshielded tx if present, otherwise use the original tx
     const baseTx = balancedUnshieldedTx ?? tx;
@@ -1154,7 +1219,7 @@ export class WalletFacade {
     } catch (error) {
       await Promise.allSettled([
         this.shielded.revertTransaction(tx),
-        this.unshielded.revertTransaction(tx),
+        this.#revertUnshieldedBooking(tx),
         this.dust.revertTransaction(tx),
       ]);
       throw error;

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -44,11 +44,12 @@ import {
   UnshieldedSectionSchema,
   mergeUnshieldedSections,
 } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
+import { TransactionOps as UnshieldedTransactionOps } from '@midnightntwrk/wallet-sdk-unshielded-wallet/v1';
 import { DustSectionSchema, mergeDustSections } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { Clock } from '@midnightntwrk/wallet-sdk-utilities';
 import { FetchTermsAndConditions as FetchTermsAndConditionsQuery } from '@midnightntwrk/wallet-sdk-indexer-client';
 import { QueryRunner } from '@midnightntwrk/wallet-sdk-indexer-client/effect';
-import { Array as Arr, pipe, Schema } from 'effect';
+import { Array as Arr, DateTime, pipe, Schema } from 'effect';
 import { TransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
 import { combineLatest, map, type Observable, firstValueFrom, type Subscription, concatMap } from 'rxjs';
 import {
@@ -535,6 +536,7 @@ export class WalletFacade {
   #txHistoryStorage: TransactionHistoryStorage.TransactionHistoryStorage<WalletEntry>;
   readonly clock: Clock.Clock;
   #pendingSubscription: Subscription;
+  #expiredReservationSubscription: Subscription;
 
   /**
    * Constructor is private on purpose - much of initialization of the facade is potentially asynchronous, and adding
@@ -569,6 +571,54 @@ export class WalletFacade {
         concatMap((item) => this.revert(item.tx)),
       )
       .subscribe();
+
+    // A reservation past its TTL stands for a transaction the ledger will not accept, so the coins it holds are
+    // free. There is no transaction to revert here — only the ids the reservation recorded.
+    this.#expiredReservationSubscription = this.pendingTransactionsService
+      .state()
+      .pipe(
+        concatMap((pending) => PendingTransactions.allExpiredReservations(pending)),
+        concatMap(async (reservation) => {
+          await this.unshielded.revertUtxos(reservation.inputs.unshielded);
+          await this.pendingTransactionsService.clearReservation(reservation.identifiers);
+        }),
+      )
+      .subscribe();
+  }
+
+  /**
+   * Records that a just-balanced transaction has unshielded coins reserved.
+   *
+   * Balancing books those coins, but nothing tracks the transaction until it is submitted, so a caller that abandons it
+   * in between leaves the coins spoken for with no record saying so. The reservation is that record, and it is matched
+   * to the transaction that eventually arrives by identifier, which proving and binding leave unchanged.
+   *
+   * Takes the transaction the unshielded wallet produced rather than the merged one: its inputs are exactly the coins
+   * booked here, and its identifiers are a subset of whatever the merged transaction ends up carrying.
+   */
+  async #reserve(
+    unshieldedTx: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish> | undefined,
+    ttl: Date,
+  ): Promise<void> {
+    if (!unshieldedTx) {
+      return;
+    }
+
+    const { publicKey } = (await firstValueFrom(this.unshielded.state)).state;
+    const bookedCoins = UnshieldedTransactionOps.extractOwnInputs(unshieldedTx, publicKey.publicKey);
+
+    if (bookedCoins.length === 0) {
+      return;
+    }
+
+    await this.pendingTransactionsService.addReservation({
+      identifiers: unshieldedTx.identifiers(),
+      intentHashes: [...(unshieldedTx.intents?.entries() ?? [])].map(([segment, intent]) => intent.intentHash(segment)),
+      inputs: { unshielded: bookedCoins.map((utxo) => `${utxo.intentHash}#${utxo.outputNo}`) },
+      ttl,
+      createdAt: DateTime.unsafeFromDate(this.clock.now()),
+      expired: false,
+    });
   }
 
   private defaultTtl(): Date {
@@ -683,6 +733,7 @@ export class WalletFacade {
       nightVerifyingKey,
       ttl,
     );
+    await this.#reserve(txWithOffers, ttl);
 
     // Step 3 — Dust attaches its DustActions onto the intent the unshielded wallet just built.
     // If this fails we must unbook the UTxOs so the caller can retry.
@@ -819,6 +870,7 @@ export class WalletFacade {
     const unshieldedBalancingTx = shouldBalanceUnshielded
       ? await this.unshielded.balanceFinalizedTransaction(tx)
       : undefined;
+    await this.#reserve(unshieldedBalancingTx, ttl);
 
     const shieldedBalancingTx = shouldBalanceShielded
       ? await this.shielded.balanceTransaction(shieldedSecretKeys, tx)
@@ -886,6 +938,7 @@ export class WalletFacade {
     const balancedUnshieldedTx = shouldBalanceUnshielded
       ? await this.unshielded.balanceUnboundTransaction(tx)
       : undefined;
+    await this.#reserve(balancedUnshieldedTx, ttl);
 
     // Step 2: Unbound unshielded tx are balanced in place, use it as base tx if present
     const baseTx = balancedUnshieldedTx ?? tx;
@@ -954,6 +1007,7 @@ export class WalletFacade {
     const balancedUnshieldedTx = shouldBalanceUnshielded
       ? await this.unshielded.balanceUnprovenTransaction(tx)
       : undefined;
+    await this.#reserve(balancedUnshieldedTx, ttl);
 
     // Step 2: Use the balanced unshielded tx if present, otherwise use the original tx
     const baseTx = balancedUnshieldedTx ?? tx;
@@ -1136,6 +1190,7 @@ export class WalletFacade {
 
     const unshieldedTx =
       unshieldedOutputs.length > 0 ? await this.unshielded.transferTransaction(unshieldedOutputs, ttl) : undefined;
+    await this.#reserve(unshieldedTx, ttl);
 
     const mergedTxs = this.mergeUnprovenTransactions(shieldedTx, unshieldedTx)!;
 
@@ -1254,6 +1309,7 @@ export class WalletFacade {
     const unshieldedTx = hasUnshieldedPart
       ? await this.unshielded.initSwap(unshieldedInputs ?? {}, unshieldedOutputs, ttl)
       : undefined;
+    await this.#reserve(unshieldedTx, ttl);
 
     const combinedTx = this.mergeUnprovenTransactions(shieldedTx, unshieldedTx);
 
@@ -1382,6 +1438,7 @@ export class WalletFacade {
       this.submissionService.close(),
       this.pendingTransactionsService.stop(),
       Promise.resolve(this.#pendingSubscription?.unsubscribe()),
+      Promise.resolve(this.#expiredReservationSubscription?.unsubscribe()),
     ]);
   }
 

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -51,7 +51,7 @@ import { FetchTermsAndConditions as FetchTermsAndConditionsQuery } from '@midnig
 import { QueryRunner } from '@midnightntwrk/wallet-sdk-indexer-client/effect';
 import { Array as Arr, DateTime, pipe, Schema } from 'effect';
 import { TransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
-import { combineLatest, map, type Observable, firstValueFrom, type Subscription, concatMap } from 'rxjs';
+import { combineLatest, map, type Observable, filter, firstValueFrom, take, type Subscription, concatMap } from 'rxjs';
 import {
   type DefaultPendingTransactionsServiceConfiguration,
   PendingTransactions,
@@ -537,6 +537,7 @@ export class WalletFacade {
   readonly clock: Clock.Clock;
   #pendingSubscription: Subscription;
   #expiredReservationSubscription: Subscription;
+  #restoredBookingSubscription: Subscription;
 
   /**
    * Constructor is private on purpose - much of initialization of the facade is potentially asynchronous, and adding
@@ -581,6 +582,25 @@ export class WalletFacade {
         concatMap(async (reservation) => {
           await this.unshielded.revertUtxos(reservation.inputs.unshielded);
           await this.pendingTransactionsService.clearReservation(reservation.identifiers);
+        }),
+      )
+      .subscribe();
+
+    // Coins a previous process left booked would otherwise sit until their transactions' TTLs, which can be an hour.
+    // Once sync reaches the tip, every transaction this address is party to has been applied, so a coin still booked
+    // was never spent — unless a reservation says a transaction for it is still out there, waiting on someone else.
+    this.#restoredBookingSubscription = this.unshielded.state
+      .pipe(
+        filter((unshielded) => unshielded.state.progress.isStrictlyComplete()),
+        // Only bookings restored at startup are candidates, and this releases all of them at once, so the first time
+        // sync reaches the tip is the only time there is anything to do. Acting once also keeps the reaction from
+        // feeding itself: releasing publishes new state, which would otherwise satisfy this same condition again.
+        take(1),
+        concatMap(async () => {
+          const stillSpokenFor = (await firstValueFrom(this.pendingTransactionsService.state())).reservations.flatMap(
+            (reservation) => reservation.inputs.unshielded,
+          );
+          await this.unshielded.releaseRestoredPending(stillSpokenFor);
         }),
       )
       .subscribe();
@@ -1439,6 +1459,7 @@ export class WalletFacade {
       this.pendingTransactionsService.stop(),
       Promise.resolve(this.#pendingSubscription?.unsubscribe()),
       Promise.resolve(this.#expiredReservationSubscription?.unsubscribe()),
+      Promise.resolve(this.#restoredBookingSubscription?.unsubscribe()),
     ]);
   }
 

--- a/packages/facade/test/reservationExpiry.test.ts
+++ b/packages/facade/test/reservationExpiry.test.ts
@@ -1,0 +1,165 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * One thing releases a booked coin: the wallet's own sweep, at the coin's TTL. A reservation records which coins a
+ * balanced transaction took, and expires on the same instant, but expiring is not a second way to release them.
+ *
+ * The two are on different clocks — the wallet sweeps as sync updates arrive, the service polls once a second — and a
+ * coin freed by the first can be booked again before the second fires. A release driven by the reservation would then
+ * free a booking taken for a different transaction, since the ids alone say nothing about which booking holds them.
+ */
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  PendingTransactions,
+  type PendingTransactionsService,
+} from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
+import { Simulator, immediateBlockProducer, type GenesisMint } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { DateTime, Effect } from 'effect';
+import * as rx from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+import { type FacadeState } from '../src/index.js';
+import {
+  createSimulatorWalletFactories,
+  deriveWalletKeys,
+  makeSimulatorFacade,
+  tokenValue,
+  waitForUnshieldedBalance,
+  type SimulatorConfig,
+} from './utils/index.js';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+const NETWORK_ID = NetworkId.NetworkId.Undeployed;
+const NIGHT = ledger.nativeToken().raw;
+const SENDER_SEED = '0000000000000000000000000000000000000000000000000000000000000002';
+
+const utxoKey = (coin: { utxo: { intentHash: string; outputNo: number } }): string =>
+  `${coin.utxo.intentHash}#${coin.utxo.outputNo}`;
+
+const nightGenesisMint = (
+  verifyingKey: ledger.SignatureVerifyingKey,
+  userAddress: ledger.UserAddress,
+): GenesisMint => ({
+  type: 'unshielded',
+  tokenType: NIGHT,
+  amount: tokenValue(100_000n),
+  recipient: userAddress,
+  verifyingKey,
+});
+
+/**
+ * A pending-transactions service whose state this test drives directly, so an expired reservation can be presented at a
+ * chosen moment rather than waited for.
+ */
+const controllablePendingService = (): PendingTransactionsService<ledger.FinalizedTransaction> & {
+  emit: (state: PendingTransactions.PendingTransactions<ledger.FinalizedTransaction>) => void;
+  current: () => PendingTransactions.PendingTransactions<ledger.FinalizedTransaction>;
+} => {
+  const subject = new rx.BehaviorSubject<PendingTransactions.PendingTransactions<ledger.FinalizedTransaction>>(
+    PendingTransactions.empty(),
+  );
+
+  return {
+    start: () => Promise.resolve(),
+    stop: () => Promise.resolve(),
+    state: () => subject.asObservable(),
+    // Nothing here submits, so tracking never starts.
+    addPendingTransaction: () => Promise.resolve(),
+    clear: () => Promise.resolve(),
+    addReservation: (reservation) => {
+      subject.next(PendingTransactions.addReservation(subject.value, reservation));
+      return Promise.resolve();
+    },
+    clearReservation: (identifiers) => {
+      subject.next(PendingTransactions.clearReservation(subject.value, identifiers));
+      return Promise.resolve();
+    },
+    emit: (state) => subject.next(state),
+    current: () => subject.value,
+  };
+};
+
+describe('A reservation reaching its expiry', () => {
+  const fundedFacade = () =>
+    Effect.gen(function* () {
+      const keys = deriveWalletKeys(SENDER_SEED, NETWORK_ID);
+      const simulator = yield* Simulator.init({
+        genesisMints: [nightGenesisMint(keys.signatureVerifyingKey, keys.userAddress)],
+        blockProducer: immediateBlockProducer(),
+      });
+      const config: SimulatorConfig = { simulator, networkId: NETWORK_ID, costParameters: { feeBlocksMargin: 5 } };
+      const pending = controllablePendingService();
+      const facade = yield* makeSimulatorFacade(config, keys, createSimulatorWalletFactories(config), {
+        pendingTransactionsService: () => pending,
+      });
+
+      yield* waitForUnshieldedBalance(facade, NIGHT, 1n);
+      yield* simulator.fastForward(10_000n);
+      const address = yield* Effect.promise(() => facade.unshielded.getAddress());
+
+      const transfer = (amount: bigint) => [
+        {
+          type: 'unshielded' as const,
+          outputs: [{ type: NIGHT, receiverAddress: address, amount }],
+        },
+      ];
+
+      return { facade, keys, simulator, transfer, pending };
+    });
+
+  it('leaves a booking alone, because only the wallet sweep releases a coin', () =>
+    // The expired reservation below names the booked coin but stands for a different spend, which is exactly the
+    // shape the two clocks produce: an abandoned transaction's record outliving the coin it once held.
+    Effect.gen(function* () {
+      const { facade, keys, transfer, pending } = yield* fundedFacade();
+
+      yield* Effect.promise(() =>
+        facade.transferTransaction(
+          transfer(tokenValue(1n)),
+          { shieldedSecretKeys: keys.shieldedKeys, dustSecretKey: keys.dustKey },
+          { ttl: new Date(Date.now() + 60 * 60 * 1000), payFees: false },
+        ),
+      );
+
+      const booked: FacadeState = yield* Effect.promise(() => rx.firstValueFrom(facade.state()));
+      const bookedIds = booked.unshielded.pendingCoins.map(utxoKey);
+      expect(bookedIds.length).toBeGreaterThan(0);
+
+      // An older spend, already gone, whose record names the same coins and has just passed its TTL.
+      pending.emit(
+        PendingTransactions.addReservation(PendingTransactions.empty(), {
+          identifiers: ['an-abandoned-spend'],
+          intentHashes: [],
+          inputs: { unshielded: bookedIds },
+          ttl: new Date(Date.now() - 1000),
+          createdAt: DateTime.unsafeNow(),
+          expired: true,
+        }),
+      );
+
+      yield* Effect.promise(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(resolve, 200);
+          }),
+      );
+
+      const after: FacadeState = yield* Effect.promise(() => rx.firstValueFrom(facade.state()));
+
+      expect(after.unshielded.pendingCoins.map(utxoKey).toSorted()).toEqual(bookedIds.toSorted());
+      expect(after.unshielded.availableCoins.map(utxoKey)).not.toContain(bookedIds[0]);
+      // The record itself is what expiry retires.
+      expect(pending.current().reservations).toEqual([]);
+    }).pipe(Effect.scoped, Effect.runPromise));
+});

--- a/packages/facade/test/reservations.test.ts
+++ b/packages/facade/test/reservations.test.ts
@@ -22,6 +22,7 @@ import { Effect } from 'effect';
 import * as rx from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 import { type FacadeState } from '../src/index.js';
+import type { ProvingService, UnboundTransaction } from '@midnightntwrk/wallet-sdk-capabilities/proving';
 import {
   createSimulatorWalletFactories,
   deriveWalletKeys,
@@ -102,9 +103,7 @@ describe('Reservations taken while balancing', () => {
 
       // Every coin that left the available side is named by a reservation.
       const reserved = new Set(after.pending.reservations.flatMap((r) => r.inputs.unshielded));
-      for (const id of booked) {
-        expect(reserved.has(id)).toBe(true);
-      }
+      expect(booked.filter((id) => !reserved.has(id))).toEqual([]);
     }).pipe(Effect.scoped, Effect.runPromise));
 
   it('gives the reservation an expiry matching the transaction it was taken for', () =>
@@ -170,5 +169,113 @@ describe('Reservations taken while balancing', () => {
       const finalized = yield* Effect.promise(() => facade.finalizeRecipe(recipe));
 
       expect([...finalized.identifiers()].toSorted()).toEqual(beforeProving);
+    }).pipe(Effect.scoped, Effect.runPromise));
+});
+
+describe('A balanced transaction that never gets proven', () => {
+  // Proving is the first thing after balancing that can fail, and the caller is handed the error with the coins
+  // already booked. The booking is undone there, and the record standing for it has to go with it: a record left
+  // behind outlives the coins it named, and the next thing to read it is told a spend is still out there.
+  const failingProver: ProvingService<UnboundTransaction> = {
+    prove: () => Promise.reject(new Error('the proof server is on a different ledger version')),
+  };
+
+  it('leaves neither a booking nor the record that stood for it', () =>
+    Effect.gen(function* () {
+      const keys = deriveWalletKeys(SENDER_SEED, NETWORK_ID);
+      const simulator = yield* Simulator.init({
+        genesisMints: [nightGenesisMint(keys.signatureVerifyingKey, keys.userAddress)],
+        blockProducer: immediateBlockProducer(),
+      });
+      const config: SimulatorConfig = { simulator, networkId: NETWORK_ID, costParameters: { feeBlocksMargin: 5 } };
+      const facade = yield* makeSimulatorFacade(config, keys, createSimulatorWalletFactories(config), {
+        provingService: () => failingProver,
+      });
+
+      yield* waitForUnshieldedBalance(facade, NIGHT, 1n);
+      yield* simulator.fastForward(10_000n);
+      const address = yield* Effect.promise(() => facade.unshielded.getAddress());
+
+      const recipe = yield* Effect.promise(() =>
+        facade.transferTransaction(
+          [
+            {
+              type: 'unshielded' as const,
+              outputs: [{ type: NIGHT, receiverAddress: address, amount: tokenValue(1n) }],
+            },
+          ],
+          { shieldedSecretKeys: keys.shieldedKeys, dustSecretKey: keys.dustKey },
+          { ttl: new Date(Date.now() + 60 * 60 * 1000), payFees: false },
+        ),
+      );
+
+      const booked: FacadeState = yield* Effect.promise(() => rx.firstValueFrom(facade.state()));
+      expect(booked.pending.reservations).toHaveLength(1);
+
+      const outcome = yield* Effect.either(Effect.tryPromise(() => facade.finalizeRecipe(recipe)));
+      expect(outcome._tag).toEqual('Left');
+
+      const after: FacadeState = yield* Effect.promise(() => rx.firstValueFrom(facade.state()));
+
+      expect(after.pending.reservations).toEqual([]);
+      expect(after.unshielded.pendingCoins).toEqual([]);
+    }).pipe(Effect.scoped, Effect.runPromise));
+});
+
+describe('Balancing a transaction the caller already put its own coins into', () => {
+  // In-place balancing hands back the caller's transaction with the wallet's inputs added, so the transaction names
+  // coins from two sources. A reservation covers the wallet's booking, and only the coins the wallet moved out of the
+  // available side are that. Naming the caller's as well would have the record hold coins it never took.
+  it('records only the coins the wallet itself booked', () =>
+    Effect.gen(function* () {
+      const keys = deriveWalletKeys(SENDER_SEED, NETWORK_ID);
+      const simulator = yield* Simulator.init({
+        genesisMints: [nightGenesisMint(keys.signatureVerifyingKey, keys.userAddress)],
+        blockProducer: immediateBlockProducer(),
+      });
+      const config: SimulatorConfig = { simulator, networkId: NETWORK_ID, costParameters: { feeBlocksMargin: 5 } };
+      const facade = yield* makeSimulatorFacade(config, keys, createSimulatorWalletFactories(config));
+
+      yield* waitForUnshieldedBalance(facade, NIGHT, 1n);
+      yield* simulator.fastForward(10_000n);
+      const address = yield* Effect.promise(() => facade.unshielded.getAddress());
+      const ttl = new Date(Date.now() + 60 * 60 * 1000);
+
+      // A transaction that already spends this wallet's coins, with the booking it was built with given back, so the
+      // coins it names are available again — the state a caller's own transaction arrives in.
+      const recipe = yield* Effect.promise(() =>
+        facade.transferTransaction(
+          [
+            {
+              type: 'unshielded' as const,
+              outputs: [{ type: NIGHT, receiverAddress: address, amount: tokenValue(1n) }],
+            },
+          ],
+          { shieldedSecretKeys: keys.shieldedKeys, dustSecretKey: keys.dustKey },
+          { ttl, payFees: false },
+        ),
+      );
+      yield* Effect.promise(() => facade.revert(recipe));
+
+      const beforeBalancing: FacadeState = yield* Effect.promise(() => rx.firstValueFrom(facade.state()));
+      expect(beforeBalancing.pending.reservations).toEqual([]);
+      const pendingBefore = new Set(beforeBalancing.unshielded.pendingCoins.map(utxoKey));
+
+      yield* Effect.promise(() =>
+        facade.balanceUnprovenTransaction(
+          recipe.transaction,
+          {
+            shieldedSecretKeys: keys.shieldedKeys,
+            dustSecretKey: keys.dustKey,
+          },
+          { ttl, tokenKindsToBalance: ['unshielded'] },
+        ),
+      );
+
+      const after: FacadeState = yield* Effect.promise(() => rx.firstValueFrom(facade.state()));
+      const newlyBooked = after.unshielded.pendingCoins.map(utxoKey).filter((id) => !pendingBefore.has(id));
+      const recorded = after.pending.reservations.flatMap((r) => r.inputs.unshielded);
+
+      expect(recorded.toSorted()).toEqual(newlyBooked.toSorted());
     }).pipe(Effect.scoped, Effect.runPromise));
 });

--- a/packages/facade/test/reservations.test.ts
+++ b/packages/facade/test/reservations.test.ts
@@ -1,0 +1,174 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * Balancing reserves coins, and nothing else records that they are spoken for until the transaction is submitted. The
+ * facade closes that window by registering a reservation as soon as it books, and dropping it once the transaction
+ * itself is being tracked.
+ */
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Simulator, immediateBlockProducer, type GenesisMint } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { Effect } from 'effect';
+import * as rx from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+import { type FacadeState } from '../src/index.js';
+import {
+  createSimulatorWalletFactories,
+  deriveWalletKeys,
+  makeSimulatorFacade,
+  tokenValue,
+  waitForUnshieldedBalance,
+  type SimulatorConfig,
+} from './utils/index.js';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+const NETWORK_ID = NetworkId.NetworkId.Undeployed;
+const NIGHT = ledger.nativeToken().raw;
+const SENDER_SEED = '0000000000000000000000000000000000000000000000000000000000000001';
+
+const utxoKey = (coin: { utxo: { intentHash: string; outputNo: number } }): string =>
+  `${coin.utxo.intentHash}#${coin.utxo.outputNo}`;
+
+const nightGenesisMint = (
+  verifyingKey: ledger.SignatureVerifyingKey,
+  userAddress: ledger.UserAddress,
+): GenesisMint => ({
+  type: 'unshielded',
+  tokenType: NIGHT,
+  amount: tokenValue(100_000n),
+  recipient: userAddress,
+  verifyingKey,
+});
+
+describe('Reservations taken while balancing', () => {
+  const fundedFacade = () =>
+    Effect.gen(function* () {
+      const keys = deriveWalletKeys(SENDER_SEED, NETWORK_ID);
+      const simulator = yield* Simulator.init({
+        genesisMints: [nightGenesisMint(keys.signatureVerifyingKey, keys.userAddress)],
+        blockProducer: immediateBlockProducer(),
+      });
+      const config: SimulatorConfig = { simulator, networkId: NETWORK_ID, costParameters: { feeBlocksMargin: 5 } };
+      const facade = yield* makeSimulatorFacade(config, keys, createSimulatorWalletFactories(config));
+
+      yield* waitForUnshieldedBalance(facade, NIGHT, 1n);
+      yield* simulator.fastForward(10_000n);
+      const address = yield* Effect.promise(() => facade.unshielded.getAddress());
+
+      /** Pays back to this wallet's own address: the point here is the booking, not where the coins land. */
+      const transfer = (amount: bigint) => [
+        {
+          type: 'unshielded' as const,
+          outputs: [{ type: NIGHT, receiverAddress: address, amount }],
+        },
+      ];
+
+      return { facade, keys, simulator, transfer };
+    });
+
+  it('records the coins a balanced transfer booked, so nothing else has to remember them', () =>
+    Effect.gen(function* () {
+      const { facade, keys, transfer } = yield* fundedFacade();
+
+      const before: FacadeState = yield* Effect.promise(() => rx.firstValueFrom(facade.state()));
+      const availableBefore = new Set(before.unshielded.availableCoins.map(utxoKey));
+
+      yield* Effect.promise(() =>
+        facade.transferTransaction(
+          transfer(tokenValue(1n)),
+          { shieldedSecretKeys: keys.shieldedKeys, dustSecretKey: keys.dustKey },
+          { ttl: new Date(Date.now() + 60 * 60 * 1000), payFees: false },
+        ),
+      );
+
+      const after: FacadeState = yield* Effect.promise(() => rx.firstValueFrom(facade.state()));
+      const booked = before.unshielded.availableCoins
+        .map(utxoKey)
+        .filter((id) => !after.unshielded.availableCoins.map(utxoKey).includes(id));
+
+      expect(booked.length).toBeGreaterThan(0);
+      expect(availableBefore.size).toBeGreaterThan(0);
+
+      // Every coin that left the available side is named by a reservation.
+      const reserved = new Set(after.pending.reservations.flatMap((r) => r.inputs.unshielded));
+      for (const id of booked) {
+        expect(reserved.has(id)).toBe(true);
+      }
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('gives the reservation an expiry matching the transaction it was taken for', () =>
+    Effect.gen(function* () {
+      const { facade, keys, transfer } = yield* fundedFacade();
+      const ttl = new Date(Date.now() + 60 * 60 * 1000);
+
+      yield* Effect.promise(() =>
+        facade.transferTransaction(
+          transfer(tokenValue(1n)),
+          { shieldedSecretKeys: keys.shieldedKeys, dustSecretKey: keys.dustKey },
+          { ttl, payFees: false },
+        ),
+      );
+
+      const state: FacadeState = yield* Effect.promise(() => rx.firstValueFrom(facade.state()));
+
+      expect(state.pending.reservations).toHaveLength(1);
+      // The ledger truncates an intent's TTL to whole seconds, so compare at that resolution.
+      expect(Math.floor(state.pending.reservations[0].ttl.getTime() / 1000)).toEqual(Math.floor(ttl.getTime() / 1000));
+      expect(state.pending.reservations[0].expired).toBe(false);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('drops the reservation once the transaction itself is being tracked', () =>
+    // From submission onwards the transaction carries its own expiry and its own release paths, so a second record
+    // of the same spend would only be another thing to keep in step.
+    Effect.gen(function* () {
+      const { facade, keys, transfer } = yield* fundedFacade();
+
+      const recipe = yield* Effect.promise(() =>
+        facade.transferTransaction(
+          transfer(tokenValue(1n)),
+          { shieldedSecretKeys: keys.shieldedKeys, dustSecretKey: keys.dustKey },
+          { ttl: new Date(Date.now() + 60 * 60 * 1000), payFees: false },
+        ),
+      );
+
+      const reservedWhileBalancing: FacadeState = yield* Effect.promise(() => rx.firstValueFrom(facade.state()));
+      expect(reservedWhileBalancing.pending.reservations).toHaveLength(1);
+
+      // Tracking begins when the finalized transaction is registered, which is what makes the reservation redundant.
+      yield* Effect.promise(() => facade.finalizeRecipe(recipe));
+
+      const afterFinalizing: FacadeState = yield* Effect.promise(() => rx.firstValueFrom(facade.state()));
+      expect(afterFinalizing.pending.reservations).toEqual([]);
+      expect(afterFinalizing.pending.all).toHaveLength(1);
+    }).pipe(Effect.scoped, Effect.runPromise));
+
+  it('keeps a transaction identifiable across proving, which is what ties a reservation to it', () =>
+    // The reservation is matched to the transaction by identifier, so proving must not change them.
+    Effect.gen(function* () {
+      const { facade, keys, transfer } = yield* fundedFacade();
+
+      const recipe = yield* Effect.promise(() =>
+        facade.transferTransaction(
+          transfer(tokenValue(1n)),
+          { shieldedSecretKeys: keys.shieldedKeys, dustSecretKey: keys.dustKey },
+          { ttl: new Date(Date.now() + 60 * 60 * 1000), payFees: false },
+        ),
+      );
+      const beforeProving = [...recipe.transaction.identifiers()].toSorted();
+
+      const finalized = yield* Effect.promise(() => facade.finalizeRecipe(recipe));
+
+      expect([...finalized.identifiers()].toSorted()).toEqual(beforeProving);
+    }).pipe(Effect.scoped, Effect.runPromise));
+});

--- a/packages/facade/test/submission.test.ts
+++ b/packages/facade/test/submission.test.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { NEVER } from 'rxjs';
 import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type SubmissionService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
@@ -70,6 +71,9 @@ describe('Facade submission', () => {
           UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(createKeystore(seed, config.networkId))),
         );
         mockedUnshielded.start.mockResolvedValue(undefined);
+        // The facade watches this stream for the moment sync reaches the tip; this wallet never gets there.
+        // Type cast required because: `state` is declared read-only on the wallet, and mocking it is the point.
+        (mockedUnshielded as unknown as { state: typeof NEVER }).state = NEVER;
         return mockedUnshielded;
       },
       dust: (config) => {

--- a/packages/facade/test/utils/helpers.ts
+++ b/packages/facade/test/utils/helpers.ts
@@ -263,11 +263,15 @@ export const deriveWalletKeys = (hexSeed: string, networkId: NetworkId.NetworkId
  * it on scope close.
  *
  * Proving and submission services are created internally from the simulator config.
+ *
+ * @param overrides - Init parameters to use instead of the simulator defaults, for a test that has to drive one of the
+ *   services itself.
  */
 export const makeSimulatorFacade = (
   config: SimulatorConfig,
   keys: WalletKeys,
   factories: SimulatorWalletFactories,
+  overrides: Partial<Parameters<typeof WalletFacade.init>[0]> = {},
 ): Effect.Effect<WalletFacade, never, Scope.Scope> => {
   const dustParameters = ledger.LedgerParameters.initialParameters().dust;
   const provingService = createSimulatorProvingService();
@@ -290,6 +294,7 @@ export const makeSimulatorFacade = (
         submissionService: () => submissionService,
         fetchBlockData: () => makeSimulatorBlockDataFetcher(config.simulator),
         clock: () => simulatorClock(config.simulator),
+        ...overrides,
       });
 
       // Start the wallet with keys

--- a/packages/unshielded-wallet/src/UnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/UnshieldedWallet.ts
@@ -182,6 +182,23 @@ export type UnshieldedWalletAPI<TSerialized = string> = {
    */
   revertUtxos(utxoIds: ReadonlyArray<UtxoHash>): Promise<void>;
 
+  /**
+   * Releases bookings that came back from a snapshot and that `coveredIds` does not account for.
+   *
+   * Call this once sync has reached the chain tip: from there, every transaction the address is party to has been
+   * applied, so a coin still booked was never spent by the process that booked it. Pass the coins some durable record
+   * still accounts for — a transaction waiting on a counterparty, say — and those stay booked.
+   *
+   * @example
+   *   ```typescript
+   *   await wallet.releaseRestoredPending(idsStillSpokenFor);
+   *   ```;
+   *
+   * @param coveredIds - Ids of coins to leave booked, each `intentHash#outputNo`
+   * @returns A promise that resolves once the wallet state has been updated
+   */
+  releaseRestoredPending(coveredIds: ReadonlyArray<UtxoHash>): Promise<void>;
+
   getAddress(): Promise<UnshieldedAddress>;
 
   stop(): Promise<void>;
@@ -359,6 +376,14 @@ export function CustomUnshieldedWallet<
       return this.runtime
         .dispatch({
           [V1Tag]: (v1) => v1.revertUtxos(utxoIds),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    releaseRestoredPending(coveredIds: ReadonlyArray<UtxoHash>): Promise<void> {
+      return this.runtime
+        .dispatch({
+          [V1Tag]: (v1) => v1.releaseRestoredPending(coveredIds),
         })
         .pipe(Effect.runPromise);
     }

--- a/packages/unshielded-wallet/src/UnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/UnshieldedWallet.ts
@@ -34,7 +34,7 @@ import {
   type UnprovenTransactionBalanceResult,
 } from './v1/Transacting.js';
 import { type WalletSyncUpdate } from './v1/SyncSchema.js';
-import { type UtxoWithMeta } from './v1/UnshieldedState.js';
+import { type UtxoHash, type UtxoWithMeta } from './v1/UnshieldedState.js';
 import { type Variant, type VariantBuilder, type WalletLike } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
 import { type Runtime, WalletBuilder } from '@midnightntwrk/wallet-sdk-runtime';
 import { type PublicKey } from './KeyStore.js';
@@ -164,6 +164,23 @@ export type UnshieldedWalletAPI<TSerialized = string> = {
   revertTransaction(
     transaction: ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>,
   ): Promise<void>;
+
+  /**
+   * Releases the booked coins named by `utxoIds`, making them spendable again.
+   *
+   * Use this when the transaction that booked them is not to hand — a caller tracking only the ids it reserved, or a
+   * reservation being cleaned up. When the transaction is available, prefer {@link revertTransaction}.
+   *
+   * @example
+   *   ```typescript
+   *   await wallet.revertUtxos(['4b0f…#0', '4b0f…#1']);
+   *   ```;
+   *
+   * @param utxoIds - Ids of the coins to release, each `intentHash#outputNo`. An id that is not booked is ignored,
+   *   since sync may have cleared the coin first.
+   * @returns A promise that resolves once the wallet state has been updated
+   */
+  revertUtxos(utxoIds: ReadonlyArray<UtxoHash>): Promise<void>;
 
   getAddress(): Promise<UnshieldedAddress>;
 
@@ -334,6 +351,14 @@ export function CustomUnshieldedWallet<
       return this.runtime
         .dispatch({
           [V1Tag]: (v1) => v1.revertTransaction(transaction),
+        })
+        .pipe(Effect.runPromise);
+    }
+
+    revertUtxos(utxoIds: ReadonlyArray<UtxoHash>): Promise<void> {
+      return this.runtime
+        .dispatch({
+          [V1Tag]: (v1) => v1.revertUtxos(utxoIds),
         })
         .pipe(Effect.runPromise);
     }

--- a/packages/unshielded-wallet/src/v1/CoinsAndBalances.ts
+++ b/packages/unshielded-wallet/src/v1/CoinsAndBalances.ts
@@ -64,7 +64,7 @@ export const makeDefaultCoinsAndBalancesCapability = (): CoinsAndBalancesCapabil
     UnshieldedState.toArrays(state.state).availableUtxos;
 
   const getPendingCoins = (state: CoreWallet): readonly UtxoWithMeta[] =>
-    UnshieldedState.toArrays(state.state).pendingUtxos;
+    UnshieldedState.toArrays(state.state).pendingUtxos.map(({ utxo }) => utxo);
 
   const getTotalCoins = (state: CoreWallet): readonly UtxoWithMeta[] => [
     ...getAvailableCoins(state),

--- a/packages/unshielded-wallet/src/v1/CoreWallet.ts
+++ b/packages/unshielded-wallet/src/v1/CoreWallet.ts
@@ -13,7 +13,7 @@
 import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { createSyncProgress, type SyncProgress, type SyncProgressData } from './SyncProgress.js';
 import { type PublicKey } from '../KeyStore.js';
-import { UnshieldedState, type UnshieldedUpdate } from './UnshieldedState.js';
+import { UnshieldedState, type UnshieldedUpdate, type UtxoHash } from './UnshieldedState.js';
 import type * as ledger from '@midnight-ntwrk/ledger-v8';
 import { Either, Array as Arr, pipe } from 'effect';
 import { ApplyTransactionError, RollbackUtxoError, SpendUtxoError, type WalletError } from './WalletError.js';
@@ -89,6 +89,17 @@ export const CoreWallet = {
   /** Releases every booking that has reached its expiry. See {@link UnshieldedState.expirePending}. */
   expirePending(coreWallet: CoreWallet, now: Date): CoreWallet {
     return { ...coreWallet, state: UnshieldedState.expirePending(coreWallet.state, now) };
+  },
+
+  /**
+   * Releases the booked coins named by `hashes`. Unlike {@link CoreWallet.rollbackUtxo}, this needs no transaction,
+   * which is what lets a caller holding only a record of the ids release them. Ids that are not booked are ignored.
+   */
+  revertUtxos(coreWallet: CoreWallet, hashes: ReadonlyArray<UtxoHash>): CoreWallet {
+    return {
+      ...coreWallet,
+      state: hashes.reduce(UnshieldedState.rollbackSpendByHash, coreWallet.state),
+    };
   },
 
   spend(coreWallet: CoreWallet, utxo: ledger.Utxo, ttl: Date): Either.Either<CoreWallet, WalletError> {

--- a/packages/unshielded-wallet/src/v1/CoreWallet.ts
+++ b/packages/unshielded-wallet/src/v1/CoreWallet.ts
@@ -86,16 +86,27 @@ export const CoreWallet = {
     );
   },
 
-  spend(coreWallet: CoreWallet, utxo: ledger.Utxo): Either.Either<CoreWallet, WalletError> {
-    return UnshieldedState.spendByUtxo(coreWallet.state, utxo).pipe(
+  /** Releases every booking that has reached its expiry. See {@link UnshieldedState.expirePending}. */
+  expirePending(coreWallet: CoreWallet, now: Date): CoreWallet {
+    return { ...coreWallet, state: UnshieldedState.expirePending(coreWallet.state, now) };
+  },
+
+  spend(coreWallet: CoreWallet, utxo: ledger.Utxo, ttl: Date): Either.Either<CoreWallet, WalletError> {
+    return UnshieldedState.spendByUtxo(coreWallet.state, utxo, ttl).pipe(
       Either.map((state) => ({ ...coreWallet, state })),
       Either.mapLeft((error) => new SpendUtxoError(error)),
     );
   },
 
+  /**
+   * Books each of `utxos` for a transaction being balanced.
+   *
+   * @param ttl - The TTL of the transaction the coins are being booked for; it bounds every reservation taken here.
+   */
   spendUtxos(
     wallet: CoreWallet,
     utxos: ReadonlyArray<ledger.Utxo>,
+    ttl: Date,
   ): Either.Either<[ReadonlyArray<ledger.Utxo>, CoreWallet], WalletError> {
     return pipe(
       utxos,
@@ -104,7 +115,7 @@ export const CoreWallet = {
         (acc, utxoToSpend) =>
           acc.pipe(
             Either.flatMap(([accUtxos, state]) =>
-              UnshieldedState.spendByUtxo(state, utxoToSpend).pipe(
+              UnshieldedState.spendByUtxo(state, utxoToSpend, ttl).pipe(
                 Either.map(
                   (nextState) => [accUtxos.concat([utxoToSpend]), nextState] as [ledger.Utxo[], UnshieldedState],
                 ),

--- a/packages/unshielded-wallet/src/v1/CoreWallet.ts
+++ b/packages/unshielded-wallet/src/v1/CoreWallet.ts
@@ -86,9 +86,27 @@ export const CoreWallet = {
     );
   },
 
+  /**
+   * Rewraps `coreWallet` around a new state, or hands back the very same wallet when the state did not change.
+   *
+   * Identity matters here: wallet state is published through a ref that emits on every write, and a caller that reacts
+   * to those emissions and then calls back in would drive itself in a loop if a no-op still produced a new object.
+   */
+  withState(coreWallet: CoreWallet, state: UnshieldedState): CoreWallet {
+    return state === coreWallet.state ? coreWallet : { ...coreWallet, state };
+  },
+
   /** Releases every booking that has reached its expiry. See {@link UnshieldedState.expirePending}. */
   expirePending(coreWallet: CoreWallet, now: Date): CoreWallet {
-    return { ...coreWallet, state: UnshieldedState.expirePending(coreWallet.state, now) };
+    return CoreWallet.withState(coreWallet, UnshieldedState.expirePending(coreWallet.state, now));
+  },
+
+  /**
+   * Releases the bookings that came back from a snapshot and that `coveredIds` does not account for. See
+   * {@link UnshieldedState.releaseRestoredPending}.
+   */
+  releaseRestoredPending(coreWallet: CoreWallet, coveredIds: ReadonlyArray<UtxoHash>): CoreWallet {
+    return CoreWallet.withState(coreWallet, UnshieldedState.releaseRestoredPending(coreWallet.state, coveredIds));
   },
 
   /**
@@ -96,10 +114,7 @@ export const CoreWallet = {
    * which is what lets a caller holding only a record of the ids release them. Ids that are not booked are ignored.
    */
   revertUtxos(coreWallet: CoreWallet, hashes: ReadonlyArray<UtxoHash>): CoreWallet {
-    return {
-      ...coreWallet,
-      state: hashes.reduce(UnshieldedState.rollbackSpendByHash, coreWallet.state),
-    };
+    return CoreWallet.withState(coreWallet, hashes.reduce(UnshieldedState.rollbackSpendByHash, coreWallet.state));
   },
 
   spend(coreWallet: CoreWallet, utxo: ledger.Utxo, ttl: Date): Either.Either<CoreWallet, WalletError> {

--- a/packages/unshielded-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/unshielded-wallet/src/v1/RunningV1Variant.ts
@@ -248,6 +248,12 @@ export class RunningV1Variant<TSerialized, TSyncUpdate> implements Variant.Runni
     );
   }
 
+  releaseRestoredPending(coveredIds: ReadonlyArray<UtxoHash>): Effect.Effect<void, WalletError> {
+    return SubscriptionRef.update(this.#context.stateRef, (state) =>
+      this.#v1Context.transactingCapability.releaseRestoredPending(state, coveredIds),
+    );
+  }
+
   serializeState(state: CoreWallet): TSerialized {
     return this.#v1Context.serializationCapability.serialize(state);
   }

--- a/packages/unshielded-wallet/src/v1/RunningV1Variant.ts
+++ b/packages/unshielded-wallet/src/v1/RunningV1Variant.ts
@@ -29,7 +29,7 @@ import {
   type UnboundTransactionBalanceResult,
   type UnprovenTransactionBalanceResult,
 } from './Transacting.js';
-import { type UtxoWithMeta } from './UnshieldedState.js';
+import { type UtxoHash, type UtxoWithMeta } from './UnshieldedState.js';
 import { type UnboundTransaction } from './TransactionOps.js';
 import { type WalletError } from './WalletError.js';
 import { type CoinsAndBalancesCapability } from './CoinsAndBalances.js';
@@ -240,6 +240,12 @@ export class RunningV1Variant<TSerialized, TSyncUpdate> implements Variant.Runni
     return SubscriptionRef.updateEffect(this.#context.stateRef, (state) => {
       return pipe(this.#v1Context.transactingCapability.revertTransaction(state, transaction), EitherOps.toEffect);
     });
+  }
+
+  revertUtxos(utxoIds: ReadonlyArray<UtxoHash>): Effect.Effect<void, WalletError> {
+    return SubscriptionRef.update(this.#context.stateRef, (state) =>
+      this.#v1Context.transactingCapability.revertUtxos(state, utxoIds),
+    );
   }
 
   serializeState(state: CoreWallet): TSerialized {

--- a/packages/unshielded-wallet/src/v1/Serialization.ts
+++ b/packages/unshielded-wallet/src/v1/Serialization.ts
@@ -25,6 +25,13 @@ export type DefaultSerializationConfiguration = {
   networkId: NetworkId.NetworkId;
 };
 
+/**
+ * How long a booking restored from a snapshot that predates booking expiries is given, measured from the moment the
+ * snapshot is loaded. It matches the transaction lifetime the facade hands out by default, so such a booking is bounded
+ * exactly like one written by this version.
+ */
+export const LEGACY_BOOKING_LIFETIME_MS = 60 * 60 * 1000;
+
 export const makeDefaultV1SerializationCapability = (): SerializationCapability<CoreWallet, string> => {
   const UtxoWithMetaSchema = Schema.Struct({
     utxo: Schema.Struct({
@@ -42,12 +49,18 @@ export const makeDefaultV1SerializationCapability = (): SerializationCapability<
 
   /**
    * A pending entry is a UTxO plus the expiry its booking was taken with. `ttl` is additive: a snapshot written before
-   * bookings carried an expiry decodes at the epoch, so the first expiry sweep releases the coin — which is the repair
-   * such a snapshot needs, because nothing in the writing process is left to release it.
+   * bookings carried an expiry has no expiry to restore, so one is granted from the moment it is loaded.
+   *
+   * Granted rather than assumed to have passed, because such a snapshot says nothing about when its coins were booked.
+   * The process that wrote it may have submitted the transaction moments before it stopped, and dating the booking in
+   * the past would offer a coin that transaction is still spending. A full lifetime ahead releases the coin only once
+   * no transaction could still be accepted, which is the bound every other booking already has.
    */
   const PendingUtxoSchema = Schema.Struct({
     ...UtxoWithMetaSchema.fields,
-    ttl: Schema.optionalWith(Schema.Date, { default: () => new Date(0) }),
+    ttl: Schema.optionalWith(Schema.Date, {
+      default: () => new Date(Date.now() + LEGACY_BOOKING_LIFETIME_MS),
+    }),
   });
 
   const SnapshotSchema = Schema.Struct({

--- a/packages/unshielded-wallet/src/v1/Serialization.ts
+++ b/packages/unshielded-wallet/src/v1/Serialization.ts
@@ -14,7 +14,7 @@ import { Either, pipe, Schema } from 'effect';
 import { OtherWalletError, type WalletError } from './WalletError.js';
 import { CoreWallet } from './CoreWallet.js';
 import { type NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
-import { UnshieldedState } from './UnshieldedState.js';
+import { UnshieldedState, UtxoWithMeta } from './UnshieldedState.js';
 
 export type SerializationCapability<TWallet, TSerialized> = {
   serialize(wallet: TWallet): TSerialized;
@@ -40,6 +40,16 @@ export const makeDefaultV1SerializationCapability = (): SerializationCapability<
     }),
   });
 
+  /**
+   * A pending entry is a UTxO plus the expiry its booking was taken with. `ttl` is additive: a snapshot written before
+   * bookings carried an expiry decodes at the epoch, so the first expiry sweep releases the coin — which is the repair
+   * such a snapshot needs, because nothing in the writing process is left to release it.
+   */
+  const PendingUtxoSchema = Schema.Struct({
+    ...UtxoWithMetaSchema.fields,
+    ttl: Schema.optionalWith(Schema.Date, { default: () => new Date(0) }),
+  });
+
   const SnapshotSchema = Schema.Struct({
     publicKey: Schema.Struct({
       publicKey: Schema.String,
@@ -48,7 +58,7 @@ export const makeDefaultV1SerializationCapability = (): SerializationCapability<
     }),
     state: Schema.Struct({
       availableUtxos: Schema.Array(UtxoWithMetaSchema),
-      pendingUtxos: Schema.Array(UtxoWithMetaSchema),
+      pendingUtxos: Schema.Array(PendingUtxoSchema),
     }),
     protocolVersion: Schema.BigInt,
     appliedId: Schema.optional(Schema.BigInt),
@@ -58,13 +68,21 @@ export const makeDefaultV1SerializationCapability = (): SerializationCapability<
   type Snapshot = Schema.Schema.Type<typeof SnapshotSchema>;
   return {
     serialize: (wallet) => {
-      const buildSnapshot = (w: CoreWallet): Snapshot => ({
-        publicKey: w.publicKey,
-        state: UnshieldedState.toArrays(w.state),
-        protocolVersion: w.protocolVersion,
-        networkId: w.networkId,
-        appliedId: w.progress?.appliedId,
-      });
+      const buildSnapshot = (w: CoreWallet): Snapshot => {
+        const { availableUtxos, pendingUtxos } = UnshieldedState.toArrays(w.state);
+
+        return {
+          publicKey: w.publicKey,
+          state: {
+            availableUtxos,
+            // The snapshot keeps one flat record per pending coin, with its booking's expiry alongside its meta.
+            pendingUtxos: pendingUtxos.map(({ utxo, ttl }) => ({ utxo: utxo.utxo, meta: utxo.meta, ttl })),
+          },
+          protocolVersion: w.protocolVersion,
+          networkId: w.networkId,
+          appliedId: w.progress?.appliedId,
+        };
+      };
 
       return pipe(wallet, buildSnapshot, Schema.encodeSync(SnapshotSchema), JSON.stringify);
     },
@@ -75,7 +93,13 @@ export const makeDefaultV1SerializationCapability = (): SerializationCapability<
         Either.mapLeft((err) => new OtherWalletError(err)),
         Either.map((snapshot) => {
           return CoreWallet.restore(
-            UnshieldedState.restore(snapshot.state.availableUtxos, snapshot.state.pendingUtxos),
+            UnshieldedState.restore(
+              snapshot.state.availableUtxos,
+              snapshot.state.pendingUtxos.map(({ utxo, meta, ttl }) => ({
+                utxo: new UtxoWithMeta({ utxo, meta }),
+                ttl,
+              })),
+            ),
             snapshot.publicKey,
             {
               highestTransactionId: snapshot.appliedId ?? 0n,

--- a/packages/unshielded-wallet/src/v1/Sync.ts
+++ b/packages/unshielded-wallet/src/v1/Sync.ts
@@ -23,7 +23,7 @@ import { WsSubscriptionClient, ConnectionHelper } from '@midnightntwrk/wallet-sd
 import { SyncWalletError, type WalletError } from './WalletError.js';
 import { WsURL } from '@midnightntwrk/wallet-sdk-utilities/networking';
 import { type TransactionHistoryService } from './TransactionHistory.js';
-import { EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
+import { Clock, EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
 import { type WalletSyncUpdate, WalletSyncUpdateSchema } from './SyncSchema.js';
 import * as ledger from '@midnight-ntwrk/ledger-v8';
 
@@ -43,6 +43,11 @@ export type IndexerClientConnection = {
 
 export type DefaultSyncConfiguration = {
   indexerClientConnection: IndexerClientConnection;
+  /**
+   * The clock the booking sweep expires against. Defaults to system time; inject one to pin the expiry boundary in a
+   * test, or to follow a simulated chain.
+   */
+  clock?: Clock.Clock;
 };
 
 export type DefaultSyncContext = {
@@ -101,24 +106,37 @@ export const makeDefaultSyncService = (config: DefaultSyncConfiguration): SyncSe
 };
 
 export const makeDefaultSyncCapability = (
-  _config: DefaultSyncConfiguration,
+  config: DefaultSyncConfiguration,
   getContext: () => DefaultSyncContext,
 ): SyncCapability<CoreWallet, WalletSyncUpdate> => {
+  const clock = config.clock ?? Clock.systemClock;
+
+  /**
+   * Releases bookings nothing else will: a transaction abandoned between balancing and submission leaves one behind,
+   * and past its TTL the ledger would reject that transaction anyway.
+   *
+   * Only once the wallet has caught up with the chain. While a replay from an earlier cursor is still running, a coin
+   * can be booked here and already spent on chain by a transaction the replay has not delivered yet; releasing it then
+   * offers a coin that is gone, and over-reports the balance until the spend arrives. Applying the update first and
+   * judging on the result is what lets the update that reaches the tip sweep straight away, rather than waiting for
+   * whatever arrives next on a chain that may now be quiet.
+   *
+   * This path follows the chain, so the expiry it compares against is wall time; the simulator path uses simulator time
+   * instead.
+   */
+  const sweepIfCaughtUp = (wallet: CoreWallet): CoreWallet =>
+    wallet.progress.isStrictlyComplete() ? CoreWallet.expirePending(wallet, clock.now()) : wallet;
+
   return {
     applyUpdate: (state: CoreWallet, update: WalletSyncUpdate): Either.Either<CoreWallet, WalletError> => {
-      // Every update is an opportunity to release a booking nothing else will: a transaction abandoned between
-      // balancing and submission leaves one behind, and past its TTL the ledger would reject that transaction
-      // anyway. Progress updates count, because a leaked booking blocks its coin whether or not the address sees
-      // further activity. This path follows the chain, so the expiry it compares against is wall time; the
-      // simulator path uses simulator time instead.
-      const swept = CoreWallet.expirePending(state, new Date());
-
       if (update.type === 'UnshieldedTransactionsProgress') {
         return Either.right(
-          CoreWallet.updateProgress(swept, {
-            highestTransactionId: BigInt(update.highestTransactionId),
-            isConnected: true,
-          }),
+          sweepIfCaughtUp(
+            CoreWallet.updateProgress(state, {
+              highestTransactionId: BigInt(update.highestTransactionId),
+              isConnected: true,
+            }),
+          ),
         );
       } else {
         const updatePayload = {
@@ -129,8 +147,8 @@ export const makeDefaultSyncCapability = (
 
         const stateAfterApplyingUpdate =
           update.status === 'FAILURE'
-            ? CoreWallet.applyFailedUpdate(swept, updatePayload)
-            : CoreWallet.applyUpdate(swept, updatePayload);
+            ? CoreWallet.applyFailedUpdate(state, updatePayload)
+            : CoreWallet.applyUpdate(state, updatePayload);
 
         return stateAfterApplyingUpdate.pipe(
           Either.map((wallet) => {
@@ -141,7 +159,7 @@ export const makeDefaultSyncCapability = (
             const { transactionHistoryService } = getContext();
             Effect.runFork(transactionHistoryService.put(update));
 
-            return stateAfterUpdatingProgress;
+            return sweepIfCaughtUp(stateAfterUpdatingProgress);
           }),
         );
       }

--- a/packages/unshielded-wallet/src/v1/Sync.ts
+++ b/packages/unshielded-wallet/src/v1/Sync.ts
@@ -213,12 +213,14 @@ export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, Simula
         .map(([, utxo]) => utxo);
 
       // Spent: in wallet (pending or available) but no longer in simulator
-      const spentUtxos = [
-        ...Array.from(HashMap.entries(state.state.pendingUtxos)),
+      const trackedUtxos: readonly (readonly [string, UtxoWithMeta])[] = [
+        ...Array.from(HashMap.entries(state.state.pendingUtxos)).map(
+          ([hash, pending]) => [hash, pending.utxo] as const,
+        ),
         ...Array.from(HashMap.entries(state.state.availableUtxos)),
-      ]
-        .filter(([hash]) => !simulatorUtxoMap.has(hash))
-        .map(([, utxo]) => utxo);
+      ];
+
+      const spentUtxos = trackedUtxos.filter(([hash]) => !simulatorUtxoMap.has(hash)).map(([, utxo]) => utxo);
 
       const blockNumber = getCurrentBlockNumber(update.update);
       const updateProgress = (wallet: CoreWallet) =>

--- a/packages/unshielded-wallet/src/v1/Sync.ts
+++ b/packages/unshielded-wallet/src/v1/Sync.ts
@@ -106,7 +106,12 @@ export const makeDefaultSyncCapability = (
 ): SyncCapability<CoreWallet, WalletSyncUpdate> => {
   return {
     applyUpdate: (state: CoreWallet, update: WalletSyncUpdate): Either.Either<CoreWallet, WalletError> => {
-      const swept = state;
+      // Every update is an opportunity to release a booking nothing else will: a transaction abandoned between
+      // balancing and submission leaves one behind, and past its TTL the ledger would reject that transaction
+      // anyway. Progress updates count, because a leaked booking blocks its coin whether or not the address sees
+      // further activity. This path follows the chain, so the expiry it compares against is wall time; the
+      // simulator path uses simulator time instead.
+      const swept = CoreWallet.expirePending(state, new Date());
 
       if (update.type === 'UnshieldedTransactionsProgress') {
         return Either.right(
@@ -190,7 +195,8 @@ export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, Simula
       update: SimulatorSyncUpdate,
     ): Either.Either<CoreWallet, WalletError> => {
       const { ledger: ledgerState, currentTime } = update.update;
-      const state = walletBeforeSweep;
+      // Simulator time drives the wallet here, so the booking sweep expires against it rather than the wall clock.
+      const state = CoreWallet.expirePending(walletBeforeSweep, currentTime);
       const walletAddress = state.publicKey.addressHex;
       const nativeTokenType = ledger.nativeToken().raw;
 

--- a/packages/unshielded-wallet/src/v1/Sync.ts
+++ b/packages/unshielded-wallet/src/v1/Sync.ts
@@ -106,9 +106,11 @@ export const makeDefaultSyncCapability = (
 ): SyncCapability<CoreWallet, WalletSyncUpdate> => {
   return {
     applyUpdate: (state: CoreWallet, update: WalletSyncUpdate): Either.Either<CoreWallet, WalletError> => {
+      const swept = state;
+
       if (update.type === 'UnshieldedTransactionsProgress') {
         return Either.right(
-          CoreWallet.updateProgress(state, {
+          CoreWallet.updateProgress(swept, {
             highestTransactionId: BigInt(update.highestTransactionId),
             isConnected: true,
           }),
@@ -122,8 +124,8 @@ export const makeDefaultSyncCapability = (
 
         const stateAfterApplyingUpdate =
           update.status === 'FAILURE'
-            ? CoreWallet.applyFailedUpdate(state, updatePayload)
-            : CoreWallet.applyUpdate(state, updatePayload);
+            ? CoreWallet.applyFailedUpdate(swept, updatePayload)
+            : CoreWallet.applyUpdate(swept, updatePayload);
 
         return stateAfterApplyingUpdate.pipe(
           Either.map((wallet) => {
@@ -183,8 +185,12 @@ export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, Simula
   const utxoKey = (utxo: { intentHash: string; outputNo: number }) => `${utxo.intentHash}#${utxo.outputNo}`;
 
   return {
-    applyUpdate: (state: CoreWallet, update: SimulatorSyncUpdate): Either.Either<CoreWallet, WalletError> => {
+    applyUpdate: (
+      walletBeforeSweep: CoreWallet,
+      update: SimulatorSyncUpdate,
+    ): Either.Either<CoreWallet, WalletError> => {
       const { ledger: ledgerState, currentTime } = update.update;
+      const state = walletBeforeSweep;
       const walletAddress = state.publicKey.addressHex;
       const nativeTokenType = ledger.nativeToken().raw;
 

--- a/packages/unshielded-wallet/src/v1/Transacting.ts
+++ b/packages/unshielded-wallet/src/v1/Transacting.ts
@@ -512,6 +512,13 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
     return CoreWallet.releaseRestoredPending(wallet, coveredIds);
   }
 
+  /**
+   * Releases the bookings a transaction took, for a caller that still holds the transaction itself.
+   *
+   * @param wallet - The wallet holding the bookings
+   * @param transaction - The transaction whose own inputs are to be released
+   * @returns The wallet with those coins available again, or the error that stopped a coin being released
+   */
   revertTransaction(
     wallet: CoreWallet,
     transaction: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>,
@@ -647,59 +654,87 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
     wallet: CoreWallet,
     transaction: T,
   ): Either.Either<[T | undefined, CoreWallet], WalletError> {
+    const segments = this.txOps.getSegments(transaction);
+
+    // no segments to balance
+    if (segments.length === 0) {
+      return Either.right([undefined, wallet]);
+    }
+
+    // Each segment is balanced against the wallet the previous segment left behind, so a coin booked for one
+    // segment can no longer be selected for the next one, and the caller receives every booking this call made.
+    return pipe(
+      [...segments, GUARANTEED_SEGMENT],
+      Arr.reduce(Either.right(wallet) as Either.Either<CoreWallet, WalletError>, (walletAcc, segment) =>
+        pipe(
+          walletAcc,
+          Either.flatMap((walletSoFar) => this.#balanceSegmentInPlace(walletSoFar, transaction, segments, segment)),
+        ),
+      ),
+      Either.map((balancedWallet): [T, CoreWallet] => [transaction, balancedWallet]),
+    );
+  }
+
+  /**
+   * Balances one segment of an unboundish transaction, merging the balancing offer into the intent that carries the
+   * segment and booking the coins it selects.
+   *
+   * @param wallet - The wallet to select and book coins from
+   * @param transaction - The transaction being balanced in place
+   * @param segments - The segments the transaction carries intents for
+   * @param segment - The segment to balance
+   * @returns The wallet with the selected coins booked, or the untouched wallet if the segment is already balanced
+   */
+  #balanceSegmentInPlace<T extends ledger.UnprovenTransaction | UnboundTransaction>(
+    wallet: CoreWallet,
+    transaction: T,
+    segments: ReadonlyArray<number>,
+    segment: number,
+  ): Either.Either<CoreWallet, WalletError> {
     return Either.gen(this, function* () {
-      const segments = this.txOps.getSegments(transaction);
+      const imbalances = this.txOps.getImbalances(transaction, segment);
 
-      // no segments to balance
-      if (segments.length === 0) {
-        return [undefined, wallet];
+      // intent is balanced
+      if (imbalances.size === 0) {
+        return wallet;
       }
 
-      for (const segment of [...segments, GUARANTEED_SEGMENT]) {
-        const imbalances = this.txOps.getImbalances(transaction, segment);
+      // if segment is GUARANTEED_SEGMENT, use the first intent to place the balancing offer in the guaranteed section
+      const intentSegment = segment === GUARANTEED_SEGMENT ? segments[0] : segment;
 
-        // intent is balanced
-        if (imbalances.size === 0) {
-          continue;
-        }
+      const intent = transaction.intents?.get(intentSegment) as IntentOf<T> | undefined;
 
-        // if segment is GUARANTEED_SEGMENT, use the first intent to place the balancing offer in the guaranteed section
-        const intentSegment = segment === GUARANTEED_SEGMENT ? segments[0] : segment;
-
-        const intent = transaction.intents?.get(intentSegment) as IntentOf<T> | undefined;
-
-        if (!intent) {
-          return yield* Either.left(new TransactingError({ message: `Intent with id ${segment} was not found` }));
-        }
-
-        const isBound = this.txOps.isIntentBound(intent);
-
-        if (isBound) {
-          return yield* Either.left(new TransactingError({ message: `Intent with id ${segment} is already bound` }));
-        }
-
-        const recipe = yield* this.#balanceSegment(wallet, imbalances, Imbalances.empty(), this.getCoinSelection());
-
-        const { offer } = yield* this.#prepareOffer(wallet, recipe, intent.ttl);
-
-        const targetOffer =
-          segment !== GUARANTEED_SEGMENT ? intent.fallibleUnshieldedOffer : intent.guaranteedUnshieldedOffer;
-
-        const mergedOffer = yield* this.#mergeOffers(offer, targetOffer);
-
-        if (segment !== GUARANTEED_SEGMENT) {
-          intent.fallibleUnshieldedOffer = mergedOffer;
-        } else {
-          intent.guaranteedUnshieldedOffer = mergedOffer;
-        }
-
-        (transaction.intents as Map<number, IntentOf<T>>) = (transaction.intents as Map<number, IntentOf<T>>).set(
-          intentSegment,
-          intent,
-        );
+      if (!intent) {
+        return yield* Either.left(new TransactingError({ message: `Intent with id ${segment} was not found` }));
       }
 
-      return [transaction, wallet];
+      const isBound = this.txOps.isIntentBound(intent);
+
+      if (isBound) {
+        return yield* Either.left(new TransactingError({ message: `Intent with id ${segment} is already bound` }));
+      }
+
+      const recipe = yield* this.#balanceSegment(wallet, imbalances, Imbalances.empty(), this.getCoinSelection());
+
+      const { newState, offer } = yield* this.#prepareOffer(wallet, recipe, intent.ttl);
+
+      const targetOffer =
+        segment !== GUARANTEED_SEGMENT ? intent.fallibleUnshieldedOffer : intent.guaranteedUnshieldedOffer;
+
+      const mergedOffer = yield* this.#mergeOffers(offer, targetOffer);
+
+      if (segment !== GUARANTEED_SEGMENT) {
+        intent.fallibleUnshieldedOffer = mergedOffer;
+      } else {
+        intent.guaranteedUnshieldedOffer = mergedOffer;
+      }
+
+      (transaction.intents as Map<number, IntentOf<T>>) = (transaction.intents as Map<number, IntentOf<T>>).set(
+        intentSegment,
+        intent,
+      );
+
+      return newState;
     });
   }
 }

--- a/packages/unshielded-wallet/src/v1/Transacting.ts
+++ b/packages/unshielded-wallet/src/v1/Transacting.ts
@@ -227,7 +227,7 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
 
       const recipe = yield* this.#balanceSegment(wallet, imbalances, Imbalances.empty(), this.getCoinSelection());
 
-      const { newState, offer } = yield* this.#prepareOffer(wallet, recipe);
+      const { newState, offer } = yield* this.#prepareOffer(wallet, recipe, intent!.ttl);
 
       const balancingIntent = ledger.Intent.new(intent!.ttl);
       balancingIntent.guaranteedUnshieldedOffer = offer;
@@ -277,10 +277,14 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
         this.getCoinSelection(),
       );
 
-      const { newState, offer } = yield* this.#prepareOffer(wallet, {
-        inputs: recipe.inputs,
-        outputs: [...recipe.outputs, ...ledgerOutputs],
-      });
+      const { newState, offer } = yield* this.#prepareOffer(
+        wallet,
+        {
+          inputs: recipe.inputs,
+          outputs: [...recipe.outputs, ...ledgerOutputs],
+        },
+        ttl,
+      );
 
       const intent = ledger.Intent.new(ttl);
 
@@ -343,7 +347,7 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
       };
 
       const allUtxos = [...guaranteedUtxos, ...fallibleUtxos].map(({ utxo }) => utxo);
-      const [, walletAfterBooking] = yield* CoreWallet.spendUtxos(wallet, allUtxos);
+      const [, walletAfterBooking] = yield* CoreWallet.spendUtxos(wallet, allUtxos, ttl);
 
       const guaranteedOffer = makeOffer(guaranteedUtxos);
       const fallibleOffer = makeOffer(fallibleUtxos);
@@ -415,10 +419,14 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
 
       const recipe = yield* this.#balanceSegment(wallet, Imbalances.empty(), targetImbalances, this.getCoinSelection());
 
-      const { newState, offer } = yield* this.#prepareOffer(wallet, {
-        inputs: recipe.inputs,
-        outputs: [...recipe.outputs, ...ledgerOutputs],
-      });
+      const { newState, offer } = yield* this.#prepareOffer(
+        wallet,
+        {
+          inputs: recipe.inputs,
+          outputs: [...recipe.outputs, ...ledgerOutputs],
+        },
+        ttl,
+      );
 
       const intent = ledger.Intent.new(ttl);
       intent.guaranteedUnshieldedOffer = offer;
@@ -553,9 +561,10 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
   #prepareOffer(
     wallet: CoreWallet,
     balanceRecipe: BalanceRecipe<ledger.Utxo, ledger.UtxoOutput>,
+    ttl: Date,
   ): Either.Either<{ newState: CoreWallet; offer: ledger.UnshieldedOffer<ledger.SignatureEnabled> }, WalletError> {
     return Either.gen(function* () {
-      const [spentInputs, updatedWallet] = yield* CoreWallet.spendUtxos(wallet, balanceRecipe.inputs);
+      const [spentInputs, updatedWallet] = yield* CoreWallet.spendUtxos(wallet, balanceRecipe.inputs, ttl);
       const { publicKey } = wallet.publicKey;
 
       const ledgerInputs = spentInputs.map((input) => ({
@@ -643,7 +652,7 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
 
         const recipe = yield* this.#balanceSegment(wallet, imbalances, Imbalances.empty(), this.getCoinSelection());
 
-        const { offer } = yield* this.#prepareOffer(wallet, recipe);
+        const { offer } = yield* this.#prepareOffer(wallet, recipe, intent.ttl);
 
         const targetOffer =
           segment !== GUARANTEED_SEGMENT ? intent.fallibleUnshieldedOffer : intent.guaranteedUnshieldedOffer;

--- a/packages/unshielded-wallet/src/v1/Transacting.ts
+++ b/packages/unshielded-wallet/src/v1/Transacting.ts
@@ -113,6 +113,9 @@ export interface TransactingCapability<TState> {
   /** Releases booked coins by id, for a caller that holds a record of the ids rather than the transaction. */
   revertUtxos(wallet: CoreWallet, utxoIds: ReadonlyArray<UtxoHash>): CoreWallet;
 
+  /** Releases bookings restored from a snapshot that nothing in `coveredIds` still accounts for. */
+  releaseRestoredPending(wallet: CoreWallet, coveredIds: ReadonlyArray<UtxoHash>): CoreWallet;
+
   signUnboundTransaction(
     transaction: UnboundTransaction,
     signSegment: (data: Uint8Array) => ledger.Signature,
@@ -496,6 +499,17 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
    */
   revertUtxos(wallet: CoreWallet, utxoIds: ReadonlyArray<UtxoHash>): CoreWallet {
     return CoreWallet.revertUtxos(wallet, utxoIds);
+  }
+
+  /**
+   * Releases bookings restored from a snapshot that `coveredIds` does not account for.
+   *
+   * @param wallet - The wallet holding the restored bookings
+   * @param coveredIds - Coins some durable record still accounts for; those stay booked
+   * @returns The wallet with the uncovered restored coins available again
+   */
+  releaseRestoredPending(wallet: CoreWallet, coveredIds: ReadonlyArray<UtxoHash>): CoreWallet {
+    return CoreWallet.releaseRestoredPending(wallet, coveredIds);
   }
 
   revertTransaction(

--- a/packages/unshielded-wallet/src/v1/Transacting.ts
+++ b/packages/unshielded-wallet/src/v1/Transacting.ts
@@ -15,7 +15,7 @@ import { type NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Either, Option, pipe, Array as Arr } from 'effect';
 import { CoreWallet } from './CoreWallet.js';
 import { InsufficientFundsError, OtherWalletError, TransactingError, type WalletError } from './WalletError.js';
-import { type UtxoWithMeta } from './UnshieldedState.js';
+import { type UtxoHash, type UtxoWithMeta } from './UnshieldedState.js';
 import {
   type BalanceRecipe,
   type CoinSelection,
@@ -109,6 +109,9 @@ export interface TransactingCapability<TState> {
     wallet: CoreWallet,
     transaction: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>,
   ): Either.Either<CoreWallet, WalletError>;
+
+  /** Releases booked coins by id, for a caller that holds a record of the ids rather than the transaction. */
+  revertUtxos(wallet: CoreWallet, utxoIds: ReadonlyArray<UtxoHash>): CoreWallet;
 
   signUnboundTransaction(
     transaction: UnboundTransaction,
@@ -484,6 +487,17 @@ export class TransactingCapabilityImplementation implements TransactingCapabilit
    *   UnprovenTransaction)
    * @returns The updated wallet with rolled back UTXOs if successful, otherwise an error
    */
+  /**
+   * Releases the booked coins named by `utxoIds`, without needing the transaction that booked them.
+   *
+   * @param wallet - The wallet holding the bookings
+   * @param utxoIds - Ids of the coins to release, as `intentHash#outputNo`
+   * @returns The wallet with those coins available again; ids that are not booked are ignored
+   */
+  revertUtxos(wallet: CoreWallet, utxoIds: ReadonlyArray<UtxoHash>): CoreWallet {
+    return CoreWallet.revertUtxos(wallet, utxoIds);
+  }
+
   revertTransaction(
     wallet: CoreWallet,
     transaction: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>,

--- a/packages/unshielded-wallet/src/v1/Transacting.ts
+++ b/packages/unshielded-wallet/src/v1/Transacting.ts
@@ -110,10 +110,36 @@ export interface TransactingCapability<TState> {
     transaction: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>,
   ): Either.Either<CoreWallet, WalletError>;
 
-  /** Releases booked coins by id, for a caller that holds a record of the ids rather than the transaction. */
+  /**
+   * Releases booked coins by id, for a caller that holds a record of the ids rather than the transaction.
+   *
+   * An implementation must move each named coin back to the available side and leave the rest alone. Prefer
+   * {@link TransactingCapability.revertTransaction} where the transaction itself is to hand.
+   *
+   * @example
+   *   const released = capability.revertUtxos(wallet, ['4b0f…#0']);
+   *
+   * @param wallet - The wallet holding the bookings
+   * @param utxoIds - Ids of the coins to release, each `intentHash#outputNo`. An id that is not booked is ignored
+   *   rather than reported, since sync may have cleared the coin first
+   * @returns The wallet with those coins available again
+   */
   revertUtxos(wallet: CoreWallet, utxoIds: ReadonlyArray<UtxoHash>): CoreWallet;
 
-  /** Releases bookings restored from a snapshot that nothing in `coveredIds` still accounts for. */
+  /**
+   * Releases bookings restored from a snapshot that nothing in `coveredIds` still accounts for.
+   *
+   * Meant for the moment sync reaches the chain tip, where every transaction the address is party to has been applied,
+   * so a coin still booked was never spent by the process that booked it. An implementation must release only bookings
+   * that came back from a snapshot, and must leave every covered id booked.
+   *
+   * @example
+   *   const reconciled = capability.releaseRestoredPending(wallet, idsStillSpokenFor);
+   *
+   * @param wallet - The wallet holding the restored bookings
+   * @param coveredIds - Coins some durable record still accounts for, such as a transaction waiting on a counterparty
+   * @returns The wallet with the uncovered restored coins available again
+   */
   releaseRestoredPending(wallet: CoreWallet, coveredIds: ReadonlyArray<UtxoHash>): CoreWallet;
 
   signUnboundTransaction(

--- a/packages/unshielded-wallet/src/v1/UnshieldedState.ts
+++ b/packages/unshielded-wallet/src/v1/UnshieldedState.ts
@@ -26,6 +26,16 @@ export class UtxoWithMeta extends Data.Class<{
   readonly meta: UtxoMeta;
 }> {}
 
+/**
+ * A coin reserved by a transaction that has been balanced but has not settled, together with the expiry that
+ * reservation was taken with. `ttl` is the TTL of the transaction the coin was booked for: from that instant the ledger
+ * rejects the transaction, so the reservation cannot still be valid and the coin returns to the available side.
+ */
+export interface PendingUtxo {
+  readonly utxo: UtxoWithMeta;
+  readonly ttl: Date;
+}
+
 export type UpdateStatus = 'SUCCESS' | 'FAILURE' | 'PARTIAL_SUCCESS';
 
 export interface UnshieldedUpdate {
@@ -36,7 +46,7 @@ export interface UnshieldedUpdate {
 
 export interface UnshieldedState {
   readonly availableUtxos: HashMap.HashMap<UtxoHash, UtxoWithMeta>;
-  readonly pendingUtxos: HashMap.HashMap<UtxoHash, UtxoWithMeta>;
+  readonly pendingUtxos: HashMap.HashMap<UtxoHash, PendingUtxo>;
 }
 
 const UtxoHash = (utxo: ledger.Utxo): UtxoHash => `${utxo.intentHash}#${utxo.outputNo}`;
@@ -52,8 +62,8 @@ export const UnshieldedState = {
    * records in both is kept on the pending side only: the spend that booked it may still be on its way, and expiry
    * releases it if it is not.
    */
-  restore: (availableUtxos: readonly UtxoWithMeta[], pendingUtxos: readonly UtxoWithMeta[]): UnshieldedState => {
-    const pending = HashMap.fromIterable(pendingUtxos.map((utxo) => [UtxoHash(utxo.utxo), utxo] as const));
+  restore: (availableUtxos: readonly UtxoWithMeta[], pendingUtxos: readonly PendingUtxo[]): UnshieldedState => {
+    const pending = HashMap.fromIterable(pendingUtxos.map((entry) => [UtxoHash(entry.utxo.utxo), entry] as const));
     return {
       availableUtxos: HashMap.fromIterable(
         availableUtxos
@@ -64,7 +74,13 @@ export const UnshieldedState = {
     };
   },
 
-  spend: (state: UnshieldedState, utxo: UtxoWithMeta): Either.Either<UnshieldedState, UtxoNotFoundError> =>
+  /**
+   * Books a coin for a transaction being balanced, moving it from the available side to the pending side.
+   *
+   * @param ttl - The TTL of the transaction the coin is being booked for. It bounds the reservation: nothing else
+   *   releases a booking whose transaction is abandoned before submission, so without it the coin is stuck forever.
+   */
+  spend: (state: UnshieldedState, utxo: UtxoWithMeta, ttl: Date): Either.Either<UnshieldedState, UtxoNotFoundError> =>
     Either.gen(function* () {
       const hash = UtxoHash(utxo.utxo);
       if (!HashMap.has(state.availableUtxos, hash)) {
@@ -72,7 +88,7 @@ export const UnshieldedState = {
       }
       return {
         availableUtxos: HashMap.remove(state.availableUtxos, hash),
-        pendingUtxos: HashMap.set(state.pendingUtxos, hash, utxo),
+        pendingUtxos: HashMap.set(state.pendingUtxos, hash, { utxo, ttl }),
       };
     }),
 
@@ -88,14 +104,18 @@ export const UnshieldedState = {
     });
   },
 
-  spendByUtxo: (state: UnshieldedState, utxo: ledger.Utxo): Either.Either<UnshieldedState, UtxoNotFoundError> =>
+  spendByUtxo: (
+    state: UnshieldedState,
+    utxo: ledger.Utxo,
+    ttl: Date,
+  ): Either.Either<UnshieldedState, UtxoNotFoundError> =>
     Either.gen(function* () {
       const hash = UtxoHash(utxo);
       const found = yield* Either.fromOption(
         HashMap.get(state.availableUtxos, hash),
         () => new UtxoNotFoundError({ utxo }),
       );
-      return yield* UnshieldedState.spend(state, found);
+      return yield* UnshieldedState.spend(state, found, ttl);
     }),
 
   rollbackSpendByUtxo: (state: UnshieldedState, utxo: ledger.Utxo): Either.Either<UnshieldedState, never> =>
@@ -103,9 +123,19 @@ export const UnshieldedState = {
       HashMap.get(state.pendingUtxos, UtxoHash(utxo)),
       Option.match({
         onNone: () => Either.right(state),
-        onSome: (found) => UnshieldedState.rollbackSpend(state, found),
+        onSome: (found) => UnshieldedState.rollbackSpend(state, found.utxo),
       }),
     ),
+
+  /**
+   * Releases every booking that has reached its expiry, returning those coins to the available side. A booking is only
+   * released by the submit path today, so a transaction abandoned between balancing and submission leaks its coins;
+   * this sweep is what bounds that leak to the transaction's own lifetime.
+   *
+   * @param now - The instant to expire against. A booking expires at its TTL, not after it, because the ledger already
+   *   rejects the transaction at that instant.
+   */
+  expirePending: (state: UnshieldedState, _now: Date): UnshieldedState => state,
 
   applyUpdate: (
     state: UnshieldedState,
@@ -160,7 +190,7 @@ export const UnshieldedState = {
     state: UnshieldedState,
   ): {
     readonly availableUtxos: readonly UtxoWithMeta[];
-    readonly pendingUtxos: readonly UtxoWithMeta[];
+    readonly pendingUtxos: readonly PendingUtxo[];
   } => ({
     availableUtxos: HashMap.toValues(state.availableUtxos),
     pendingUtxos: HashMap.toValues(state.pendingUtxos),

--- a/packages/unshielded-wallet/src/v1/UnshieldedState.ts
+++ b/packages/unshielded-wallet/src/v1/UnshieldedState.ts
@@ -57,6 +57,33 @@ export interface UnshieldedState {
 
 const UtxoHash = (utxo: ledger.Utxo): UtxoHash => `${utxo.intentHash}#${utxo.outputNo}`;
 
+/**
+ * Moves every booking `shouldRelease` selects back to the available side.
+ *
+ * The three ways a booking ends — its id is named, it came back from a snapshot nothing accounts for, its expiry has
+ * passed — differ only in which bookings they pick, so the move itself lives here. A booking nothing selects is left
+ * alone rather than reported: sync may have cleared the coin first, and that race is expected.
+ *
+ * Returns the state it was given when nothing is selected, so a caller publishing on change does not publish on a sweep
+ * that found nothing.
+ */
+const releaseBookings = (
+  state: UnshieldedState,
+  shouldRelease: (booking: PendingUtxo, hash: UtxoHash) => boolean,
+): UnshieldedState => {
+  const releasable = HashMap.filter(state.pendingUtxos, shouldRelease);
+
+  return HashMap.isEmpty(releasable)
+    ? state
+    : {
+        availableUtxos: HashMap.union(
+          state.availableUtxos,
+          HashMap.map(releasable, ({ utxo }) => utxo),
+        ),
+        pendingUtxos: HashMap.removeMany(state.pendingUtxos, HashMap.keys(releasable)),
+      };
+};
+
 export const UnshieldedState = {
   empty: (): UnshieldedState => ({
     availableUtxos: HashMap.empty(),
@@ -147,16 +174,7 @@ export const UnshieldedState = {
    * have cleared the coin first, and that race is expected.
    */
   rollbackSpendByHash: (state: UnshieldedState, hash: UtxoHash): UnshieldedState =>
-    pipe(
-      HashMap.get(state.pendingUtxos, hash),
-      Option.match({
-        onNone: () => state,
-        onSome: ({ utxo }) => ({
-          availableUtxos: HashMap.set(state.availableUtxos, hash, utxo),
-          pendingUtxos: HashMap.remove(state.pendingUtxos, hash),
-        }),
-      }),
-    ),
+    releaseBookings(state, (_booking, booked) => booked === hash),
 
   /**
    * Releases every booking that came back from a snapshot and that `coveredIds` does not account for.
@@ -169,20 +187,9 @@ export const UnshieldedState = {
    *   Those stay booked: the wallet cannot see that transaction, but something else knows it is still live.
    */
   releaseRestoredPending: (state: UnshieldedState, coveredIds: ReadonlyArray<UtxoHash>): UnshieldedState => {
-    const releasable = HashMap.filter(
-      state.pendingUtxos,
-      ({ restored }, hash) => restored && !coveredIds.includes(hash),
-    );
+    const covered = new Set(coveredIds);
 
-    return HashMap.isEmpty(releasable)
-      ? state
-      : {
-          availableUtxos: HashMap.union(
-            state.availableUtxos,
-            HashMap.map(releasable, ({ utxo }) => utxo),
-          ),
-          pendingUtxos: HashMap.removeMany(state.pendingUtxos, HashMap.keys(releasable)),
-        };
+    return releaseBookings(state, ({ restored }, hash) => restored && !covered.has(hash));
   },
 
   /**
@@ -190,22 +197,12 @@ export const UnshieldedState = {
    * released by the submit path today, so a transaction abandoned between balancing and submission leaks its coins;
    * this sweep is what bounds that leak to the transaction's own lifetime.
    *
-   * @param now - The instant to expire against. A booking expires at its TTL, not after it, because the ledger already
-   *   rejects the transaction at that instant.
+   * @param now - The instant to expire against. A booking expires once its TTL has passed, not at it: the ledger
+   *   accepts an intent while its TTL is at or after the block's timestamp, so the transaction is still valid at the
+   *   instant its TTL names.
    */
-  expirePending: (state: UnshieldedState, now: Date): UnshieldedState => {
-    const expired = HashMap.filter(state.pendingUtxos, ({ ttl }) => ttl.getTime() <= now.getTime());
-
-    return HashMap.isEmpty(expired)
-      ? state
-      : {
-          availableUtxos: HashMap.union(
-            state.availableUtxos,
-            HashMap.map(expired, ({ utxo }) => utxo),
-          ),
-          pendingUtxos: HashMap.removeMany(state.pendingUtxos, HashMap.keys(expired)),
-        };
-  },
+  expirePending: (state: UnshieldedState, now: Date): UnshieldedState =>
+    releaseBookings(state, ({ ttl }) => ttl.getTime() < now.getTime()),
 
   applyUpdate: (
     state: UnshieldedState,

--- a/packages/unshielded-wallet/src/v1/UnshieldedState.ts
+++ b/packages/unshielded-wallet/src/v1/UnshieldedState.ts
@@ -34,6 +34,12 @@ export class UtxoWithMeta extends Data.Class<{
 export interface PendingUtxo {
   readonly utxo: UtxoWithMeta;
   readonly ttl: Date;
+  /**
+   * True when this booking came back from a snapshot rather than being taken by the running process. The process that
+   * took it is gone, so once sync proves nothing on chain spent the coin, only a durable record of the transaction can
+   * justify keeping it booked.
+   */
+  readonly restored: boolean;
 }
 
 export type UpdateStatus = 'SUCCESS' | 'FAILURE' | 'PARTIAL_SUCCESS';
@@ -62,8 +68,14 @@ export const UnshieldedState = {
    * records in both is kept on the pending side only: the spend that booked it may still be on its way, and expiry
    * releases it if it is not.
    */
-  restore: (availableUtxos: readonly UtxoWithMeta[], pendingUtxos: readonly PendingUtxo[]): UnshieldedState => {
-    const pending = HashMap.fromIterable(pendingUtxos.map((entry) => [UtxoHash(entry.utxo.utxo), entry] as const));
+  restore: (
+    availableUtxos: readonly UtxoWithMeta[],
+    // Every entry read back is restored by definition, so the caller does not get to say otherwise.
+    pendingUtxos: ReadonlyArray<Omit<PendingUtxo, 'restored'>>,
+  ): UnshieldedState => {
+    const pending = HashMap.fromIterable(
+      pendingUtxos.map((entry) => [UtxoHash(entry.utxo.utxo), { ...entry, restored: true }] as const),
+    );
     return {
       availableUtxos: HashMap.fromIterable(
         availableUtxos
@@ -88,7 +100,7 @@ export const UnshieldedState = {
       }
       return {
         availableUtxos: HashMap.remove(state.availableUtxos, hash),
-        pendingUtxos: HashMap.set(state.pendingUtxos, hash, { utxo, ttl }),
+        pendingUtxos: HashMap.set(state.pendingUtxos, hash, { utxo, ttl, restored: false }),
       };
     }),
 
@@ -145,6 +157,33 @@ export const UnshieldedState = {
         }),
       }),
     ),
+
+  /**
+   * Releases every booking that came back from a snapshot and that `coveredIds` does not account for.
+   *
+   * Meant for the moment sync reaches the chain tip: from there, every transaction the address is party to has been
+   * applied, so a coin still booked was never spent by the process that booked it. Releasing it then returns it in
+   * seconds rather than at the transaction's TTL.
+   *
+   * @param coveredIds - Coins some durable record still accounts for, such as a transaction waiting on a counterparty.
+   *   Those stay booked: the wallet cannot see that transaction, but something else knows it is still live.
+   */
+  releaseRestoredPending: (state: UnshieldedState, coveredIds: ReadonlyArray<UtxoHash>): UnshieldedState => {
+    const releasable = HashMap.filter(
+      state.pendingUtxos,
+      ({ restored }, hash) => restored && !coveredIds.includes(hash),
+    );
+
+    return HashMap.isEmpty(releasable)
+      ? state
+      : {
+          availableUtxos: HashMap.union(
+            state.availableUtxos,
+            HashMap.map(releasable, ({ utxo }) => utxo),
+          ),
+          pendingUtxos: HashMap.removeMany(state.pendingUtxos, HashMap.keys(releasable)),
+        };
+  },
 
   /**
    * Releases every booking that has reached its expiry, returning those coins to the available side. A booking is only

--- a/packages/unshielded-wallet/src/v1/UnshieldedState.ts
+++ b/packages/unshielded-wallet/src/v1/UnshieldedState.ts
@@ -47,10 +47,22 @@ export const UnshieldedState = {
     pendingUtxos: HashMap.empty(),
   }),
 
-  restore: (availableUtxos: readonly UtxoWithMeta[], pendingUtxos: readonly UtxoWithMeta[]): UnshieldedState => ({
-    availableUtxos: HashMap.fromIterable(availableUtxos.map((utxo) => [UtxoHash(utxo.utxo), utxo])),
-    pendingUtxos: HashMap.fromIterable(pendingUtxos.map((utxo) => [UtxoHash(utxo.utxo), utxo])),
-  }),
+  /**
+   * Rebuilds the state from a persisted snapshot. The two maps are disjoint by construction, so a UTxO a snapshot
+   * records in both is kept on the pending side only: the spend that booked it may still be on its way, and expiry
+   * releases it if it is not.
+   */
+  restore: (availableUtxos: readonly UtxoWithMeta[], pendingUtxos: readonly UtxoWithMeta[]): UnshieldedState => {
+    const pending = HashMap.fromIterable(pendingUtxos.map((utxo) => [UtxoHash(utxo.utxo), utxo] as const));
+    return {
+      availableUtxos: HashMap.fromIterable(
+        availableUtxos
+          .filter((utxo) => !HashMap.has(pending, UtxoHash(utxo.utxo)))
+          .map((utxo) => [UtxoHash(utxo.utxo), utxo] as const),
+      ),
+      pendingUtxos: pending,
+    };
+  },
 
   spend: (state: UnshieldedState, utxo: UtxoWithMeta): Either.Either<UnshieldedState, UtxoNotFoundError> =>
     Either.gen(function* () {
@@ -104,18 +116,22 @@ export const UnshieldedState = {
         return yield* Either.left(new ApplyTransactionError({ message: `Invalid status: ${update.status}` }));
       }
 
+      const spentHashes = update.spentUtxos.map((utxo) => UtxoHash(utxo.utxo));
+      const pendingUtxos = HashMap.removeMany(state.pendingUtxos, spentHashes);
+
       return {
         availableUtxos: HashMap.union(
-          HashMap.removeMany(
-            state.availableUtxos,
-            update.spentUtxos.map((utxo) => UtxoHash(utxo.utxo)),
+          HashMap.removeMany(state.availableUtxos, spentHashes),
+          // A created UTxO that is still booked must not re-enter availableUtxos. The indexer replays the
+          // transaction that created a booked coin whenever sync resumes from a cursor predating it, and the two
+          // maps are disjoint by construction — every balance accessor counts them independently.
+          HashMap.fromIterable(
+            update.createdUtxos
+              .filter((utxo) => !HashMap.has(pendingUtxos, UtxoHash(utxo.utxo)))
+              .map((utxo) => [UtxoHash(utxo.utxo), utxo] as const),
           ),
-          HashMap.fromIterable(update.createdUtxos.map((utxo) => [UtxoHash(utxo.utxo), utxo])),
         ),
-        pendingUtxos: HashMap.removeMany(
-          state.pendingUtxos,
-          update.spentUtxos.map((utxo) => UtxoHash(utxo.utxo)),
-        ),
+        pendingUtxos,
       };
     }),
 

--- a/packages/unshielded-wallet/src/v1/UnshieldedState.ts
+++ b/packages/unshielded-wallet/src/v1/UnshieldedState.ts
@@ -135,7 +135,19 @@ export const UnshieldedState = {
    * @param now - The instant to expire against. A booking expires at its TTL, not after it, because the ledger already
    *   rejects the transaction at that instant.
    */
-  expirePending: (state: UnshieldedState, _now: Date): UnshieldedState => state,
+  expirePending: (state: UnshieldedState, now: Date): UnshieldedState => {
+    const expired = HashMap.filter(state.pendingUtxos, ({ ttl }) => ttl.getTime() <= now.getTime());
+
+    return HashMap.isEmpty(expired)
+      ? state
+      : {
+          availableUtxos: HashMap.union(
+            state.availableUtxos,
+            HashMap.map(expired, ({ utxo }) => utxo),
+          ),
+          pendingUtxos: HashMap.removeMany(state.pendingUtxos, HashMap.keys(expired)),
+        };
+  },
 
   applyUpdate: (
     state: UnshieldedState,

--- a/packages/unshielded-wallet/src/v1/UnshieldedState.ts
+++ b/packages/unshielded-wallet/src/v1/UnshieldedState.ts
@@ -128,6 +128,25 @@ export const UnshieldedState = {
     ),
 
   /**
+   * Releases a booked coin named by its id, returning it to the available side. A reservation records the ids of the
+   * coins it books rather than the coins themselves, so releasing one has to be possible from the id alone.
+   *
+   * Like {@link UnshieldedState.rollbackSpend}, an id that is not booked is left alone rather than reported: sync may
+   * have cleared the coin first, and that race is expected.
+   */
+  rollbackSpendByHash: (state: UnshieldedState, hash: UtxoHash): UnshieldedState =>
+    pipe(
+      HashMap.get(state.pendingUtxos, hash),
+      Option.match({
+        onNone: () => state,
+        onSome: ({ utxo }) => ({
+          availableUtxos: HashMap.set(state.availableUtxos, hash, utxo),
+          pendingUtxos: HashMap.remove(state.pendingUtxos, hash),
+        }),
+      }),
+    ),
+
+  /**
    * Releases every booking that has reached its expiry, returning those coins to the available side. A booking is only
    * released by the submit path today, so a transaction abandoned between balancing and submission leaks its coins;
    * this sweep is what bounds that leak to the transaction's own lifetime.

--- a/packages/unshielded-wallet/src/v1/test/Serialization.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/Serialization.test.ts
@@ -1,0 +1,198 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Either, HashMap, Option, pipe } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { createKeystore, PublicKey } from '../../KeyStore.js';
+import { CoreWallet } from '../CoreWallet.js';
+import { makeDefaultV1SerializationCapability } from '../Serialization.js';
+import { type PendingUtxo, UnshieldedState, type UtxoWithMeta } from '../UnshieldedState.js';
+import { generateMockUtxoWithMeta, utxoHash } from './testUtils.js';
+
+const TTL = new Date('2026-01-01T01:00:00.000Z');
+
+const keystore = createKeystore(Buffer.from(ledger.sampleSigningKey(), 'hex'), NetworkId.NetworkId.Undeployed);
+const ownerPublicKey = PublicKey.fromKeyStore(keystore);
+
+/** One coin as the snapshot records it. `ttl` is present only on a pending entry. */
+type PersistedEntry = {
+  readonly utxo: { readonly intentHash: string; readonly outputNo: number; readonly value: string };
+  readonly meta: { readonly ctime: string; readonly registeredForDustGeneration: boolean };
+  readonly ttl?: string;
+};
+
+type PersistedSnapshot = {
+  readonly state: {
+    readonly availableUtxos: readonly PersistedEntry[];
+    readonly pendingUtxos: readonly PersistedEntry[];
+  };
+};
+
+const getOrThrow = <E, A>(either: Either.Either<A, E>): A =>
+  pipe(
+    either,
+    Either.getOrThrowWith((e) => new Error(`Unexpected error: ${JSON.stringify(e)}`)),
+  );
+
+const walletHolding = (available: readonly UtxoWithMeta[], pending: readonly PendingUtxo[]): CoreWallet =>
+  CoreWallet.restore(
+    UnshieldedState.restore(available, pending),
+    ownerPublicKey,
+    { appliedId: 7n, highestTransactionId: 7n },
+    ProtocolVersion.ProtocolVersion(1n),
+    NetworkId.NetworkId.Undeployed,
+  );
+
+describe('Unshielded wallet serialization', () => {
+  const capability = makeDefaultV1SerializationCapability();
+
+  const persist = (wallet: CoreWallet): string => capability.serialize(wallet);
+  const load = (snapshot: string): CoreWallet => getOrThrow(capability.deserialize(snapshot));
+  const roundTrip = (wallet: CoreWallet): CoreWallet => load(persist(wallet));
+
+  /**
+   * The snapshot as written, so a test can assert on the persisted shape rather than on what we read back, and can edit
+   * it to build a snapshot an older writer would have produced.
+   *
+   * Type cast required because: `JSON.parse` is untyped, and asserting on the persisted shape is the point here — a
+   * decode through the schema would hide exactly the field layout under test.
+   */
+  const persistedShapeOf = (wallet: CoreWallet): PersistedSnapshot => JSON.parse(persist(wallet)) as PersistedSnapshot;
+
+  describe('a booking across a persist and restore cycle', () => {
+    it('carries the booking and its expiry, so a coin an abandoned swap still holds stays reserved', () => {
+      const booked = generateMockUtxoWithMeta({ intentHash: 'h-booked', outputNo: 0 });
+
+      const restored = roundTrip(walletHolding([], [{ utxo: booked, ttl: TTL }]));
+
+      expect(Option.getOrNull(HashMap.get(restored.state.pendingUtxos, utxoHash(booked)))).toEqual({
+        utxo: booked,
+        ttl: TTL,
+      });
+      expect(HashMap.size(restored.state.availableUtxos)).toEqual(0);
+    });
+
+    it('keeps an available coin available', () => {
+      const spendable = generateMockUtxoWithMeta({ intentHash: 'h-spendable', outputNo: 0 });
+
+      const restored = roundTrip(walletHolding([spendable], []));
+
+      expect(Option.getOrNull(HashMap.get(restored.state.availableUtxos, utxoHash(spendable)))).toEqual(spendable);
+      expect(HashMap.size(restored.state.pendingUtxos)).toEqual(0);
+    });
+
+    it('writes each pending coin as its own fields plus a sibling expiry, not nested under a wrapper', () => {
+      // The pending array keeps the shape it had before bookings carried an expiry, with `ttl` added beside `meta`.
+      // A reader that predates the expiry therefore still finds every field it knows where it expects it.
+      const booked = generateMockUtxoWithMeta({ intentHash: 'h-shape', outputNo: 3 });
+
+      const [entry] = persistedShapeOf(walletHolding([], [{ utxo: booked, ttl: TTL }])).state.pendingUtxos;
+
+      expect(Object.keys(entry).toSorted()).toEqual(['meta', 'ttl', 'utxo']);
+      expect(entry.utxo).toMatchObject({ intentHash: 'h-shape', outputNo: 3 });
+      expect(entry.ttl).toEqual(TTL.toISOString());
+    });
+
+    it('writes no expiry against an available coin', () => {
+      const spendable = generateMockUtxoWithMeta({ intentHash: 'h-no-ttl', outputNo: 0 });
+
+      const [entry] = persistedShapeOf(walletHolding([spendable], [])).state.availableUtxos;
+
+      expect(Object.keys(entry).toSorted()).toEqual(['meta', 'utxo']);
+    });
+  });
+
+  describe('a snapshot written before bookings carried an expiry', () => {
+    /** Such a snapshot is today's shape minus `ttl` on each pending entry. */
+    const withoutExpiries = (wallet: CoreWallet): string => {
+      const snapshot = persistedShapeOf(wallet);
+
+      return JSON.stringify({
+        ...snapshot,
+        state: {
+          ...snapshot.state,
+          pendingUtxos: snapshot.state.pendingUtxos.map(({ ttl: _ttl, ...rest }) => rest),
+        },
+      });
+    };
+
+    it('decodes, rather than being rejected as malformed', () => {
+      const booked = generateMockUtxoWithMeta({ intentHash: 'h-legacy', outputNo: 0 });
+
+      const result = capability.deserialize(withoutExpiries(walletHolding([], [{ utxo: booked, ttl: TTL }])));
+
+      expect(Either.isRight(result)).toBe(true);
+    });
+
+    it('dates the booking at the epoch, so the first expiry sweep releases the coin', () => {
+      // Nothing in the process that wrote such a snapshot is left to release its bookings, so the wallet must.
+      const booked = generateMockUtxoWithMeta({ intentHash: 'h-legacy-sweep', outputNo: 0 });
+
+      const restored = load(withoutExpiries(walletHolding([], [{ utxo: booked, ttl: TTL }])));
+
+      expect(Option.getOrNull(HashMap.get(restored.state.pendingUtxos, utxoHash(booked)))).toEqual({
+        utxo: booked,
+        ttl: new Date(0),
+      });
+
+      const swept = CoreWallet.expirePending(restored, new Date('2000-01-01T00:00:00.000Z'));
+
+      expect(HashMap.has(swept.state.availableUtxos, utxoHash(booked))).toBe(true);
+      expect(HashMap.size(swept.state.pendingUtxos)).toEqual(0);
+    });
+  });
+
+  describe('a snapshot holding the same coin as both available and pending', () => {
+    /**
+     * The corruption a leaked booking produced: one coin written into both arrays. Built by copying the persisted
+     * pending entry, minus its expiry, into the available array, so both records are the same coin as written.
+     */
+    const withPendingAlsoAvailable = (wallet: CoreWallet): string => {
+      const snapshot = persistedShapeOf(wallet);
+
+      return JSON.stringify({
+        ...snapshot,
+        state: {
+          ...snapshot.state,
+          availableUtxos: [
+            ...snapshot.state.availableUtxos,
+            ...snapshot.state.pendingUtxos.map(({ ttl: _ttl, ...rest }) => rest),
+          ],
+        },
+      });
+    };
+
+    it('loads with the coin on the pending side only, so its balance is counted once', () => {
+      const duplicated = generateMockUtxoWithMeta({ intentHash: 'h-duplicated', outputNo: 0 });
+
+      const restored = load(withPendingAlsoAvailable(walletHolding([], [{ utxo: duplicated, ttl: TTL }])));
+
+      expect(HashMap.has(restored.state.availableUtxos, utxoHash(duplicated))).toBe(false);
+      expect(HashMap.size(restored.state.pendingUtxos)).toEqual(1);
+    });
+  });
+
+  describe('the rest of the snapshot', () => {
+    it('round-trips the public key, protocol version, network and applied cursor', () => {
+      const wallet = walletHolding([generateMockUtxoWithMeta({ intentHash: 'h-meta', outputNo: 0 })], []);
+
+      const restored = roundTrip(wallet);
+
+      expect(restored.publicKey).toEqual(wallet.publicKey);
+      expect(restored.protocolVersion).toEqual(wallet.protocolVersion);
+      expect(restored.networkId).toEqual(wallet.networkId);
+      expect(restored.progress.appliedId).toEqual(7n);
+    });
+  });
+});

--- a/packages/unshielded-wallet/src/v1/test/Serialization.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/Serialization.test.ts
@@ -16,7 +16,7 @@ import { Either, HashMap, Option, pipe } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { createKeystore, PublicKey } from '../../KeyStore.js';
 import { CoreWallet } from '../CoreWallet.js';
-import { makeDefaultV1SerializationCapability } from '../Serialization.js';
+import { makeDefaultV1SerializationCapability, LEGACY_BOOKING_LIFETIME_MS } from '../Serialization.js';
 import { type PendingUtxo, UnshieldedState, type UtxoWithMeta } from '../UnshieldedState.js';
 import { generateMockUtxoWithMeta, utxoHash } from './testUtils.js';
 
@@ -139,22 +139,26 @@ describe('Unshielded wallet serialization', () => {
       expect(Either.isRight(result)).toBe(true);
     });
 
-    it('dates the booking at the epoch, so the first expiry sweep releases the coin', () => {
-      // Nothing in the process that wrote such a snapshot is left to release its bookings, so the wallet must.
+    it('gives the booking a full transaction lifetime from now, rather than an expiry already behind it', () => {
+      // The snapshot does not say when these coins were booked, and the writing process may have submitted the
+      // transaction moments before it stopped. Dating them in the past would release a coin that a live transaction
+      // is still spending; dating them a lifetime ahead releases them only once no transaction could still be
+      // accepted, which is the same bound every other booking gets.
       const booked = generateMockUtxoWithMeta({ intentHash: 'h-legacy-sweep', outputNo: 0 });
+      const loadedAt = Date.now();
 
       const restored = load(withoutExpiries(walletHolding([], [{ utxo: booked, ttl: TTL }])));
+      const entry = Option.getOrThrow(HashMap.get(restored.state.pendingUtxos, utxoHash(booked)));
 
-      expect(Option.getOrNull(HashMap.get(restored.state.pendingUtxos, utxoHash(booked)))).toEqual({
-        utxo: booked,
-        ttl: new Date(0),
-        restored: true,
-      });
+      expect(entry.ttl.getTime()).toBeGreaterThanOrEqual(loadedAt + LEGACY_BOOKING_LIFETIME_MS);
+      expect(entry.restored).toBe(true);
 
-      const swept = CoreWallet.expirePending(restored, new Date('2000-01-01T00:00:00.000Z'));
+      const sweptWithinLifetime = CoreWallet.expirePending(restored, new Date(loadedAt));
+      expect(HashMap.has(sweptWithinLifetime.state.pendingUtxos, utxoHash(booked))).toBe(true);
 
-      expect(HashMap.has(swept.state.availableUtxos, utxoHash(booked))).toBe(true);
-      expect(HashMap.size(swept.state.pendingUtxos)).toEqual(0);
+      const sweptAfterLifetime = CoreWallet.expirePending(restored, new Date(entry.ttl.getTime() + 1));
+      expect(HashMap.has(sweptAfterLifetime.state.availableUtxos, utxoHash(booked))).toBe(true);
+      expect(HashMap.size(sweptAfterLifetime.state.pendingUtxos)).toEqual(0);
     });
   });
 

--- a/packages/unshielded-wallet/src/v1/test/Serialization.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/Serialization.test.ts
@@ -45,7 +45,10 @@ const getOrThrow = <E, A>(either: Either.Either<A, E>): A =>
     Either.getOrThrowWith((e) => new Error(`Unexpected error: ${JSON.stringify(e)}`)),
   );
 
-const walletHolding = (available: readonly UtxoWithMeta[], pending: readonly PendingUtxo[]): CoreWallet =>
+const walletHolding = (
+  available: readonly UtxoWithMeta[],
+  pending: ReadonlyArray<Omit<PendingUtxo, 'restored'>>,
+): CoreWallet =>
   CoreWallet.restore(
     UnshieldedState.restore(available, pending),
     ownerPublicKey,
@@ -79,6 +82,7 @@ describe('Unshielded wallet serialization', () => {
       expect(Option.getOrNull(HashMap.get(restored.state.pendingUtxos, utxoHash(booked)))).toEqual({
         utxo: booked,
         ttl: TTL,
+        restored: true,
       });
       expect(HashMap.size(restored.state.availableUtxos)).toEqual(0);
     });
@@ -144,6 +148,7 @@ describe('Unshielded wallet serialization', () => {
       expect(Option.getOrNull(HashMap.get(restored.state.pendingUtxos, utxoHash(booked)))).toEqual({
         utxo: booked,
         ttl: new Date(0),
+        restored: true,
       });
 
       const swept = CoreWallet.expirePending(restored, new Date('2000-01-01T00:00:00.000Z'));

--- a/packages/unshielded-wallet/src/v1/test/Sync.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/Sync.test.ts
@@ -34,7 +34,10 @@ const FAR_FUTURE = new Date('2999-01-01T00:00:00.000Z');
 const keystore = createKeystore(Buffer.from(ledger.sampleSigningKey(), 'hex'), NetworkId.NetworkId.Undeployed);
 const ownerPublicKey = PublicKey.fromKeyStore(keystore);
 
-const walletHolding = (available: readonly UtxoWithMeta[], pending: readonly PendingUtxo[]): CoreWalletType =>
+const walletHolding = (
+  available: readonly UtxoWithMeta[],
+  pending: ReadonlyArray<Omit<PendingUtxo, 'restored'>>,
+): CoreWalletType =>
   CoreWallet.restore(
     UnshieldedState.restore(available, pending),
     ownerPublicKey,
@@ -115,6 +118,7 @@ describe('Unshielded indexer sync capability', () => {
       expect(Option.getOrNull(HashMap.get(after.state.pendingUtxos, utxoHash(booked)))).toEqual({
         utxo: booked,
         ttl: FAR_FUTURE,
+        restored: true,
       });
     });
 
@@ -264,6 +268,7 @@ describe('Unshielded simulator sync capability', () => {
           expect(Option.getOrNull(HashMap.get(after.state.pendingUtxos, utxoHash(coin)))).toEqual({
             utxo: coin,
             ttl: SIM_TTL,
+            restored: true,
           });
         }),
       ),

--- a/packages/unshielded-wallet/src/v1/test/Sync.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/Sync.test.ts
@@ -34,17 +34,38 @@ const FAR_FUTURE = new Date('2999-01-01T00:00:00.000Z');
 const keystore = createKeystore(Buffer.from(ledger.sampleSigningKey(), 'hex'), NetworkId.NetworkId.Undeployed);
 const ownerPublicKey = PublicKey.fromKeyStore(keystore);
 
+const connected = (
+  available: readonly UtxoWithMeta[],
+  pending: ReadonlyArray<Omit<PendingUtxo, 'restored'>>,
+  progress: { appliedId: bigint; highestTransactionId: bigint },
+): CoreWalletType =>
+  pipe(
+    CoreWallet.restore(
+      UnshieldedState.restore(available, pending),
+      ownerPublicKey,
+      progress,
+      ProtocolVersion.ProtocolVersion(1n),
+      NetworkId.NetworkId.Undeployed,
+    ),
+    (wallet) => CoreWallet.updateProgress(wallet, { isConnected: true }),
+  );
+
+/**
+ * Connected and level with the chain at `atTransactionId`, which is where the wallet has the whole picture and may
+ * sweep. Tests pass the id the update under test carries, so the wallet is still level once that update is applied.
+ */
 const walletHolding = (
   available: readonly UtxoWithMeta[],
   pending: ReadonlyArray<Omit<PendingUtxo, 'restored'>>,
+  atTransactionId: bigint = 1n,
 ): CoreWalletType =>
-  CoreWallet.restore(
-    UnshieldedState.restore(available, pending),
-    ownerPublicKey,
-    { appliedId: 1n, highestTransactionId: 1n },
-    ProtocolVersion.ProtocolVersion(1n),
-    NetworkId.NetworkId.Undeployed,
-  );
+  connected(available, pending, { appliedId: atTransactionId, highestTransactionId: atTransactionId });
+
+/** Still replaying history from a cursor behind the chain, so transactions it has not seen yet are still coming. */
+const walletCatchingUp = (
+  available: readonly UtxoWithMeta[],
+  pending: ReadonlyArray<Omit<PendingUtxo, 'restored'>>,
+): CoreWalletType => connected(available, pending, { appliedId: 1n, highestTransactionId: 900n });
 
 /** Records nothing: these tests are about wallet state, and history is written on a forked fibre regardless. */
 const historyContext = { transactionHistoryService: { put: () => Effect.void } };
@@ -100,11 +121,29 @@ describe('Unshielded indexer sync capability', () => {
       const booked = generateMockUtxoWithMeta({ intentHash: 'h-stale', outputNo: 0 });
 
       const after = getOrThrow(
-        capability.applyUpdate(walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }]), progressUpdate(9)),
+        capability.applyUpdate(walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }], 9n), progressUpdate(9)),
       );
 
       expect(HashMap.has(after.state.availableUtxos, utxoHash(booked))).toBe(true);
       expect(HashMap.size(after.state.pendingUtxos)).toEqual(0);
+    });
+
+    it('leaves a booking alone while sync is still catching up, however old its expiry', () => {
+      // Replaying history from a cursor behind the chain, the wallet has not yet been told about the transaction
+      // that spent this coin. Releasing on that evidence offers a coin the chain has already taken, and the
+      // over-reported balance lasts until the replay reaches the spend.
+      const booked = generateMockUtxoWithMeta({ intentHash: 'h-catching-up', outputNo: 0 });
+
+      const after = getOrThrow(
+        capability.applyUpdate(walletCatchingUp([], [{ utxo: booked, ttl: LONG_EXPIRED }]), progressUpdate(900)),
+      );
+
+      expect(HashMap.has(after.state.availableUtxos, utxoHash(booked))).toBe(false);
+      expect(Option.getOrNull(HashMap.get(after.state.pendingUtxos, utxoHash(booked)))).toEqual({
+        utxo: booked,
+        ttl: LONG_EXPIRED,
+        restored: true,
+      });
     });
 
     it('leaves a booking whose expiry has not passed', () => {
@@ -127,7 +166,7 @@ describe('Unshielded indexer sync capability', () => {
       const booked = generateMockUtxoWithMeta({ intentHash: 'h-quiet', outputNo: 0 });
 
       const after = getOrThrow(
-        capability.applyUpdate(walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }]), progressUpdate(42)),
+        capability.applyUpdate(walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }], 42n), progressUpdate(42)),
       );
 
       expect(HashMap.has(after.state.availableUtxos, utxoHash(booked))).toBe(true);
@@ -140,7 +179,7 @@ describe('Unshielded indexer sync capability', () => {
 
       const after = getOrThrow(
         capability.applyUpdate(
-          walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }]),
+          walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }], 5n),
           transactionUpdate(5, [arriving], []),
         ),
       );
@@ -175,7 +214,7 @@ describe('Unshielded indexer sync capability', () => {
 
       const after = getOrThrow(
         capability.applyUpdate(
-          walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }]),
+          walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }], 6n),
           transactionUpdate(6, [booked], []),
         ),
       );
@@ -190,7 +229,7 @@ describe('Unshielded indexer sync capability', () => {
 
       const after = getOrThrow(
         capability.applyUpdate(
-          walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }]),
+          walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }], 7n),
           transactionUpdate(7, [], [booked]),
         ),
       );

--- a/packages/unshielded-wallet/src/v1/test/Sync.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/Sync.test.ts
@@ -1,0 +1,271 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type SimulatorState, Simulator } from '@midnightntwrk/wallet-sdk-capabilities/simulation';
+import { Effect, Either, HashMap, Option, pipe, type Scope } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { createKeystore, PublicKey } from '../../KeyStore.js';
+import { type CoreWallet as CoreWalletType, CoreWallet } from '../CoreWallet.js';
+import { makeDefaultSyncCapability, makeSimulatorSyncCapability } from '../Sync.js';
+import { type PendingUtxo, UnshieldedState, UtxoWithMeta } from '../UnshieldedState.js';
+import { type UnshieldedTransaction, type WalletSyncUpdate } from '../SyncSchema.js';
+import { generateMockUtxoWithMeta, utxoHash } from './testUtils.js';
+
+/** Simulator time in the simulator tests, which set it either side of this instant. */
+const SIM_TTL = new Date('2026-01-01T01:00:00.000Z');
+
+/** An expiry every real clock has passed, so the indexer path always treats a booking dated here as stale. */
+const LONG_EXPIRED = new Date(0);
+
+/** An expiry no real clock has reached, so a booking dated here is always still live. */
+const FAR_FUTURE = new Date('2999-01-01T00:00:00.000Z');
+
+const keystore = createKeystore(Buffer.from(ledger.sampleSigningKey(), 'hex'), NetworkId.NetworkId.Undeployed);
+const ownerPublicKey = PublicKey.fromKeyStore(keystore);
+
+const walletHolding = (available: readonly UtxoWithMeta[], pending: readonly PendingUtxo[]): CoreWalletType =>
+  CoreWallet.restore(
+    UnshieldedState.restore(available, pending),
+    ownerPublicKey,
+    { appliedId: 1n, highestTransactionId: 1n },
+    ProtocolVersion.ProtocolVersion(1n),
+    NetworkId.NetworkId.Undeployed,
+  );
+
+/** Records nothing: these tests are about wallet state, and history is written on a forked fibre regardless. */
+const historyContext = { transactionHistoryService: { put: () => Effect.void } };
+
+const transaction = (id: number): UnshieldedTransaction =>
+  ({
+    id,
+    hash: `hash-${id}`,
+    type: 'RegularTransaction',
+    protocolVersion: 1,
+    block: { hash: `block-${id}`, height: id, timestamp: new Date('2026-01-01T00:00:00.000Z') },
+    transactionResult: { status: 'SUCCESS', segments: null },
+    // Type cast required because: `UnshieldedTransaction` is a Schema.Data class, and these tests need a plain
+    // decoded value rather than a wire payload to decode.
+  }) as unknown as UnshieldedTransaction;
+
+const transactionUpdate = (
+  id: number,
+  created: readonly UtxoWithMeta[],
+  spent: readonly UtxoWithMeta[],
+): WalletSyncUpdate => ({
+  type: 'UnshieldedTransaction',
+  transaction: transaction(id),
+  createdUtxos: created,
+  spentUtxos: spent,
+  status: 'SUCCESS',
+});
+
+const progressUpdate = (highestTransactionId: number): WalletSyncUpdate => ({
+  type: 'UnshieldedTransactionsProgress',
+  highestTransactionId,
+});
+
+const getOrThrow = <E, A>(either: Either.Either<A, E>): A =>
+  pipe(
+    either,
+    Either.getOrThrowWith((e) => new Error(`Unexpected error: ${JSON.stringify(e)}`)),
+  );
+
+describe('Unshielded indexer sync capability', () => {
+  // This path follows the chain, so it expires against wall time. These tests pick expiries no real clock can sit
+  // between: the epoch is always past, and the year 2999 is always ahead. The boundary at the expiry itself is
+  // pinned where it belongs, on `UnshieldedState.expirePending`.
+  const capability = makeDefaultSyncCapability(
+    { indexerClientConnection: { indexerHttpUrl: 'http://unused' } },
+    () => historyContext,
+  );
+
+  describe('expiring bookings on an applied update', () => {
+    it('releases a booking whose expiry has passed', () => {
+      // Nothing else releases a booking taken for a transaction that was abandoned before submission, so the
+      // wallet has to notice on its own that the transaction can no longer be accepted.
+      const booked = generateMockUtxoWithMeta({ intentHash: 'h-stale', outputNo: 0 });
+
+      const after = getOrThrow(
+        capability.applyUpdate(walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }]), progressUpdate(9)),
+      );
+
+      expect(HashMap.has(after.state.availableUtxos, utxoHash(booked))).toBe(true);
+      expect(HashMap.size(after.state.pendingUtxos)).toEqual(0);
+    });
+
+    it('leaves a booking whose expiry has not passed', () => {
+      const booked = generateMockUtxoWithMeta({ intentHash: 'h-live', outputNo: 0 });
+
+      const after = getOrThrow(
+        capability.applyUpdate(walletHolding([], [{ utxo: booked, ttl: FAR_FUTURE }]), progressUpdate(9)),
+      );
+
+      expect(HashMap.has(after.state.availableUtxos, utxoHash(booked))).toBe(false);
+      expect(Option.getOrNull(HashMap.get(after.state.pendingUtxos, utxoHash(booked)))).toEqual({
+        utxo: booked,
+        ttl: FAR_FUTURE,
+      });
+    });
+
+    it('sweeps on a progress update, so a wallet with no transactions of its own still recovers', () => {
+      // A leaked booking blocks its coin whether or not the address sees further activity.
+      const booked = generateMockUtxoWithMeta({ intentHash: 'h-quiet', outputNo: 0 });
+
+      const after = getOrThrow(
+        capability.applyUpdate(walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }]), progressUpdate(42)),
+      );
+
+      expect(HashMap.has(after.state.availableUtxos, utxoHash(booked))).toBe(true);
+      expect(after.progress.highestTransactionId).toEqual(42n);
+    });
+
+    it('sweeps on a transaction update, and still applies the update', () => {
+      const booked = generateMockUtxoWithMeta({ intentHash: 'h-stale-tx', outputNo: 0 });
+      const arriving = generateMockUtxoWithMeta({ intentHash: 'h-arriving', outputNo: 0 });
+
+      const after = getOrThrow(
+        capability.applyUpdate(
+          walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }]),
+          transactionUpdate(5, [arriving], []),
+        ),
+      );
+
+      expect(HashMap.has(after.state.availableUtxos, utxoHash(booked))).toBe(true);
+      expect(HashMap.has(after.state.availableUtxos, utxoHash(arriving))).toBe(true);
+      expect(HashMap.size(after.state.pendingUtxos)).toEqual(0);
+      expect(after.progress.appliedId).toEqual(5n);
+    });
+
+    it('leaves an unexpired booking alone while releasing an expired one in the same sweep', () => {
+      const stale = generateMockUtxoWithMeta({ intentHash: 'h-mixed-stale', outputNo: 0 });
+      const live = generateMockUtxoWithMeta({ intentHash: 'h-mixed-live', outputNo: 0 });
+      const wallet = walletHolding(
+        [],
+        [
+          { utxo: stale, ttl: LONG_EXPIRED },
+          { utxo: live, ttl: FAR_FUTURE },
+        ],
+      );
+
+      const after = getOrThrow(capability.applyUpdate(wallet, progressUpdate(1)));
+
+      expect([...HashMap.keys(after.state.availableUtxos)]).toEqual([utxoHash(stale)]);
+      expect([...HashMap.keys(after.state.pendingUtxos)]).toEqual([utxoHash(live)]);
+    });
+
+    it('ends with one entry for a coin whose creating transaction replays after its booking expired', () => {
+      // The two halves of the reported failure meet here: a stale booking and a resync that re-delivers the
+      // transaction which created the booked coin.
+      const booked = generateMockUtxoWithMeta({ intentHash: 'h-replayed', outputNo: 0 });
+
+      const after = getOrThrow(
+        capability.applyUpdate(
+          walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }]),
+          transactionUpdate(6, [booked], []),
+        ),
+      );
+
+      expect([...HashMap.keys(after.state.availableUtxos)]).toEqual([utxoHash(booked)]);
+      expect(HashMap.size(after.state.pendingUtxos)).toEqual(0);
+    });
+
+    it('keeps a confirmed spend gone rather than releasing it', () => {
+      // A booking cleared by its transaction confirming must not come back through the sweep.
+      const booked = generateMockUtxoWithMeta({ intentHash: 'h-confirmed', outputNo: 0 });
+
+      const after = getOrThrow(
+        capability.applyUpdate(
+          walletHolding([], [{ utxo: booked, ttl: LONG_EXPIRED }]),
+          transactionUpdate(7, [], [booked]),
+        ),
+      );
+
+      expect(HashMap.has(after.state.availableUtxos, utxoHash(booked))).toBe(false);
+      expect(HashMap.size(after.state.pendingUtxos)).toEqual(0);
+    });
+  });
+});
+
+describe('Unshielded simulator sync capability', () => {
+  /**
+   * The simulator path works out created and spent coins by diffing against the simulator's own UTxO set, so a booked
+   * coin has to be one the simulator actually holds — a fabricated one reads as spent and is dropped, not swept.
+   */
+  const simulatorHoldingOneCoin = (
+    currentTime: Date,
+  ): Effect.Effect<{ state: SimulatorState; coin: UtxoWithMeta }, unknown, Scope.Scope> =>
+    Effect.gen(function* () {
+      const simulator = yield* Simulator.init({
+        genesisMints: [
+          {
+            type: 'unshielded',
+            tokenType: ledger.nativeToken().raw,
+            // Night is claimed rather than minted, and a claim below roughly 14,000 does not go through.
+            amount: 1_000_000n,
+            recipient: ownerPublicKey.addressHex,
+            verifyingKey: ownerPublicKey.publicKey,
+          },
+        ],
+      });
+      const latest = yield* simulator.getLatestState();
+      const state = { ...latest, currentTime };
+      const [utxo] = Array.from(state.ledger.utxo.filter(ownerPublicKey.addressHex));
+
+      return {
+        state,
+        coin: new UtxoWithMeta({ utxo, meta: { ctime: currentTime, registeredForDustGeneration: false } }),
+      };
+    });
+
+  it('expires a booking against simulator time, not the system clock', () =>
+    Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          // Simulator time is the wallet's clock in simulation mode, and it does not track the wall clock at all.
+          const { state, coin } = yield* simulatorHoldingOneCoin(new Date(SIM_TTL.getTime() + 1));
+
+          const after = getOrThrow(
+            makeSimulatorSyncCapability().applyUpdate(walletHolding([], [{ utxo: coin, ttl: SIM_TTL }]), {
+              update: state,
+            }),
+          );
+
+          expect(HashMap.has(after.state.availableUtxos, utxoHash(coin))).toBe(true);
+          expect(HashMap.size(after.state.availableUtxos)).toEqual(1);
+          expect(HashMap.size(after.state.pendingUtxos)).toEqual(0);
+        }),
+      ),
+    ));
+
+  it('leaves a booking whose expiry simulator time has not yet reached', () =>
+    Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const { state, coin } = yield* simulatorHoldingOneCoin(new Date(SIM_TTL.getTime() - 1));
+
+          const after = getOrThrow(
+            makeSimulatorSyncCapability().applyUpdate(walletHolding([], [{ utxo: coin, ttl: SIM_TTL }]), {
+              update: state,
+            }),
+          );
+
+          expect(HashMap.size(after.state.availableUtxos)).toEqual(0);
+          expect(Option.getOrNull(HashMap.get(after.state.pendingUtxos, utxoHash(coin)))).toEqual({
+            utxo: coin,
+            ttl: SIM_TTL,
+          });
+        }),
+      ),
+    ));
+});

--- a/packages/unshielded-wallet/src/v1/test/UnshieldedState.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/UnshieldedState.test.ts
@@ -485,6 +485,80 @@ describe('UnshieldedState', () => {
     });
   });
 
+  describe('rollbackSpendByHash', () => {
+    // A reservation records the ids of the coins it books, not the coins themselves, so releasing one has to be
+    // possible from the id alone.
+    const bookedState = (...utxos: readonly UtxoWithMeta[]): UnshieldedState =>
+      utxos.reduce(
+        (state, utxo) =>
+          pipe(
+            UnshieldedState.applyUpdate(state, { createdUtxos: [utxo], spentUtxos: [], status: 'SUCCESS' }),
+            getOrThrow,
+            (s) => UnshieldedState.spend(s, utxo, TTL),
+            getOrThrow,
+          ),
+        UnshieldedState.empty(),
+      );
+
+    it('returns a booked coin to the available side, with its meta intact', () => {
+      const booked = generateMockUtxoWithMeta({ intentHash: 'h-by-hash', outputNo: 0 });
+
+      const state = UnshieldedState.rollbackSpendByHash(bookedState(booked), utxoHash(booked));
+
+      expect(Option.getOrNull(HashMap.get(state.availableUtxos, utxoHash(booked)))).toEqual(booked);
+      expect(HashMap.size(state.pendingUtxos)).toEqual(0);
+    });
+
+    it('releases only the coin named by the id', () => {
+      const released = generateMockUtxoWithMeta({ intentHash: 'h-released', outputNo: 0 });
+      const kept = generateMockUtxoWithMeta({ intentHash: 'h-kept', outputNo: 0 });
+
+      const state = UnshieldedState.rollbackSpendByHash(bookedState(released, kept), utxoHash(released));
+
+      expect([...HashMap.keys(state.availableUtxos)]).toEqual([utxoHash(released)]);
+      expect([...HashMap.keys(state.pendingUtxos)]).toEqual([utxoHash(kept)]);
+    });
+
+    it('ignores an id that is not booked, since sync may have cleared it first', () => {
+      const available = generateMockUtxoWithMeta({ intentHash: 'h-not-booked', outputNo: 0 });
+      const seeded = pipe(
+        UnshieldedState.applyUpdate(UnshieldedState.empty(), {
+          createdUtxos: [available],
+          spentUtxos: [],
+          status: 'SUCCESS',
+        }),
+        getOrThrow,
+      );
+
+      const state = UnshieldedState.rollbackSpendByHash(seeded, utxoHash(available));
+
+      expect([...HashMap.keys(state.availableUtxos)]).toEqual([utxoHash(available)]);
+      expect(HashMap.size(state.pendingUtxos)).toEqual(0);
+    });
+
+    it('ignores an id this wallet has never seen', () => {
+      const stranger = generateMockUtxoWithMeta({ intentHash: 'h-stranger', outputNo: 0 });
+
+      const state = UnshieldedState.rollbackSpendByHash(UnshieldedState.empty(), utxoHash(stranger));
+
+      expect(HashMap.size(state.availableUtxos)).toEqual(0);
+      expect(HashMap.size(state.pendingUtxos)).toEqual(0);
+    });
+
+    it('is safe to repeat, so a release racing with sync cannot fail', () => {
+      const booked = generateMockUtxoWithMeta({ intentHash: 'h-twice', outputNo: 0 });
+
+      const state = pipe(
+        bookedState(booked),
+        (s) => UnshieldedState.rollbackSpendByHash(s, utxoHash(booked)),
+        (s) => UnshieldedState.rollbackSpendByHash(s, utxoHash(booked)),
+      );
+
+      expect([...HashMap.keys(state.availableUtxos)]).toEqual([utxoHash(booked)]);
+      expect(HashMap.size(state.pendingUtxos)).toEqual(0);
+    });
+  });
+
   describe('booking expiry', () => {
     const seedAvailable = (...utxos: readonly UtxoWithMeta[]): UnshieldedState =>
       pipe(

--- a/packages/unshielded-wallet/src/v1/test/UnshieldedState.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/UnshieldedState.test.ts
@@ -13,7 +13,7 @@
 import { Either, HashMap, Option, pipe } from 'effect';
 import * as fc from 'fast-check';
 import { describe, expect, it } from 'vitest';
-import { UnshieldedState, type UnshieldedUpdate, type UtxoWithMeta } from '../UnshieldedState.js';
+import { type PendingUtxo, UnshieldedState, type UnshieldedUpdate, type UtxoWithMeta } from '../UnshieldedState.js';
 import { UtxoNotFoundError } from '../WalletError.js';
 import { generateMockUpdate, generateMockUtxoWithMeta, utxoArb, utxoHash } from './testUtils.js';
 
@@ -22,6 +22,12 @@ const getOrThrow = <E, A>(either: Either.Either<A, E>): A =>
     either,
     Either.getOrThrowWith((e) => new Error(`Unexpected error: ${JSON.stringify(e)}`)),
   );
+
+/** The expiry every booking in these tests is given: the TTL of the transaction it was taken for. */
+const TTL = new Date('2026-01-01T01:00:00.000Z');
+
+/** A pending entry as `restore` expects one: the coin plus the expiry it was booked with. */
+const pendingAt = (utxo: UtxoWithMeta, ttl: Date = TTL): PendingUtxo => ({ utxo, ttl });
 
 describe('UnshieldedState', () => {
   describe('applyUpdate', () => {
@@ -112,7 +118,7 @@ describe('UnshieldedState', () => {
             status: 'SUCCESS',
           }),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, u),
+        (s) => UnshieldedState.spend(s, u, TTL),
         getOrThrow,
         (s) => {
           expect(HashMap.has(s.pendingUtxos, utxoHash(u))).toBe(true);
@@ -214,7 +220,7 @@ describe('UnshieldedState', () => {
         UnshieldedState.empty(),
         (s) => UnshieldedState.applyUpdate(s, created),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, u),
+        (s) => UnshieldedState.spend(s, u, TTL),
         getOrThrow,
         // A resync from an earlier cursor delivers the creating transaction again while `u` is still booked.
         (s) => UnshieldedState.applyUpdate(s, created),
@@ -222,7 +228,7 @@ describe('UnshieldedState', () => {
       );
 
       expect(HashMap.has(state.availableUtxos, utxoHash(u))).toBe(false);
-      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual(u);
+      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual(pendingAt(u));
       expect(HashMap.size(state.availableUtxos)).toEqual(0);
       expect(HashMap.size(state.pendingUtxos)).toEqual(1);
     });
@@ -235,7 +241,7 @@ describe('UnshieldedState', () => {
         UnshieldedState.empty(),
         (s) => UnshieldedState.applyUpdate(s, { createdUtxos: [pending], spentUtxos: [], status: 'SUCCESS' }),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, pending),
+        (s) => UnshieldedState.spend(s, pending, TTL),
         getOrThrow,
         (s) => UnshieldedState.applyUpdate(s, { createdUtxos: [pending, fresh], spentUtxos: [], status: 'SUCCESS' }),
         getOrThrow,
@@ -261,7 +267,7 @@ describe('UnshieldedState', () => {
         UnshieldedState.empty(),
         (s) => UnshieldedState.applyUpdate(s, update),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, utxoToSpend),
+        (s) => UnshieldedState.spend(s, utxoToSpend, TTL),
         getOrThrow,
         (s) => UnshieldedState.applyFailedUpdate(s, failedUpdate),
         getOrThrow,
@@ -294,7 +300,7 @@ describe('UnshieldedState', () => {
             status: 'SUCCESS',
           }),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, a),
+        (s) => UnshieldedState.spend(s, a, TTL),
         getOrThrow,
         // sanity
         (s) => {
@@ -364,7 +370,7 @@ describe('UnshieldedState', () => {
         UnshieldedState.empty(),
         (s) => UnshieldedState.applyUpdate(s, update),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, update.createdUtxos[0]),
+        (s) => UnshieldedState.spend(s, update.createdUtxos[0], TTL),
         getOrThrow,
       );
 
@@ -379,7 +385,7 @@ describe('UnshieldedState', () => {
         UnshieldedState.empty(),
         (s) => UnshieldedState.applyUpdate(s, update),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, generateMockUtxoWithMeta({ owner: 'owner21', type: 'type12' })),
+        (s) => UnshieldedState.spend(s, generateMockUtxoWithMeta({ owner: 'owner21', type: 'type12' }), TTL),
       );
 
       expect(Either.isLeft(result)).toBe(true);
@@ -396,7 +402,7 @@ describe('UnshieldedState', () => {
         UnshieldedState.empty(),
         (s) => UnshieldedState.applyUpdate(s, update),
         getOrThrow,
-        (s) => UnshieldedState.spendByUtxo(s, update.createdUtxos[0].utxo),
+        (s) => UnshieldedState.spendByUtxo(s, update.createdUtxos[0].utxo, TTL),
         getOrThrow,
       );
 
@@ -407,7 +413,7 @@ describe('UnshieldedState', () => {
     it('should fail to spendByUtxo with UtxoNotFoundError when utxo is not available', () => {
       const ghost = generateMockUtxoWithMeta({ intentHash: 'h-ghost', outputNo: 0 });
 
-      const result = UnshieldedState.spendByUtxo(UnshieldedState.empty(), ghost.utxo);
+      const result = UnshieldedState.spendByUtxo(UnshieldedState.empty(), ghost.utxo, TTL);
 
       expect(Either.isLeft(result)).toBe(true);
       pipe(
@@ -430,7 +436,7 @@ describe('UnshieldedState', () => {
         UnshieldedState.empty(),
         (s) => UnshieldedState.applyUpdate(s, update),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, utxoToSpend),
+        (s) => UnshieldedState.spend(s, utxoToSpend, TTL),
         getOrThrow,
         (s) => UnshieldedState.rollbackSpend(s, utxoToSpend),
         getOrThrow,
@@ -448,7 +454,7 @@ describe('UnshieldedState', () => {
         UnshieldedState.empty(),
         (s) => UnshieldedState.applyUpdate(s, update),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, utxoToSpend),
+        (s) => UnshieldedState.spend(s, utxoToSpend, TTL),
         getOrThrow,
         (s) => UnshieldedState.rollbackSpendByUtxo(s, utxoToSpend.utxo),
         getOrThrow,
@@ -466,7 +472,7 @@ describe('UnshieldedState', () => {
         UnshieldedState.empty(),
         (s) => UnshieldedState.applyUpdate(s, update),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, utxoToSpend),
+        (s) => UnshieldedState.spend(s, utxoToSpend, TTL),
         getOrThrow,
         (s) => UnshieldedState.rollbackSpendByUtxo(s, utxoToSpend.utxo),
         getOrThrow,
@@ -479,13 +485,121 @@ describe('UnshieldedState', () => {
     });
   });
 
+  describe('booking expiry', () => {
+    const seedAvailable = (...utxos: readonly UtxoWithMeta[]): UnshieldedState =>
+      pipe(
+        UnshieldedState.empty(),
+        (s) => UnshieldedState.applyUpdate(s, { createdUtxos: utxos, spentUtxos: [], status: 'SUCCESS' }),
+        getOrThrow,
+      );
+
+    it('records the expiry the booking was taken with, alongside the coin', () => {
+      const u = generateMockUtxoWithMeta({ intentHash: 'h-ttl', outputNo: 0 });
+
+      const state = pipe(seedAvailable(u), (s) => UnshieldedState.spend(s, u, TTL), getOrThrow);
+
+      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual({ utxo: u, ttl: TTL });
+    });
+
+    it('records the expiry when booking by ledger utxo', () => {
+      const u = generateMockUtxoWithMeta({ intentHash: 'h-ttl-by-utxo', outputNo: 0 });
+
+      const state = pipe(seedAvailable(u), (s) => UnshieldedState.spendByUtxo(s, u.utxo, TTL), getOrThrow);
+
+      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual({ utxo: u, ttl: TTL });
+    });
+
+    it('releases a booking whose expiry has passed, coin and meta intact', () => {
+      const u = generateMockUtxoWithMeta({ intentHash: 'h-expired', outputNo: 0 });
+
+      const state = pipe(
+        seedAvailable(u),
+        (s) => UnshieldedState.spend(s, u, TTL),
+        getOrThrow,
+        (s) => UnshieldedState.expirePending(s, new Date(TTL.getTime() + 1)),
+      );
+
+      expect(Option.getOrNull(HashMap.get(state.availableUtxos, utxoHash(u)))).toEqual(u);
+      expect(HashMap.size(state.pendingUtxos)).toEqual(0);
+    });
+
+    it('releases a booking at exactly its expiry, since the ledger rejects the transaction from that instant', () => {
+      const u = generateMockUtxoWithMeta({ intentHash: 'h-boundary', outputNo: 0 });
+
+      const state = pipe(
+        seedAvailable(u),
+        (s) => UnshieldedState.spend(s, u, TTL),
+        getOrThrow,
+        (s) => UnshieldedState.expirePending(s, TTL),
+      );
+
+      expect(HashMap.has(state.availableUtxos, utxoHash(u))).toBe(true);
+      expect(HashMap.size(state.pendingUtxos)).toEqual(0);
+    });
+
+    it('keeps a booking one millisecond before its expiry', () => {
+      const u = generateMockUtxoWithMeta({ intentHash: 'h-not-yet', outputNo: 0 });
+
+      const state = pipe(
+        seedAvailable(u),
+        (s) => UnshieldedState.spend(s, u, TTL),
+        getOrThrow,
+        (s) => UnshieldedState.expirePending(s, new Date(TTL.getTime() - 1)),
+      );
+
+      expect(HashMap.has(state.availableUtxos, utxoHash(u))).toBe(false);
+      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual({ utxo: u, ttl: TTL });
+    });
+
+    it('releases only the bookings that have expired', () => {
+      const early = generateMockUtxoWithMeta({ intentHash: 'h-early', outputNo: 0 });
+      const late = generateMockUtxoWithMeta({ intentHash: 'h-late', outputNo: 0 });
+      const earlyTtl = new Date('2026-01-01T00:30:00.000Z');
+      const lateTtl = new Date('2026-01-01T02:00:00.000Z');
+
+      const state = pipe(
+        seedAvailable(early, late),
+        (s) => UnshieldedState.spend(s, early, earlyTtl),
+        getOrThrow,
+        (s) => UnshieldedState.spend(s, late, lateTtl),
+        getOrThrow,
+        (s) => UnshieldedState.expirePending(s, new Date('2026-01-01T01:00:00.000Z')),
+      );
+
+      expect([...HashMap.keys(state.availableUtxos)]).toEqual([utxoHash(early)]);
+      expect([...HashMap.keys(state.pendingUtxos)]).toEqual([utxoHash(late)]);
+    });
+
+    it('is a no-op when nothing is booked', () => {
+      const u = generateMockUtxoWithMeta({ intentHash: 'h-none-booked', outputNo: 0 });
+      const seeded = seedAvailable(u);
+
+      const state = UnshieldedState.expirePending(seeded, new Date(TTL.getTime() + 1));
+
+      expect([...HashMap.keys(state.availableUtxos)]).toEqual([utxoHash(u)]);
+      expect(HashMap.size(state.pendingUtxos)).toEqual(0);
+    });
+
+    it('releases a booking restored from a snapshot written before bookings carried an expiry', () => {
+      // Such a snapshot decodes with an expiry at the epoch, so the first sweep releases it.
+      const u = generateMockUtxoWithMeta({ intentHash: 'h-legacy', outputNo: 0 });
+
+      const state = pipe(UnshieldedState.restore([], [pendingAt(u, new Date(0))]), (s) =>
+        UnshieldedState.expirePending(s, new Date(TTL.getTime())),
+      );
+
+      expect(HashMap.has(state.availableUtxos, utxoHash(u))).toBe(true);
+      expect(HashMap.size(state.pendingUtxos)).toEqual(0);
+    });
+  });
+
   describe('restore / toArrays', () => {
     it('should restore state from arrays', () => {
       const utxo1 = generateMockUtxoWithMeta({ owner: 'owner1', type: 'type1' });
       const utxo2 = generateMockUtxoWithMeta({ owner: 'owner2', type: 'type2' });
       const pendingUtxo = generateMockUtxoWithMeta({ owner: 'owner3', type: 'type3' });
 
-      const state = UnshieldedState.restore([utxo1, utxo2], [pendingUtxo]);
+      const state = UnshieldedState.restore([utxo1, utxo2], [pendingAt(pendingUtxo)]);
 
       expect(HashMap.size(state.availableUtxos)).toEqual(2);
       expect(HashMap.size(state.pendingUtxos)).toEqual(1);
@@ -496,7 +610,7 @@ describe('UnshieldedState', () => {
       const utxo2 = generateMockUtxoWithMeta({ owner: 'owner2', type: 'type2' });
       const pendingUtxo = generateMockUtxoWithMeta({ owner: 'owner3', type: 'type3' });
 
-      const arrays = pipe(UnshieldedState.restore([utxo1, utxo2], [pendingUtxo]), UnshieldedState.toArrays);
+      const arrays = pipe(UnshieldedState.restore([utxo1, utxo2], [pendingAt(pendingUtxo)]), UnshieldedState.toArrays);
 
       expect(arrays.availableUtxos.length).toEqual(2);
       expect(arrays.pendingUtxos.length).toEqual(1);
@@ -506,10 +620,10 @@ describe('UnshieldedState', () => {
       const duplicated = generateMockUtxoWithMeta({ intentHash: 'h-dup', outputNo: 0 });
       const onlyAvailable = generateMockUtxoWithMeta({ intentHash: 'h-avail', outputNo: 0 });
 
-      const state = UnshieldedState.restore([onlyAvailable, duplicated], [duplicated]);
+      const state = UnshieldedState.restore([onlyAvailable, duplicated], [pendingAt(duplicated)]);
 
       expect([...HashMap.keys(state.availableUtxos)]).toEqual([utxoHash(onlyAvailable)]);
-      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(duplicated)))).toEqual(duplicated);
+      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(duplicated)))).toEqual(pendingAt(duplicated));
       expect(HashMap.size(state.pendingUtxos)).toEqual(1);
     });
 
@@ -523,7 +637,10 @@ describe('UnshieldedState', () => {
             const available = utxos.filter((_, i) => (placements[i] ?? 0) !== 1);
             const pending = utxos.filter((_, i) => (placements[i] ?? 0) !== 0);
 
-            const state = UnshieldedState.restore(available, pending);
+            const state = UnshieldedState.restore(
+              available,
+              pending.map((u) => pendingAt(u)),
+            );
 
             const availableKeys = new Set(HashMap.keys(state.availableUtxos));
             const pendingKeys = [...HashMap.keys(state.pendingUtxos)];
@@ -550,7 +667,7 @@ describe('UnshieldedState', () => {
             status: 'SUCCESS',
           }),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, u),
+        (s) => UnshieldedState.spend(s, u, TTL),
         getOrThrow,
         (s) =>
           UnshieldedState.applyUpdate(s, {
@@ -577,7 +694,7 @@ describe('UnshieldedState', () => {
             status: 'SUCCESS',
           }),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, u),
+        (s) => UnshieldedState.spend(s, u, TTL),
         getOrThrow,
         (s) =>
           UnshieldedState.applyFailedUpdate(s, {
@@ -587,7 +704,7 @@ describe('UnshieldedState', () => {
           }),
         getOrThrow,
         // re-spend should succeed
-        (s) => UnshieldedState.spend(s, u),
+        (s) => UnshieldedState.spend(s, u, TTL),
         getOrThrow,
       );
 
@@ -607,11 +724,11 @@ describe('UnshieldedState', () => {
             status: 'SUCCESS',
           }),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, u),
+        (s) => UnshieldedState.spend(s, u, TTL),
         getOrThrow,
         (s) => UnshieldedState.rollbackSpend(s, u),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, u),
+        (s) => UnshieldedState.spend(s, u, TTL),
         getOrThrow,
       );
 
@@ -638,7 +755,7 @@ describe('UnshieldedState', () => {
       );
 
       const after = pipe(
-        UnshieldedState.spend(seeded, b),
+        UnshieldedState.spend(seeded, b, TTL),
         getOrThrow,
         (s) =>
           UnshieldedState.applyFailedUpdate(s, {
@@ -670,9 +787,9 @@ describe('UnshieldedState', () => {
             status: 'SUCCESS',
           }),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, a),
+        (s) => UnshieldedState.spend(s, a, TTL),
         getOrThrow,
-        (s) => UnshieldedState.spend(s, b),
+        (s) => UnshieldedState.spend(s, b, TTL),
         getOrThrow,
         (s) =>
           UnshieldedState.applyUpdate(s, {
@@ -695,7 +812,8 @@ describe('UnshieldedState', () => {
       | { tag: 'rollback'; utxo: UtxoWithMeta }
       | { tag: 'confirm'; utxo: UtxoWithMeta }
       | { tag: 'fail'; utxo: UtxoWithMeta }
-      | { tag: 'replay'; utxo: UtxoWithMeta };
+      | { tag: 'replay'; utxo: UtxoWithMeta }
+      | { tag: 'expire'; utxo: UtxoWithMeta };
 
     // Apply an operation, ignoring failures (e.g. spending a missing utxo).
     // The point of these invariants is that *valid* operations preserve them;
@@ -704,7 +822,7 @@ describe('UnshieldedState', () => {
       const result: Either.Either<UnshieldedState, unknown> = (() => {
         switch (op.tag) {
           case 'spend':
-            return UnshieldedState.spend(state, op.utxo);
+            return UnshieldedState.spend(state, op.utxo, TTL);
           case 'rollback':
             return UnshieldedState.rollbackSpend(state, op.utxo);
           case 'confirm':
@@ -726,6 +844,9 @@ describe('UnshieldedState', () => {
               spentUtxos: [],
               status: 'SUCCESS',
             });
+          case 'expire':
+            // A sweep past the expiry every booking here was taken with.
+            return Either.right(UnshieldedState.expirePending(state, new Date(TTL.getTime() + 1)));
         }
       })();
       return Either.match(result, {
@@ -738,7 +859,7 @@ describe('UnshieldedState', () => {
       fc.assert(
         fc.property(
           fc.array(utxoArb, { minLength: 1, maxLength: 5 }),
-          fc.array(fc.nat(4), { maxLength: 20 }),
+          fc.array(fc.nat(5), { maxLength: 20 }),
           (utxos, opTags) => {
             // Seed state with all utxos available.
             const initial = pipe(
@@ -764,8 +885,10 @@ describe('UnshieldedState', () => {
                   return { tag: 'confirm', utxo };
                 case 3:
                   return { tag: 'fail', utxo };
-                default:
+                case 4:
                   return { tag: 'replay', utxo };
+                default:
+                  return { tag: 'expire', utxo };
               }
             });
 
@@ -796,7 +919,7 @@ describe('UnshieldedState', () => {
           );
 
           const roundTripped = pipe(
-            UnshieldedState.spend(seeded, u),
+            UnshieldedState.spend(seeded, u, TTL),
             getOrThrow,
             (s) => UnshieldedState.rollbackSpend(s, u),
             getOrThrow,
@@ -826,7 +949,7 @@ describe('UnshieldedState', () => {
           );
 
           const roundTripped = pipe(
-            UnshieldedState.spend(seeded, u),
+            UnshieldedState.spend(seeded, u, TTL),
             getOrThrow,
             (s) =>
               UnshieldedState.applyFailedUpdate(s, {

--- a/packages/unshielded-wallet/src/v1/test/UnshieldedState.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/UnshieldedState.test.ts
@@ -662,7 +662,7 @@ describe('UnshieldedState', () => {
       expect(HashMap.size(state.pendingUtxos)).toEqual(0);
     });
 
-    it('releases a booking at exactly its expiry, since the ledger rejects the transaction from that instant', () => {
+    it('keeps a booking at exactly its expiry, since a block stamped with that instant still accepts it', () => {
       const u = generateMockUtxoWithMeta({ intentHash: 'h-boundary', outputNo: 0 });
 
       const state = pipe(
@@ -672,8 +672,8 @@ describe('UnshieldedState', () => {
         (s) => UnshieldedState.expirePending(s, TTL),
       );
 
-      expect(HashMap.has(state.availableUtxos, utxoHash(u))).toBe(true);
-      expect(HashMap.size(state.pendingUtxos)).toEqual(0);
+      expect(HashMap.has(state.availableUtxos, utxoHash(u))).toBe(false);
+      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual(bookedNow(u));
     });
 
     it('keeps a booking one millisecond before its expiry', () => {

--- a/packages/unshielded-wallet/src/v1/test/UnshieldedState.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/UnshieldedState.test.ts
@@ -27,7 +27,10 @@ const getOrThrow = <E, A>(either: Either.Either<A, E>): A =>
 const TTL = new Date('2026-01-01T01:00:00.000Z');
 
 /** A pending entry as `restore` expects one: the coin plus the expiry it was booked with. */
-const pendingAt = (utxo: UtxoWithMeta, ttl: Date = TTL): PendingUtxo => ({ utxo, ttl });
+const pendingAt = (utxo: UtxoWithMeta, ttl: Date = TTL): PendingUtxo => ({ utxo, ttl, restored: true });
+
+/** A pending entry as `spend` produces one, booked by the running process. */
+const bookedNow = (utxo: UtxoWithMeta, ttl: Date = TTL): PendingUtxo => ({ utxo, ttl, restored: false });
 
 describe('UnshieldedState', () => {
   describe('applyUpdate', () => {
@@ -228,7 +231,7 @@ describe('UnshieldedState', () => {
       );
 
       expect(HashMap.has(state.availableUtxos, utxoHash(u))).toBe(false);
-      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual(pendingAt(u));
+      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual(bookedNow(u));
       expect(HashMap.size(state.availableUtxos)).toEqual(0);
       expect(HashMap.size(state.pendingUtxos)).toEqual(1);
     });
@@ -559,6 +562,68 @@ describe('UnshieldedState', () => {
     });
   });
 
+  describe('releasing bookings restored from a snapshot', () => {
+    // Once sync has caught up, every transaction the address is party to has been applied, so a coin still booked
+    // was never spent by the process that booked it. Only a durable record of that transaction justifies keeping it.
+    const restoredHolding = (...utxos: readonly UtxoWithMeta[]): UnshieldedState =>
+      UnshieldedState.restore(
+        [],
+        utxos.map((u) => pendingAt(u)),
+      );
+
+    it('returns a restored coin nothing accounts for, rather than waiting out its expiry', () => {
+      const abandoned = generateMockUtxoWithMeta({ intentHash: 'h-abandoned', outputNo: 0 });
+
+      const state = UnshieldedState.releaseRestoredPending(restoredHolding(abandoned), []);
+
+      expect(Option.getOrNull(HashMap.get(state.availableUtxos, utxoHash(abandoned)))).toEqual(abandoned);
+      expect(HashMap.size(state.pendingUtxos)).toEqual(0);
+    });
+
+    it('keeps a restored coin something still accounts for', () => {
+      // The wallet cannot see that transaction — it may be sitting with a counterparty — but something else knows.
+      const heldForSwap = generateMockUtxoWithMeta({ intentHash: 'h-swap', outputNo: 0 });
+
+      const state = UnshieldedState.releaseRestoredPending(restoredHolding(heldForSwap), [utxoHash(heldForSwap)]);
+
+      expect(HashMap.has(state.availableUtxos, utxoHash(heldForSwap))).toBe(false);
+      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(heldForSwap)))).toEqual(pendingAt(heldForSwap));
+    });
+
+    it('releases only the restored coins nothing accounts for', () => {
+      const abandoned = generateMockUtxoWithMeta({ intentHash: 'h-abandoned-2', outputNo: 0 });
+      const held = generateMockUtxoWithMeta({ intentHash: 'h-held', outputNo: 0 });
+
+      const state = UnshieldedState.releaseRestoredPending(restoredHolding(abandoned, held), [utxoHash(held)]);
+
+      expect([...HashMap.keys(state.availableUtxos)]).toEqual([utxoHash(abandoned)]);
+      expect([...HashMap.keys(state.pendingUtxos)]).toEqual([utxoHash(held)]);
+    });
+
+    it('never touches a booking this process took, since its caller may still be proving', () => {
+      const bookedHere = generateMockUtxoWithMeta({ intentHash: 'h-in-flight', outputNo: 0 });
+      const booked = pipe(
+        UnshieldedState.applyUpdate(UnshieldedState.empty(), {
+          createdUtxos: [bookedHere],
+          spentUtxos: [],
+          status: 'SUCCESS',
+        }),
+        getOrThrow,
+        (s) => UnshieldedState.spend(s, bookedHere, TTL),
+        getOrThrow,
+      );
+
+      const state = UnshieldedState.releaseRestoredPending(booked, []);
+
+      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(bookedHere)))).toEqual(bookedNow(bookedHere));
+      expect(HashMap.size(state.availableUtxos)).toEqual(0);
+    });
+
+    it('is a no-op when nothing was restored', () => {
+      expect(UnshieldedState.releaseRestoredPending(UnshieldedState.empty(), [])).toEqual(UnshieldedState.empty());
+    });
+  });
+
   describe('booking expiry', () => {
     const seedAvailable = (...utxos: readonly UtxoWithMeta[]): UnshieldedState =>
       pipe(
@@ -572,7 +637,7 @@ describe('UnshieldedState', () => {
 
       const state = pipe(seedAvailable(u), (s) => UnshieldedState.spend(s, u, TTL), getOrThrow);
 
-      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual({ utxo: u, ttl: TTL });
+      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual(bookedNow(u));
     });
 
     it('records the expiry when booking by ledger utxo', () => {
@@ -580,7 +645,7 @@ describe('UnshieldedState', () => {
 
       const state = pipe(seedAvailable(u), (s) => UnshieldedState.spendByUtxo(s, u.utxo, TTL), getOrThrow);
 
-      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual({ utxo: u, ttl: TTL });
+      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual(bookedNow(u));
     });
 
     it('releases a booking whose expiry has passed, coin and meta intact', () => {
@@ -622,7 +687,7 @@ describe('UnshieldedState', () => {
       );
 
       expect(HashMap.has(state.availableUtxos, utxoHash(u))).toBe(false);
-      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual({ utxo: u, ttl: TTL });
+      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual(bookedNow(u));
     });
 
     it('releases only the bookings that have expired', () => {

--- a/packages/unshielded-wallet/src/v1/test/UnshieldedState.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/UnshieldedState.test.ts
@@ -205,6 +205,45 @@ describe('UnshieldedState', () => {
       expect(Option.getOrNull(HashMap.get(state.availableUtxos, utxoHash(b)))).toEqual(b);
       expect(HashMap.size(state.availableUtxos)).toEqual(2);
     });
+
+    it('does not re-admit a created utxo that is currently pending (replay of the creating tx)', () => {
+      const u = generateMockUtxoWithMeta({ intentHash: 'h-replay', outputNo: 0 });
+      const created: UnshieldedUpdate = { createdUtxos: [u], spentUtxos: [], status: 'SUCCESS' };
+
+      const state = pipe(
+        UnshieldedState.empty(),
+        (s) => UnshieldedState.applyUpdate(s, created),
+        getOrThrow,
+        (s) => UnshieldedState.spend(s, u),
+        getOrThrow,
+        // A resync from an earlier cursor delivers the creating transaction again while `u` is still booked.
+        (s) => UnshieldedState.applyUpdate(s, created),
+        getOrThrow,
+      );
+
+      expect(HashMap.has(state.availableUtxos, utxoHash(u))).toBe(false);
+      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(u)))).toEqual(u);
+      expect(HashMap.size(state.availableUtxos)).toEqual(0);
+      expect(HashMap.size(state.pendingUtxos)).toEqual(1);
+    });
+
+    it('still admits the other created utxos of an update that replays a pending one', () => {
+      const pending = generateMockUtxoWithMeta({ intentHash: 'h-mixed', outputNo: 0 });
+      const fresh = generateMockUtxoWithMeta({ intentHash: 'h-mixed', outputNo: 1 });
+
+      const state = pipe(
+        UnshieldedState.empty(),
+        (s) => UnshieldedState.applyUpdate(s, { createdUtxos: [pending], spentUtxos: [], status: 'SUCCESS' }),
+        getOrThrow,
+        (s) => UnshieldedState.spend(s, pending),
+        getOrThrow,
+        (s) => UnshieldedState.applyUpdate(s, { createdUtxos: [pending, fresh], spentUtxos: [], status: 'SUCCESS' }),
+        getOrThrow,
+      );
+
+      expect([...HashMap.keys(state.availableUtxos)]).toEqual([utxoHash(fresh)]);
+      expect([...HashMap.keys(state.pendingUtxos)]).toEqual([utxoHash(pending)]);
+    });
   });
 
   describe('applyFailedUpdate', () => {
@@ -462,6 +501,40 @@ describe('UnshieldedState', () => {
       expect(arrays.availableUtxos.length).toEqual(2);
       expect(arrays.pendingUtxos.length).toEqual(1);
     });
+
+    it('drops a utxo present in both arrays, keeping the pending side (repairs a corrupted snapshot)', () => {
+      const duplicated = generateMockUtxoWithMeta({ intentHash: 'h-dup', outputNo: 0 });
+      const onlyAvailable = generateMockUtxoWithMeta({ intentHash: 'h-avail', outputNo: 0 });
+
+      const state = UnshieldedState.restore([onlyAvailable, duplicated], [duplicated]);
+
+      expect([...HashMap.keys(state.availableUtxos)]).toEqual([utxoHash(onlyAvailable)]);
+      expect(Option.getOrNull(HashMap.get(state.pendingUtxos, utxoHash(duplicated)))).toEqual(duplicated);
+      expect(HashMap.size(state.pendingUtxos)).toEqual(1);
+    });
+
+    it('restore always yields disjoint maps, whatever overlap the arrays carry', () => {
+      fc.assert(
+        fc.property(
+          fc.uniqueArray(utxoArb, { maxLength: 6, selector: utxoHash }),
+          fc.array(fc.nat(2), { maxLength: 6 }),
+          (utxos, placements) => {
+            // 0 = available only, 1 = pending only, 2 = both (the shape a corrupted snapshot carries).
+            const available = utxos.filter((_, i) => (placements[i] ?? 0) !== 1);
+            const pending = utxos.filter((_, i) => (placements[i] ?? 0) !== 0);
+
+            const state = UnshieldedState.restore(available, pending);
+
+            const availableKeys = new Set(HashMap.keys(state.availableUtxos));
+            const pendingKeys = [...HashMap.keys(state.pendingUtxos)];
+            expect(pendingKeys.some((k) => availableKeys.has(k))).toBe(false);
+            expect(HashMap.size(state.availableUtxos) + HashMap.size(state.pendingUtxos)).toEqual(utxos.length);
+            expect(pendingKeys.toSorted()).toEqual(pending.map(utxoHash).toSorted());
+          },
+        ),
+        { numRuns: 100 },
+      );
+    });
   });
 
   describe('lifecycle sequences', () => {
@@ -621,7 +694,8 @@ describe('UnshieldedState', () => {
       | { tag: 'spend'; utxo: UtxoWithMeta }
       | { tag: 'rollback'; utxo: UtxoWithMeta }
       | { tag: 'confirm'; utxo: UtxoWithMeta }
-      | { tag: 'fail'; utxo: UtxoWithMeta };
+      | { tag: 'fail'; utxo: UtxoWithMeta }
+      | { tag: 'replay'; utxo: UtxoWithMeta };
 
     // Apply an operation, ignoring failures (e.g. spending a missing utxo).
     // The point of these invariants is that *valid* operations preserve them;
@@ -645,6 +719,13 @@ describe('UnshieldedState', () => {
               spentUtxos: [op.utxo],
               status: 'FAILURE',
             });
+          case 'replay':
+            // The indexer re-delivers the transaction that created the utxo (resync from an earlier cursor).
+            return UnshieldedState.applyUpdate(state, {
+              createdUtxos: [op.utxo],
+              spentUtxos: [],
+              status: 'SUCCESS',
+            });
         }
       })();
       return Either.match(result, {
@@ -657,7 +738,7 @@ describe('UnshieldedState', () => {
       fc.assert(
         fc.property(
           fc.array(utxoArb, { minLength: 1, maxLength: 5 }),
-          fc.array(fc.nat(3), { maxLength: 20 }),
+          fc.array(fc.nat(4), { maxLength: 20 }),
           (utxos, opTags) => {
             // Seed state with all utxos available.
             const initial = pipe(
@@ -681,8 +762,10 @@ describe('UnshieldedState', () => {
                   return { tag: 'rollback', utxo };
                 case 2:
                   return { tag: 'confirm', utxo };
-                default:
+                case 3:
                   return { tag: 'fail', utxo };
+                default:
+                  return { tag: 'replay', utxo };
               }
             });
 

--- a/packages/unshielded-wallet/src/v1/test/transacting.test.ts
+++ b/packages/unshielded-wallet/src/v1/test/transacting.test.ts
@@ -134,6 +134,36 @@ describe('Unshielded wallet transacting', () => {
     keysCapability: makeDefaultKeysCapability(),
   };
 
+  const buildWalletWithNightUtxos = (count: number): { wallet: CoreWallet; utxos: ReadonlyArray<UtxoWithMeta> } => {
+    const keystore = createKeystore(Buffer.from(ledger.sampleSigningKey(), 'hex'), NetworkId.NetworkId.Undeployed);
+    const ownerPK = PublicKey.fromKeyStore(keystore);
+    const utxos: ReadonlyArray<UtxoWithMeta> = pipe(
+      Arr.range(0, count - 1),
+      Arr.map(
+        (i) =>
+          new UtxoWithMeta({
+            utxo: {
+              value: 1_000n + BigInt(i),
+              owner: ownerPK.addressHex,
+              type: NIGHT,
+              intentHash: ledger.sampleIntentHash(),
+              outputNo: i,
+            },
+            meta: { ctime: new Date(0), registeredForDustGeneration: false },
+          }),
+      ),
+    );
+    const state = UnshieldedState.restore(utxos, []);
+    const wallet = CoreWallet.restore(
+      state,
+      ownerPK,
+      { appliedId: 0n, highestTransactionId: 0n },
+      ProtocolVersion.ProtocolVersion(1n),
+      NetworkId.NetworkId.Undeployed,
+    );
+    return { wallet, utxos };
+  };
+
   it('uses fallible section for issuing transfers involving Night', () => {
     const transacting = makeDefaultTransactingCapability(config, () => context);
     const ttl = DateOps.addSeconds(new Date(), 1800);
@@ -303,36 +333,6 @@ describe('Unshielded wallet transacting', () => {
   });
 
   describe('rotateUtxos', () => {
-    const buildWalletWithNightUtxos = (count: number): { wallet: CoreWallet; utxos: ReadonlyArray<UtxoWithMeta> } => {
-      const keystore = createKeystore(Buffer.from(ledger.sampleSigningKey(), 'hex'), NetworkId.NetworkId.Undeployed);
-      const ownerPK = PublicKey.fromKeyStore(keystore);
-      const utxos: ReadonlyArray<UtxoWithMeta> = pipe(
-        Arr.range(0, count - 1),
-        Arr.map(
-          (i) =>
-            new UtxoWithMeta({
-              utxo: {
-                value: 1_000n + BigInt(i),
-                owner: ownerPK.addressHex,
-                type: NIGHT,
-                intentHash: ledger.sampleIntentHash(),
-                outputNo: i,
-              },
-              meta: { ctime: new Date(0), registeredForDustGeneration: false },
-            }),
-        ),
-      );
-      const state = UnshieldedState.restore(utxos, []);
-      const wallet = CoreWallet.restore(
-        state,
-        ownerPK,
-        { appliedId: 0n, highestTransactionId: 0n },
-        ProtocolVersion.ProtocolVersion(1n),
-        NetworkId.NetworkId.Undeployed,
-      );
-      return { wallet, utxos };
-    };
-
     const transacting = makeDefaultTransactingCapability(config, () => context);
     const ttl = DateOps.addSeconds(new Date(), 1800);
 
@@ -484,6 +484,118 @@ describe('Unshielded wallet transacting', () => {
         .pipe(EitherOps.getOrThrowRight);
 
       expect(error).toBeInstanceOf(TransactingError);
+    });
+  });
+
+  describe('when balancing a transaction in place', () => {
+    const transacting = makeDefaultTransactingCapability(config, () => context);
+    const ttl = DateOps.addSeconds(new Date(), 1800);
+    const receiverAddress = new UnshieldedAddress(Buffer.alloc(32, 7)).data.toString('hex');
+
+    /** An intent owing `value` Night in its fallible section, so the segment it lands in needs balancing. */
+    const owingIntent = (value: bigint): ledger.Intent<ledger.SignatureEnabled, ledger.PreProof, ledger.PreBinding> => {
+      const intent = ledger.Intent.new(ttl);
+      intent.fallibleUnshieldedOffer = ledger.UnshieldedOffer.new(
+        [],
+        [{ owner: receiverAddress, type: NIGHT, value }],
+        [],
+      );
+      return intent;
+    };
+
+    const unbalancedTransaction = (value: bigint): ledger.UnprovenTransaction =>
+      ledger.Transaction.fromParts(config.networkId, undefined, undefined, owingIntent(value));
+
+    /** Ids of every UTxO the transaction spends, across all intents and both sections. */
+    const inputIdsOf = (
+      transaction: ledger.Transaction<ledger.SignatureEnabled, ledger.Proofish, ledger.Bindingish>,
+    ): ReadonlyArray<string> =>
+      pipe(
+        Arr.fromIterable(transaction.intents?.values() ?? []),
+        Arr.flatMap((intent) => [
+          ...(intent.guaranteedUnshieldedOffer?.inputs ?? []),
+          ...(intent.fallibleUnshieldedOffer?.inputs ?? []),
+        ]),
+        Arr.map((input) => `${input.intentHash}#${input.outputNo}`),
+      );
+
+    it('books the coins it selects, so they leave availableUtxos and appear in pendingUtxos', () => {
+      const { wallet } = buildWalletWithNightUtxos(2);
+
+      const [balanced, newState] = transacting
+        .balanceUnprovenTransaction(wallet, unbalancedTransaction(900n))
+        .pipe(EitherOps.getOrThrowLeft);
+
+      const spentIds = inputIdsOf(balanced!);
+
+      expect(spentIds.length).toBeGreaterThan(0);
+      expect(HashMap.size(newState.state.pendingUtxos)).toBe(spentIds.length);
+      expect(Arr.every(spentIds, (id) => HashMap.has(newState.state.pendingUtxos, id))).toBe(true);
+      expect(Arr.every(spentIds, (id) => !HashMap.has(newState.state.availableUtxos, id))).toBe(true);
+    });
+
+    it('books the coins with the transaction TTL, so the booking expires with the transaction', () => {
+      const { wallet } = buildWalletWithNightUtxos(2);
+
+      const [balanced, newState] = transacting
+        .balanceUnprovenTransaction(wallet, unbalancedTransaction(900n))
+        .pipe(EitherOps.getOrThrowLeft);
+
+      const intentTtl = balanced!.intents!.values().take(1).next().value!.ttl;
+      const bookings = Arr.fromIterable(HashMap.values(newState.state.pendingUtxos));
+
+      expect(bookings.length).toBeGreaterThan(0);
+      expect(Arr.every(bookings, (booking) => booking.ttl.getTime() === intentTtl.getTime())).toBe(true);
+    });
+
+    it('never picks the same coin for two transactions balanced one after the other', () => {
+      const { wallet } = buildWalletWithNightUtxos(2);
+
+      const [firstBalanced, stateAfterFirst] = transacting
+        .balanceUnprovenTransaction(wallet, unbalancedTransaction(900n))
+        .pipe(EitherOps.getOrThrowLeft);
+
+      const [secondBalanced] = transacting
+        .balanceUnprovenTransaction(stateAfterFirst, unbalancedTransaction(900n))
+        .pipe(EitherOps.getOrThrowLeft);
+
+      const firstIds = inputIdsOf(firstBalanced!);
+      const secondIds = inputIdsOf(secondBalanced!);
+
+      expect(Arr.intersection(firstIds, secondIds)).toEqual([]);
+    });
+
+    it('never picks the same coin twice when one transaction has two segments to balance', () => {
+      const { wallet } = buildWalletWithNightUtxos(2);
+
+      const twoSegmentTransaction = ledger.Transaction.fromParts(
+        config.networkId,
+        undefined,
+        undefined,
+        owingIntent(900n),
+      ).addIntent({ tag: 'specific', value: 2 }, owingIntent(900n));
+
+      const [balanced] = transacting
+        .balanceUnprovenTransaction(wallet, twoSegmentTransaction)
+        .pipe(EitherOps.getOrThrowLeft);
+
+      const spentIds = inputIdsOf(balanced!);
+
+      expect(Arr.dedupe(spentIds)).toEqual(spentIds);
+    });
+
+    it('reports insufficient funds once its own bookings leave nothing to select', () => {
+      const { wallet } = buildWalletWithNightUtxos(1);
+
+      const [, stateAfterFirst] = transacting
+        .balanceUnprovenTransaction(wallet, unbalancedTransaction(900n))
+        .pipe(EitherOps.getOrThrowLeft);
+
+      const error = transacting
+        .balanceUnprovenTransaction(stateAfterFirst, unbalancedTransaction(900n))
+        .pipe(EitherOps.getOrThrowRight);
+
+      expect(error).toBeInstanceOf(InsufficientFundsError);
     });
   });
 });

--- a/packages/unshielded-wallet/test/UnshieldedWallet.integration.test.ts
+++ b/packages/unshielded-wallet/test/UnshieldedWallet.integration.test.ts
@@ -123,6 +123,96 @@ describe('UnshieldedWallet', () => {
     await restoredWallet.stop();
   });
 
+  describe('bookings carried across a restart', () => {
+    // These start from a hand-written snapshot rather than a funded wallet: the coins only have to be tracked, and
+    // the indexer never mentions them, so what is being watched is how the wallet treats its own restored state
+    // while real sync updates arrive.
+    const coin = (intentHash: string, ttl?: string) => ({
+      utxo: { value: '1000', owner: 'owner-1', type: 'token-1', intentHash, outputNo: 0 },
+      meta: { ctime: '2026-01-01T00:00:00.000Z', registeredForDustGeneration: false },
+      ...(ttl === undefined ? {} : { ttl }),
+    });
+
+    const coinId = (intentHash: string) => `${intentHash}#0`;
+
+    /** A snapshot this wallet would accept, with its coin arrays replaced. */
+    const snapshotHolding = async (
+      available: ReturnType<typeof coin>[],
+      pending: ReturnType<typeof coin>[],
+    ): Promise<string> => {
+      const config = createWalletConfig(indexerPort);
+      const keystore = createKeystore(unshieldedSeed, config.networkId);
+      const wallet = UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(keystore));
+      await wallet.start();
+      const empty = JSON.parse(await wallet.serializeState()) as { state: unknown };
+      await wallet.stop();
+
+      return JSON.stringify({ ...empty, state: { availableUtxos: available, pendingUtxos: pending } });
+    };
+
+    it('loads a snapshot holding one coin as both available and pending with the coin only pending, and keeps the two apart while syncing', async () => {
+      const duplicated = 'h-integration-duplicate';
+      const snapshot = await snapshotHolding([coin(duplicated)], [coin(duplicated, '2999-01-01T00:00:00.000Z')]);
+
+      const wallet = UnshieldedWallet(createWalletConfig(indexerPort)).restore(snapshot);
+      await wallet.start();
+
+      const seen: { available: string[]; pending: string[] }[] = [];
+      const subscription = wallet.state.subscribe((state) => {
+        seen.push({
+          available: state.availableCoins.map((c) => coinId(c.utxo.intentHash)),
+          pending: state.pendingCoins.map((c) => coinId(c.utxo.intentHash)),
+        });
+      });
+
+      await wallet.waitForSyncedState();
+      subscription.unsubscribe();
+      await wallet.stop();
+
+      expect(seen.length).toBeGreaterThan(0);
+      for (const { available, pending } of seen) {
+        expect(pending.filter((id) => available.includes(id))).toEqual([]);
+      }
+      expect(seen.at(-1)?.pending).toEqual([coinId(duplicated)]);
+    });
+
+    it('releases a booking whose transaction can no longer be accepted, as sync updates arrive', async () => {
+      // Nothing on chain will ever mention this coin, so only the wallet noticing the expiry can free it.
+      const stale = 'h-integration-stale';
+      const snapshot = await snapshotHolding([], [coin(stale, '1970-01-01T00:00:00.000Z')]);
+
+      const wallet = UnshieldedWallet(createWalletConfig(indexerPort)).restore(snapshot);
+      await wallet.start();
+      const state = await wallet.waitForSyncedState();
+      await wallet.stop();
+
+      expect(state.pendingCoins.map((c) => coinId(c.utxo.intentHash))).not.toContain(coinId(stale));
+      expect(state.availableCoins.map((c) => coinId(c.utxo.intentHash))).toContain(coinId(stale));
+    });
+
+    it('keeps a restored booking something still accounts for, and frees it once nothing does', async () => {
+      // The coin a counterparty has not answered on yet: sync proves nothing spent it, but a record elsewhere says
+      // its transaction is still out there.
+      const held = 'h-integration-held';
+      const snapshot = await snapshotHolding([], [coin(held, '2999-01-01T00:00:00.000Z')]);
+
+      const wallet = UnshieldedWallet(createWalletConfig(indexerPort)).restore(snapshot);
+      await wallet.start();
+      await wallet.waitForSyncedState();
+
+      await wallet.releaseRestoredPending([coinId(held)]);
+      const stillHeld = await firstValueFrom(wallet.state);
+      expect(stillHeld.pendingCoins.map((c) => coinId(c.utxo.intentHash))).toEqual([coinId(held)]);
+
+      await wallet.releaseRestoredPending([]);
+      const freed = await firstValueFrom(wallet.state);
+      await wallet.stop();
+
+      expect(freed.pendingCoins.map((c) => coinId(c.utxo.intentHash))).not.toContain(coinId(held));
+      expect(freed.availableCoins.map((c) => coinId(c.utxo.intentHash))).toContain(coinId(held));
+    });
+  });
+
   afterAll(async () => {
     if (startedEnvironment) {
       await startedEnvironment.down();


### PR DESCRIPTION
Related issue: #697

# Description

A wallet holding only unshielded Night reported exactly twice its on-chain balance, kept doing so across restarts, and simultaneously reported nothing available to spend. Deleting the persisted state was the only recovery.

Two defects combined. The indexer sync path re-admitted a created coin without checking whether it was still booked, so a resync from a cursor predating the creating transaction put that coin into `availableUtxos` while it was also in `pendingUtxos`. And a booking taken during balancing was released only through the submit path, so a transaction abandoned before submission — a proof server on a mismatched ledger version, in the reported case — left its coins booked forever. Both maps are persisted, so the corruption survived every restart and no amount of resyncing cleared it.

# Proposed Solution

ADR 0008 in this PR records the decision and the options weighed. The short version: a booking is not the caller's private intent, it is a record of something the wallet has already released into the world, so it must survive a restart — and therefore needs something that can eventually retire it.

Four mechanisms, smallest first, each useful without the ones after it.

The invariant is enforced where it broke. `applyUpdate` no longer admits a created coin that is still booked, the guard the simulator path already had, and loading a snapshot holding one coin in both maps keeps it on the pending side only, so state already corrupted in the field repairs itself on the next start.

A booked coin carries the TTL of the transaction it was booked for, and both sync capabilities release expired bookings as updates arrive. This is the only thing that releases a booking, so nothing else can free a coin some other transaction has since booked. It sweeps only once sync has caught up with the chain, because a replay from an earlier cursor can still be carrying the transaction that spent a booked coin, and it releases strictly after the TTL rather than at it, because the ledger accepts an intent while its TTL is at or after the block's timestamp. This bounds any abandoned transaction to its own lifetime with no help from the caller, and works for a wallet used without the facade.

A transaction that has been balanced but not yet proven is recorded as a reservation in the pending-transactions service: its identifiers, the ids of the coins it booked, and its TTL. Never the transaction itself, which carries key material. In-place balancing records only the coins the wallet moved onto the pending side, since the transaction it hands back may already carry inputs the caller put there. The record persists, so a booking held for a counterparty that has not answered yet survives a restart. Registering or clearing the real transaction drops the reservation standing in for it, and so does reverting the booking on any failure path.

Bookings restored from a snapshot are reconciled once sync reaches the chain tip: every transaction the address is party to has been applied by then, so a coin still booked was never spent — unless a reservation or a transaction being tracked says the spend is still out there. Both halves matter, because registering a transaction drops the reservation that stood for it, so from submission onwards the tracked transaction is the only thing holding its coins. Uncovered coins come back in seconds rather than waiting out a TTL that defaults to an hour.

Separately, and in the same class as the reported defect: balancing a transaction in place discarded the state coin selection produced, so it never booked the coins it selected. Two balance calls could hand the same coin to two transactions. It now books them like every other path.

# Important Changes Introduced

Breaking, unshielded wallet: `UnshieldedState.spend`, `UnshieldedState.spendByUtxo`, `CoreWallet.spend` and `CoreWallet.spendUtxos` take the transaction's TTL as a required last argument. `UnshieldedState.restore` and `toArrays` exchange pending entries as `{ utxo, ttl, restored }` rather than bare UTxOs. `TransactingCapability` gains `revertUtxos` and `releaseRestoredPending`, so a custom implementation must add them. The public coin accessors are unchanged: `pendingCoins`, `availableCoins` and `balances` still report UTxOs.

New on the unshielded wallet: `revertUtxos(ids)` releases booked coins without the transaction that booked them, for a caller holding only a record of the ids.

Stored-format compatibility, worth a reviewer's attention. Both formats gained an optional member rather than a new version, so a store written by this release is still readable by an earlier one, which simply does not see the new member. The unshielded snapshot carries each booking's expiry; a snapshot written before expiries existed says nothing about when its coins were booked, so each booking is granted a full transaction lifetime from the moment it is loaded rather than being treated as already expired. The pending-transactions store carries its reservations the same way.

The commits building this are ordered so each test commit precedes the implementation it specifies. The last seven are the exception: they carry one round of review fixes, grouped by theme with their tests alongside, because those changes reach across the same files.

# Testing

Unit tests cover the state transitions, the snapshot round trip in both directions, both sync paths, the reservation collection and its persistence, the service poll, the facade registering and dropping reservations, and in-place balancing booking what it selects. Integration tests run against a real node and indexer under Docker, starting from a hand-written snapshot so the coins under test are ones the indexer never mentions: a snapshot holding one coin in both maps loads disjoint and stays disjoint on every emitted state, a booking whose transaction can no longer be accepted is released as updates arrive, and a restored booking something still accounts for stays booked until nothing does.

One path has no automated test, and I would rather say so than imply otherwise: the facade's trigger that calls the reconciliation when sync reaches the tip. The simulator never reports a chain tip, so the condition cannot be reached in that harness. The wallet behaviour behind it is covered against the real indexer; the subscription that calls it is not.

Worth a reviewer's eye: the sentence the reconciliation turns on, since all three of its simpler forms are wrong. Releasing restored bookings on sync completion unguarded would invalidate a swap whose counterpart has not answered; never releasing them leaves a coin stuck for up to an hour after sync has already proved nothing holds it; and guarding on reservations alone frees the coins of a transaction that was submitted and is still in the mempool, because registering it dropped its reservation. Related to that last point, the facade's default pending-transactions service starts empty, so a consumer that restores the wallet snapshot but not the pending store reaches the tip with nothing accounting for the spends its previous process submitted. That is stated in ADR 0008 rather than worked around here.
