### PR TITLE
docs(shielded-wallet): replace 'NIGHT' placeholder in examples — NIGHT is unshielded

### DIFF
--- a/.changeset/docs-shielded-readme-token-type.md
+++ b/.changeset/docs-shielded-readme-token-type.md
@@ -1,0 +1,11 @@
+---
+'@midnightntwrk/wallet-sdk-shielded': patch
+---
+
+docs(shielded-wallet): replace 'NIGHT' placeholder in examples — NIGHT is unshielded
+
+The transfer and swap examples used `'NIGHT'` and `'TOKEN_A'` as token types. Both are placeholders the API rejects:
+`type` feeds `ledger.createShieldedCoinInfo()`, which needs a real shielded token type (raw hex), and NIGHT is an
+unshielded token that can never appear in a shielded offer. The examples now use `tokenType` / `tokenTypeA` /
+`tokenTypeB` bindings with a comment saying what to pass. The README's ledger import is also aligned with the package's
+actual dependency (`@midnight-ntwrk/ledger-v8`).

--- a/packages/shielded-wallet/README.md
+++ b/packages/shielded-wallet/README.md
@@ -25,7 +25,7 @@ while maintaining verifiability. It provides:
 
 ```typescript
 import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
-import * as ledger from '@midnight-ntwrk/ledger-v7';
+import * as ledger from '@midnight-ntwrk/ledger-v8';
 import { randomBytes } from 'node:crypto';
 
 // Configuration for the wallet
@@ -78,8 +78,10 @@ wallet.state.subscribe((state) => {
 ### Creating Transfer Transactions
 
 ```typescript
+// tokenType: the shielded token type (raw hex) of a token you hold,
+// e.g. one minted by a contract — NIGHT is unshielded and cannot appear here
 const tx = await wallet.transferTransaction(shieldedSecretKeys, [
-  { type: 'NIGHT', receiverAddress: 'mn_shield-addr1...', amount: 1000n },
+  { type: tokenType, receiverAddress: 'mn_shield-addr1...', amount: 1000n },
 ]);
 ```
 
@@ -92,10 +94,12 @@ const balancingTx = await wallet.balanceTransaction(shieldedSecretKeys, transact
 ### Creating Swap Offers
 
 ```typescript
+// tokenTypeA / tokenTypeB: shielded token types (raw hex) — both sides of a
+// shielded swap are shielded tokens; NIGHT is unshielded and cannot appear here
 const swapTx = await wallet.initSwap(
   shieldedSecretKeys,
-  { NIGHT: 500n }, // inputs
-  [{ type: 'TOKEN_A', receiverAddress: shieldedAddress, amount: 100n }], // outputs
+  { [tokenTypeA]: 500n }, // inputs
+  [{ type: tokenTypeB, receiverAddress: shieldedAddress, amount: 100n }], // outputs
 );
 ```
 


### PR DESCRIPTION
The `Creating Transfer Transactions` and `Creating Swap Offers` examples in `packages/shielded-wallet/README.md` used
`'NIGHT'` and `'TOKEN_A'` as token types. Both are placeholders that don't match the API, and one of them is actively
misleading:

- The `type` field of a `TokenTransfer` feeds `ledger.createShieldedCoinInfo(type, amount)`
  ([`Transacting.ts:433`](https://github.com/midnightntwrk/midnight-wallet/blob/main/packages/shielded-wallet/src/v1/Transacting.ts#L433)),
  which needs a real shielded token type — a raw hex `ledger.RawTokenType`, not a human-readable name. The same goes for
  the keys of `initSwap`'s `desiredInputs: Record<ledger.RawTokenType, bigint>`.
- **NIGHT is an unshielded token.** It can never appear in a shielded offer, so a reader who copies the example is being
  pointed at something the shielded wallet cannot do at all.

While in the file, the README's ledger import was still `@midnight-ntwrk/ledger-v7`, but the package has depended on
`@midnight-ntwrk/ledger-v8` (`^8.1.0`) for a while — every `.ts` file under `packages/shielded-wallet/src` already
imports v8.

# Proposed Solution

Replace the placeholders with named bindings plus a comment explaining what a reader actually has to supply, rather
than inventing a fake-looking hex constant that would read as copy-pasteable:

```typescript
// tokenType: the shielded token type (raw hex) of a token you hold,
// e.g. one minted by a contract — NIGHT is unshielded and cannot appear here
const tx = await wallet.transferTransaction(shieldedSecretKeys, [
  { type: tokenType, receiverAddress: 'mn_shield-addr1...', amount: 1000n },
]);
```

The swap example gets the mirrored change on both legs (`{ [tokenTypeA]: 500n }` in, `type: tokenTypeB` out), since both
sides of a shielded swap are shielded tokens.

This matches the canonical usage already in `packages/docs-snippets/src/snippets/shielded-transfer.ts`
(`ledger.shieldedToken().raw`) and `packages/docs-snippets/src/snippets/swap.ts` (raw hex token-type constants).

# Important Changes Introduced

Documentation only — no source, type, or behaviour changes. A `patch` changeset is included because the README ships
inside the published npm package.

# Testing

No functional change to test. Reviewers may want to confirm:

- `packages/shielded-wallet/package.json` depends on `@midnight-ntwrk/ledger-v8`, so the README import now matches.
- `TokenTransfer.type` is typed `ledger.RawTokenType` in `packages/shielded-wallet/src/v1/Transacting.ts`.

Out of scope, flagged for a follow-up rather than fixed here: `receiverAddress` is typed as a `ShieldedAddress` object
(the class in `packages/address-format/src/index.ts`), not the bech32m string `'mn_shield-addr1...'` that both examples
still show. That inaccuracy predates this change and is a separate fix.
