### PR TITLE
docs(snippets): make the documentation snippets hard-fork ready

### DIFF
--- a/.changeset/fold-fork-constant.md
+++ b/.changeset/fold-fork-constant.md
@@ -1,0 +1,12 @@
+---
+'@midnightntwrk/wallet-sdk-abstractions': minor
+'@midnightntwrk/wallet-sdk-shielded': minor
+'@midnightntwrk/wallet-sdk-testkit': patch
+---
+
+The v9-native fork version lives with the version type: `ProtocolVersion.V9NativeForkVersion` in the abstractions
+package (and through the umbrella package's `ProtocolVersion`), next to `MinSupportedVersion` and `MaxSupportedVersion`.
+It is the same value the shielded package published as `V9_NATIVE_FORK_VERSION` — a property of the chain, not of one
+wallet, which is why it moves. The shielded export stays as a deprecated alias of the new constant, so existing imports
+keep working; it will be removed in a later release. As before, it is a named value and not a default: every wallet's
+`forkVersion` remains required.

--- a/.changeset/hard-fork-ready-snippets.md
+++ b/.changeset/hard-fork-ready-snippets.md
@@ -2,8 +2,9 @@
 ---
 
 Make the documentation snippets hard-fork ready. Every snippet now imports only from `@midnightntwrk/wallet-sdk` and
-its subpaths (the fork constant from the root, the ledger from `./ledger/v9`); the examples that author their own
-transactions seal them with the protocol version the wallets are acting at instead of version 0, which a wallet on a
-chain past the fork refuses; the in-process prover example registers its WASM prover from `forkVersion`, the way a proof
-server is registered under `provingServers`; and the projections fast-sync example restates `withStartAuxDefaults()`
-after `withSync`, which drops it, so a start from a seed works again. Documentation and tests only — no API changes.
+its subpaths; the examples that author their own transactions pick the ledger — `./ledger/v8` below `forkVersion`,
+`./ledger/v9` from it — by the protocol version the wallets are acting at and seal the handle with that version, so they
+run on a pre-fork chain and follow it across the fork instead of stamping version 0, which a wallet past the fork
+refuses; the in-process prover example registers its WASM prover from `forkVersion`, the way a proof server is
+registered under `provingServers`; and the projections fast-sync example restates `withStartAuxDefaults()` after
+`withSync`, which drops it, so a start from a seed works again. Documentation and tests only — no API changes.

--- a/.changeset/hard-fork-ready-snippets.md
+++ b/.changeset/hard-fork-ready-snippets.md
@@ -2,9 +2,11 @@
 ---
 
 Make the documentation snippets hard-fork ready. Every snippet now imports only from `@midnightntwrk/wallet-sdk` and
-its subpaths; the examples that author their own transactions pick the ledger — `./ledger/v8` below `forkVersion`,
-`./ledger/v9` from it — by the protocol version the wallets are acting at and seal the handle with that version, so they
-run on a pre-fork chain and follow it across the fork instead of stamping version 0, which a wallet past the fork
-refuses; the in-process prover example registers its WASM prover from `forkVersion`, the way a proof server is
-registered under `provingServers`; and the projections fast-sync example restates `withStartAuxDefaults()` after
-`withSync`, which drops it, so a start from a seed works again. Documentation and tests only — no API changes.
+its subpaths; every wallet is configured to run on ledger-v8 below `forkVersion` and on ledger-v9 from it — proving
+included, with a proof server per ledger version under `provers` (the in-process prover needs one entry, since the
+same backend serves both); the examples that author their own transactions pick the ledger — `./ledger/v8` below
+`forkVersion`, `./ledger/v9` from it — by the protocol version the wallets are acting at and seal the handle with that
+version, so they run on a pre-fork chain and follow it across the fork instead of stamping version 0, which a wallet
+past the fork refuses; and the projections fast-sync example is composed either side of the boundary — ledger-v8 event
+replay below it, projections from it — with `withStartAuxDefaults()` restated after `withSync`, which drops it, so a
+start from a seed works again. Documentation and tests only — no API changes.

--- a/.changeset/hard-fork-ready-snippets.md
+++ b/.changeset/hard-fork-ready-snippets.md
@@ -1,0 +1,9 @@
+---
+---
+
+Make the documentation snippets hard-fork ready. Every snippet now imports only from `@midnightntwrk/wallet-sdk` and
+its subpaths (the fork constant from the root, the ledger from `./ledger/v9`); the examples that author their own
+transactions seal them with the protocol version the wallets are acting at instead of version 0, which a wallet on a
+chain past the fork refuses; the in-process prover example registers its WASM prover from `forkVersion`, the way a proof
+server is registered under `provingServers`; and the projections fast-sync example restates `withStartAuxDefaults()`
+after `withSync`, which drops it, so a start from a seed works again. Documentation and tests only — no API changes.

--- a/.changeset/hard-fork-support.md
+++ b/.changeset/hard-fork-support.md
@@ -24,8 +24,8 @@ no longer import a ledger package.
 ### Breaking: configuration and starting
 
 - `forkVersion` is required in the shielded, dust, unshielded and facade configurations: the protocol version at which
-  the chain switches ledgers. There is no default. `V9_NATIVE_FORK_VERSION`, exported from the shielded package, is the
-  value a 2.x chain reports (2000000); the final mainnet constant is not fixed yet, so supply it per environment.
+  the chain switches ledgers. There is no default. `ProtocolVersion.V9NativeForkVersion`, from the abstractions package, is
+  the value a 2.x chain reports (2000000); the final mainnet constant is not fixed yet, so supply it per environment.
 - `chainVersionProbe` is a new optional setting on all three wallets. By default a wallet asks the indexer, on every
   start, which protocol version the chain's first block was produced under, with a 5-second timeout, and starts on the
   matching side. A failed probe never fails a start: the wallet starts pre-fork and crosses on its first synced update.
@@ -79,7 +79,7 @@ no longer import a ledger package.
   `SchemeMismatchError`; `Simulator` on `./v1` is the ledger-v8 simulator only. Both subpaths gain a `Migration`
   namespace, and their builders gain `withStartAux`, `withStartAuxDefaults`, `withMigration` and
   `withMigrationDefaults`.
-- Root entry points keep their names and gain the forking wallet types, `V9_NATIVE_FORK_VERSION`, `DustGenerationRates`
+- Root entry points keep their names and gain the forking wallet types, `ProtocolVersion.V9NativeForkVersion`, `DustGenerationRates`
   with `asPreForkDustParameters` and `asPostForkDustParameters`, and snapshot inspection: `Restore` (shielded) and
   `UnshieldedRestore` namespaces, and the dust `peekProtocolVersion` and `UnsupportedSnapshotVersionError`.
 - Existing snapshots restore; `restore` and the new `tryRestore` route on the protocol version a snapshot declares, and

--- a/packages/abstractions/src/ProtocolVersion.ts
+++ b/packages/abstractions/src/ProtocolVersion.ts
@@ -71,6 +71,22 @@ export const MinSupportedVersion = ProtocolVersion(0n);
 export const MaxSupportedVersion = ProtocolVersion(BigInt(Number.MAX_SAFE_INTEGER));
 
 /**
+ * The protocol version a ledger-v9-native chain hands over at, for the current node line.
+ *
+ * @remarks
+ *   Measured, not assumed: a `midnight-node` 2.x reports protocol version `2000000` on its ledger events — the runtime
+ *   version, scaled, rather than a small ordinal or the ledger major. A chain of the previous node line reports a
+ *   1.x-encoded value, which is below this, so a wallet configured with it stays on the pre-fork variant there and
+ *   reaches the post-fork variant on any v9-native chain.
+ *
+ *   Offered as a named value so applications and test suites pointed at a v9-native chain do not each invent a magic
+ *   number. It is **not** a default: every wallet's `forkVersion` stays required, because the right value is a property
+ *   of the chain an application points at. The final mainnet fork constant is still an open question; when it is fixed
+ *   it will join this one here.
+ */
+export const V9NativeForkVersion: ProtocolVersion = ProtocolVersion(2_000_000n);
+
+/**
  * The range of protocol versions on the same side of a protocol boundary as a given version.
  *
  * @remarks

--- a/packages/abstractions/src/test/protocolVersion.test.ts
+++ b/packages/abstractions/src/test/protocolVersion.test.ts
@@ -29,6 +29,18 @@ describe('ProtocolVersion', () => {
     });
   });
 
+  describe('V9NativeForkVersion', () => {
+    it('is the version a midnight-node 2.x reports on its ledger events, 2000000', () => {
+      expect(ProtocolVersion.V9NativeForkVersion).toBe(2_000_000n);
+      expect(ProtocolVersion.is(ProtocolVersion.V9NativeForkVersion)).toBeTruthy();
+    });
+
+    it('lies strictly inside the supported range, so it splits it into two non-empty epochs', () => {
+      expect(ProtocolVersion.V9NativeForkVersion).toBeGreaterThan(ProtocolVersion.MinSupportedVersion);
+      expect(ProtocolVersion.V9NativeForkVersion).toBeLessThan(ProtocolVersion.MaxSupportedVersion);
+    });
+  });
+
   it.each([ProtocolVersion.MinSupportedVersion, ProtocolVersion.MaxSupportedVersion])(
     'should be encodable and decodable',
     (input) => {

--- a/packages/docs-snippets/src/snippets/addresses.no-net.ts
+++ b/packages/docs-snippets/src/snippets/addresses.no-net.ts
@@ -20,7 +20,9 @@ import {
   mainnet,
   type NetworkId,
 } from '@midnightntwrk/wallet-sdk';
-import * as ledger from '@midnightntwrk/ledger-v9';
+// Addresses are a property of the seed, not of the ledger version: the pre-fork ledger derives the same keys from the
+// same seeds, so an address stays valid across a protocol boundary. The post-fork ledger is imported here to derive them.
+import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
 
 const networkId: NetworkId.NetworkId = 'undeployed';
 

--- a/packages/docs-snippets/src/snippets/balancing.ts
+++ b/packages/docs-snippets/src/snippets/balancing.ts
@@ -10,8 +10,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { generateRandomSeed, Token, WalletTransaction } from '@midnightntwrk/wallet-sdk';
-import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
+import { type FacadeState, generateRandomSeed, Token, WalletTransaction } from '@midnightntwrk/wallet-sdk';
+import * as v8 from '@midnightntwrk/wallet-sdk/ledger/v8';
+import * as v9 from '@midnightntwrk/wallet-sdk/ledger/v9';
 import { Buffer } from 'buffer';
 import * as rx from 'rxjs';
 import { configuration, initWalletWithSeed } from '../utils.ts';
@@ -24,41 +25,34 @@ const receiver = await initWalletWithSeed(Buffer.from(generateRandomSeed()));
 const initialSenderState = await rx.firstValueFrom(sender.wallet.state().pipe(rx.filter((s) => s.isSynced)));
 const initialBalance = initialSenderState.unshielded.balances[Token.night] ?? 0n;
 
-// Authoring is choosing a ledger version, and the module imported above is the post-fork one. A transaction it builds
-// is sealed with the version the wallets are acting at, which is what every wallet entry point checks a handle against.
-// Below the boundary the import would be `@midnightntwrk/wallet-sdk/ledger/v8`, so this example refuses to run there
-// rather than hand post-fork bytes to a wallet on the pre-fork ledger.
-const authoredFor = initialSenderState.activeProtocolVersion;
-if (authoredFor < configuration.forkVersion) {
-  throw new Error(
-    `This example authors with the post-fork ledger, but the chain is at protocol version ${authoredFor}`,
-  );
-}
-
-const makeTransactionBlueprint = () => {
-  const unshieldedOffer = ledger.UnshieldedOffer.new(
-    [],
-    [
-      {
-        value: initialBalance,
-        owner: receiver.unshieldedKeystore.getAddress(),
-        type: Token.night,
-      },
-    ],
-    [],
-  );
-  const intent = ledger.Intent.new(new Date(Date.now() + 30 * 60 * 1000));
-  intent.fallibleUnshieldedOffer = unshieldedOffer;
-  // An application that builds its own transaction is the one thing that has to say which ledger version built it.
+// Authoring is choosing a ledger version, and the wallet says which: the version the wallets are acting at decides
+// whether the bytes follow the pre-fork ledger's rules or the post-fork one's. It is read when the transaction is
+// built, not once at start — a wallet that follows the chain across the fork moves from one ledger to the other, and
+// the code that authors for it has to move with it. The two bodies below are the same call for call; only the module
+// differs. The handle is sealed with that version, which is how the wallet knows which of its variants may read it.
+const makeTransactionBlueprint = (state: FacadeState) => {
+  const ttl = new Date(Date.now() + 30 * 60 * 1000);
+  const output = { value: initialBalance, owner: receiver.unshieldedKeystore.getAddress(), type: Token.night };
+  const authoredFor = state.activeProtocolVersion;
+  const authorPreFork = () => {
+    const intent = v8.Intent.new(ttl);
+    intent.fallibleUnshieldedOffer = v8.UnshieldedOffer.new([], [output], []);
+    return v8.Transaction.fromParts(configuration.networkId, undefined, undefined, intent);
+  };
+  const authorPostFork = () => {
+    const intent = v9.Intent.new(ttl);
+    intent.fallibleUnshieldedOffer = v9.UnshieldedOffer.new([], [output], []);
+    return v9.Transaction.fromParts(configuration.networkId, undefined, undefined, intent);
+  };
   return WalletTransaction.adopt(
     'Unproven',
-    ledger.Transaction.fromParts(configuration.networkId, undefined, undefined, intent),
+    authoredFor < configuration.forkVersion ? authorPreFork() : authorPostFork(),
     authoredFor,
   );
 };
 
 await sender.wallet
-  .balanceUnprovenTransaction(makeTransactionBlueprint(), {
+  .balanceUnprovenTransaction(makeTransactionBlueprint(initialSenderState), {
     ttl: new Date(Date.now() + 30 * 60 * 1000),
   })
   .then((recipe) => {

--- a/packages/docs-snippets/src/snippets/balancing.ts
+++ b/packages/docs-snippets/src/snippets/balancing.ts
@@ -10,11 +10,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { generateRandomSeed, ProtocolVersion, Token, WalletTransaction } from '@midnightntwrk/wallet-sdk';
+import { generateRandomSeed, Token, WalletTransaction } from '@midnightntwrk/wallet-sdk';
 import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
 import { Buffer } from 'buffer';
 import * as rx from 'rxjs';
-import { initWalletWithSeed } from '../utils.ts';
+import { configuration, initWalletWithSeed } from '../utils.ts';
 
 const sender = await initWalletWithSeed(
   Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex'),
@@ -23,6 +23,17 @@ const receiver = await initWalletWithSeed(Buffer.from(generateRandomSeed()));
 
 const initialSenderState = await rx.firstValueFrom(sender.wallet.state().pipe(rx.filter((s) => s.isSynced)));
 const initialBalance = initialSenderState.unshielded.balances[Token.night] ?? 0n;
+
+// Authoring is choosing a ledger version, and the module imported above is the post-fork one. A transaction it builds
+// is sealed with the version the wallets are acting at, which is what every wallet entry point checks a handle against.
+// Below the boundary the import would be `@midnightntwrk/wallet-sdk/ledger/v8`, so this example refuses to run there
+// rather than hand post-fork bytes to a wallet on the pre-fork ledger.
+const authoredFor = initialSenderState.activeProtocolVersion;
+if (authoredFor < configuration.forkVersion) {
+  throw new Error(
+    `This example authors with the post-fork ledger, but the chain is at protocol version ${authoredFor}`,
+  );
+}
 
 const makeTransactionBlueprint = () => {
   const unshieldedOffer = ledger.UnshieldedOffer.new(
@@ -38,12 +49,11 @@ const makeTransactionBlueprint = () => {
   );
   const intent = ledger.Intent.new(new Date(Date.now() + 30 * 60 * 1000));
   intent.fallibleUnshieldedOffer = unshieldedOffer;
-  // Sealed together with the protocol version the ledger module above serves: an application that builds its own
-  // transaction is the one thing that has to say which ledger version built it.
+  // An application that builds its own transaction is the one thing that has to say which ledger version built it.
   return WalletTransaction.adopt(
     'Unproven',
-    ledger.Transaction.fromParts('undeployed', undefined, undefined, intent),
-    ProtocolVersion.MinSupportedVersion,
+    ledger.Transaction.fromParts(configuration.networkId, undefined, undefined, intent),
+    authoredFor,
   );
 };
 

--- a/packages/docs-snippets/src/snippets/dust-fast-sync.ts
+++ b/packages/docs-snippets/src/snippets/dust-fast-sync.ts
@@ -10,7 +10,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import {
   WalletSeeds,
   type DefaultConfiguration,
@@ -26,6 +25,7 @@ import {
   PublicKey,
   UnshieldedWallet,
   mergeWalletEntries,
+  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { V2Builder } from '@midnightntwrk/wallet-sdk/dust/v2';
 import { Buffer } from 'buffer';
@@ -73,7 +73,13 @@ const configuration: DefaultConfiguration = {
 const fastSyncDustWallet = (config: DefaultDustConfiguration) =>
   CustomDustWallet(
     { ...config, anonymityLevel: 7 },
-    new V2Builder().withDefaults().withSync(makeEventLessSyncService, makeEventLessSyncCapability),
+    new V2Builder()
+      .withDefaults()
+      .withSync(makeEventLessSyncService, makeEventLessSyncCapability)
+      // Restated because `withSync` drops it: a sync service names the key material it is started with, so choosing
+      // one un-chooses the derivation from a seed the defaults had set. This service is started with the same
+      // `DustSecretKey` the default one is, and `startWithSeed` below needs the derivation by name.
+      .withStartAuxDefaults(),
   );
 
 const initWalletWithSeed = async (seed: Buffer) => {

--- a/packages/docs-snippets/src/snippets/dust-fast-sync.ts
+++ b/packages/docs-snippets/src/snippets/dust-fast-sync.ts
@@ -27,7 +27,6 @@ import {
   UnshieldedWallet,
   mergeWalletEntries,
   ProtocolVersion,
-  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { makeIndexerChainVersionProbe } from '@midnightntwrk/wallet-sdk/capabilities';
 import { V1Builder } from '@midnightntwrk/wallet-sdk/dust/v1';
@@ -49,7 +48,7 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
   costParameters: {
     feeBlocksMargin: 5,
   },
@@ -63,7 +62,7 @@ const configuration: DefaultConfiguration = {
       backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
     },
     {
-      sinceVersion: V9_NATIVE_FORK_VERSION,
+      sinceVersion: ProtocolVersion.V9NativeForkVersion,
       backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
     },
   ],

--- a/packages/docs-snippets/src/snippets/dust-fast-sync.ts
+++ b/packages/docs-snippets/src/snippets/dust-fast-sync.ts
@@ -14,7 +14,8 @@ import {
   WalletSeeds,
   type DefaultConfiguration,
   type DefaultDustConfiguration,
-  CustomDustWallet,
+  asPreForkDustParameters,
+  CustomForkingDustWallet,
   InMemoryTransactionHistoryStorage,
   WalletEntrySchema,
   WalletFacade,
@@ -25,15 +26,22 @@ import {
   PublicKey,
   UnshieldedWallet,
   mergeWalletEntries,
+  ProtocolVersion,
   V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
-import { V2Builder } from '@midnightntwrk/wallet-sdk/dust/v2';
+import { makeIndexerChainVersionProbe } from '@midnightntwrk/wallet-sdk/capabilities';
+import { V1Builder } from '@midnightntwrk/wallet-sdk/dust/v1';
+import { Migration, V2Builder } from '@midnightntwrk/wallet-sdk/dust/v2';
+import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
 import { Buffer } from 'buffer';
 import { pick } from 'lodash-es';
 
 const INDEXER_PORT = Number.parseInt(process.env['INDEXER_PORT'] ?? '8088', 10);
 const NODE_PORT = Number.parseInt(process.env['NODE_PORT'] ?? '9944', 10);
 const PROOF_SERVER_PORT = Number.parseInt(process.env['PROOF_SERVER_PORT'] ?? '6300', 10);
+// The proof server built against ledger-v8, for the chain's history below `forkVersion`. Never contacted on a chain
+// that has been post-fork since genesis, like the one this runs against.
+const V8_PROOF_SERVER_PORT = Number.parseInt(process.env['V8_PROOF_SERVER_PORT'] ?? '6301', 10);
 const INDEXER_HTTP_URL = `http://localhost:${INDEXER_PORT}/api/v4/graphql`;
 const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
@@ -46,7 +54,19 @@ const configuration: DefaultConfiguration = {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  provingServerUrl: new URL(`http://localhost:${PROOF_SERVER_PORT}`),
+  // One proof server per ledger version: the one built against ledger-v8 answers below `forkVersion`, the one built
+  // against ledger-v9 from it. A transaction is proved by the entry for the version its bytes were authored at, so the
+  // wallet proves on either side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
+  provers: [
+    {
+      sinceVersion: ProtocolVersion.MinSupportedVersion,
+      backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
+    },
+    {
+      sinceVersion: V9_NATIVE_FORK_VERSION,
+      backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
+    },
+  ],
   indexerClientConnection: {
     indexerHttpUrl: INDEXER_HTTP_URL,
     indexerWsUrl: INDEXER_WS_URL,
@@ -63,24 +83,40 @@ const configuration: DefaultConfiguration = {
 // so the wallet hides among roughly 2^anonymityLevel candidate nullifiers (default 7). Raising
 // it improves privacy but downloads more non-matching candidates to filter out locally.
 //
-// Note the `CustomDustWallet` composition: fast sync registers a SINGLE variant, and deliberately
-// so. `DustWallet(config)` registers one variant either side of `forkVersion`, and the pre-fork
-// variant has no projections path at all — it needs `DustLocalState` APIs no pre-fork ledger
-// version has, permanently. A two-variant wallet therefore always begins on the event-replay
-// variant and would only reach projections after migrating, which defeats the point. A wallet
-// composed this way starts on the post-fork variant directly and cannot cross a fork; that is the
-// trade this path makes.
-const fastSyncDustWallet = (config: DefaultDustConfiguration) =>
-  CustomDustWallet(
-    { ...config, anonymityLevel: 7 },
-    new V2Builder()
-      .withDefaults()
-      .withSync(makeEventLessSyncService, makeEventLessSyncCapability)
-      // Restated because `withSync` drops it: a sync service names the key material it is started with, so choosing
-      // one un-chooses the derivation from a seed the defaults had set. This service is started with the same
-      // `DustSecretKey` the default one is, and `startWithSeed` below needs the derivation by name.
-      .withStartAuxDefaults(),
+// Note the composition. `DustWallet(config)` registers the event-replay variant either side of `forkVersion`, and
+// only the ledger-v9 side has a projections path — it rests on `DustLocalState` APIs no ledger-v8 has, permanently. So
+// the fast-syncing wallet is put together from its two halves by hand, the way the shipped one is: the ledger-v8
+// replay variant below the boundary, exactly as shipped, and from the boundary a ledger-v9 variant whose sync is the
+// projections one. On a chain still below the fork it replays events; at the fork it hands its state over
+// (`makeCrossLedgerMigration`) and every pass after that reads projections; on a chain past the fork since genesis —
+// like the one this runs against — the probe starts it on the projections side from the first block.
+const fastSyncDustWallet = (config: DefaultDustConfiguration) => {
+  const dustParameters = config.dustParameters ?? ledger.LedgerParameters.initialParameters().dust;
+  const withProbe: DefaultDustConfiguration = {
+    ...config,
+    chainVersionProbe: config.chainVersionProbe ?? makeIndexerChainVersionProbe(config),
+  };
+  return CustomForkingDustWallet(
+    withProbe,
+    {
+      builder: new V1Builder().withDefaults(),
+      // `dustParameters` is a WASM object of whichever ledger produced it, so the ledger-v8 variant is handed the
+      // ledger-v8 rebuild of the same rates rather than the object itself.
+      configuration: { ...config, dustParameters: asPreForkDustParameters(dustParameters) },
+    },
+    {
+      builder: new V2Builder()
+        .withDefaults()
+        .withSync(makeEventLessSyncService, makeEventLessSyncCapability)
+        // Restated because `withSync` drops it: a sync service names the key material it is started with, so choosing
+        // one un-chooses the derivation from a seed the defaults had set. This service is started with the same
+        // `DustSecretKey` the default one is, and a start from a seed needs the derivation by name on both sides.
+        .withStartAuxDefaults()
+        .withMigration(() => Migration.makeCrossLedgerMigration({ dustParameters })),
+      configuration: { ...config, anonymityLevel: 7 },
+    },
   );
+};
 
 const initWalletWithSeed = async (seed: Buffer) => {
   // One master seed, three wallet seeds. A seed is the only key material that crosses a protocol boundary, so this is

--- a/packages/docs-snippets/src/snippets/dust-sponsorship.ts
+++ b/packages/docs-snippets/src/snippets/dust-sponsorship.ts
@@ -11,16 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
-import {
-  generateRandomSeed,
-  ProtocolVersion,
-  Token,
-  type UnboundTx,
-  WalletTransaction,
-} from '@midnightntwrk/wallet-sdk';
+import { generateRandomSeed, Token, type UnboundTx, WalletTransaction } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import * as rx from 'rxjs';
-import { aFakeProvingProvider, initWalletWithSeed } from '../utils.ts';
+import { aFakeProvingProvider, configuration, initWalletWithSeed } from '../utils.ts';
 
 /*
  * This file demonstrates the flow for "Dust sponsorship" - where the user's wallet is only used
@@ -73,6 +67,17 @@ const userReceivedNight = await rx.firstValueFrom(
 );
 console.log('User received night for main transaction', userReceivedNight.unshielded.balances[Token.night]);
 
+// Authoring is choosing a ledger version, and the module imported above is the post-fork one. A transaction it builds
+// is sealed with the version the wallets are acting at, which is what every wallet entry point checks a handle against.
+// Below the boundary the import would be `@midnightntwrk/wallet-sdk/ledger/v8`, so this example refuses to run there
+// rather than hand post-fork bytes to a wallet on the pre-fork ledger.
+const authoredFor = userReceivedNight.activeProtocolVersion;
+if (authoredFor < configuration.forkVersion) {
+  throw new Error(
+    `This example authors with the post-fork ledger, but the chain is at protocol version ${authoredFor}`,
+  );
+}
+
 const prepareTransactionToBalance = async (): Promise<UnboundTx> => {
   const unshieldedOffer = ledger.UnshieldedOffer.new(
     [],
@@ -87,15 +92,15 @@ const prepareTransactionToBalance = async (): Promise<UnboundTx> => {
   );
   const intent = ledger.Intent.new(new Date(Date.now() + 30 * 60 * 1000));
   intent.fallibleUnshieldedOffer = unshieldedOffer;
-  const unprovenTransaction = ledger.Transaction.fromParts('undeployed', undefined, undefined, intent);
+  const unprovenTransaction = ledger.Transaction.fromParts(configuration.networkId, undefined, undefined, intent);
   // Fake proving will work here as no proofs are involved. This is a major difference compared to real flow
   const proven = await unprovenTransaction.prove(
     aFakeProvingProvider,
     ledger.LedgerParameters.initialParameters().transactionCostModel.runtimeCostModel,
   );
-  // Sealed with the protocol version the ledger module above serves: a transaction an application built for itself is
-  // handed to the wallet as a handle, saying which ledger version made it.
-  return WalletTransaction.adopt('Unbound', proven, ProtocolVersion.MinSupportedVersion);
+  // A transaction an application built for itself is handed to the wallet as a handle, saying which ledger version
+  // made it.
+  return WalletTransaction.adopt('Unbound', proven, authoredFor);
 };
 //Transaction as DApp could prepare it
 const transactionToBalance = await prepareTransactionToBalance();

--- a/packages/docs-snippets/src/snippets/dust-sponsorship.ts
+++ b/packages/docs-snippets/src/snippets/dust-sponsorship.ts
@@ -10,8 +10,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
-import { generateRandomSeed, Token, type UnboundTx, WalletTransaction } from '@midnightntwrk/wallet-sdk';
+import * as v8 from '@midnightntwrk/wallet-sdk/ledger/v8';
+import * as v9 from '@midnightntwrk/wallet-sdk/ledger/v9';
+import {
+  type FacadeState,
+  generateRandomSeed,
+  Token,
+  type UnboundTx,
+  WalletTransaction,
+} from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import * as rx from 'rxjs';
 import { aFakeProvingProvider, configuration, initWalletWithSeed } from '../utils.ts';
@@ -67,43 +74,39 @@ const userReceivedNight = await rx.firstValueFrom(
 );
 console.log('User received night for main transaction', userReceivedNight.unshielded.balances[Token.night]);
 
-// Authoring is choosing a ledger version, and the module imported above is the post-fork one. A transaction it builds
-// is sealed with the version the wallets are acting at, which is what every wallet entry point checks a handle against.
-// Below the boundary the import would be `@midnightntwrk/wallet-sdk/ledger/v8`, so this example refuses to run there
-// rather than hand post-fork bytes to a wallet on the pre-fork ledger.
-const authoredFor = userReceivedNight.activeProtocolVersion;
-if (authoredFor < configuration.forkVersion) {
-  throw new Error(
-    `This example authors with the post-fork ledger, but the chain is at protocol version ${authoredFor}`,
-  );
-}
-
-const prepareTransactionToBalance = async (): Promise<UnboundTx> => {
-  const unshieldedOffer = ledger.UnshieldedOffer.new(
-    [],
-    [
-      {
-        value: nightAmountToSend,
-        owner: sponsor.unshieldedKeystore.getAddress(),
-        type: Token.night,
-      },
-    ],
-    [],
-  );
-  const intent = ledger.Intent.new(new Date(Date.now() + 30 * 60 * 1000));
-  intent.fallibleUnshieldedOffer = unshieldedOffer;
-  const unprovenTransaction = ledger.Transaction.fromParts(configuration.networkId, undefined, undefined, intent);
+// Authoring is choosing a ledger version, and the wallet says which: the version the wallets are acting at decides
+// whether the bytes follow the pre-fork ledger's rules or the post-fork one's. It is read when the transaction is
+// built, not once at start — a wallet that follows the chain across the fork moves from one ledger to the other, and
+// the code that authors for it has to move with it. The two bodies below are the same call for call; only the module
+// differs. The handle is sealed with that version, which is how the wallet knows which of its variants may read it.
+const prepareTransactionToBalance = async (state: FacadeState): Promise<UnboundTx> => {
+  const ttl = new Date(Date.now() + 30 * 60 * 1000);
+  const output = { value: nightAmountToSend, owner: sponsor.unshieldedKeystore.getAddress(), type: Token.night };
+  const authoredFor = state.activeProtocolVersion;
   // Fake proving will work here as no proofs are involved. This is a major difference compared to real flow
-  const proven = await unprovenTransaction.prove(
-    aFakeProvingProvider,
-    ledger.LedgerParameters.initialParameters().transactionCostModel.runtimeCostModel,
-  );
+  const authorPreFork = () => {
+    const intent = v8.Intent.new(ttl);
+    intent.fallibleUnshieldedOffer = v8.UnshieldedOffer.new([], [output], []);
+    return v8.Transaction.fromParts(configuration.networkId, undefined, undefined, intent).prove(
+      aFakeProvingProvider,
+      v8.LedgerParameters.initialParameters().transactionCostModel.runtimeCostModel,
+    );
+  };
+  const authorPostFork = () => {
+    const intent = v9.Intent.new(ttl);
+    intent.fallibleUnshieldedOffer = v9.UnshieldedOffer.new([], [output], []);
+    return v9.Transaction.fromParts(configuration.networkId, undefined, undefined, intent).prove(
+      aFakeProvingProvider,
+      v9.LedgerParameters.initialParameters().transactionCostModel.runtimeCostModel,
+    );
+  };
+  const proven = await (authoredFor < configuration.forkVersion ? authorPreFork() : authorPostFork());
   // A transaction an application built for itself is handed to the wallet as a handle, saying which ledger version
   // made it.
   return WalletTransaction.adopt('Unbound', proven, authoredFor);
 };
 //Transaction as DApp could prepare it
-const transactionToBalance = await prepareTransactionToBalance();
+const transactionToBalance = await prepareTransactionToBalance(userReceivedNight);
 
 // Balanced by user without paying fees
 const transactionWithoutFees = await user.wallet

--- a/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
+++ b/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
@@ -10,7 +10,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import {
   type DefaultConfiguration,
   DustWallet,
@@ -24,6 +23,7 @@ import {
   PublicKey,
   UnshieldedWallet,
   mergeWalletEntries,
+  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import { pick } from 'lodash-es';

--- a/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
+++ b/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
@@ -23,6 +23,7 @@ import {
   PublicKey,
   UnshieldedWallet,
   mergeWalletEntries,
+  ProtocolVersion,
   V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
@@ -31,6 +32,9 @@ import { pick } from 'lodash-es';
 const INDEXER_PORT = Number.parseInt(process.env['INDEXER_PORT'] ?? '8088', 10);
 const NODE_PORT = Number.parseInt(process.env['NODE_PORT'] ?? '9944', 10);
 const PROOF_SERVER_PORT = Number.parseInt(process.env['PROOF_SERVER_PORT'] ?? '6300', 10);
+// The proof server built against ledger-v8, for the chain's history below `forkVersion`. Never contacted on a chain
+// that has been post-fork since genesis, like the one this runs against.
+const V8_PROOF_SERVER_PORT = Number.parseInt(process.env['V8_PROOF_SERVER_PORT'] ?? '6301', 10);
 const INDEXER_HTTP_URL = `http://localhost:${INDEXER_PORT}/api/v4/graphql`;
 const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
@@ -43,7 +47,19 @@ const configuration: DefaultConfiguration = {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  provingServerUrl: new URL(`http://localhost:${PROOF_SERVER_PORT}`),
+  // One proof server per ledger version: the one built against ledger-v8 answers below `forkVersion`, the one built
+  // against ledger-v9 from it. A transaction is proved by the entry for the version its bytes were authored at, so the
+  // wallet proves on either side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
+  provers: [
+    {
+      sinceVersion: ProtocolVersion.MinSupportedVersion,
+      backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
+    },
+    {
+      sinceVersion: V9_NATIVE_FORK_VERSION,
+      backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
+    },
+  ],
   indexerClientConnection: {
     indexerHttpUrl: INDEXER_HTTP_URL,
     indexerWsUrl: INDEXER_WS_URL,

--- a/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
+++ b/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
@@ -24,7 +24,6 @@ import {
   UnshieldedWallet,
   mergeWalletEntries,
   ProtocolVersion,
-  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import { pick } from 'lodash-es';
@@ -42,7 +41,7 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
   costParameters: {
     feeBlocksMargin: 5,
   },
@@ -56,7 +55,7 @@ const configuration: DefaultConfiguration = {
       backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
     },
     {
-      sinceVersion: V9_NATIVE_FORK_VERSION,
+      sinceVersion: ProtocolVersion.V9NativeForkVersion,
       backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
     },
   ],

--- a/packages/docs-snippets/src/snippets/hard-fork-support.ts
+++ b/packages/docs-snippets/src/snippets/hard-fork-support.ts
@@ -46,7 +46,6 @@ import {
   WalletEntrySchema,
   WalletFacade,
   WalletSeeds,
-  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import { Either } from 'effect';
@@ -68,7 +67,7 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
   costParameters: {
     feeBlocksMargin: 5,
   },
@@ -92,7 +91,7 @@ const configuration: DefaultConfiguration = {
       backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
     },
     {
-      sinceVersion: V9_NATIVE_FORK_VERSION,
+      sinceVersion: ProtocolVersion.V9NativeForkVersion,
       backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
     },
   ],

--- a/packages/docs-snippets/src/snippets/hard-fork-support.ts
+++ b/packages/docs-snippets/src/snippets/hard-fork-support.ts
@@ -33,7 +33,6 @@
  * executable proof of it lives in each wallet package's `src/test/forkSimulation.test.ts` and
  * `src/test/forkStart.test.ts`.
  */
-import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import {
   createKeystore,
   type DefaultConfiguration,
@@ -46,6 +45,7 @@ import {
   WalletEntrySchema,
   WalletFacade,
   WalletSeeds,
+  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import { Either } from 'effect';

--- a/packages/docs-snippets/src/snippets/hd.no-net.ts
+++ b/packages/docs-snippets/src/snippets/hd.no-net.ts
@@ -10,7 +10,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import * as ledger from '@midnightntwrk/ledger-v9';
+// Key objects belong to one ledger version; the seeds they are derived from do not. Every ledger version derives the
+// same identity from the same seed, which is why a wallet that has to follow the chain across a protocol boundary is
+// started from seeds — `WalletSeeds.fromMasterSeed` does the derivation below — and not from the key objects. The
+// post-fork ledger is imported here only to show what those seeds become.
+import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
 import { type Role, type AccountKey, HDWallet, Roles } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 
@@ -45,7 +49,7 @@ function deriveAllKeys(seed: Uint8Array) {
   };
 }
 
-const seed = Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex'); // or generateRandomSeed() from @midnightntwrk/wallet-sdk-hd
+const seed = Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex'); // or generateRandomSeed() from @midnightntwrk/wallet-sdk
 const derivedKeys = deriveAllKeys(seed);
 seed.fill(0);
 

--- a/packages/docs-snippets/src/snippets/initialization.ts
+++ b/packages/docs-snippets/src/snippets/initialization.ts
@@ -10,7 +10,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import {
   WalletSeeds,
   type DefaultConfiguration,
@@ -23,6 +22,7 @@ import {
   PublicKey,
   UnshieldedWallet,
   mergeWalletEntries,
+  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import { pick } from 'lodash-es';

--- a/packages/docs-snippets/src/snippets/initialization.ts
+++ b/packages/docs-snippets/src/snippets/initialization.ts
@@ -22,6 +22,7 @@ import {
   PublicKey,
   UnshieldedWallet,
   mergeWalletEntries,
+  ProtocolVersion,
   V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
@@ -30,6 +31,9 @@ import { pick } from 'lodash-es';
 const INDEXER_PORT = Number.parseInt(process.env['INDEXER_PORT'] ?? '8088', 10);
 const NODE_PORT = Number.parseInt(process.env['NODE_PORT'] ?? '9944', 10);
 const PROOF_SERVER_PORT = Number.parseInt(process.env['PROOF_SERVER_PORT'] ?? '6300', 10);
+// The proof server built against ledger-v8, for the chain's history below `forkVersion`. Never contacted on a chain
+// that has been post-fork since genesis, like the one this runs against.
+const V8_PROOF_SERVER_PORT = Number.parseInt(process.env['V8_PROOF_SERVER_PORT'] ?? '6301', 10);
 const INDEXER_HTTP_URL = `http://localhost:${INDEXER_PORT}/api/v4/graphql`;
 const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
@@ -42,7 +46,19 @@ const configuration: DefaultConfiguration = {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  provingServerUrl: new URL(`http://localhost:${PROOF_SERVER_PORT}`),
+  // One proof server per ledger version: the one built against ledger-v8 answers below `forkVersion`, the one built
+  // against ledger-v9 from it. A transaction is proved by the entry for the version its bytes were authored at, so the
+  // wallet proves on either side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
+  provers: [
+    {
+      sinceVersion: ProtocolVersion.MinSupportedVersion,
+      backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
+    },
+    {
+      sinceVersion: V9_NATIVE_FORK_VERSION,
+      backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
+    },
+  ],
   indexerClientConnection: {
     indexerHttpUrl: INDEXER_HTTP_URL,
     indexerWsUrl: INDEXER_WS_URL,

--- a/packages/docs-snippets/src/snippets/initialization.ts
+++ b/packages/docs-snippets/src/snippets/initialization.ts
@@ -23,7 +23,6 @@ import {
   UnshieldedWallet,
   mergeWalletEntries,
   ProtocolVersion,
-  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import { pick } from 'lodash-es';
@@ -41,7 +40,7 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
   costParameters: {
     feeBlocksMargin: 5,
   },
@@ -55,7 +54,7 @@ const configuration: DefaultConfiguration = {
       backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
     },
     {
-      sinceVersion: V9_NATIVE_FORK_VERSION,
+      sinceVersion: ProtocolVersion.V9NativeForkVersion,
       backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
     },
   ],

--- a/packages/docs-snippets/src/snippets/wasm-prover.ts
+++ b/packages/docs-snippets/src/snippets/wasm-prover.ts
@@ -31,7 +31,6 @@ import {
   PublicKey,
   UnshieldedWallet,
   mergeWalletEntries,
-  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import { pick } from 'lodash-es';
@@ -45,7 +44,7 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/wasm-prover.ts
+++ b/packages/docs-snippets/src/snippets/wasm-prover.ts
@@ -64,10 +64,12 @@ const initWalletWithSeed = async (seed: Buffer) => {
     shielded: (config) => ShieldedWallet(config).startWithSeed(seeds.shielded),
     unshielded: (config) => UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
     dust: (config) => DustWallet(config).startWithSeed(seeds.dust),
-    // In-process proving instead of a proof server. The prover is built against the post-fork ledger's circuits, so it
-    // is registered from `forkVersion` — the same way a proof server is under `provingServers`. A transaction is proved
-    // by the backend registered for the version its own bytes were authored at, and one authored below the boundary is
-    // refused (`UnsupportedProvingVersionError`) rather than proved with the wrong circuits.
+    // In-process proving instead of a proof server. The prover holds the post-fork ledger's circuits, so it answers
+    // from `forkVersion`, the way a proof server does under `provingServers`: a transaction is proved by the backend
+    // registered for the version its own bytes were authored at. The pre-fork ledger has no in-process prover, so on a
+    // chain below the boundary that range is served by a proof server built for it — one more entry in the same
+    // registry, `{ range: makeRange(MinSupportedVersion, forkVersion), value: makeServerProvingServiceEffect({ url }) }`,
+    // once such a server is deployed. Until then this wallet proves nothing below `forkVersion`.
     provingService: () =>
       wrapVersionedEffectService(makeVersionedProvingServiceEffect(makeWasmProvingServices(V9_NATIVE_FORK_VERSION))),
   });

--- a/packages/docs-snippets/src/snippets/wasm-prover.ts
+++ b/packages/docs-snippets/src/snippets/wasm-prover.ts
@@ -10,7 +10,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import {
   WalletSeeds,
   type DefaultConfiguration,
@@ -23,8 +22,13 @@ import {
   PublicKey,
   UnshieldedWallet,
   mergeWalletEntries,
+  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
-import { makeWasmProvingService } from '@midnightntwrk/wallet-sdk/capabilities';
+import {
+  makeVersionedProvingServiceEffect,
+  makeWasmProvingServices,
+  wrapVersionedEffectService,
+} from '@midnightntwrk/wallet-sdk/capabilities';
 import { Buffer } from 'buffer';
 import { pick } from 'lodash-es';
 
@@ -60,7 +64,12 @@ const initWalletWithSeed = async (seed: Buffer) => {
     shielded: (config) => ShieldedWallet(config).startWithSeed(seeds.shielded),
     unshielded: (config) => UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
     dust: (config) => DustWallet(config).startWithSeed(seeds.dust),
-    provingService: () => makeWasmProvingService(),
+    // In-process proving instead of a proof server. The prover is built against the post-fork ledger's circuits, so it
+    // is registered from `forkVersion` — the same way a proof server is under `provingServers`. A transaction is proved
+    // by the backend registered for the version its own bytes were authored at, and one authored below the boundary is
+    // refused (`UnsupportedProvingVersionError`) rather than proved with the wrong circuits.
+    provingService: () =>
+      wrapVersionedEffectService(makeVersionedProvingServiceEffect(makeWasmProvingServices(V9_NATIVE_FORK_VERSION))),
   });
 
   await wallet.start(seeds);

--- a/packages/docs-snippets/src/snippets/well-formed-validation.ts
+++ b/packages/docs-snippets/src/snippets/well-formed-validation.ts
@@ -10,8 +10,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
-import { generateRandomSeed, Token, WalletTransaction } from '@midnightntwrk/wallet-sdk';
+import * as v8 from '@midnightntwrk/wallet-sdk/ledger/v8';
+import * as v9 from '@midnightntwrk/wallet-sdk/ledger/v9';
+import { type FacadeState, generateRandomSeed, Token, WalletTransaction } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import * as rx from 'rxjs';
 import { configuration, initWalletWithSeed } from '../utils.ts';
@@ -24,35 +25,34 @@ const receiver = await initWalletWithSeed(Buffer.from(generateRandomSeed()));
 const initialSenderState = await rx.firstValueFrom(sender.wallet.state().pipe(rx.filter((s) => s.isSynced)));
 const initialBalance = initialSenderState.unshielded.balances[Token.night] ?? 0n;
 
-// Authoring is choosing a ledger version, and the module imported above is the post-fork one. A transaction it builds
-// is sealed with the version the wallets are acting at, which is what every wallet entry point checks a handle against.
-// Below the boundary the import would be `@midnightntwrk/wallet-sdk/ledger/v8`, so this example refuses to run there
-// rather than hand post-fork bytes to a wallet on the pre-fork ledger.
-const authoredFor = initialSenderState.activeProtocolVersion;
-if (authoredFor < configuration.forkVersion) {
-  throw new Error(
-    `This example authors with the post-fork ledger, but the chain is at protocol version ${authoredFor}`,
-  );
-}
-
-const buildUnprovenTransaction = () => {
-  const unshieldedOffer = ledger.UnshieldedOffer.new(
-    [],
-    [{ value: initialBalance, owner: receiver.unshieldedKeystore.getAddress(), type: Token.night }],
-    [],
-  );
-  const intent = ledger.Intent.new(new Date(Date.now() + 30 * 60 * 1000));
-  intent.fallibleUnshieldedOffer = unshieldedOffer;
-  // The version is how the wallet knows which of its variants may read these bytes, and which prover and validator
-  // answer for them.
+// Authoring is choosing a ledger version, and the wallet says which: the version the wallets are acting at decides
+// whether the bytes follow the pre-fork ledger's rules or the post-fork one's. It is read when the transaction is
+// built, not once at start — a wallet that follows the chain across the fork moves from one ledger to the other, and
+// the code that authors for it has to move with it. The two bodies below are the same call for call; only the module
+// differs. The handle is sealed with that version, which is how the wallet knows which of its variants may read it.
+const buildUnprovenTransaction = (state: FacadeState) => {
+  const ttl = new Date(Date.now() + 30 * 60 * 1000);
+  const output = { value: initialBalance, owner: receiver.unshieldedKeystore.getAddress(), type: Token.night };
+  const authoredFor = state.activeProtocolVersion;
+  const authorPreFork = () => {
+    const intent = v8.Intent.new(ttl);
+    intent.fallibleUnshieldedOffer = v8.UnshieldedOffer.new([], [output], []);
+    return v8.Transaction.fromParts(configuration.networkId, undefined, undefined, intent);
+  };
+  const authorPostFork = () => {
+    const intent = v9.Intent.new(ttl);
+    intent.fallibleUnshieldedOffer = v9.UnshieldedOffer.new([], [output], []);
+    return v9.Transaction.fromParts(configuration.networkId, undefined, undefined, intent);
+  };
+  // The version also picks which prover and validator answer for these bytes further down.
   return WalletTransaction.adopt(
     'Unproven',
-    ledger.Transaction.fromParts(configuration.networkId, undefined, undefined, intent),
+    authoredFor < configuration.forkVersion ? authorPreFork() : authorPostFork(),
     authoredFor,
   );
 };
 
-const unprovenTx = buildUnprovenTransaction();
+const unprovenTx = buildUnprovenTransaction(initialSenderState);
 
 // Stage 1: validate the unproven transaction before balancing.
 // The same flag combination applies to balanceUnboundTransaction.

--- a/packages/docs-snippets/src/snippets/well-formed-validation.ts
+++ b/packages/docs-snippets/src/snippets/well-formed-validation.ts
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
-import { generateRandomSeed, ProtocolVersion, Token, WalletTransaction } from '@midnightntwrk/wallet-sdk';
+import { generateRandomSeed, Token, WalletTransaction } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import * as rx from 'rxjs';
-import { initWalletWithSeed } from '../utils.ts';
+import { configuration, initWalletWithSeed } from '../utils.ts';
 
 const sender = await initWalletWithSeed(
   Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex'),
@@ -24,6 +24,17 @@ const receiver = await initWalletWithSeed(Buffer.from(generateRandomSeed()));
 const initialSenderState = await rx.firstValueFrom(sender.wallet.state().pipe(rx.filter((s) => s.isSynced)));
 const initialBalance = initialSenderState.unshielded.balances[Token.night] ?? 0n;
 
+// Authoring is choosing a ledger version, and the module imported above is the post-fork one. A transaction it builds
+// is sealed with the version the wallets are acting at, which is what every wallet entry point checks a handle against.
+// Below the boundary the import would be `@midnightntwrk/wallet-sdk/ledger/v8`, so this example refuses to run there
+// rather than hand post-fork bytes to a wallet on the pre-fork ledger.
+const authoredFor = initialSenderState.activeProtocolVersion;
+if (authoredFor < configuration.forkVersion) {
+  throw new Error(
+    `This example authors with the post-fork ledger, but the chain is at protocol version ${authoredFor}`,
+  );
+}
+
 const buildUnprovenTransaction = () => {
   const unshieldedOffer = ledger.UnshieldedOffer.new(
     [],
@@ -32,12 +43,12 @@ const buildUnprovenTransaction = () => {
   );
   const intent = ledger.Intent.new(new Date(Date.now() + 30 * 60 * 1000));
   intent.fallibleUnshieldedOffer = unshieldedOffer;
-  // Sealed with the protocol version the ledger module above serves, which is how the wallet knows which of its
-  // variants may read these bytes and which prover and validator answer for them.
+  // The version is how the wallet knows which of its variants may read these bytes, and which prover and validator
+  // answer for them.
   return WalletTransaction.adopt(
     'Unproven',
-    ledger.Transaction.fromParts('undeployed', undefined, undefined, intent),
-    ProtocolVersion.MinSupportedVersion,
+    ledger.Transaction.fromParts(configuration.networkId, undefined, undefined, intent),
+    authoredFor,
   );
 };
 

--- a/packages/docs-snippets/src/test/__snapshots__/test-snippets.undeployed.test.ts.snap
+++ b/packages/docs-snippets/src/test/__snapshots__/test-snippets.undeployed.test.ts.snap
@@ -499,7 +499,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '4f01b08ab148c772c79546ddd0ea01e590faff67d2b8c45d6286c3b712e56566',
+          intentHash: '712928a30857eaf9156d6586cfd4da630857890204141095a06abf35ddc1a45f',
           outputNo: 0
         },
         meta: {
@@ -512,7 +512,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '9088914a55294e336fc812e224c8f49fd9e85a77a949f0cd5d803fcf3617f58a',
+          intentHash: '60a18d41c9c5bf3eabe7af5c76bd1f51a2a2a3be7b39d252a624bbaa40f1ab64',
           outputNo: 0
         },
         meta: {
@@ -525,7 +525,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '3ed92a2b3eb60560d7731ab3991c8727ffa10422053d908ee1abebe4efa983f3',
+          intentHash: '25fe03f8906c9bd2a9db4f2690d2e9e4f17b4194cc41b79458076d8ae486afaf',
           outputNo: 0
         },
         meta: {
@@ -538,7 +538,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: 'b4d50fe61f991089873e1024e101b4796df0a0a32d7ac2b68c2ab0f389ed163d',
+          intentHash: 'f66718af2c6a3d4f217f605194408c13563121e936f0015f22a2a405598e60f6',
           outputNo: 0
         },
         meta: {
@@ -551,7 +551,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '01c5ad3ff58d687dfe27fc779726188adfe777de5efa8f938a014d7fd7045c59',
+          intentHash: '8333a6a659b0000423af1448f1621662ebb8335bfaa0947b295c301483ab882f',
           outputNo: 0
         },
         meta: {
@@ -567,7 +567,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '4f01b08ab148c772c79546ddd0ea01e590faff67d2b8c45d6286c3b712e56566',
+          intentHash: '712928a30857eaf9156d6586cfd4da630857890204141095a06abf35ddc1a45f',
           outputNo: 0
         },
         meta: {
@@ -580,7 +580,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '9088914a55294e336fc812e224c8f49fd9e85a77a949f0cd5d803fcf3617f58a',
+          intentHash: '60a18d41c9c5bf3eabe7af5c76bd1f51a2a2a3be7b39d252a624bbaa40f1ab64',
           outputNo: 0
         },
         meta: {
@@ -593,7 +593,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '3ed92a2b3eb60560d7731ab3991c8727ffa10422053d908ee1abebe4efa983f3',
+          intentHash: '25fe03f8906c9bd2a9db4f2690d2e9e4f17b4194cc41b79458076d8ae486afaf',
           outputNo: 0
         },
         meta: {
@@ -606,7 +606,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: 'b4d50fe61f991089873e1024e101b4796df0a0a32d7ac2b68c2ab0f389ed163d',
+          intentHash: 'f66718af2c6a3d4f217f605194408c13563121e936f0015f22a2a405598e60f6',
           outputNo: 0
         },
         meta: {
@@ -619,7 +619,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '01c5ad3ff58d687dfe27fc779726188adfe777de5efa8f938a014d7fd7045c59',
+          intentHash: '8333a6a659b0000423af1448f1621662ebb8335bfaa0947b295c301483ab882f',
           outputNo: 0
         },
         meta: {
@@ -655,26 +655,10 @@ exports[`Snippet outputs > with network > should output the correct result for '
         token: {
           initialValue: 0n,
           owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 13088517450973686970152768661065689363167451574549707287779681333087175449879n,
+          nonce: 24034453359289059849897357334564325073097009103426486395115878951231362120630n,
           seq: 0,
           ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: '47efc37cb1f6e9840820529e664a26ef73faae932466aaf94cb523c2df577051',
-          mtIndex: 3n
-        },
-        dtime: undefined,
-        maxCap: 250000000000000000000000n,
-        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
-        generatedNow: 0n,
-        rate: 413350000000000000n
-      },
-      {
-        token: {
-          initialValue: 0n,
-          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 42893292875135508753536130035348474003127516395402026718833581445210855971899n,
-          seq: 0,
-          ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: 'f5e761a22c22f362f1e62435c303c3f6210d93cde80f4ada80465002a172ecc9',
+          backingNight: '10ba51819808fc09897af46574aa37b3fee89f7dc0dde00cae2924d09d3c33b5',
           mtIndex: 1n
         },
         dtime: undefined,
@@ -687,26 +671,10 @@ exports[`Snippet outputs > with network > should output the correct result for '
         token: {
           initialValue: 0n,
           owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 1745140344819704722944939379634971667776427568416407665182918455673712706265n,
+          nonce: 31442200660458619681158617659182332215873696935192568222776955722661365985367n,
           seq: 0,
           ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: 'dbc992416fb38e47a2bf278c7b1ae21ffd5cbd9e8053e8a005b0b5f169d3ba0d',
-          mtIndex: 0n
-        },
-        dtime: undefined,
-        maxCap: 250000000000000000000000n,
-        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
-        generatedNow: 0n,
-        rate: 413350000000000000n
-      },
-      {
-        token: {
-          initialValue: 0n,
-          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 47328617721753985431634820245914989086163962200470388189810085622249242341812n,
-          seq: 0,
-          ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: 'd087d400e91da16db57f168bf66a3a81ef6dc81d19e65f5b15c45a2b1a1bdb37',
+          backingNight: 'adde850d59eb29dfe814ef592dcbdb5589841a219d37d9adbfccef7049323761',
           mtIndex: 4n
         },
         dtime: undefined,
@@ -719,11 +687,43 @@ exports[`Snippet outputs > with network > should output the correct result for '
         token: {
           initialValue: 0n,
           owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 27457460796546782211544967038462586941404094425927548594800125881255297448521n,
+          nonce: 32085853901361226275975148233968772158240692306844594632853942642512958619094n,
           seq: 0,
           ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: '26016f630a34d8c1c5f43c41783ff67ceb82c5181529428cca0fbe9efcd28296',
+          backingNight: 'adf6979ee2caf3662dabe4588eb2311de04e97293c6f96e366bd4a67034d87e7',
+          mtIndex: 0n
+        },
+        dtime: undefined,
+        maxCap: 250000000000000000000000n,
+        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
+        generatedNow: 0n,
+        rate: 413350000000000000n
+      },
+      {
+        token: {
+          initialValue: 0n,
+          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
+          nonce: 50586679687627173730485799926282314706847051589385752828012176203617501615946n,
+          seq: 0,
+          ctime: 2025-08-05T12:00:00.000Z,
+          backingNight: '35c11fc00b7f242d172ebade4edbb1d123134b444f6562ecfa80feb76eda126a',
           mtIndex: 2n
+        },
+        dtime: undefined,
+        maxCap: 250000000000000000000000n,
+        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
+        generatedNow: 0n,
+        rate: 413350000000000000n
+      },
+      {
+        token: {
+          initialValue: 0n,
+          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
+          nonce: 39236833992364654568272956423128803082965139162007277965439978026566466488297n,
+          seq: 0,
+          ctime: 2025-08-05T12:00:00.000Z,
+          backingNight: '15b3234d60a4ed3adefcc87dd4673c738a40455848a52787079dabddc072cbde',
+          mtIndex: 3n
         },
         dtime: undefined,
         maxCap: 250000000000000000000000n,
@@ -737,26 +737,10 @@ exports[`Snippet outputs > with network > should output the correct result for '
         token: {
           initialValue: 0n,
           owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 13088517450973686970152768661065689363167451574549707287779681333087175449879n,
+          nonce: 24034453359289059849897357334564325073097009103426486395115878951231362120630n,
           seq: 0,
           ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: '47efc37cb1f6e9840820529e664a26ef73faae932466aaf94cb523c2df577051',
-          mtIndex: 3n
-        },
-        dtime: undefined,
-        maxCap: 250000000000000000000000n,
-        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
-        generatedNow: 0n,
-        rate: 413350000000000000n
-      },
-      {
-        token: {
-          initialValue: 0n,
-          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 42893292875135508753536130035348474003127516395402026718833581445210855971899n,
-          seq: 0,
-          ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: 'f5e761a22c22f362f1e62435c303c3f6210d93cde80f4ada80465002a172ecc9',
+          backingNight: '10ba51819808fc09897af46574aa37b3fee89f7dc0dde00cae2924d09d3c33b5',
           mtIndex: 1n
         },
         dtime: undefined,
@@ -769,26 +753,10 @@ exports[`Snippet outputs > with network > should output the correct result for '
         token: {
           initialValue: 0n,
           owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 1745140344819704722944939379634971667776427568416407665182918455673712706265n,
+          nonce: 31442200660458619681158617659182332215873696935192568222776955722661365985367n,
           seq: 0,
           ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: 'dbc992416fb38e47a2bf278c7b1ae21ffd5cbd9e8053e8a005b0b5f169d3ba0d',
-          mtIndex: 0n
-        },
-        dtime: undefined,
-        maxCap: 250000000000000000000000n,
-        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
-        generatedNow: 0n,
-        rate: 413350000000000000n
-      },
-      {
-        token: {
-          initialValue: 0n,
-          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 47328617721753985431634820245914989086163962200470388189810085622249242341812n,
-          seq: 0,
-          ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: 'd087d400e91da16db57f168bf66a3a81ef6dc81d19e65f5b15c45a2b1a1bdb37',
+          backingNight: 'adde850d59eb29dfe814ef592dcbdb5589841a219d37d9adbfccef7049323761',
           mtIndex: 4n
         },
         dtime: undefined,
@@ -801,11 +769,43 @@ exports[`Snippet outputs > with network > should output the correct result for '
         token: {
           initialValue: 0n,
           owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 27457460796546782211544967038462586941404094425927548594800125881255297448521n,
+          nonce: 32085853901361226275975148233968772158240692306844594632853942642512958619094n,
           seq: 0,
           ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: '26016f630a34d8c1c5f43c41783ff67ceb82c5181529428cca0fbe9efcd28296',
+          backingNight: 'adf6979ee2caf3662dabe4588eb2311de04e97293c6f96e366bd4a67034d87e7',
+          mtIndex: 0n
+        },
+        dtime: undefined,
+        maxCap: 250000000000000000000000n,
+        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
+        generatedNow: 0n,
+        rate: 413350000000000000n
+      },
+      {
+        token: {
+          initialValue: 0n,
+          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
+          nonce: 50586679687627173730485799926282314706847051589385752828012176203617501615946n,
+          seq: 0,
+          ctime: 2025-08-05T12:00:00.000Z,
+          backingNight: '35c11fc00b7f242d172ebade4edbb1d123134b444f6562ecfa80feb76eda126a',
           mtIndex: 2n
+        },
+        dtime: undefined,
+        maxCap: 250000000000000000000000n,
+        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
+        generatedNow: 0n,
+        rate: 413350000000000000n
+      },
+      {
+        token: {
+          initialValue: 0n,
+          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
+          nonce: 39236833992364654568272956423128803082965139162007277965439978026566466488297n,
+          seq: 0,
+          ctime: 2025-08-05T12:00:00.000Z,
+          backingNight: '15b3234d60a4ed3adefcc87dd4673c738a40455848a52787079dabddc072cbde',
+          mtIndex: 3n
         },
         dtime: undefined,
         maxCap: 250000000000000000000000n,
@@ -816,8 +816,8 @@ exports[`Snippet outputs > with network > should output the correct result for '
     ],
     pendingCoins: [],
     progress: {
-      appliedIndex: 128n,
-      highestRelevantWalletIndex: 128n,
+      appliedIndex: 50n,
+      highestRelevantWalletIndex: 50n,
       highestIndex: 0n,
       highestRelevantIndex: 0n,
       isConnected: true,
@@ -1095,7 +1095,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '4f01b08ab148c772c79546ddd0ea01e590faff67d2b8c45d6286c3b712e56566',
+          intentHash: '712928a30857eaf9156d6586cfd4da630857890204141095a06abf35ddc1a45f',
           outputNo: 0
         },
         meta: {
@@ -1108,7 +1108,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '9088914a55294e336fc812e224c8f49fd9e85a77a949f0cd5d803fcf3617f58a',
+          intentHash: '60a18d41c9c5bf3eabe7af5c76bd1f51a2a2a3be7b39d252a624bbaa40f1ab64',
           outputNo: 0
         },
         meta: {
@@ -1121,7 +1121,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '3ed92a2b3eb60560d7731ab3991c8727ffa10422053d908ee1abebe4efa983f3',
+          intentHash: '25fe03f8906c9bd2a9db4f2690d2e9e4f17b4194cc41b79458076d8ae486afaf',
           outputNo: 0
         },
         meta: {
@@ -1134,7 +1134,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: 'b4d50fe61f991089873e1024e101b4796df0a0a32d7ac2b68c2ab0f389ed163d',
+          intentHash: 'f66718af2c6a3d4f217f605194408c13563121e936f0015f22a2a405598e60f6',
           outputNo: 0
         },
         meta: {
@@ -1147,7 +1147,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '01c5ad3ff58d687dfe27fc779726188adfe777de5efa8f938a014d7fd7045c59',
+          intentHash: '8333a6a659b0000423af1448f1621662ebb8335bfaa0947b295c301483ab882f',
           outputNo: 0
         },
         meta: {
@@ -1163,7 +1163,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '4f01b08ab148c772c79546ddd0ea01e590faff67d2b8c45d6286c3b712e56566',
+          intentHash: '712928a30857eaf9156d6586cfd4da630857890204141095a06abf35ddc1a45f',
           outputNo: 0
         },
         meta: {
@@ -1176,7 +1176,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '9088914a55294e336fc812e224c8f49fd9e85a77a949f0cd5d803fcf3617f58a',
+          intentHash: '60a18d41c9c5bf3eabe7af5c76bd1f51a2a2a3be7b39d252a624bbaa40f1ab64',
           outputNo: 0
         },
         meta: {
@@ -1189,7 +1189,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '3ed92a2b3eb60560d7731ab3991c8727ffa10422053d908ee1abebe4efa983f3',
+          intentHash: '25fe03f8906c9bd2a9db4f2690d2e9e4f17b4194cc41b79458076d8ae486afaf',
           outputNo: 0
         },
         meta: {
@@ -1202,7 +1202,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: 'b4d50fe61f991089873e1024e101b4796df0a0a32d7ac2b68c2ab0f389ed163d',
+          intentHash: 'f66718af2c6a3d4f217f605194408c13563121e936f0015f22a2a405598e60f6',
           outputNo: 0
         },
         meta: {
@@ -1215,7 +1215,7 @@ exports[`Snippet outputs > with network > should output the correct result for '
           value: 50000000000000n,
           owner: 'mn_addr_undeployed1h3ssm5ru2t6eqy4g3she78zlxn96e36ms6pq996aduvmateh9p9sk96u7s',
           type: '0000000000000000000000000000000000000000000000000000000000000000',
-          intentHash: '01c5ad3ff58d687dfe27fc779726188adfe777de5efa8f938a014d7fd7045c59',
+          intentHash: '8333a6a659b0000423af1448f1621662ebb8335bfaa0947b295c301483ab882f',
           outputNo: 0
         },
         meta: {
@@ -1251,26 +1251,10 @@ exports[`Snippet outputs > with network > should output the correct result for '
         token: {
           initialValue: 0n,
           owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 13088517450973686970152768661065689363167451574549707287779681333087175449879n,
+          nonce: 24034453359289059849897357334564325073097009103426486395115878951231362120630n,
           seq: 0,
           ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: '47efc37cb1f6e9840820529e664a26ef73faae932466aaf94cb523c2df577051',
-          mtIndex: 3n
-        },
-        dtime: undefined,
-        maxCap: 250000000000000000000000n,
-        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
-        generatedNow: 0n,
-        rate: 413350000000000000n
-      },
-      {
-        token: {
-          initialValue: 0n,
-          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 42893292875135508753536130035348474003127516395402026718833581445210855971899n,
-          seq: 0,
-          ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: 'f5e761a22c22f362f1e62435c303c3f6210d93cde80f4ada80465002a172ecc9',
+          backingNight: '10ba51819808fc09897af46574aa37b3fee89f7dc0dde00cae2924d09d3c33b5',
           mtIndex: 1n
         },
         dtime: undefined,
@@ -1283,26 +1267,10 @@ exports[`Snippet outputs > with network > should output the correct result for '
         token: {
           initialValue: 0n,
           owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 1745140344819704722944939379634971667776427568416407665182918455673712706265n,
+          nonce: 31442200660458619681158617659182332215873696935192568222776955722661365985367n,
           seq: 0,
           ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: 'dbc992416fb38e47a2bf278c7b1ae21ffd5cbd9e8053e8a005b0b5f169d3ba0d',
-          mtIndex: 0n
-        },
-        dtime: undefined,
-        maxCap: 250000000000000000000000n,
-        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
-        generatedNow: 0n,
-        rate: 413350000000000000n
-      },
-      {
-        token: {
-          initialValue: 0n,
-          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 47328617721753985431634820245914989086163962200470388189810085622249242341812n,
-          seq: 0,
-          ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: 'd087d400e91da16db57f168bf66a3a81ef6dc81d19e65f5b15c45a2b1a1bdb37',
+          backingNight: 'adde850d59eb29dfe814ef592dcbdb5589841a219d37d9adbfccef7049323761',
           mtIndex: 4n
         },
         dtime: undefined,
@@ -1315,11 +1283,43 @@ exports[`Snippet outputs > with network > should output the correct result for '
         token: {
           initialValue: 0n,
           owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 27457460796546782211544967038462586941404094425927548594800125881255297448521n,
+          nonce: 32085853901361226275975148233968772158240692306844594632853942642512958619094n,
           seq: 0,
           ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: '26016f630a34d8c1c5f43c41783ff67ceb82c5181529428cca0fbe9efcd28296',
+          backingNight: 'adf6979ee2caf3662dabe4588eb2311de04e97293c6f96e366bd4a67034d87e7',
+          mtIndex: 0n
+        },
+        dtime: undefined,
+        maxCap: 250000000000000000000000n,
+        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
+        generatedNow: 0n,
+        rate: 413350000000000000n
+      },
+      {
+        token: {
+          initialValue: 0n,
+          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
+          nonce: 50586679687627173730485799926282314706847051589385752828012176203617501615946n,
+          seq: 0,
+          ctime: 2025-08-05T12:00:00.000Z,
+          backingNight: '35c11fc00b7f242d172ebade4edbb1d123134b444f6562ecfa80feb76eda126a',
           mtIndex: 2n
+        },
+        dtime: undefined,
+        maxCap: 250000000000000000000000n,
+        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
+        generatedNow: 0n,
+        rate: 413350000000000000n
+      },
+      {
+        token: {
+          initialValue: 0n,
+          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
+          nonce: 39236833992364654568272956423128803082965139162007277965439978026566466488297n,
+          seq: 0,
+          ctime: 2025-08-05T12:00:00.000Z,
+          backingNight: '15b3234d60a4ed3adefcc87dd4673c738a40455848a52787079dabddc072cbde',
+          mtIndex: 3n
         },
         dtime: undefined,
         maxCap: 250000000000000000000000n,
@@ -1333,26 +1333,10 @@ exports[`Snippet outputs > with network > should output the correct result for '
         token: {
           initialValue: 0n,
           owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 13088517450973686970152768661065689363167451574549707287779681333087175449879n,
+          nonce: 24034453359289059849897357334564325073097009103426486395115878951231362120630n,
           seq: 0,
           ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: '47efc37cb1f6e9840820529e664a26ef73faae932466aaf94cb523c2df577051',
-          mtIndex: 3n
-        },
-        dtime: undefined,
-        maxCap: 250000000000000000000000n,
-        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
-        generatedNow: 0n,
-        rate: 413350000000000000n
-      },
-      {
-        token: {
-          initialValue: 0n,
-          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 42893292875135508753536130035348474003127516395402026718833581445210855971899n,
-          seq: 0,
-          ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: 'f5e761a22c22f362f1e62435c303c3f6210d93cde80f4ada80465002a172ecc9',
+          backingNight: '10ba51819808fc09897af46574aa37b3fee89f7dc0dde00cae2924d09d3c33b5',
           mtIndex: 1n
         },
         dtime: undefined,
@@ -1365,26 +1349,10 @@ exports[`Snippet outputs > with network > should output the correct result for '
         token: {
           initialValue: 0n,
           owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 1745140344819704722944939379634971667776427568416407665182918455673712706265n,
+          nonce: 31442200660458619681158617659182332215873696935192568222776955722661365985367n,
           seq: 0,
           ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: 'dbc992416fb38e47a2bf278c7b1ae21ffd5cbd9e8053e8a005b0b5f169d3ba0d',
-          mtIndex: 0n
-        },
-        dtime: undefined,
-        maxCap: 250000000000000000000000n,
-        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
-        generatedNow: 0n,
-        rate: 413350000000000000n
-      },
-      {
-        token: {
-          initialValue: 0n,
-          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 47328617721753985431634820245914989086163962200470388189810085622249242341812n,
-          seq: 0,
-          ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: 'd087d400e91da16db57f168bf66a3a81ef6dc81d19e65f5b15c45a2b1a1bdb37',
+          backingNight: 'adde850d59eb29dfe814ef592dcbdb5589841a219d37d9adbfccef7049323761',
           mtIndex: 4n
         },
         dtime: undefined,
@@ -1397,11 +1365,43 @@ exports[`Snippet outputs > with network > should output the correct result for '
         token: {
           initialValue: 0n,
           owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
-          nonce: 27457460796546782211544967038462586941404094425927548594800125881255297448521n,
+          nonce: 32085853901361226275975148233968772158240692306844594632853942642512958619094n,
           seq: 0,
           ctime: 2025-08-05T12:00:00.000Z,
-          backingNight: '26016f630a34d8c1c5f43c41783ff67ceb82c5181529428cca0fbe9efcd28296',
+          backingNight: 'adf6979ee2caf3662dabe4588eb2311de04e97293c6f96e366bd4a67034d87e7',
+          mtIndex: 0n
+        },
+        dtime: undefined,
+        maxCap: 250000000000000000000000n,
+        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
+        generatedNow: 0n,
+        rate: 413350000000000000n
+      },
+      {
+        token: {
+          initialValue: 0n,
+          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
+          nonce: 50586679687627173730485799926282314706847051589385752828012176203617501615946n,
+          seq: 0,
+          ctime: 2025-08-05T12:00:00.000Z,
+          backingNight: '35c11fc00b7f242d172ebade4edbb1d123134b444f6562ecfa80feb76eda126a',
           mtIndex: 2n
+        },
+        dtime: undefined,
+        maxCap: 250000000000000000000000n,
+        maxCapReachedAt: 2025-08-12T12:00:15.000Z,
+        generatedNow: 0n,
+        rate: 413350000000000000n
+      },
+      {
+        token: {
+          initialValue: 0n,
+          owner: 11886380015789543296729785856017363359697744265386149017101029008360306658047n,
+          nonce: 39236833992364654568272956423128803082965139162007277965439978026566466488297n,
+          seq: 0,
+          ctime: 2025-08-05T12:00:00.000Z,
+          backingNight: '15b3234d60a4ed3adefcc87dd4673c738a40455848a52787079dabddc072cbde',
+          mtIndex: 3n
         },
         dtime: undefined,
         maxCap: 250000000000000000000000n,
@@ -1412,8 +1412,8 @@ exports[`Snippet outputs > with network > should output the correct result for '
     ],
     pendingCoins: [],
     progress: {
-      appliedIndex: 128n,
-      highestRelevantWalletIndex: 128n,
+      appliedIndex: 50n,
+      highestRelevantWalletIndex: 50n,
       highestIndex: 0n,
       highestRelevantIndex: 0n,
       isConnected: true,

--- a/packages/docs-snippets/src/utils.ts
+++ b/packages/docs-snippets/src/utils.ts
@@ -25,7 +25,6 @@ import {
   WalletSeeds,
   mergeWalletEntries,
   ProtocolVersion,
-  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { type Buffer } from 'buffer';
 
@@ -42,7 +41,7 @@ export const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
   costParameters: {
     feeBlocksMargin: 5,
   },
@@ -56,7 +55,7 @@ export const configuration: DefaultConfiguration = {
       backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
     },
     {
-      sinceVersion: V9_NATIVE_FORK_VERSION,
+      sinceVersion: ProtocolVersion.V9NativeForkVersion,
       backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
     },
   ],

--- a/packages/docs-snippets/src/utils.ts
+++ b/packages/docs-snippets/src/utils.ts
@@ -24,6 +24,7 @@ import {
   type UnshieldedKeystore,
   WalletSeeds,
   mergeWalletEntries,
+  ProtocolVersion,
   V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { type Buffer } from 'buffer';
@@ -31,6 +32,9 @@ import { type Buffer } from 'buffer';
 const INDEXER_PORT = Number.parseInt(process.env['INDEXER_PORT'] ?? '8088', 10);
 const NODE_PORT = Number.parseInt(process.env['NODE_PORT'] ?? '9944', 10);
 const PROOF_SERVER_PORT = Number.parseInt(process.env['PROOF_SERVER_PORT'] ?? '6300', 10);
+// The proof server built against ledger-v8, for the chain's history below `forkVersion`. Never contacted on a chain
+// that has been post-fork since genesis, like the one this runs against.
+const V8_PROOF_SERVER_PORT = Number.parseInt(process.env['V8_PROOF_SERVER_PORT'] ?? '6301', 10);
 const INDEXER_HTTP_URL = `http://localhost:${INDEXER_PORT}/api/v4/graphql`;
 const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
@@ -43,7 +47,19 @@ export const configuration: DefaultConfiguration = {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  provingServerUrl: new URL(`http://localhost:${PROOF_SERVER_PORT}`),
+  // One proof server per ledger version: the one built against ledger-v8 answers below `forkVersion`, the one built
+  // against ledger-v9 from it. A transaction is proved by the entry for the version its bytes were authored at, so the
+  // wallet proves on either side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
+  provers: [
+    {
+      sinceVersion: ProtocolVersion.MinSupportedVersion,
+      backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
+    },
+    {
+      sinceVersion: V9_NATIVE_FORK_VERSION,
+      backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
+    },
+  ],
   indexerClientConnection: {
     indexerHttpUrl: INDEXER_HTTP_URL,
     indexerWsUrl: INDEXER_WS_URL,

--- a/packages/docs-snippets/src/utils.ts
+++ b/packages/docs-snippets/src/utils.ts
@@ -10,8 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
-import type * as ledger from '@midnightntwrk/ledger-v9';
+import type * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
 import {
   type DefaultConfiguration,
   DustWallet,
@@ -25,6 +24,7 @@ import {
   type UnshieldedKeystore,
   WalletSeeds,
   mergeWalletEntries,
+  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { type Buffer } from 'buffer';
 
@@ -34,7 +34,7 @@ const PROOF_SERVER_PORT = Number.parseInt(process.env['PROOF_SERVER_PORT'] ?? '6
 const INDEXER_HTTP_URL = `http://localhost:${INDEXER_PORT}/api/v4/graphql`;
 const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
-const configuration: DefaultConfiguration = {
+export const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.

--- a/packages/dust-wallet/src/DustWallet.ts
+++ b/packages/dust-wallet/src/DustWallet.ts
@@ -368,9 +368,8 @@ export type DefaultDustConfiguration = {
    *   application points at, not of the SDK.
    *
    *   A node reporting a 2.x runtime version reports protocol version `2000000`, which is therefore the value for a
-   *   ledger-v9-native chain — the shielded package publishes it as `V9_NATIVE_FORK_VERSION`. The final mainnet fork
-   *   constant is not yet fixed; a `ProtocolVersion.Forks.*` default will ship once it is, and this field keeps working
-   *   unchanged.
+   *   ledger-v9-native chain — published as `ProtocolVersion.V9NativeForkVersion`. The final mainnet fork constant is
+   *   not yet fixed; it will join that one once it is, and this field keeps working unchanged.
    */
   forkVersion: ProtocolVersion.ProtocolVersion;
   /**

--- a/packages/e2e-tests/src/tests/dustDeregistration.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dustDeregistration.undeployed.test.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
@@ -27,7 +27,7 @@ import {
   isFinalizedWalletEntry,
   mergeWalletEntries,
 } from '@midnightntwrk/wallet-sdk-facade';
-import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, InMemoryTransactionHistoryStorage, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { makeDefaultSubmissionService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { carried } from './helpers/transactions.js';
@@ -83,7 +83,7 @@ describe('Dust Deregistration', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/dustRegistration.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dustRegistration.undeployed.test.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import * as crypto from 'node:crypto';
 import { randomUUID } from 'node:crypto';
@@ -37,7 +37,7 @@ import {
   isFinalizedWalletEntry,
   mergeWalletEntries,
 } from '@midnightntwrk/wallet-sdk-facade';
-import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, InMemoryTransactionHistoryStorage, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { ArrayOps, DateOps } from '@midnightntwrk/wallet-sdk-utilities';
 import { carried } from './helpers/transactions.js';
@@ -91,7 +91,7 @@ describe('Dust Registration', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/facadeTransfer.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/facadeTransfer.undeployed.test.ts
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, InMemoryTransactionHistoryStorage, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { PublicKey, UnshieldedWallet, createKeystore } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnightntwrk/wallet-sdk-utilities/testing';
 import { pipe } from 'effect';
@@ -92,7 +92,7 @@ describe('Wallet Facade Transfer', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/hardFork.fork.test.ts
+++ b/packages/e2e-tests/src/tests/hardFork.fork.test.ts
@@ -30,7 +30,7 @@ import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type WalletSeeds as WalletSeedsType, WalletSeeds } from '@midnightntwrk/wallet-sdk-hd';
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import {
   createKeystore,
   PublicKey,
@@ -265,7 +265,7 @@ const projectionsTwinDustWallet = (configuration: DefaultDustConfiguration) => {
 const hasCrossed = (state: FacadeState | undefined): boolean =>
   state !== undefined &&
   state.protocol._tag === 'Settled' &&
-  state.activeProtocolVersion >= V9_NATIVE_FORK_VERSION &&
+  state.activeProtocolVersion >= ProtocolVersion.V9NativeForkVersion &&
   state.isSynced;
 
 describe.sequential('Hard fork crossing @fork', () => {
@@ -326,7 +326,10 @@ describe.sequential('Hard fork crossing @fork', () => {
           sinceVersion: ProtocolVersion.MinSupportedVersion,
           backend: { kind: 'server', url: new URL(fixture.getV8ProverUri()) },
         },
-        { sinceVersion: V9_NATIVE_FORK_VERSION, backend: { kind: 'server', url: new URL(fixture.getProverUri()) } },
+        {
+          sinceVersion: ProtocolVersion.V9NativeForkVersion,
+          backend: { kind: 'server', url: new URL(fixture.getProverUri()) },
+        },
       ] as const satisfies DefaultConfiguration['provers'],
     };
     unshieldedKeystore = createKeystore({ kind: 'schnorr', secret: seeds.unshielded }, fixture.getNetworkId());
@@ -376,7 +379,7 @@ describe.sequential('Hard fork crossing @fork', () => {
     logger.info(`PRE-FORK SYNCED ${summarize(preFork)}`);
 
     expect(preFork.protocol._tag).toBe('Settled');
-    expect(preFork.activeProtocolVersion).toBeLessThan(V9_NATIVE_FORK_VERSION);
+    expect(preFork.activeProtocolVersion).toBeLessThan(ProtocolVersion.V9NativeForkVersion);
 
     const specVersion = await fixture.specVersionAtHead();
     expect(specVersion).toBe(PRE_FORK_SPEC_VERSION);
@@ -403,7 +406,7 @@ describe.sequential('Hard fork crossing @fork', () => {
           ` ${twinState.dust.state.progress.highestIndex}`,
       );
 
-      expect(twinState.protocolVersion.dust).toBeLessThan(V9_NATIVE_FORK_VERSION);
+      expect(twinState.protocolVersion.dust).toBeLessThan(ProtocolVersion.V9NativeForkVersion);
       expect(sameDustCoins(eventsState.dust.state.state, twinState.dust.state.state)).toBe(true);
       expect(rootsEqual(eventsState.dust.state.state, twinState.dust.state.state)).toBe(true);
     },
@@ -426,7 +429,7 @@ describe.sequential('Hard fork crossing @fork', () => {
       expect(receiverBefore.unshielded.balances[NIGHT] ?? 0n).toBe(0n);
 
       const before = await wallet.waitForSyncedState();
-      expect(before.activeProtocolVersion).toBeLessThan(V9_NATIVE_FORK_VERSION);
+      expect(before.activeProtocolVersion).toBeLessThan(ProtocolVersion.V9NativeForkVersion);
       const nightBefore = before.unshielded.balances[NIGHT];
 
       // Dust accrues with time, and this chain is seconds old: for the first half-minute of it there is not enough for
@@ -487,7 +490,7 @@ describe.sequential('Hard fork crossing @fork', () => {
     logger.info(`phase transitions observed: ${observed.phases.join('  ->  ')}`);
 
     expect(postFork.protocol._tag).toBe('Settled');
-    expect(postFork.activeProtocolVersion).toBeGreaterThanOrEqual(V9_NATIVE_FORK_VERSION);
+    expect(postFork.activeProtocolVersion).toBeGreaterThanOrEqual(ProtocolVersion.V9NativeForkVersion);
     expect(postFork.isSynced).toBe(true);
 
     // The wallets do not cross together: each learns of the change when its own synchronization
@@ -515,7 +518,7 @@ describe.sequential('Hard fork crossing @fork', () => {
       logDustCounts('B post-fork', eventsState, twinState);
 
       expect(twinState.protocol._tag).toBe('Settled');
-      expect(twinState.activeProtocolVersion).toBeGreaterThanOrEqual(V9_NATIVE_FORK_VERSION);
+      expect(twinState.activeProtocolVersion).toBeGreaterThanOrEqual(ProtocolVersion.V9NativeForkVersion);
       expect(twinState.isSynced).toBe(true);
       // The twin's post-fork variant has exactly one synchronization — the projections one — so a settled post-fork
       // state is itself the proof that the projections path ran, and ran on a state produced by the migration.

--- a/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
@@ -25,7 +25,7 @@ import {
   WalletFacade,
   mergeWalletEntries,
 } from '@midnightntwrk/wallet-sdk-facade';
-import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { makeWasmProvingService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { pipe } from 'effect';
@@ -99,7 +99,7 @@ describe('Optional Balancing', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/projectionsBasedSync.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/projectionsBasedSync.undeployed.test.ts
@@ -43,7 +43,11 @@ describe('Projections-based synchronisation model', () => {
   const eventLessDustWallet = (config: DefaultDustConfiguration) =>
     CustomDustWallet(
       config,
-      new V2Builder().withDefaults().withSync(makeEventLessSyncService, makeEventLessSyncCapability),
+      new V2Builder()
+        .withDefaults()
+        .withSync(makeEventLessSyncService, makeEventLessSyncCapability)
+        // Restated because `withSync` drops it: the seed-to-key derivation a start from a seed needs.
+        .withStartAuxDefaults(),
     );
 
   let fixture: TestContainersFixture;

--- a/packages/e2e-tests/src/tests/swap.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/swap.undeployed.test.ts
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, InMemoryTransactionHistoryStorage, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { V2Builder } from '@midnightntwrk/wallet-sdk-shielded/v2';
-import { CustomShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { CustomShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { PublicKey, UnshieldedWallet, createKeystore } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnightntwrk/wallet-sdk-utilities/testing';
@@ -95,7 +95,7 @@ describe('Swaps', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/test-fixture.ts
+++ b/packages/e2e-tests/src/tests/test-fixture.ts
@@ -11,14 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { type DefaultShieldedConfiguration, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { type DefaultShieldedConfiguration } from '@midnightntwrk/wallet-sdk-shielded';
 import { exit } from 'process';
 import { randomUUID } from 'node:crypto';
 import { DockerComposeEnvironment, type StartedDockerComposeEnvironment, Wait } from 'testcontainers';
 import { type StartedGenericContainer } from 'testcontainers/build/generic-container/started-generic-container';
 import { type MidnightNetwork, sleep } from './helpers/network.js';
 import { logger } from './logger.js';
-import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { WalletEntrySchema, mergeWalletEntries } from '@midnightntwrk/wallet-sdk-facade';
 import { type DefaultV2Configuration as DefaultDustV2Configuration } from '@midnightntwrk/wallet-sdk-dust-wallet/v2';
 import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnightntwrk/wallet-sdk-utilities/testing';
@@ -249,7 +249,7 @@ export class TestContainersFixture {
       // Every environment these suites run against is on the ledger-v9-native node line, which reports
       // this protocol version, so the wallet reaches its post-fork variant. Defined once here rather than
       // at each construction site; the final mainnet fork constant is still an open question.
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
     };
   }
 

--- a/packages/facade/test/lateVerdictAcrossFork.test.ts
+++ b/packages/facade/test/lateVerdictAcrossFork.test.ts
@@ -41,7 +41,7 @@ import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pend
 import type { PendingTransactionsService } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import type { SubmissionService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { DustWallet, type DustWalletState } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import { ShieldedWallet, type ShieldedWalletState, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet, type ShieldedWalletState } from '@midnightntwrk/wallet-sdk-shielded';
 import {
   createKeystore,
   PublicKey,
@@ -72,7 +72,7 @@ import {
 } from './utils/index.js';
 
 /** The boundary this chain forks at. */
-const forkVersion = V9_NATIVE_FORK_VERSION;
+const forkVersion = ProtocolVersion.V9NativeForkVersion;
 
 /** Where the three wallets are before it: one epoch, ordinary drift within it. */
 const beforeFork = ProtocolVersion.ProtocolVersion(3n);

--- a/packages/facade/test/orphanOnFork.test.ts
+++ b/packages/facade/test/orphanOnFork.test.ts
@@ -25,7 +25,7 @@ import {
 import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import type { PendingTransactionsService } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { DateTime, Option } from 'effect';
 import * as rx from 'rxjs';
@@ -101,7 +101,7 @@ describe('A pending transaction the fork left behind', () => {
   beforeEach(async () => {
     configuration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServerUrl: new URL('http://localhost:6300'),
@@ -191,7 +191,7 @@ describe('A pending transaction the fork left behind', () => {
           result: {
             status: 'ORPHANED_BY_FORK',
             authoredFor: ProtocolVersion.MinSupportedVersion,
-            chainNow: V9_NATIVE_FORK_VERSION,
+            chainNow: ProtocolVersion.V9NativeForkVersion,
           },
         },
       ],

--- a/packages/facade/test/pendingTransactions.test.ts
+++ b/packages/facade/test/pendingTransactions.test.ts
@@ -21,7 +21,7 @@ import {
   WalletTransaction,
 } from '@midnightntwrk/wallet-sdk-abstractions';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
@@ -47,7 +47,7 @@ describe('Wallet Facade handling pending transactions', () => {
   beforeEach(async () => {
     configuration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',

--- a/packages/facade/test/protocolPhaseWiring.test.ts
+++ b/packages/facade/test/protocolPhaseWiring.test.ts
@@ -42,7 +42,7 @@ import {
 import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import type { PendingTransactionsService } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import { DustWallet, type DustWalletState } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import { ShieldedWallet, type ShieldedWalletState, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet, type ShieldedWalletState } from '@midnightntwrk/wallet-sdk-shielded';
 import {
   createKeystore,
   PublicKey,
@@ -66,7 +66,7 @@ import {
 } from './utils/index.js';
 
 /** The boundary the facade reads `protocol` against. */
-const forkVersion = V9_NATIVE_FORK_VERSION;
+const forkVersion = ProtocolVersion.V9NativeForkVersion;
 
 /** Three versions below the boundary, all different: ordinary drift within one epoch. */
 const beforeFork = {

--- a/packages/facade/test/submission.test.ts
+++ b/packages/facade/test/submission.test.ts
@@ -20,7 +20,7 @@ import {
 } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type SubmissionService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { Either } from 'effect';
 import * as crypto from 'node:crypto';
@@ -64,7 +64,7 @@ describe('Facade submission', () => {
     })();
     const configuration: DefaultConfiguration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -111,7 +111,7 @@ describe('Facade submission', () => {
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -192,7 +192,7 @@ describe('Facade submission', () => {
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -260,7 +260,7 @@ describe('Facade transaction history reads return entries regardless of lifecycl
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServerUrl: new URL('http://localhost:6300'),

--- a/packages/facade/test/versionedProving.test.ts
+++ b/packages/facade/test/versionedProving.test.ts
@@ -29,7 +29,7 @@ import {
   type VersionedProvingService,
 } from '@midnightntwrk/wallet-sdk-capabilities/proving';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { Cause, Either, Option, Runtime } from 'effect';
 import * as rx from 'rxjs';
@@ -71,7 +71,7 @@ describe('Proving a transaction at the version it was built for', () => {
   beforeEach(async () => {
     configuration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServers: [{ sinceVersion: ProtocolVersion.MinSupportedVersion, url: new URL('http://localhost:6300') }],
@@ -146,7 +146,7 @@ describe('Proving a transaction at the version it was built for', () => {
   });
 
   it('refuses a transaction built on the other side of the boundary, without asking any prover', async () => {
-    const failure = await facade.finalizeTransaction(anyTransaction(V9_NATIVE_FORK_VERSION)).then(
+    const failure = await facade.finalizeTransaction(anyTransaction(ProtocolVersion.V9NativeForkVersion)).then(
       () => undefined,
       (error: unknown) => error,
     );
@@ -167,7 +167,7 @@ describe('Proving with the backend configured for the epoch a transaction belong
   const started = async (proving: Partial<DefaultConfiguration>): Promise<WalletFacade> => {
     const configuration: DefaultConfiguration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       costParameters: { feeBlocksMargin: 0 },
@@ -240,7 +240,10 @@ describe('Proving with the backend configured for the epoch a transaction belong
 
   const provenBy = (finalized: WalletTransaction<WalletTransaction.Stage>) =>
     Either.getOrThrow(
-      WalletTransaction.unwrapWithin<unknown>(finalized, ProtocolVersion.epochOf(PRE_FORK, V9_NATIVE_FORK_VERSION)),
+      WalletTransaction.unwrapWithin<unknown>(
+        finalized,
+        ProtocolVersion.epochOf(PRE_FORK, ProtocolVersion.V9NativeForkVersion),
+      ),
     );
 
   const v8ServerAndV9Wasm: Partial<DefaultConfiguration> = {
@@ -249,7 +252,7 @@ describe('Proving with the backend configured for the epoch a transaction belong
         sinceVersion: ProtocolVersion.MinSupportedVersion,
         backend: { kind: 'server', url: new URL('http://pre-fork-prover:6300') },
       },
-      { sinceVersion: V9_NATIVE_FORK_VERSION, backend: { kind: 'wasm' } },
+      { sinceVersion: ProtocolVersion.V9NativeForkVersion, backend: { kind: 'wasm' } },
     ],
   };
 
@@ -286,7 +289,7 @@ describe('Proving with the backend configured for the epoch a transaction belong
     const facade = await started({
       provers: [
         {
-          sinceVersion: V9_NATIVE_FORK_VERSION,
+          sinceVersion: ProtocolVersion.V9NativeForkVersion,
           backend: { kind: 'server', url: new URL('http://post-fork-prover:6300') },
         },
       ],

--- a/packages/shielded-wallet/README.md
+++ b/packages/shielded-wallet/README.md
@@ -24,8 +24,8 @@ while maintaining verifiability. It provides:
 ### Starting the Wallet
 
 ```typescript
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
-import { InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
+import { InMemoryTransactionHistoryStorage, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { TransactionHistory } from '@midnightntwrk/wallet-sdk-shielded/v2';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { randomBytes } from 'node:crypto';
@@ -40,7 +40,7 @@ const configuration = {
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so it is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
 };
 
 // Create secret keys from a shielded seed

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -237,20 +237,13 @@ export type CustomizedShieldedWallet<
   WalletLike.WalletLike<[Variant.VersionedVariant<V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>>]>;
 
 /**
- * The protocol version a ledger-v9-native chain hands over at, for the current node line.
+ * The protocol version a ledger-v9-native chain hands over at.
  *
- * @remarks
- *   Measured, not assumed: a `midnight-node` 2.x reports protocol version `2000000` on its ledger events — the runtime
- *   version, scaled, rather than a small ordinal or the ledger major. A chain of the previous node line reports a
- *   1.x-encoded value, which is below this, so a wallet configured with it stays on the pre-fork variant there and
- *   reaches the post-fork variant on any v9-native chain.
- *
- *   Offered as a named value so applications and test suites pointed at a v9-native chain do not each invent a magic
- *   number. It is **not** a default: {@link DefaultShieldedConfiguration.forkVersion} stays required, because the right
- *   value is a property of the chain an application points at. The final mainnet fork constant is still an open
- *   question; when it is fixed a `ProtocolVersion.Forks.*` value will join this one.
+ * @deprecated Use {@link ProtocolVersion.V9NativeForkVersion} from `@midnightntwrk/wallet-sdk-abstractions` (or the
+ *   umbrella package) — the value is a property of the chain, not of the shielded wallet, and lives with the version
+ *   type now. This alias is the same value and will be removed in a later release.
  */
-export const V9_NATIVE_FORK_VERSION: ProtocolVersion.ProtocolVersion = ProtocolVersion.ProtocolVersion(2_000_000n);
+export const V9_NATIVE_FORK_VERSION: ProtocolVersion.ProtocolVersion = ProtocolVersion.V9NativeForkVersion;
 
 /**
  * The configuration a default {@link ShieldedWallet} is built from.

--- a/packages/shielded-wallet/src/test/shieldedWallet.test.ts
+++ b/packages/shielded-wallet/src/test/shieldedWallet.test.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Effect, Scope, Stream } from 'effect';
 import { describe, expect, it } from 'vitest';
 import {
@@ -26,7 +26,7 @@ const configuration: DefaultShieldedConfiguration = {
   networkId: NetworkId.NetworkId.Undeployed,
   indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
 };
 
 /**
@@ -167,5 +167,11 @@ describe('CustomShieldedWallet post-migration sync restart', () => {
 
     expect(recorder.watchers).toEqual([]);
     expect(recorder.resumed).toEqual([]);
+  });
+});
+
+describe('V9_NATIVE_FORK_VERSION', () => {
+  it('is the same value as ProtocolVersion.V9NativeForkVersion, kept only so existing imports keep working', () => {
+    expect(V9_NATIVE_FORK_VERSION).toBe(ProtocolVersion.V9NativeForkVersion);
   });
 });

--- a/packages/shielded-wallet/src/test/tryRestore.test.ts
+++ b/packages/shielded-wallet/src/test/tryRestore.test.ts
@@ -25,7 +25,7 @@ import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@
 import { Either } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { UnsupportedSnapshotVersionError } from '../Restore.js';
-import { type DefaultShieldedConfiguration, V9_NATIVE_FORK_VERSION } from '../ShieldedWallet.js';
+import { type DefaultShieldedConfiguration } from '../ShieldedWallet.js';
 import { ShieldedWallet } from '../ForkingShieldedWallet.js';
 import { TransactionHistory } from '../v2/index.js';
 
@@ -33,7 +33,7 @@ const configuration: DefaultShieldedConfiguration = {
   networkId: NetworkId.NetworkId.Undeployed,
   indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
 };
 
 /** A snapshot declaring a protocol version far beyond anything this build registers a variant for. */

--- a/packages/unshielded-wallet/README.md
+++ b/packages/unshielded-wallet/README.md
@@ -25,8 +25,7 @@ Unlike shielded transactions, unshielded operations do not use zero-knowledge pr
 
 ```typescript
 import { UnshieldedWallet, createKeystore, PublicKey } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
-import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
-import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { randomBytes } from 'node:crypto';
 
 // Configuration for the wallet
@@ -39,7 +38,7 @@ const configuration = {
   txHistoryStorage: new InMemoryTransactionHistoryStorage(),
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so it is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
 };
 
 // Create a keystore from a random unshielded seed

--- a/packages/unshielded-wallet/src/UnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/UnshieldedWallet.ts
@@ -183,9 +183,8 @@ export type DefaultUnshieldedConfiguration = {
    *   application points at, not of the SDK.
    *
    *   A node reporting a 2.x runtime version reports protocol version `2000000`, which is therefore the value for a
-   *   ledger-v9-native chain — the shielded package publishes it as `V9_NATIVE_FORK_VERSION`. The final mainnet fork
-   *   constant is not yet fixed; a `ProtocolVersion.Forks.*` default will ship once it is, and this field keeps working
-   *   unchanged.
+   *   ledger-v9-native chain — published as `ProtocolVersion.V9NativeForkVersion`. The final mainnet fork constant is
+   *   not yet fixed; it will join that one once it is, and this field keeps working unchanged.
    */
   forkVersion: ProtocolVersion.ProtocolVersion;
   /**

--- a/packages/unshielded-wallet/test/testUtils.ts
+++ b/packages/unshielded-wallet/test/testUtils.ts
@@ -126,9 +126,8 @@ export const createWalletConfig = (
     networkId: NetworkId.NetworkId.Undeployed,
     txHistoryStorage: new InMemoryTransactionHistoryStorage(UnshieldedEntrySchema),
     // The ledger-v9-native node line these suites run against reports this protocol version, so the wallet reaches its
-    // post-fork variant. Spelled out rather than imported: it is published as `V9_NATIVE_FORK_VERSION` by the shielded
-    // package, which this one does not depend on.
-    forkVersion: ProtocolVersion.ProtocolVersion(2_000_000n),
+    // post-fork variant.
+    forkVersion: ProtocolVersion.V9NativeForkVersion,
   };
 
   return { ...defaultConfig, ...overrides };

--- a/packages/wallet-integration-tests/test/serializationAndRestoration.integration.test.ts
+++ b/packages/wallet-integration-tests/test/serializationAndRestoration.integration.test.ts
@@ -15,7 +15,6 @@ import {
   type ShieldedWalletClass,
   type ShieldedWalletState,
   type DefaultShieldedConfiguration,
-  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk-shielded';
 import { UnshieldedWallet, createKeystore, PublicKey } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import * as ledger from '@midnightntwrk/ledger-v9';
@@ -29,7 +28,7 @@ import { firstValueFrom } from 'rxjs';
 import * as rx from 'rxjs';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getShieldedSeed, getUnshieldedSeed } from './utils.js';
-import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { WalletEntrySchema, mergeWalletEntries } from '@midnightntwrk/wallet-sdk-facade';
 
 vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
@@ -58,7 +57,7 @@ describe('Wallet serialization and restoration', () => {
     indexerPort = startedEnvironment.getContainer(`indexer_${environmentId}`).getMappedPort(8088);
 
     shieldedConfiguration = {
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       indexerClientConnection: {
         indexerHttpUrl: `http://localhost:${indexerPort}/api/v4/graphql`,
       },
@@ -69,7 +68,7 @@ describe('Wallet serialization and restoration', () => {
     unshieldedConfiguration = {
       // The same boundary the shielded configuration names, for the same reason: this stack runs the
       // ledger-v9-native node line, so the unshielded wallet reaches its post-fork variant too.
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       indexerClientConnection: {
         indexerWsUrl: `ws://localhost:${indexerPort}/api/v4/graphql/ws`,
         indexerHttpUrl: `http://localhost:${indexerPort}/api/v4/graphql`,

--- a/packages/wallet-sdk-testkit/src/environment.ts
+++ b/packages/wallet-sdk-testkit/src/environment.ts
@@ -10,8 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
-import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { WalletEntrySchema, mergeWalletEntries } from '@midnightntwrk/wallet-sdk-facade';
 import {
   type DustWalletConfiguration,
@@ -89,7 +88,7 @@ export const makeEnvironment = (
       // Every environment this testkit drives runs the ledger-v9-native node line, which reports this
       // protocol version, so the wallet reaches its post-fork variant. Defined once here rather than at
       // each construction site; the final mainnet fork constant is still an open question.
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
     };
   },
   getDustWalletConfig(): DustWalletConfiguration {
@@ -104,7 +103,7 @@ export const makeEnvironment = (
       },
       // The same boundary the shielded configuration names, for the same reason: this testkit's environments all run
       // the ledger-v9-native node line, so the dust wallet reaches its post-fork variant too.
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
     };
   },
   down: options.down ?? (async () => {}),


### PR DESCRIPTION
## Summary

Makes every documentation snippet hard-fork ready, on top of the dual-ledger support that landed in #715 and the per-version proving that landed in #718. Every wallet a snippet builds runs on ledger-v8 below `forkVersion` and on ledger-v9 from it — syncing, transacting and proving — so the same code works on a chain still below the fork, on one past it since genesis (the compose stack it runs against), and across the crossing.

- **Imports come from the umbrella package only.** Six files imported the fork constant from `@midnightntwrk/wallet-sdk-shielded` and two imported `@midnightntwrk/ledger-v9` directly — neither is a dependency of the package, and neither is what a user copying a snippet has installed. They now use `@midnightntwrk/wallet-sdk` and its `ledger/v8` / `ledger/v9`, `dust/v1` / `dust/v2` and `capabilities` subpaths.
- **Hand-authored transactions follow the chain.** `balancing.ts`, `well-formed-validation.ts` and `dust-sponsorship.ts` stamped bytes built with the post-fork ledger as protocol version 0. On any chain past the fork the facade refuses such a handle with `ProtocolVersionMismatchError`, so all three were broken on the stack they run against (the snippet lane is nightly-only on `main` and had not run since #715). They now import both `ledger/v8` and `ledger/v9`, author with the one the wallets are acting at (`state.activeProtocolVersion` against `forkVersion`), and seal the handle with that version.
- **Proving is per ledger version everywhere.** `hard-fork-support.ts` and `wasm-prover.ts` came over from #718 on `provers`. The remaining four configurations — `utils.ts` (shared by eleven snippets), `initialization.ts`, `ecdsa-initialization.ts`, `dust-fast-sync.ts` — moved from the single `provingServerUrl` to two `provers` entries, a proof server built against ledger-v8 below the fork (`V8_PROOF_SERVER_PORT`, default 6301, never contacted on a post-fork-since-genesis chain) and one built against ledger-v9 from it. The single-URL form is correct only while the one image behind it matches the chain's current side.
- **The projections fast-sync recipe crosses the fork.** `dust-fast-sync.ts` was a single ledger-v9 variant that could not start on a pre-fork chain. It is now composed either side of the boundary with `CustomForkingDustWallet`, the way the fork e2e test's `projectionsTwinDustWallet` does it: ledger-v8 event replay below `forkVersion`, and from it a ledger-v9 variant whose sync is the projections one, handed its state by `Migration.makeCrossLedgerMigration` and started on the right side by `makeIndexerChainVersionProbe`. `withStartAuxDefaults()` is restated after `withSync`, which drops it (also fixed in the `projectionsBasedSync` e2e test).
- **The two no-net snippets say why seeds, not keys, are what crosses a fork.**
- **Three stale snapshots regenerated.** `initialization`, `dust-fast-sync` and `wasm-prover` print genesis UTXOs; #715 bumped the node image in the compose file without regenerating them. Only genesis-derived values changed.

No API changes; empty changeset.

## Verification

Full docs-snippets e2e lane run locally against the compose stack, twice on the final tree: 18/18 both times, no snapshot changes from the proving and fast-sync edits. `yarn typecheck`, `yarn lint`, `yarn format:check` and Effect diagnostics green for the package.
