### PR TITLE
feat(proving): prove on either side of the protocol boundary with a backend per ledger version

### DIFF
--- a/.changeset/proving-per-version.md
+++ b/.changeset/proving-per-version.md
@@ -1,0 +1,53 @@
+---
+'@midnightntwrk/wallet-sdk-capabilities': major
+'@midnightntwrk/wallet-sdk-prover-client': minor
+'@midnightntwrk/wallet-sdk-facade': minor
+'@midnightntwrk/wallet-sdk': minor
+---
+
+Prove on either side of a protocol boundary. Routing a transaction to a prover by the version stamped on it already
+worked; every backend, however, was bound to the current ledger — it drove `Transaction.prove` with the current cost
+model, framed its proof-server requests with the current payload helpers, and resolved key material at a fixed circuit
+line. A pre-fork entry in `provingServers` was therefore accepted by configuration and could not be honoured: handing a
+pre-fork transaction the current ledger's cost model fails at the wasm-bindgen boundary with `expected instance of
+CostModel`. There is now a backend per ledger version, and the registration that says which serves which range of
+protocol versions.
+
+Proving backends are configured with `provers`, which — unlike `provingServers` — can also name the in-process prover:
+
+```ts
+const configuration = {
+  forkVersion,
+  provers: [
+    { sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'server', url: preForkProofServer } },
+    { sinceVersion: forkVersion, backend: { kind: 'wasm' } },
+  ],
+};
+```
+
+`provingServers` and `provingServerUrl` are unchanged and still supported; precedence is `provers` > `provingServers` >
+`provingServerUrl`, and naming none is still a `ProvingConfigurationError`. A backend whose range spans `forkVersion` —
+which `provingServerUrl` always does — is split at the boundary and driven by each ledger version in turn, so the same
+description frames correctly on both sides. Whether one proof server can in fact prove both is an operational fact
+about that server, not something the SDK can enforce: no published image serves both today, so a chain with history
+below the boundary wants an entry per side. The in-process prover works on bytes and does serve both, with the same
+published circuits.
+
+Each registered backend refuses the other ledger version's transaction with a new `ProvingEpochMismatchError` naming
+the epoch it serves, rather than passing a foreign object to a ledger that cannot read it.
+
+BREAKING CHANGE (`@midnightntwrk/wallet-sdk-capabilities`) — `makeDefaultVersionedProvingService` and
+`makeDefaultVersionedProvingServiceEffect` take the chain's fork version as a second argument, and a new
+`makeDefaultProvingServices(configuration, forkVersion)` exposes the registry they build. The facade passes
+`configuration.forkVersion` for you; only a direct caller of these factories is affected. `ProvingServiceEffect`'s error
+channel widens from `ProvingError` to `ProvingFailure` (`ProvingError | ProvingEpochMismatchError`) — existing
+implementations stay assignable. The facade's `InitParams.provingService` widens to
+`VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>`, which existing current-ledger
+implementations also satisfy.
+
+`@midnightntwrk/wallet-sdk-prover-client` gains `@midnight-ntwrk/ledger-v8` as a runtime dependency, so
+`HttpProverClient` can frame a pre-fork request as the pre-fork ledger would: `asPreForkProvingProvider()` alongside the
+unchanged `asProvingProvider()`. Both ledgers are WASM modules, so a consumer bundling this package directly now ships
+both; users of `@midnightntwrk/wallet-sdk` or `-capabilities` already did.
+`WasmProver.makeDefaultKeyMaterialProvider` now takes an optional `{ circuits: 8 | 9 }` naming the circuit line to read,
+defaulting to what both ledger versions accept.

--- a/.changeset/proving-per-version.md
+++ b/.changeset/proving-per-version.md
@@ -6,10 +6,10 @@
 ---
 
 Prove on either side of a protocol boundary. Routing a transaction to a prover by the version stamped on it already
-worked; every backend, however, was bound to the current ledger — it drove `Transaction.prove` with the current cost
-model, framed its proof-server requests with the current payload helpers, and resolved key material at a fixed circuit
+worked; every backend, however, was bound to ledger-v9 — it drove `Transaction.prove` with ledger-v9's cost
+model, framed its proof-server requests with ledger-v9's payload helpers, and resolved key material at a fixed circuit
 line. A pre-fork entry in `provingServers` was therefore accepted by configuration and could not be honoured: handing a
-pre-fork transaction the current ledger's cost model fails at the wasm-bindgen boundary with `expected instance of
+ledger-v8 transaction ledger-v9's cost model fails at the wasm-bindgen boundary with `expected instance of
 CostModel`. There is now a backend per ledger version, and the registration that says which serves which range of
 protocol versions.
 
@@ -19,7 +19,7 @@ Proving backends are configured with `provers`, which — unlike `provingServers
 const configuration = {
   forkVersion,
   provers: [
-    { sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'server', url: preForkProofServer } },
+    { sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'server', url: v8ProofServer } },
     { sinceVersion: forkVersion, backend: { kind: 'wasm' } },
   ],
 };
@@ -42,12 +42,12 @@ BREAKING CHANGE (`@midnightntwrk/wallet-sdk-capabilities`) — `makeDefaultVersi
 `configuration.forkVersion` for you; only a direct caller of these factories is affected. `ProvingServiceEffect`'s error
 channel widens from `ProvingError` to `ProvingFailure` (`ProvingError | ProvingEpochMismatchError`) — existing
 implementations stay assignable. The facade's `InitParams.provingService` widens to
-`VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>`, which existing current-ledger
+`VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>`, which existing ledger-v9
 implementations also satisfy.
 
 `@midnightntwrk/wallet-sdk-prover-client` gains `@midnight-ntwrk/ledger-v8` as a runtime dependency, so
-`HttpProverClient` can frame a pre-fork request as the pre-fork ledger would: `asPreForkProvingProvider()` alongside the
-unchanged `asProvingProvider()`. Both ledgers are WASM modules, so a consumer bundling this package directly now ships
+`HttpProverClient` can frame a ledger-v8 request as ledger-v8 would: `asV8ProvingProvider()` alongside the
+unchanged `asProvingProvider()`, which `asV9ProvingProvider()` now also names. Both ledgers are WASM modules, so a consumer bundling this package directly now ships
 both; users of `@midnightntwrk/wallet-sdk` or `-capabilities` already did.
 `WasmProver.makeDefaultKeyMaterialProvider` now takes an optional `{ circuits: 8 | 9 }` naming the circuit line to read,
 defaulting to what both ledger versions accept.

--- a/.github/workflows/e2e-hard-fork.yml
+++ b/.github/workflows/e2e-hard-fork.yml
@@ -48,9 +48,14 @@ on:
         default: '4.4.0-rc.5'
       proof_server_tag:
         type: string
-        description: proof-server image
+        description: proof-server image (post-fork, ledger 9)
         required: false
         default: '9.0.0-rc.7'
+      proof_server_pre_fork_tag:
+        type: string
+        description: proof-server image the pre-fork half proves at (ledger 8)
+        required: false
+        default: '8.1.0'
   pull_request:
     # Exactly the lane's own files. Everything about the lane lives in these six paths, so a PR that does not
     # touch them cannot change what it does.
@@ -98,6 +103,7 @@ jobs:
       TOOLKIT_TAG: ${{ inputs.toolkit_tag || '2.1.0-beta.1' }}
       INDEXER_TAG: ${{ inputs.indexer_tag || '4.4.0-rc.5' }}
       PROOF_SERVER_TAG: ${{ inputs.proof_server_tag || '9.0.0-rc.7' }}
+      PROOF_SERVER_PRE_FORK_TAG: ${{ inputs.proof_server_pre_fork_tag || '8.1.0' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/e2e-hard-fork.yml
+++ b/.github/workflows/e2e-hard-fork.yml
@@ -51,7 +51,7 @@ on:
         description: proof-server image (post-fork, ledger 9)
         required: false
         default: '9.0.0-rc.7'
-      proof_server_pre_fork_tag:
+      proof_server_v8_tag:
         type: string
         description: proof-server image the pre-fork half proves at (ledger 8)
         required: false
@@ -103,7 +103,7 @@ jobs:
       TOOLKIT_TAG: ${{ inputs.toolkit_tag || '2.1.0-beta.1' }}
       INDEXER_TAG: ${{ inputs.indexer_tag || '4.4.0-rc.5' }}
       PROOF_SERVER_TAG: ${{ inputs.proof_server_tag || '9.0.0-rc.7' }}
-      PROOF_SERVER_PRE_FORK_TAG: ${{ inputs.proof_server_pre_fork_tag || '8.1.0' }}
+      PROOF_SERVER_V8_TAG: ${{ inputs.proof_server_v8_tag || '8.1.0' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/infra/compose/docker-compose-fork-dynamic.yml
+++ b/infra/compose/docker-compose-fork-dynamic.yml
@@ -133,9 +133,9 @@ services:
   # The proof server of the epoch before the boundary. A second service rather than a second tag on the
   # first: no image serves both sides, and this lane is the one place a wallet has to prove on each in
   # turn. It runs from the start, because the pre-fork transfer happens before the fork is enacted.
-  proof-server-pre-fork:
-    image: 'ghcr.io/midnight-ntwrk/proof-server:${PROOF_SERVER_PRE_FORK_TAG:-8.1.0}'
-    container_name: proof-server-pre-fork_$TESTCONTAINERS_UID
+  proof-server-v8:
+    image: 'ghcr.io/midnight-ntwrk/proof-server:${PROOF_SERVER_V8_TAG:-8.1.0}'
+    container_name: proof-server-v8_$TESTCONTAINERS_UID
     cap_drop:
       - ALL
     security_opt:

--- a/infra/compose/docker-compose-fork-dynamic.yml
+++ b/infra/compose/docker-compose-fork-dynamic.yml
@@ -130,6 +130,22 @@ services:
     # No healthcheck, for the same reason as the indexer: no curl in the image. The fixture waits on
     # the listening port, exactly as the smoke fixture does.
 
+  # The proof server of the epoch before the boundary. A second service rather than a second tag on the
+  # first: no image serves both sides, and this lane is the one place a wallet has to prove on each in
+  # turn. It runs from the start, because the pre-fork transfer happens before the fork is enacted.
+  proof-server-pre-fork:
+    image: 'ghcr.io/midnight-ntwrk/proof-server:${PROOF_SERVER_PRE_FORK_TAG:-8.1.0}'
+    container_name: proof-server-pre-fork_$TESTCONTAINERS_UID
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    ports:
+      - '127.0.0.1::6300'
+    environment:
+      RUST_BACKTRACE: 'full'
+      EXTRA_ARGS: -v
+
   # Never started by `up` — the fixture drives it with
   # `docker compose … --profile tools run --rm toolkit runtime-upgrade …`, which joins the project
   # network so `ws://node:9944` resolves. No `container_name`: `compose run` names its own container.

--- a/packages/capabilities/README.md
+++ b/packages/capabilities/README.md
@@ -109,7 +109,7 @@ import { makeDefaultVersionedProvingService } from '@midnightntwrk/wallet-sdk-ca
 const service = makeDefaultVersionedProvingService(
   {
     provers: [
-      { sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'server', url: preForkProofServer } },
+      { sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'server', url: v8ProofServer } },
       { sinceVersion: forkVersion, backend: { kind: 'wasm' } },
     ],
   },
@@ -125,7 +125,7 @@ const service = makeDefaultVersionedProvingService(
 - Each registered backend refuses the other ledger version's transaction with `ProvingEpochMismatchError` rather than
   handing it to a ledger that cannot read it.
 - `makeServerProvingServiceEffect` / `makeWasmProvingServiceEffect` build a single current-ledger backend;
-  `makePreForkServerProvingServiceEffect` / `makePreForkWasmProvingServiceEffect` are their pre-fork twins.
+  `makeV8ServerProvingServiceEffect` / `makeV8WasmProvingServiceEffect` are their ledger-v8 twins.
 
 ## Exports
 

--- a/packages/capabilities/README.md
+++ b/packages/capabilities/README.md
@@ -95,6 +95,38 @@ try {
 }
 ```
 
+### Proving, either side of a protocol boundary
+
+A proving backend is written against one ledger version — it drives that version's `Transaction.prove` with that
+version's cost model, and frames its proof-server requests with that version's payload helpers. Which backend answers
+for which protocol version is therefore a registration, and it is made from the same `forkVersion` the wallets are built
+with:
+
+```typescript
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { makeDefaultVersionedProvingService } from '@midnightntwrk/wallet-sdk-capabilities/proving';
+
+const service = makeDefaultVersionedProvingService(
+  {
+    provers: [
+      { sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'server', url: preForkProofServer } },
+      { sinceVersion: forkVersion, backend: { kind: 'wasm' } },
+    ],
+  },
+  forkVersion,
+); // Either<VersionedProvingService, ProvingConfigurationError>
+```
+
+- `provers` > `provingServers` > `provingServerUrl`; naming none is a `ProvingConfigurationError`, as is naming them out
+  of order.
+- A range that spans `forkVersion` is split at it, so each side is driven by its own ledger version. That is what makes
+  the single-URL form frame correctly on both sides; whether one server can actually prove both is an operational fact
+  about that server, not something the SDK enforces.
+- Each registered backend refuses the other ledger version's transaction with `ProvingEpochMismatchError` rather than
+  handing it to a ledger that cannot read it.
+- `makeServerProvingServiceEffect` / `makeWasmProvingServiceEffect` build a single current-ledger backend;
+  `makePreForkServerProvingServiceEffect` / `makePreForkWasmProvingServiceEffect` are their pre-fork twins.
+
 ## Exports
 
 ### Balancer

--- a/packages/capabilities/src/proving/index.ts
+++ b/packages/capabilities/src/proving/index.ts
@@ -13,6 +13,6 @@
  * limitations under the License.
  */
 
-export * from './preForkProvingService.js';
+export * from './v8ProvingService.js';
 export * from './provingService.js';
 export * from './versionedProving.js';

--- a/packages/capabilities/src/proving/index.ts
+++ b/packages/capabilities/src/proving/index.ts
@@ -13,4 +13,6 @@
  * limitations under the License.
  */
 
+export * from './preForkProvingService.js';
 export * from './provingService.js';
+export * from './versionedProving.js';

--- a/packages/capabilities/src/proving/preForkProvingService.ts
+++ b/packages/capabilities/src/proving/preForkProvingService.ts
@@ -1,0 +1,118 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * Proving on the pre-fork ledger version.
+ *
+ * @remarks
+ *   The pre-fork twin of the backends in `provingService.ts`: structurally the same three steps — obtain a proving
+ *   provider, drive the transaction's own `prove` with that ledger version's cost model, report failures as a
+ *   {@link ProvingError} — against a different ledger version's classes. It is the classes that make this a separate
+ *   module: a pre-fork transaction handed the current ledger's cost model fails at the wasm-bindgen boundary, and a
+ *   proof-server request framed by the current ledger is not the request the pre-fork one would have sent.
+ */
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { HttpProverClient, WasmProver } from '@midnightntwrk/wallet-sdk-prover-client/effect';
+import {
+  ClientError,
+  type InvalidProtocolSchemeError,
+  ServerError,
+} from '@midnightntwrk/wallet-sdk-utilities/networking';
+import { Effect, pipe } from 'effect';
+import {
+  ProvingError,
+  type ProvingFailure,
+  type ProvingServiceEffect,
+  type ServerProvingConfiguration,
+  type WasmProvingConfiguration,
+} from './provingService.js';
+
+/** A pre-fork transaction that has not been proved yet. */
+export type PreForkUnprovenTransaction = ledger.UnprovenTransaction;
+
+/** A pre-fork transaction that has been proved but not yet bound. */
+export type PreForkUnboundTransaction = ledger.Transaction<ledger.SignatureEnabled, ledger.Proof, ledger.PreBinding>;
+
+/** A proving backend written against the pre-fork ledger version. */
+export type PreForkProvingServiceEffect = ProvingServiceEffect<PreForkUnboundTransaction, PreForkUnprovenTransaction>;
+
+/**
+ * Drives a pre-fork transaction's proving with a low-level proving provider.
+ *
+ * @param provider The proving provider, or the reason one could not be built.
+ * @returns A backend that proves pre-fork transactions.
+ */
+export const fromPreForkProvingProviderEffect = (
+  provider: Effect.Effect<ledger.ProvingProvider, InvalidProtocolSchemeError>,
+): PreForkProvingServiceEffect => ({
+  prove(transaction: PreForkUnprovenTransaction): Effect.Effect<PreForkUnboundTransaction, ProvingFailure> {
+    return pipe(
+      provider,
+      Effect.flatMap((provider) =>
+        Effect.tryPromise({
+          try: () => transaction.prove(provider, ledger.CostModel.initialCostModel()),
+          catch: (error) =>
+            error instanceof ClientError || error instanceof ServerError
+              ? error
+              : new ClientError({ message: 'Failed to prove transaction', cause: error }),
+        }),
+      ),
+      Effect.catchAll((error) => Effect.fail(new ProvingError({ message: error.message, cause: error }))),
+    );
+  },
+});
+
+/**
+ * Drives a pre-fork transaction's proving with a low-level proving provider.
+ *
+ * @param provider The proving provider.
+ * @returns A backend that proves pre-fork transactions.
+ */
+export const fromPreForkProvingProvider = (provider: ledger.ProvingProvider): PreForkProvingServiceEffect =>
+  fromPreForkProvingProviderEffect(Effect.succeed(provider));
+
+/**
+ * Proves pre-fork transactions at a proof server.
+ *
+ * @param configuration The proof server to send pre-fork proving requests to.
+ * @returns A backend that proves pre-fork transactions over HTTP.
+ */
+export const makePreForkServerProvingServiceEffect = (
+  configuration: ServerProvingConfiguration,
+): PreForkProvingServiceEffect =>
+  pipe(
+    HttpProverClient.create({ url: configuration.provingServerUrl }),
+    Effect.map((client) => client.asPreForkProvingProvider()),
+    fromPreForkProvingProviderEffect,
+  );
+
+/**
+ * Proves pre-fork transactions in this process.
+ *
+ * @remarks
+ *   The zkir runtime the bundled prover drives is shared by both ledger lines, so there is nothing version-specific about
+ *   the proving loop — and the key material the pre-fork ledger accepts turns out to be the same line the current one
+ *   uses, which is why no key-material override is applied here. See the pre-fork spike in `prover-client`'s
+ *   `preForkWasmProver.integration.test.ts` for the evidence.
+ * @param configuration Optional key material override.
+ * @returns A backend that proves pre-fork transactions in-process.
+ */
+export const makePreForkWasmProvingServiceEffect = (
+  configuration?: WasmProvingConfiguration,
+): PreForkProvingServiceEffect =>
+  pipe(
+    WasmProver.create({
+      keyMaterialProvider: configuration?.keyMaterialProvider ?? WasmProver.makeDefaultKeyMaterialProvider(),
+    }),
+    Effect.map((prover) => prover.asProvingProvider()),
+    fromPreForkProvingProviderEffect,
+  );

--- a/packages/capabilities/src/proving/provingService.ts
+++ b/packages/capabilities/src/proving/provingService.ts
@@ -27,6 +27,27 @@ export class ProvingError extends Data.TaggedError('Wallet.Proving')<{
 }> {}
 
 /**
+ * Raised when a proving backend is handed a transaction from the other side of a protocol boundary.
+ *
+ * @remarks
+ *   Every backend is written against exactly one ledger version, and the two ledger versions' transactions are different
+ *   classes that neither can read. The router has already chosen a backend by the version stamped on the transaction,
+ *   so reaching this error means the stamp and the bytes disagreed — which is worth saying out loud, and in terms of
+ *   the epoch the backend serves, rather than letting a foreign object reach the wasm-bindgen boundary and fail there
+ *   as something unreadable.
+ */
+export class ProvingEpochMismatchError extends Data.TaggedError(
+  '@midnightntwrk/wallet-sdk-capabilities/proving/provingService/ProvingEpochMismatchError',
+)<{
+  readonly message: string;
+  /** The range of protocol versions the backend that refused the transaction serves. */
+  readonly epoch: ProtocolVersion.ProtocolVersion.Range;
+}> {}
+
+/** Everything a proving backend can fail with. */
+export type ProvingFailure = ProvingError | ProvingEpochMismatchError;
+
+/**
  * Turns an unproven transaction into a proven one.
  *
  * @typeParam TProven The proven transaction this backend produces.
@@ -35,7 +56,7 @@ export class ProvingError extends Data.TaggedError('Wallet.Proving')<{
  *   {@link VersionedProvingServiceEffect}'s job and not this interface's.
  */
 export interface ProvingServiceEffect<TProven, TUnproven = ledger.UnprovenTransaction> {
-  prove(transaction: TUnproven): Effect.Effect<TProven, ProvingError>;
+  prove(transaction: TUnproven): Effect.Effect<TProven, ProvingFailure>;
 }
 
 export interface ProvingService<TProven, TUnproven = ledger.UnprovenTransaction> {
@@ -63,7 +84,7 @@ export interface VersionedProvingServiceEffect<TProven, TUnproven = ledger.Unpro
   prove(
     transaction: TUnproven,
     protocolVersion: ProtocolVersion.ProtocolVersion,
-  ): Effect.Effect<TProven, ProvingError | UnsupportedProvingVersionError>;
+  ): Effect.Effect<TProven, ProvingFailure | UnsupportedProvingVersionError>;
 }
 
 export interface VersionedProvingService<TProven, TUnproven = ledger.UnprovenTransaction> {
@@ -132,7 +153,7 @@ export const fromProvingProviderEffect = (
   provider: Effect.Effect<ledger.ProvingProvider, InvalidProtocolSchemeError>,
 ): ProvingServiceEffect<UnboundTransaction> => {
   return {
-    prove(transaction: ledger.UnprovenTransaction): Effect.Effect<UnboundTransaction, ProvingError> {
+    prove(transaction: ledger.UnprovenTransaction): Effect.Effect<UnboundTransaction, ProvingFailure> {
       return pipe(
         provider,
         Effect.flatMap((provider) =>
@@ -176,18 +197,44 @@ export type ProvingServerActivation = Readonly<{
 }>;
 
 /**
- * Which proof server serves which protocol version.
+ * Where proving happens: at a proof server over HTTP, or in this process.
  *
  * @remarks
- *   The two settings are alternatives, not a pair: `provingServers` is the version-keyed form, and `provingServerUrl` is
- *   the single-server form that reads as one server for every version. Giving both is not an error — the list wins —
- *   but naming neither is, because there is then nothing to prove with.
+ *   Deliberately says nothing about a ledger version. Which ledger drives a backend follows from the protocol versions it
+ *   is registered for, so the same description can be registered on either side of a fork and mean the right thing both
+ *   times.
+ */
+export type ProvingBackend =
+  Readonly<{ kind: 'server'; url: URL }> | Readonly<{ kind: 'wasm'; keyMaterialProvider?: KeyMaterialProvider }>;
+
+/** A proving backend together with the protocol version it starts serving. */
+export type ProverActivation = Readonly<{
+  sinceVersion: ProtocolVersion.ProtocolVersion;
+  backend: ProvingBackend;
+}>;
+
+/**
+ * Which proving backend serves which protocol version.
+ *
+ * @remarks
+ *   The three settings are alternatives, not a set: `provers` is the general form, `provingServers` is the shorthand for
+ *   "these proof servers", and `provingServerUrl` the shorthand for "this one proof server, for every version". Giving
+ *   more than one is not an error — `provers` wins, then `provingServers` — but naming none is, because there is then
+ *   nothing to prove with.
+ *
+ *   A backend registered across a protocol boundary (which is what `provingServerUrl` always is, and what a `provers`
+ *   list with a single entry at the minimum version is) is split at that boundary and driven by each ledger version in
+ *   turn. That is what makes one URL frame its requests correctly on both sides. Whether a given proof server can in
+ *   fact serve both is an operational fact about that server, not something the SDK can know or enforce — today's
+ *   images serve one side each, so a chain that spans a fork wants two entries.
  */
 export type DefaultProvingConfiguration = {
   /** One proof server for every protocol version. */
   provingServerUrl?: URL;
   /** Proof servers keyed by the protocol version each one starts serving, in ascending order. */
   provingServers?: readonly ProvingServerActivation[];
+  /** Proving backends keyed by the protocol version each one starts serving, in ascending order. */
+  provers?: readonly ProverActivation[];
 };
 
 /** Raised when the proving configuration names no proof server, or names them out of order. */
@@ -198,9 +245,24 @@ export class ProvingConfigurationError extends Data.TaggedError(
   readonly cause?: unknown;
 }> {}
 
+const noBackendNamed = () =>
+  new ProvingConfigurationError({
+    message:
+      "Missing required configuration: set 'provers' (or 'provingServers', or 'provingServerUrl'), or provide a custom provingService in init parameters.",
+  });
+
+const outOfOrder = (cause: unknown) =>
+  new ProvingConfigurationError({
+    message: 'Proving backends must be listed in strictly ascending order of the version each starts serving.',
+    cause,
+  });
+
 /**
  * Reads a proving configuration as the proof servers it names, keyed by protocol version.
  *
+ * @remarks
+ *   The server-only view of {@link resolveProvingBackends}, which is what a caller that can only talk to a proof server
+ *   wants. A configuration that names in-process backends is not readable this way, and says so.
  * @param configuration The proving configuration.
  * @returns The proof server URLs by version range, or the reason the configuration names none.
  */
@@ -215,62 +277,44 @@ export const resolveProvingServers = (
         : [];
 
   return activations.length === 0
-    ? Either.left(
-        new ProvingConfigurationError({
-          message:
-            "Missing required configuration: set 'provingServers' (or 'provingServerUrl'), or provide a custom provingService in init parameters.",
-        }),
-      )
-    : ProtocolVersion.makeRegistryFromActivations(activations).pipe(
-        Either.mapLeft(
-          (cause) =>
-            new ProvingConfigurationError({
-              message: 'Proof servers must be listed in strictly ascending order of the version each starts serving.',
-              cause,
-            }),
-        ),
-      );
+    ? Either.left(noBackendNamed())
+    : ProtocolVersion.makeRegistryFromActivations(activations).pipe(Either.mapLeft(outOfOrder));
 };
 
 /**
- * Builds the version-routed proving service a proving configuration describes.
- *
- * @param configuration The proving configuration.
- * @returns The routed proving service, or the reason the configuration names no proof server.
- */
-export const makeDefaultVersionedProvingServiceEffect = (
-  configuration: DefaultProvingConfiguration,
-): Either.Either<VersionedProvingServiceEffect<UnboundTransaction>, ProvingConfigurationError> =>
-  resolveProvingServers(configuration).pipe(
-    Either.map((servers) =>
-      makeVersionedProvingServiceEffect<UnboundTransaction, ledger.UnprovenTransaction>({
-        entries: servers.entries.map((entry) => ({
-          range: entry.range,
-          value: makeServerProvingServiceEffect({ provingServerUrl: entry.value }),
-        })),
-      }),
-    ),
-  );
-
-/**
- * Builds the version-routed proving service a proving configuration describes, on the promise-facing surface.
- *
- * @param configuration The proving configuration.
- * @returns The routed proving service, or the reason the configuration names no proof server.
- */
-export const makeDefaultVersionedProvingService = (
-  configuration: DefaultProvingConfiguration,
-): Either.Either<VersionedProvingService<UnboundTransaction>, ProvingConfigurationError> =>
-  makeDefaultVersionedProvingServiceEffect(configuration).pipe(Either.map(wrapVersionedEffectService));
-
-/**
- * Registers the in-process WASM prover for the protocol versions it can actually prove.
+ * Reads a proving configuration as the backends it names, keyed by protocol version.
  *
  * @remarks
- *   The bundled prover resolves its key material at a single, fixed ledger version, so there is no local proving for
- *   anything below the fork. Registering nothing there is what turns that into an {@link UnsupportedProvingVersionError}
- *   naming the version, rather than a proof built from the wrong keys.
- * @param sinceVersion The first protocol version the bundled prover's key material covers.
+ *   Where the precedence between the three settings is decided, once, so that reading a configuration and building
+ *   services from it cannot disagree about which one was meant.
+ * @param configuration The proving configuration.
+ * @returns The backends by version range, or the reason the configuration names none.
+ */
+export const resolveProvingBackends = (
+  configuration: DefaultProvingConfiguration,
+): Either.Either<ProtocolVersion.Registry<ProvingBackend>, ProvingConfigurationError> =>
+  configuration.provers !== undefined && configuration.provers.length > 0
+    ? ProtocolVersion.makeRegistryFromActivations(
+        configuration.provers.map(({ sinceVersion, backend }) => ({ sinceVersion, value: backend })),
+      ).pipe(Either.mapLeft(outOfOrder))
+    : resolveProvingServers(configuration).pipe(
+        Either.map((servers) => ({
+          entries: servers.entries.map((entry) => ({
+            range: entry.range,
+            value: { kind: 'server', url: entry.value } as const,
+          })),
+        })),
+      );
+
+/**
+ * Registers the in-process WASM prover, driven by the current ledger version, from a given protocol version upwards.
+ *
+ * @remarks
+ *   Every entry here is the current ledger version's backend, so `sinceVersion` should not be below a protocol boundary:
+ *   what a version below it needs is the pre-fork driver, which `makeDefaultProvingServices` registers from the fork
+ *   version it is given. Registering nothing below is what turns that into an {@link UnsupportedProvingVersionError}
+ *   naming the version, rather than a pre-fork transaction handed to a ledger that cannot read it.
+ * @param sinceVersion The first protocol version to register the bundled prover for.
  * @param configuration Optional key material override.
  * @returns The proving backends, keyed by version.
  */

--- a/packages/capabilities/src/proving/provingService.ts
+++ b/packages/capabilities/src/proving/provingService.ts
@@ -307,13 +307,13 @@ export const resolveProvingBackends = (
       );
 
 /**
- * Registers the in-process WASM prover, driven by the current ledger version, from a given protocol version upwards.
+ * Registers the in-process WASM prover, driven by ledger-v9, from a given protocol version upwards.
  *
  * @remarks
- *   Every entry here is the current ledger version's backend, so `sinceVersion` should not be below a protocol boundary:
- *   what a version below it needs is the pre-fork driver, which `makeDefaultProvingServices` registers from the fork
- *   version it is given. Registering nothing below is what turns that into an {@link UnsupportedProvingVersionError}
- *   naming the version, rather than a pre-fork transaction handed to a ledger that cannot read it.
+ *   Every entry here is ledger-v9's backend, so `sinceVersion` should not be below a protocol boundary: what a version
+ *   below it needs is the ledger-v8 driver, which `makeDefaultProvingServices` registers from the fork version it is
+ *   given. Registering nothing below is what turns that into an {@link UnsupportedProvingVersionError} naming the
+ *   version, rather than a ledger-v8 transaction handed to a ledger that cannot read it.
  * @param sinceVersion The first protocol version to register the bundled prover for.
  * @param configuration Optional key material override.
  * @returns The proving backends, keyed by version.

--- a/packages/capabilities/src/proving/test/versionedProving.test.ts
+++ b/packages/capabilities/src/proving/test/versionedProving.test.ts
@@ -15,7 +15,7 @@ import * as ledger from '@midnightntwrk/ledger-v9';
 import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Cause, Effect, Either, Exit, Option } from 'effect';
 import { describe, expect, it } from 'vitest';
-import { fromPreForkProvingProvider } from '../preForkProvingService.js';
+import { fromV8ProvingProvider } from '../v8ProvingService.js';
 import { ProvingConfigurationError, ProvingEpochMismatchError, resolveProvingBackends } from '../provingService.js';
 import { makeDefaultProvingServices, makeDefaultVersionedProvingServiceEffect } from '../versionedProving.js';
 
@@ -35,8 +35,8 @@ const aFakeProvingProvider: preForkLedger.ProvingProvider = {
   prove: () => Promise.resolve(new Uint8Array(0)),
 };
 
-/** A pre-fork transaction with nothing in it that needs a proof. */
-const aPreForkTransaction = (): preForkLedger.UnprovenTransaction =>
+/** A ledger-v8 transaction with nothing in it that needs a proof. */
+const aV8Transaction = (): preForkLedger.UnprovenTransaction =>
   preForkLedger.Transaction.fromParts(
     'undeployed',
     undefined,
@@ -57,11 +57,11 @@ const failureOf = async <A, E>(effect: Effect.Effect<A, E>): Promise<E> => {
 /** A URL no test ever connects to: nothing in this file has anything to prove, so no request is ever made. */
 const unusedServer = (host: string) => new URL(`http://${host}:6300`);
 
-describe('Proving with the pre-fork ledger', () => {
-  it("drives the transaction with the pre-fork ledger, and hands back that ledger version's transaction", async () => {
-    const service = fromPreForkProvingProvider(aFakeProvingProvider);
+describe('Proving with ledger-v8', () => {
+  it("drives the transaction with ledger-v8, and hands back that ledger version's transaction", async () => {
+    const service = fromV8ProvingProvider(aFakeProvingProvider);
 
-    const proven = await Effect.runPromise(service.prove(aPreForkTransaction()));
+    const proven = await Effect.runPromise(service.prove(aV8Transaction()));
 
     expect(proven).toBeInstanceOf(preForkLedger.Transaction);
     expect(proven).not.toBeInstanceOf(ledger.Transaction);
@@ -76,16 +76,16 @@ describe('Composing proving backends either side of the protocol boundary', () =
     ],
   } as const;
 
-  it('proves a transaction stamped below the fork with the pre-fork ledger', async () => {
+  it('proves a transaction stamped below the fork with ledger-v8', async () => {
     const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORK));
 
-    const proven = await Effect.runPromise(router.prove(aPreForkTransaction(), BEFORE_FORK));
+    const proven = await Effect.runPromise(router.prove(aV8Transaction(), BEFORE_FORK));
 
     expect(proven).toBeInstanceOf(preForkLedger.Transaction);
     expect(proven).not.toBeInstanceOf(ledger.Transaction);
   });
 
-  it('proves a transaction stamped at the fork with the current ledger', async () => {
+  it('proves a transaction stamped at the fork with ledger-v9', async () => {
     const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORK));
 
     const proven = await Effect.runPromise(router.prove(aCurrentLedgerTransaction(), FORK));
@@ -107,7 +107,7 @@ describe('Composing proving backends either side of the protocol boundary', () =
     const router = Either.getOrThrow(
       makeDefaultVersionedProvingServiceEffect({ provingServerUrl: unusedServer('only') }, FORK),
     );
-    expect(await Effect.runPromise(router.prove(aPreForkTransaction(), BEFORE_FORK))).toBeInstanceOf(
+    expect(await Effect.runPromise(router.prove(aV8Transaction(), BEFORE_FORK))).toBeInstanceOf(
       preForkLedger.Transaction,
     );
     expect(await Effect.runPromise(router.prove(aCurrentLedgerTransaction(), FORK))).toBeInstanceOf(ledger.Transaction);
@@ -144,10 +144,10 @@ describe('Composing proving backends either side of the protocol boundary', () =
     );
   });
 
-  it('refuses a pre-fork transaction handed to the current ledger, naming the epoch that backend serves', async () => {
+  it('refuses a ledger-v8 transaction handed to ledger-v9, naming the epoch that backend serves', async () => {
     const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORK));
 
-    const error = await failureOf(router.prove(aPreForkTransaction(), FORK));
+    const error = await failureOf(router.prove(aV8Transaction(), FORK));
 
     expect(error).toBeInstanceOf(ProvingEpochMismatchError);
     expect((error as ProvingEpochMismatchError).epoch).toStrictEqual(

--- a/packages/capabilities/src/proving/test/versionedProving.test.ts
+++ b/packages/capabilities/src/proving/test/versionedProving.test.ts
@@ -1,0 +1,241 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Cause, Effect, Either, Exit, Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { fromPreForkProvingProvider } from '../preForkProvingService.js';
+import { ProvingConfigurationError, ProvingEpochMismatchError, resolveProvingBackends } from '../provingService.js';
+import { makeDefaultProvingServices, makeDefaultVersionedProvingServiceEffect } from '../versionedProving.js';
+
+const version = (value: bigint): ProtocolVersion.ProtocolVersion => ProtocolVersion.ProtocolVersion(value);
+const FORK = version(2_000_000n);
+const BEFORE_FORK = version(5n);
+
+/**
+ * A proving provider that answers with nothing.
+ *
+ * @remarks
+ *   Enough for every transaction in this file: none of them contains anything that has to be proved, so the ledger never
+ *   asks. What is under test is which ledger version drives the proving loop, not the proofs it would produce.
+ */
+const aFakeProvingProvider: preForkLedger.ProvingProvider = {
+  check: () => Promise.resolve([]),
+  prove: () => Promise.resolve(new Uint8Array(0)),
+};
+
+/** A pre-fork transaction with nothing in it that needs a proof. */
+const aPreForkTransaction = (): preForkLedger.UnprovenTransaction =>
+  preForkLedger.Transaction.fromParts(
+    'undeployed',
+    undefined,
+    undefined,
+    preForkLedger.Intent.new(new Date(Date.now() + 3_600_000)),
+  );
+
+/** A current-ledger transaction with nothing in it that needs a proof. */
+const aCurrentLedgerTransaction = (): ledger.UnprovenTransaction =>
+  ledger.Transaction.fromParts('undeployed', undefined, undefined, ledger.Intent.new(new Date(Date.now() + 3_600_000)));
+
+const failureOf = async <A, E>(effect: Effect.Effect<A, E>): Promise<E> => {
+  const exit = await Effect.runPromiseExit(effect);
+  if (Exit.isSuccess(exit)) throw new Error('expected the effect to fail');
+  return Option.getOrThrow(Cause.failureOption(exit.cause));
+};
+
+/** A URL no test ever connects to: nothing in this file has anything to prove, so no request is ever made. */
+const unusedServer = (host: string) => new URL(`http://${host}:6300`);
+
+describe('Proving with the pre-fork ledger', () => {
+  it("drives the transaction with the pre-fork ledger, and hands back that ledger version's transaction", async () => {
+    const service = fromPreForkProvingProvider(aFakeProvingProvider);
+
+    const proven = await Effect.runPromise(service.prove(aPreForkTransaction()));
+
+    expect(proven).toBeInstanceOf(preForkLedger.Transaction);
+    expect(proven).not.toBeInstanceOf(ledger.Transaction);
+  });
+});
+
+describe('Composing proving backends either side of the protocol boundary', () => {
+  const bothSides = {
+    provers: [
+      { sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'server', url: unusedServer('pre-fork') } },
+      { sinceVersion: FORK, backend: { kind: 'server', url: unusedServer('post-fork') } },
+    ],
+  } as const;
+
+  it('proves a transaction stamped below the fork with the pre-fork ledger', async () => {
+    const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORK));
+
+    const proven = await Effect.runPromise(router.prove(aPreForkTransaction(), BEFORE_FORK));
+
+    expect(proven).toBeInstanceOf(preForkLedger.Transaction);
+    expect(proven).not.toBeInstanceOf(ledger.Transaction);
+  });
+
+  it('proves a transaction stamped at the fork with the current ledger', async () => {
+    const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORK));
+
+    const proven = await Effect.runPromise(router.prove(aCurrentLedgerTransaction(), FORK));
+
+    expect(proven).toBeInstanceOf(ledger.Transaction);
+    expect(proven).not.toBeInstanceOf(preForkLedger.Transaction);
+  });
+
+  it('splits a backend whose range straddles the fork, so each side is driven by its own ledger', async () => {
+    // One server for every version says nothing about ledger versions, and cannot: the two epochs frame their proving
+    // requests differently. Splitting the range at the boundary is what makes the same URL mean the right thing twice.
+    const services = Either.getOrThrow(makeDefaultProvingServices({ provingServerUrl: unusedServer('only') }, FORK));
+
+    expect(services.entries.map((entry) => entry.range)).toStrictEqual([
+      ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, FORK),
+      ProtocolVersion.makeRange(FORK, ProtocolVersion.MaxSupportedVersion),
+    ]);
+
+    const router = Either.getOrThrow(
+      makeDefaultVersionedProvingServiceEffect({ provingServerUrl: unusedServer('only') }, FORK),
+    );
+    expect(await Effect.runPromise(router.prove(aPreForkTransaction(), BEFORE_FORK))).toBeInstanceOf(
+      preForkLedger.Transaction,
+    );
+    expect(await Effect.runPromise(router.prove(aCurrentLedgerTransaction(), FORK))).toBeInstanceOf(ledger.Transaction);
+  });
+
+  it('registers a single epoch for a chain whose boundary is at or below the minimum supported version', async () => {
+    const services = Either.getOrThrow(
+      makeDefaultProvingServices({ provingServerUrl: unusedServer('only') }, ProtocolVersion.MinSupportedVersion),
+    );
+
+    expect(services.entries.map((entry) => entry.range)).toStrictEqual([
+      ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, ProtocolVersion.MaxSupportedVersion),
+    ]);
+
+    const router = Either.getOrThrow(
+      makeDefaultVersionedProvingServiceEffect(
+        { provingServerUrl: unusedServer('only') },
+        ProtocolVersion.MinSupportedVersion,
+      ),
+    );
+    expect(await Effect.runPromise(router.prove(aCurrentLedgerTransaction(), BEFORE_FORK))).toBeInstanceOf(
+      ledger.Transaction,
+    );
+  });
+
+  it('refuses a transaction from the other side of the boundary, naming the epoch the backend serves', async () => {
+    const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORK));
+
+    const error = await failureOf(router.prove(aCurrentLedgerTransaction(), BEFORE_FORK));
+
+    expect(error).toBeInstanceOf(ProvingEpochMismatchError);
+    expect((error as ProvingEpochMismatchError).epoch).toStrictEqual(
+      ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, FORK),
+    );
+  });
+
+  it('refuses a pre-fork transaction handed to the current ledger, naming the epoch that backend serves', async () => {
+    const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORK));
+
+    const error = await failureOf(router.prove(aPreForkTransaction(), FORK));
+
+    expect(error).toBeInstanceOf(ProvingEpochMismatchError);
+    expect((error as ProvingEpochMismatchError).epoch).toStrictEqual(
+      ProtocolVersion.makeRange(FORK, ProtocolVersion.MaxSupportedVersion),
+    );
+  });
+});
+
+describe('Reading which backend serves which protocol version', () => {
+  it('reads the version-keyed backends as the versions they each start serving', () => {
+    const registry = Either.getOrThrow(
+      resolveProvingBackends({
+        provers: [
+          { sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'server', url: unusedServer('pre') } },
+          { sinceVersion: FORK, backend: { kind: 'wasm' } },
+        ],
+      }),
+    );
+
+    expect(ProtocolVersion.select(registry, BEFORE_FORK)).toStrictEqual(
+      Option.some({ kind: 'server', url: unusedServer('pre') }),
+    );
+    expect(ProtocolVersion.select(registry, FORK)).toStrictEqual(Option.some({ kind: 'wasm' }));
+  });
+
+  it('prefers the version-keyed backends over both server shorthands', () => {
+    const registry = Either.getOrThrow(
+      resolveProvingBackends({
+        provingServerUrl: unusedServer('ignored'),
+        provingServers: [{ sinceVersion: ProtocolVersion.MinSupportedVersion, url: unusedServer('also-ignored') }],
+        provers: [
+          {
+            sinceVersion: ProtocolVersion.MinSupportedVersion,
+            backend: { kind: 'server', url: unusedServer('named') },
+          },
+        ],
+      }),
+    );
+
+    expect(ProtocolVersion.select(registry, FORK)).toStrictEqual(
+      Option.some({ kind: 'server', url: unusedServer('named') }),
+    );
+  });
+
+  it('prefers the version-keyed server list over the single-server shorthand', () => {
+    const registry = Either.getOrThrow(
+      resolveProvingBackends({
+        provingServerUrl: unusedServer('ignored'),
+        provingServers: [{ sinceVersion: ProtocolVersion.MinSupportedVersion, url: unusedServer('listed') }],
+      }),
+    );
+
+    expect(ProtocolVersion.select(registry, FORK)).toStrictEqual(
+      Option.some({ kind: 'server', url: unusedServer('listed') }),
+    );
+  });
+
+  it('reads the single-server shorthand as one server for every version', () => {
+    const registry = Either.getOrThrow(resolveProvingBackends({ provingServerUrl: unusedServer('only') }));
+
+    expect(ProtocolVersion.select(registry, ProtocolVersion.MinSupportedVersion)).toStrictEqual(
+      Option.some({ kind: 'server', url: unusedServer('only') }),
+    );
+  });
+
+  it('refuses a configuration that names no backend at all', () => {
+    const failure = resolveProvingBackends({});
+
+    expect(Either.isLeft(failure)).toBe(true);
+    expect(Either.getLeft(failure).pipe(Option.getOrThrow)).toBeInstanceOf(ProvingConfigurationError);
+  });
+
+  it('refuses backends that are not in ascending version order', () => {
+    const failure = resolveProvingBackends({
+      provers: [
+        { sinceVersion: FORK, backend: { kind: 'server', url: unusedServer('later') } },
+        {
+          sinceVersion: ProtocolVersion.MinSupportedVersion,
+          backend: { kind: 'server', url: unusedServer('earlier') },
+        },
+      ],
+    });
+
+    expect(Either.isLeft(failure)).toBe(true);
+    expect(Either.getLeft(failure).pipe(Option.getOrThrow)).toBeInstanceOf(ProvingConfigurationError);
+  });
+
+  it('refuses an empty list of backends, rather than reading it as no configuration at all', () => {
+    expect(Either.isLeft(makeDefaultProvingServices({ provers: [] }, FORK))).toBe(true);
+  });
+});

--- a/packages/capabilities/src/proving/v8ProvingService.ts
+++ b/packages/capabilities/src/proving/v8ProvingService.ts
@@ -11,14 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 /**
- * Proving on the pre-fork ledger version.
+ * Proving on ledger-v8.
  *
  * @remarks
- *   The pre-fork twin of the backends in `provingService.ts`: structurally the same three steps — obtain a proving
+ *   The ledger-v8 twin of the backends in `provingService.ts`: structurally the same three steps — obtain a proving
  *   provider, drive the transaction's own `prove` with that ledger version's cost model, report failures as a
  *   {@link ProvingError} — against a different ledger version's classes. It is the classes that make this a separate
- *   module: a pre-fork transaction handed the current ledger's cost model fails at the wasm-bindgen boundary, and a
- *   proof-server request framed by the current ledger is not the request the pre-fork one would have sent.
+ *   module: a ledger-v8 transaction handed ledger-v9's cost model fails at the wasm-bindgen boundary, and a
+ *   proof-server request framed by ledger-v9 is not the request ledger-v8 would have sent.
  */
 import * as ledger from '@midnight-ntwrk/ledger-v8';
 import { HttpProverClient, WasmProver } from '@midnightntwrk/wallet-sdk-prover-client/effect';
@@ -36,25 +36,25 @@ import {
   type WasmProvingConfiguration,
 } from './provingService.js';
 
-/** A pre-fork transaction that has not been proved yet. */
-export type PreForkUnprovenTransaction = ledger.UnprovenTransaction;
+/** A ledger-v8 transaction that has not been proved yet. */
+export type V8UnprovenTransaction = ledger.UnprovenTransaction;
 
-/** A pre-fork transaction that has been proved but not yet bound. */
-export type PreForkUnboundTransaction = ledger.Transaction<ledger.SignatureEnabled, ledger.Proof, ledger.PreBinding>;
+/** A ledger-v8 transaction that has been proved but not yet bound. */
+export type V8UnboundTransaction = ledger.Transaction<ledger.SignatureEnabled, ledger.Proof, ledger.PreBinding>;
 
-/** A proving backend written against the pre-fork ledger version. */
-export type PreForkProvingServiceEffect = ProvingServiceEffect<PreForkUnboundTransaction, PreForkUnprovenTransaction>;
+/** A proving backend written against ledger-v8. */
+export type V8ProvingServiceEffect = ProvingServiceEffect<V8UnboundTransaction, V8UnprovenTransaction>;
 
 /**
- * Drives a pre-fork transaction's proving with a low-level proving provider.
+ * Drives a ledger-v8 transaction's proving with a low-level proving provider.
  *
  * @param provider The proving provider, or the reason one could not be built.
- * @returns A backend that proves pre-fork transactions.
+ * @returns A backend that proves ledger-v8 transactions.
  */
-export const fromPreForkProvingProviderEffect = (
+export const fromV8ProvingProviderEffect = (
   provider: Effect.Effect<ledger.ProvingProvider, InvalidProtocolSchemeError>,
-): PreForkProvingServiceEffect => ({
-  prove(transaction: PreForkUnprovenTransaction): Effect.Effect<PreForkUnboundTransaction, ProvingFailure> {
+): V8ProvingServiceEffect => ({
+  prove(transaction: V8UnprovenTransaction): Effect.Effect<V8UnboundTransaction, ProvingFailure> {
     return pipe(
       provider,
       Effect.flatMap((provider) =>
@@ -72,47 +72,43 @@ export const fromPreForkProvingProviderEffect = (
 });
 
 /**
- * Drives a pre-fork transaction's proving with a low-level proving provider.
+ * Drives a ledger-v8 transaction's proving with a low-level proving provider.
  *
  * @param provider The proving provider.
- * @returns A backend that proves pre-fork transactions.
+ * @returns A backend that proves ledger-v8 transactions.
  */
-export const fromPreForkProvingProvider = (provider: ledger.ProvingProvider): PreForkProvingServiceEffect =>
-  fromPreForkProvingProviderEffect(Effect.succeed(provider));
+export const fromV8ProvingProvider = (provider: ledger.ProvingProvider): V8ProvingServiceEffect =>
+  fromV8ProvingProviderEffect(Effect.succeed(provider));
 
 /**
- * Proves pre-fork transactions at a proof server.
+ * Proves ledger-v8 transactions at a proof server.
  *
- * @param configuration The proof server to send pre-fork proving requests to.
- * @returns A backend that proves pre-fork transactions over HTTP.
+ * @param configuration The proof server to send ledger-v8 proving requests to.
+ * @returns A backend that proves ledger-v8 transactions over HTTP.
  */
-export const makePreForkServerProvingServiceEffect = (
-  configuration: ServerProvingConfiguration,
-): PreForkProvingServiceEffect =>
+export const makeV8ServerProvingServiceEffect = (configuration: ServerProvingConfiguration): V8ProvingServiceEffect =>
   pipe(
     HttpProverClient.create({ url: configuration.provingServerUrl }),
-    Effect.map((client) => client.asPreForkProvingProvider()),
-    fromPreForkProvingProviderEffect,
+    Effect.map((client) => client.asV8ProvingProvider()),
+    fromV8ProvingProviderEffect,
   );
 
 /**
- * Proves pre-fork transactions in this process.
+ * Proves ledger-v8 transactions in this process.
  *
  * @remarks
  *   The zkir runtime the bundled prover drives is shared by both ledger lines, so there is nothing version-specific about
- *   the proving loop — and the key material the pre-fork ledger accepts turns out to be the same line the current one
- *   uses, which is why no key-material override is applied here. See the pre-fork spike in `prover-client`'s
- *   `preForkWasmProver.integration.test.ts` for the evidence.
+ *   the proving loop — and the key material ledger-v8 accepts turns out to be the same line the current one uses, which
+ *   is why no key-material override is applied here. See the ledger-v8 spike in `prover-client`'s
+ *   `v8WasmProver.integration.test.ts` for the evidence.
  * @param configuration Optional key material override.
- * @returns A backend that proves pre-fork transactions in-process.
+ * @returns A backend that proves ledger-v8 transactions in-process.
  */
-export const makePreForkWasmProvingServiceEffect = (
-  configuration?: WasmProvingConfiguration,
-): PreForkProvingServiceEffect =>
+export const makeV8WasmProvingServiceEffect = (configuration?: WasmProvingConfiguration): V8ProvingServiceEffect =>
   pipe(
     WasmProver.create({
       keyMaterialProvider: configuration?.keyMaterialProvider ?? WasmProver.makeDefaultKeyMaterialProvider(),
     }),
     Effect.map((prover) => prover.asProvingProvider()),
-    fromPreForkProvingProviderEffect,
+    fromV8ProvingProviderEffect,
   );

--- a/packages/capabilities/src/proving/versionedProving.ts
+++ b/packages/capabilities/src/proving/versionedProving.ts
@@ -1,0 +1,203 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Proving for an SDK that spans a protocol boundary: one backend per ledger version, chosen by the version a
+ * transaction was built for.
+ *
+ * @remarks
+ *   The routing already existed and the backends already existed; what this module supplies is the only thing neither
+ *   could: the registration that says which range of protocol versions each backend answers for, taken from the same
+ *   fork version the wallets are built with. Written the same way validation's `versionedValidation.ts` is, because it
+ *   is the same problem.
+ */
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect, Either } from 'effect';
+import {
+  makePreForkServerProvingServiceEffect,
+  makePreForkWasmProvingServiceEffect,
+  type PreForkUnboundTransaction,
+  type PreForkUnprovenTransaction,
+} from './preForkProvingService.js';
+import {
+  makeServerProvingServiceEffect,
+  makeVersionedProvingServiceEffect,
+  makeWasmProvingServiceEffect,
+  ProvingEpochMismatchError,
+  resolveProvingBackends,
+  wrapVersionedEffectService,
+  type DefaultProvingConfiguration,
+  type ProvingBackend,
+  type ProvingConfigurationError,
+  type ProvingServiceEffect,
+  type ProvingServices,
+  type UnboundTransaction,
+  type VersionedProvingService,
+  type VersionedProvingServiceEffect,
+  type WasmProvingConfiguration,
+} from './provingService.js';
+
+/**
+ * Every unproven transaction either ledger version can be asked to prove.
+ *
+ * @remarks
+ *   A genuine union: the two ledger versions' transaction types are nominally distinct, so a caller holding one of them
+ *   is holding something the other version's backend provably cannot read.
+ */
+export type AnyVersionUnprovenTransaction = ledger.UnprovenTransaction | PreForkUnprovenTransaction;
+
+/** Every proved-but-unbound transaction either ledger version can hand back. */
+export type AnyVersionUnboundTransaction = UnboundTransaction | PreForkUnboundTransaction;
+
+/** A backend registered in a two-version registry, whichever ledger version it was written against. */
+export type VersionProvingServiceEffect = ProvingServiceEffect<
+  AnyVersionUnboundTransaction,
+  AnyVersionUnprovenTransaction
+>;
+
+/**
+ * Narrows a backend written against one ledger version to the union the registry is keyed by.
+ *
+ * @remarks
+ *   The router has already chosen this backend by the version stamped on the transaction, so the check is a restatement
+ *   of that choice rather than a second one — but it is where a transaction that does not belong is refused rather than
+ *   handed to a ledger that cannot read it. What comes back from a wasm-bindgen boundary handed a foreign object is not
+ *   an error anyone can act on; this is.
+ * @param service The backend, written against one ledger version.
+ * @param isOwn Whether a transaction is that ledger version's.
+ * @param epoch The range of protocol versions this backend answers for.
+ * @returns The same backend, in terms of the union.
+ */
+const onlyFrom = <TUnproven extends AnyVersionUnprovenTransaction, TUnbound extends AnyVersionUnboundTransaction>(
+  service: ProvingServiceEffect<TUnbound, TUnproven>,
+  isOwn: (transaction: AnyVersionUnprovenTransaction) => transaction is TUnproven,
+  epoch: ProtocolVersion.ProtocolVersion.Range,
+): VersionProvingServiceEffect => ({
+  prove: (transaction) =>
+    isOwn(transaction)
+      ? service.prove(transaction)
+      : Effect.fail(
+          new ProvingEpochMismatchError({
+            message: `The proving backend registered for protocol versions [${epoch[0]}, ${epoch[1]}) was handed a transaction built by the other ledger version.`,
+            epoch,
+          }),
+        ),
+});
+
+const isPreForkTransaction = (transaction: AnyVersionUnprovenTransaction): transaction is PreForkUnprovenTransaction =>
+  transaction instanceof preForkLedger.Transaction;
+
+const isCurrentLedgerTransaction = (
+  transaction: AnyVersionUnprovenTransaction,
+): transaction is ledger.UnprovenTransaction => transaction instanceof ledger.Transaction;
+
+/** The in-process backend's configuration, with a key material override only when one was named. */
+const wasmConfigurationOf = (backend: Extract<ProvingBackend, { kind: 'wasm' }>): WasmProvingConfiguration =>
+  backend.keyMaterialProvider === undefined ? {} : { keyMaterialProvider: backend.keyMaterialProvider };
+
+/** Builds the backend a description names, on the ledger version the epoch it is registered for belongs to. */
+const makeBackend = (
+  backend: ProvingBackend,
+  epoch: ProtocolVersion.ProtocolVersion.Range,
+  forkVersion: ProtocolVersion.ProtocolVersion,
+): VersionProvingServiceEffect =>
+  epoch[1] <= forkVersion
+    ? onlyFrom(
+        backend.kind === 'server'
+          ? makePreForkServerProvingServiceEffect({ provingServerUrl: backend.url })
+          : makePreForkWasmProvingServiceEffect(wasmConfigurationOf(backend)),
+        isPreForkTransaction,
+        epoch,
+      )
+    : onlyFrom(
+        backend.kind === 'server'
+          ? makeServerProvingServiceEffect({ provingServerUrl: backend.url })
+          : makeWasmProvingServiceEffect(wasmConfigurationOf(backend)),
+        isCurrentLedgerTransaction,
+        epoch,
+      );
+
+/**
+ * Splits a registered range at the protocol boundary, so no single entry spans two ledger versions.
+ *
+ * @remarks
+ *   A range that straddles the boundary is a description of _where_ to prove that says nothing about _which_ ledger
+ *   frames the request — and both are needed. Splitting it keeps the operator's answer to the first question and lets
+ *   the boundary answer the second, which is what makes "one proof server for every version" mean the right thing on
+ *   both sides rather than the current ledger's thing on both.
+ */
+const splitAtFork = (
+  entry: ProtocolVersion.RegistryEntry<ProvingBackend>,
+  forkVersion: ProtocolVersion.ProtocolVersion,
+): readonly ProtocolVersion.RegistryEntry<ProvingBackend>[] => {
+  const [start, end] = entry.range;
+  return start < forkVersion && forkVersion < end
+    ? [
+        { range: ProtocolVersion.makeRange(start, forkVersion), value: entry.value },
+        { range: ProtocolVersion.makeRange(forkVersion, end), value: entry.value },
+      ]
+    : [entry];
+};
+
+/**
+ * Registers a proving backend either side of the protocol boundary.
+ *
+ * @param configuration The proving configuration.
+ * @param forkVersion The protocol version at which the chain hands over to the current ledger version.
+ * @returns The backends and the version ranges they serve, or the reason the configuration names none.
+ */
+export const makeDefaultProvingServices = (
+  configuration: DefaultProvingConfiguration,
+  forkVersion: ProtocolVersion.ProtocolVersion,
+): Either.Either<
+  ProvingServices<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>,
+  ProvingConfigurationError
+> =>
+  resolveProvingBackends(configuration).pipe(
+    Either.map((backends) => ({
+      // A chain whose boundary is at or below the minimum supported version has no pre-fork epoch to register for, so
+      // nothing is split and every range is the current ledger's.
+      entries: backends.entries
+        .flatMap((entry) =>
+          forkVersion > ProtocolVersion.MinSupportedVersion ? splitAtFork(entry, forkVersion) : [entry],
+        )
+        .map((entry) => ({ range: entry.range, value: makeBackend(entry.value, entry.range, forkVersion) })),
+    })),
+  );
+
+/**
+ * Builds the version-routed proving service an SDK spanning a protocol boundary proves with.
+ *
+ * @param configuration The proving configuration.
+ * @param forkVersion The protocol version at which the chain hands over to the current ledger version.
+ * @returns A proving service that routes on the version a transaction was built for, or the reason the configuration
+ *   names no backend.
+ */
+export const makeDefaultVersionedProvingServiceEffect = (
+  configuration: DefaultProvingConfiguration,
+  forkVersion: ProtocolVersion.ProtocolVersion,
+): Either.Either<
+  VersionedProvingServiceEffect<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>,
+  ProvingConfigurationError
+> => makeDefaultProvingServices(configuration, forkVersion).pipe(Either.map(makeVersionedProvingServiceEffect));
+
+/** The promise-facing surface of {@link makeDefaultVersionedProvingServiceEffect}, for the facade to expose. */
+export const makeDefaultVersionedProvingService = (
+  configuration: DefaultProvingConfiguration,
+  forkVersion: ProtocolVersion.ProtocolVersion,
+): Either.Either<
+  VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>,
+  ProvingConfigurationError
+> => makeDefaultVersionedProvingServiceEffect(configuration, forkVersion).pipe(Either.map(wrapVersionedEffectService));

--- a/packages/capabilities/src/proving/versionedProving.ts
+++ b/packages/capabilities/src/proving/versionedProving.ts
@@ -26,11 +26,11 @@ import * as ledger from '@midnightntwrk/ledger-v9';
 import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Effect, Either } from 'effect';
 import {
-  makePreForkServerProvingServiceEffect,
-  makePreForkWasmProvingServiceEffect,
-  type PreForkUnboundTransaction,
-  type PreForkUnprovenTransaction,
-} from './preForkProvingService.js';
+  makeV8ServerProvingServiceEffect,
+  makeV8WasmProvingServiceEffect,
+  type V8UnboundTransaction,
+  type V8UnprovenTransaction,
+} from './v8ProvingService.js';
 import {
   makeServerProvingServiceEffect,
   makeVersionedProvingServiceEffect,
@@ -56,10 +56,16 @@ import {
  *   A genuine union: the two ledger versions' transaction types are nominally distinct, so a caller holding one of them
  *   is holding something the other version's backend provably cannot read.
  */
-export type AnyVersionUnprovenTransaction = ledger.UnprovenTransaction | PreForkUnprovenTransaction;
+/** Ledger-v9's unproven transaction, named for symmetry with {@link V8UnprovenTransaction}. */
+export type V9UnprovenTransaction = ledger.UnprovenTransaction;
+
+/** Ledger-v9's proven-but-unbound transaction, named for symmetry with {@link V8UnboundTransaction}. */
+export type V9UnboundTransaction = UnboundTransaction;
+
+export type AnyVersionUnprovenTransaction = V9UnprovenTransaction | V8UnprovenTransaction;
 
 /** Every proved-but-unbound transaction either ledger version can hand back. */
-export type AnyVersionUnboundTransaction = UnboundTransaction | PreForkUnboundTransaction;
+export type AnyVersionUnboundTransaction = V9UnboundTransaction | V8UnboundTransaction;
 
 /** A backend registered in a two-version registry, whichever ledger version it was written against. */
 export type VersionProvingServiceEffect = ProvingServiceEffect<
@@ -96,12 +102,11 @@ const onlyFrom = <TUnproven extends AnyVersionUnprovenTransaction, TUnbound exte
         ),
 });
 
-const isPreForkTransaction = (transaction: AnyVersionUnprovenTransaction): transaction is PreForkUnprovenTransaction =>
+const isV8Transaction = (transaction: AnyVersionUnprovenTransaction): transaction is V8UnprovenTransaction =>
   transaction instanceof preForkLedger.Transaction;
 
-const isCurrentLedgerTransaction = (
-  transaction: AnyVersionUnprovenTransaction,
-): transaction is ledger.UnprovenTransaction => transaction instanceof ledger.Transaction;
+const isV9Transaction = (transaction: AnyVersionUnprovenTransaction): transaction is ledger.UnprovenTransaction =>
+  transaction instanceof ledger.Transaction;
 
 /** The in-process backend's configuration, with a key material override only when one was named. */
 const wasmConfigurationOf = (backend: Extract<ProvingBackend, { kind: 'wasm' }>): WasmProvingConfiguration =>
@@ -116,16 +121,16 @@ const makeBackend = (
   epoch[1] <= forkVersion
     ? onlyFrom(
         backend.kind === 'server'
-          ? makePreForkServerProvingServiceEffect({ provingServerUrl: backend.url })
-          : makePreForkWasmProvingServiceEffect(wasmConfigurationOf(backend)),
-        isPreForkTransaction,
+          ? makeV8ServerProvingServiceEffect({ provingServerUrl: backend.url })
+          : makeV8WasmProvingServiceEffect(wasmConfigurationOf(backend)),
+        isV8Transaction,
         epoch,
       )
     : onlyFrom(
         backend.kind === 'server'
           ? makeServerProvingServiceEffect({ provingServerUrl: backend.url })
           : makeWasmProvingServiceEffect(wasmConfigurationOf(backend)),
-        isCurrentLedgerTransaction,
+        isV9Transaction,
         epoch,
       );
 
@@ -136,7 +141,7 @@ const makeBackend = (
  *   A range that straddles the boundary is a description of _where_ to prove that says nothing about _which_ ledger
  *   frames the request — and both are needed. Splitting it keeps the operator's answer to the first question and lets
  *   the boundary answer the second, which is what makes "one proof server for every version" mean the right thing on
- *   both sides rather than the current ledger's thing on both.
+ *   both sides rather than ledger-v9's thing on both.
  */
 const splitAtFork = (
   entry: ProtocolVersion.RegistryEntry<ProvingBackend>,
@@ -155,7 +160,7 @@ const splitAtFork = (
  * Registers a proving backend either side of the protocol boundary.
  *
  * @param configuration The proving configuration.
- * @param forkVersion The protocol version at which the chain hands over to the current ledger version.
+ * @param forkVersion The protocol version at which the chain hands over to ledger-v9.
  * @returns The backends and the version ranges they serve, or the reason the configuration names none.
  */
 export const makeDefaultProvingServices = (
@@ -168,7 +173,7 @@ export const makeDefaultProvingServices = (
   resolveProvingBackends(configuration).pipe(
     Either.map((backends) => ({
       // A chain whose boundary is at or below the minimum supported version has no pre-fork epoch to register for, so
-      // nothing is split and every range is the current ledger's.
+      // nothing is split and every range is ledger-v9's.
       entries: backends.entries
         .flatMap((entry) =>
           forkVersion > ProtocolVersion.MinSupportedVersion ? splitAtFork(entry, forkVersion) : [entry],
@@ -181,7 +186,7 @@ export const makeDefaultProvingServices = (
  * Builds the version-routed proving service an SDK spanning a protocol boundary proves with.
  *
  * @param configuration The proving configuration.
- * @param forkVersion The protocol version at which the chain hands over to the current ledger version.
+ * @param forkVersion The protocol version at which the chain hands over to ledger-v9.
  * @returns A proving service that routes on the version a transaction was built for, or the reason the configuration
  *   names no backend.
  */

--- a/packages/capabilities/src/validation/preForkValidationService.ts
+++ b/packages/capabilities/src/validation/preForkValidationService.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnight-ntwrk/ledger-v8';
-import type { PreForkUnboundTransaction } from '../proving/preForkProvingService.js';
+import type { V8UnboundTransaction } from '../proving/v8ProvingService.js';
 import {
   makeValidationServiceEffect,
   type AnyLedgerParameters,
@@ -22,13 +22,13 @@ import {
 } from './validationService.js';
 
 /**
- * A pre-fork transaction that has been proven but not yet bound.
+ * A ledger-v8 transaction that has been proven but not yet bound.
  *
  * @remarks
- *   Taken from proving rather than restated, exactly as the current ledger version's `UnboundTransaction` is: it is the
- *   pre-fork prover that produces this shape, and validation is one of the things that can be asked about it.
+ *   Taken from proving rather than restated, exactly as ledger-v9's `UnboundTransaction` is: it is the ledger-v8 prover
+ *   that produces this shape, and validation is one of the things that can be asked about it.
  */
-export type { PreForkUnboundTransaction };
+export type PreForkUnboundTransaction = V8UnboundTransaction;
 
 /**
  * Every pre-fork transaction shape well-formedness can be asked about — the pre-fork counterpart of

--- a/packages/capabilities/src/validation/preForkValidationService.ts
+++ b/packages/capabilities/src/validation/preForkValidationService.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnight-ntwrk/ledger-v8';
+import type { PreForkUnboundTransaction } from '../proving/preForkProvingService.js';
 import {
   makeValidationServiceEffect,
   type AnyLedgerParameters,
@@ -20,8 +21,14 @@ import {
   type WellFormedStrictnessFlags,
 } from './validationService.js';
 
-/** A pre-fork transaction that has been proven but not yet bound. */
-export type PreForkUnboundTransaction = ledger.Transaction<ledger.SignatureEnabled, ledger.Proof, ledger.PreBinding>;
+/**
+ * A pre-fork transaction that has been proven but not yet bound.
+ *
+ * @remarks
+ *   Taken from proving rather than restated, exactly as the current ledger version's `UnboundTransaction` is: it is the
+ *   pre-fork prover that produces this shape, and validation is one of the things that can be asked about it.
+ */
+export type { PreForkUnboundTransaction };
 
 /**
  * Every pre-fork transaction shape well-formedness can be asked about — the pre-fork counterpart of

--- a/packages/docs-snippets/src/snippets/hard-fork-support.ts
+++ b/packages/docs-snippets/src/snippets/hard-fork-support.ts
@@ -54,9 +54,9 @@ import { Either } from 'effect';
 const INDEXER_PORT = Number.parseInt(process.env['INDEXER_PORT'] ?? '8088', 10);
 const NODE_PORT = Number.parseInt(process.env['NODE_PORT'] ?? '9944', 10);
 const PROOF_SERVER_PORT = Number.parseInt(process.env['PROOF_SERVER_PORT'] ?? '6300', 10);
-// The proof server built against the pre-fork ledger. A separate deployment from the one above — see the `provers`
+// The proof server built against ledger-v8. A separate deployment from the one above — see the `provers`
 // comment below — and never contacted on a chain that has been post-fork since genesis.
-const PRE_FORK_PROOF_SERVER_PORT = Number.parseInt(process.env['PRE_FORK_PROOF_SERVER_PORT'] ?? '6301', 10);
+const V8_PROOF_SERVER_PORT = Number.parseInt(process.env['V8_PROOF_SERVER_PORT'] ?? '6301', 10);
 const INDEXER_HTTP_URL = `http://localhost:${INDEXER_PORT}/api/v4/graphql`;
 const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
@@ -89,7 +89,7 @@ const configuration: DefaultConfiguration = {
   provers: [
     {
       sinceVersion: ProtocolVersion.MinSupportedVersion,
-      backend: { kind: 'server', url: new URL(`http://localhost:${PRE_FORK_PROOF_SERVER_PORT}`) },
+      backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
     },
     {
       sinceVersion: V9_NATIVE_FORK_VERSION,

--- a/packages/docs-snippets/src/snippets/hard-fork-support.ts
+++ b/packages/docs-snippets/src/snippets/hard-fork-support.ts
@@ -21,7 +21,7 @@
  *
  * This file is the copy-paste shape, in the order the code runs:
  *
- * 1. version-keyed proving configuration (`provingServers`)
+ * 1. version-keyed proving configuration (`provers`)
  * 2. the seed-first start, which is the primary and the only one that crosses a fork
  * 3. reading the protocol phase off the state (`Settled` / `Crossing`)
  * 4. finding transactions the fork orphaned (`PendingStatus.Orphaned`)
@@ -37,6 +37,7 @@ import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import {
   createKeystore,
   type DefaultConfiguration,
+  ProtocolVersion,
   DustWallet,
   InMemoryTransactionHistoryStorage,
   mergeWalletEntries,
@@ -53,6 +54,9 @@ import { Either } from 'effect';
 const INDEXER_PORT = Number.parseInt(process.env['INDEXER_PORT'] ?? '8088', 10);
 const NODE_PORT = Number.parseInt(process.env['NODE_PORT'] ?? '9944', 10);
 const PROOF_SERVER_PORT = Number.parseInt(process.env['PROOF_SERVER_PORT'] ?? '6300', 10);
+// The proof server built against the pre-fork ledger. A separate deployment from the one above — see the `provers`
+// comment below — and never contacted on a chain that has been post-fork since genesis.
+const PRE_FORK_PROOF_SERVER_PORT = Number.parseInt(process.env['PRE_FORK_PROOF_SERVER_PORT'] ?? '6301', 10);
 const INDEXER_HTTP_URL = `http://localhost:${INDEXER_PORT}/api/v4/graphql`;
 const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
@@ -69,18 +73,28 @@ const configuration: DefaultConfiguration = {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  // Proof servers keyed by the protocol version each starts serving, in ascending order. A transaction is proved by
-  // the server registered for the version its own bytes were authored at, so a fork landing between building a
-  // transaction and proving it cannot send it to the wrong prover. `provingServerUrl: url` is the single-server form
-  // and means exactly `[{ sinceVersion: ProtocolVersion.MinSupportedVersion, url }]` — one server for every version.
+  // Proving backends keyed by the protocol version each starts serving, in ascending order. A transaction is proved by
+  // the backend registered for the version its own bytes were authored at, so a fork landing between building a
+  // transaction and proving it cannot send it to the wrong prover — and, just as importantly, the ledger version that
+  // built those bytes is the one that frames the proving request.
   //
-  // A pre-fork entry would point at a proof server built against the pre-fork ledger: a separate external deployment,
-  // not yet available, which is why the line below is commented out rather than pointed somewhere. Without it, this
-  // configuration can prove nothing below `forkVersion` — which is correct for a chain already past it, and is what an
-  // application still expecting pre-fork traffic has to add.
-  provingServers: [
-    { sinceVersion: V9_NATIVE_FORK_VERSION, url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
-    // { sinceVersion: ProtocolVersion.MinSupportedVersion, url: new URL('http://localhost:6301') },
+  // Two entries, because a proof server is built against one ledger version and no published image serves both: the
+  // pre-fork half of a chain that has history below `forkVersion` needs its own deployment. On a chain that has been
+  // post-fork since genesis — like the one this runs against — the first entry is simply never reached.
+  //
+  // `provingServerUrl: url` is the shortest form and means one server for every version; the SDK splits its range at
+  // `forkVersion` so each side is framed by its own ledger, which makes it correct but rarely what an operator wants,
+  // since the one URL then has to answer for both. `provingServers: [...]` is the same list as below with every entry
+  // a server.
+  provers: [
+    {
+      sinceVersion: ProtocolVersion.MinSupportedVersion,
+      backend: { kind: 'server', url: new URL(`http://localhost:${PRE_FORK_PROOF_SERVER_PORT}`) },
+    },
+    {
+      sinceVersion: V9_NATIVE_FORK_VERSION,
+      backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
+    },
   ],
   indexerClientConnection: {
     indexerHttpUrl: INDEXER_HTTP_URL,

--- a/packages/docs-snippets/src/snippets/wasm-prover.ts
+++ b/packages/docs-snippets/src/snippets/wasm-prover.ts
@@ -10,12 +10,21 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+/*
+ * Proving in this process, either side of a protocol boundary.
+ *
+ * The bundled prover drives a zkir runtime over bytes and never looks at a ledger version, so — unlike a proof server,
+ * which is built against one — the same backend serves both epochs. One `provers` entry starting at the minimum
+ * supported version therefore covers the whole timeline: the SDK splits its range at `forkVersion` and drives each side
+ * with its own ledger.
+ */
 import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import {
   WalletSeeds,
   type DefaultConfiguration,
   DustWallet,
   InMemoryTransactionHistoryStorage,
+  ProtocolVersion,
   WalletEntrySchema,
   WalletFacade,
   ShieldedWallet,
@@ -24,7 +33,6 @@ import {
   UnshieldedWallet,
   mergeWalletEntries,
 } from '@midnightntwrk/wallet-sdk';
-import { makeWasmProvingService } from '@midnightntwrk/wallet-sdk/capabilities';
 import { Buffer } from 'buffer';
 import { pick } from 'lodash-es';
 
@@ -42,6 +50,9 @@ const configuration: DefaultConfiguration = {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
+  // The in-process prover, for every protocol version. `keyMaterialProvider` can be supplied here to point the prover
+  // at key material of your own; left out, it reads the published circuits, which both ledger versions accept.
+  provers: [{ sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'wasm' } }],
   indexerClientConnection: {
     indexerHttpUrl: INDEXER_HTTP_URL,
     indexerWsUrl: INDEXER_WS_URL,
@@ -60,7 +71,6 @@ const initWalletWithSeed = async (seed: Buffer) => {
     shielded: (config) => ShieldedWallet(config).startWithSeed(seeds.shielded),
     unshielded: (config) => UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
     dust: (config) => DustWallet(config).startWithSeed(seeds.dust),
-    provingService: () => makeWasmProvingService(),
   });
 
   await wallet.start(seeds);

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@cardano-sdk/key-management": "0.29.18",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnightntwrk/ledger-v9": "1.0.0-rc.4",
     "@midnightntwrk/wallet-sdk-abstractions": "workspace:*",
     "@midnightntwrk/wallet-sdk-address-format": "workspace:*",

--- a/packages/e2e-tests/src/tests/fork-fixture.ts
+++ b/packages/e2e-tests/src/tests/fork-fixture.ts
@@ -48,11 +48,11 @@ const IMAGE_TAG_VARIABLES = [
   'TOOLKIT_TAG',
   'INDEXER_TAG',
   'PROOF_SERVER_TAG',
-  'PROOF_SERVER_PRE_FORK_TAG',
+  'PROOF_SERVER_V8_TAG',
 ] as const;
 
 /** Services whose logs are streamed to disk, so a teardown does not take the evidence with it. */
-const LOGGED_SERVICES = ['node', 'indexer', 'proof-server', 'proof-server-pre-fork'] as const;
+const LOGGED_SERVICES = ['node', 'indexer', 'proof-server', 'proof-server-v8'] as const;
 
 /**
  * `twox128("CNightObservation") ++ twox128(<item>)`. The cNIGHT dust replay is node-team territory: these are read and
@@ -198,7 +198,7 @@ export function useForkFixture(): () => ForkFixture {
       // healthcheck cannot answer this, and a listening port alone does not mean it is serving.
       .withWaitStrategy(`indexer_${uid}`, Wait.forHttp('/ready', TestContainersFixture.INDEXER_PORT))
       .withWaitStrategy(`proof-server_${uid}`, Wait.forListeningPorts())
-      .withWaitStrategy(`proof-server-pre-fork_${uid}`, Wait.forListeningPorts())
+      .withWaitStrategy(`proof-server-v8_${uid}`, Wait.forListeningPorts())
       .withStartupTimeout(600_000)
       .up();
 
@@ -262,9 +262,9 @@ export class ForkFixture extends TestContainersFixture {
    *   no published image serves both. This lane is the only one that needs both at once, because it is the only one
    *   whose wallet is on each side in turn.
    */
-  public getPreForkProverUri(): string {
+  public getV8ProverUri(): string {
     return `http://localhost:${this.composeEnvironment
-      .getContainer(`proof-server-pre-fork_${this.#uid}`)
+      .getContainer(`proof-server-v8_${this.#uid}`)
       .getMappedPort(TestContainersFixture.PROOF_SERVER_PORT)}`;
   }
 

--- a/packages/e2e-tests/src/tests/fork-fixture.ts
+++ b/packages/e2e-tests/src/tests/fork-fixture.ts
@@ -48,10 +48,11 @@ const IMAGE_TAG_VARIABLES = [
   'TOOLKIT_TAG',
   'INDEXER_TAG',
   'PROOF_SERVER_TAG',
+  'PROOF_SERVER_PRE_FORK_TAG',
 ] as const;
 
 /** Services whose logs are streamed to disk, so a teardown does not take the evidence with it. */
-const LOGGED_SERVICES = ['node', 'indexer', 'proof-server'] as const;
+const LOGGED_SERVICES = ['node', 'indexer', 'proof-server', 'proof-server-pre-fork'] as const;
 
 /**
  * `twox128("CNightObservation") ++ twox128(<item>)`. The cNIGHT dust replay is node-team territory: these are read and
@@ -197,6 +198,7 @@ export function useForkFixture(): () => ForkFixture {
       // healthcheck cannot answer this, and a listening port alone does not mean it is serving.
       .withWaitStrategy(`indexer_${uid}`, Wait.forHttp('/ready', TestContainersFixture.INDEXER_PORT))
       .withWaitStrategy(`proof-server_${uid}`, Wait.forListeningPorts())
+      .withWaitStrategy(`proof-server-pre-fork_${uid}`, Wait.forListeningPorts())
       .withStartupTimeout(600_000)
       .up();
 
@@ -250,6 +252,20 @@ export class ForkFixture extends TestContainersFixture {
 
   public override getNodeUri(): string {
     return `ws://localhost:${this.#nodeRpcPort()}`;
+  }
+
+  /**
+   * The proof server that proves transactions built below the boundary.
+   *
+   * @remarks
+   *   A second server rather than a second use of the first: the two epochs are proved by different ledger versions and
+   *   no published image serves both. This lane is the only one that needs both at once, because it is the only one
+   *   whose wallet is on each side in turn.
+   */
+  public getPreForkProverUri(): string {
+    return `http://localhost:${this.composeEnvironment
+      .getContainer(`proof-server-pre-fork_${this.#uid}`)
+      .getMappedPort(TestContainersFixture.PROOF_SERVER_PORT)}`;
   }
 
   /** The node's JSON-RPC endpoint over HTTP, which is how this fixture reads the chain. */

--- a/packages/e2e-tests/src/tests/hardFork.fork.test.ts
+++ b/packages/e2e-tests/src/tests/hardFork.fork.test.ts
@@ -22,11 +22,13 @@
 import * as rx from 'rxjs';
 import { Buffer } from 'node:buffer';
 import { inspect } from 'node:util';
-import { Either } from 'effect';
+import { Cause, Either, Option, Runtime } from 'effect';
 import { describe, test, expect, beforeAll, afterAll } from 'vitest';
-// The post-fork ledger, and the only one these tests author at: everything from `re-registers its NIGHT`
-// onwards is built after the boundary, so a v9 token constant is the right way to name what is moved.
+// Both ledgers, because this file is the one that authors on both sides of the boundary: the spend before the fork is
+// the pre-fork ledger's transaction and everything from `re-registers its NIGHT` onwards is the post-fork ledger's.
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type WalletSeeds as WalletSeedsType, WalletSeeds } from '@midnightntwrk/wallet-sdk-hd';
 import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import {
@@ -45,7 +47,12 @@ import {
 } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { V1Builder } from '@midnightntwrk/wallet-sdk-dust-wallet/v1';
 import { Migration, V2Builder } from '@midnightntwrk/wallet-sdk-dust-wallet/v2';
-import { type FacadeState, type WalletEntry, WalletFacade } from '@midnightntwrk/wallet-sdk-facade';
+import {
+  type DefaultConfiguration,
+  type FacadeState,
+  type WalletEntry,
+  WalletFacade,
+} from '@midnightntwrk/wallet-sdk-facade';
 import { type ForkFixture, useForkFixture } from './fork-fixture.js';
 import * as utils from './utils.js';
 import { carried } from './helpers/transactions.js';
@@ -57,6 +64,9 @@ const FUNDED_SEED = '00000000000000000000000000000000000000000000000000000000000
 
 /** An account with nothing on it, which is what makes the post-fork spends' arrival assertions exact. */
 const RECEIVER_SEED = 'b7d32a5094ec502af45aa913b196530e155f17ef05bbf5d75e743c17c3824a82';
+
+/** A second empty account, for the spend made before the boundary: the post-fork receiver must still start at zero. */
+const PRE_FORK_RECEIVER_SEED = '4c1d1e0e9a2a4a3f8b5c6d7e8f90112233445566778899aabbccddeeff001122';
 
 /**
  * Native NIGHT. Written out rather than read from a ledger binding on purpose: the wallet holds this balance on both
@@ -72,6 +82,9 @@ const CROSSING_TIMEOUT_MS = 8 * 60 * 1000;
 
 /** How long the re-registration is given to settle and the first post-fork dust to appear. */
 const DUST_TIMEOUT_MS = 4 * 60 * 1000;
+
+/** How long to leave between attempts at a transaction the wallet could not yet pay for. */
+const DUST_POLL_MS = 5 * 1000;
 
 /** How long a post-fork spend is given to be proven, included, and observed by both sides. */
 const SPEND_TIMEOUT_MS = 10 * 60 * 1000;
@@ -139,6 +152,43 @@ const failingAfter = <T>(label: string, milliseconds: number): rx.MonoTypeOperat
 /** Caps a wait that would otherwise only be bounded by the file's hour-long test timeout. */
 const within = <T>(label: string, milliseconds: number, work: Promise<T>): Promise<T> =>
   rx.firstValueFrom(rx.from(work).pipe(failingAfter(label, milliseconds)));
+
+/**
+ * Whether a failure is the wallet saying it has not been given enough dust to pay for something.
+ *
+ * @remarks
+ *   Matched by tag rather than by class: each wallet raises its own class under this tag on each side of the boundary, so
+ *   `instanceof` would name one of six and treat the other five as something else. The failure arrives wrapped, because
+ *   the facade's balancing runs on an Effect runtime.
+ */
+const isDustShortfall = (error: unknown): boolean => {
+  const reported: unknown = Runtime.isFiberFailure(error)
+    ? Option.getOrElse(Cause.failureOption(error[Runtime.FiberFailureCauseId]), () => error)
+    : error;
+  return (
+    typeof reported === 'object' &&
+    reported !== null &&
+    '_tag' in reported &&
+    reported._tag === 'Wallet.InsufficientFunds'
+  );
+};
+
+/**
+ * Builds a transaction once the wallet has accrued enough dust to pay for it.
+ *
+ * @param build The build to attempt, afresh each time.
+ * @returns What `build` produced once it could be paid for.
+ */
+const onceEnoughDustHasBeenGenerated = <T>(build: () => Promise<T>): Promise<T> =>
+  rx.firstValueFrom(
+    rx.defer(build).pipe(
+      rx.retry({
+        delay: (error: unknown) =>
+          isDustShortfall(error) ? rx.timer(DUST_POLL_MS) : rx.throwError(() => error as Error),
+      }),
+      failingAfter('enough dust to have been generated for a pre-fork transfer', DUST_TIMEOUT_MS),
+    ),
+  );
 
 /** The first state satisfying `settled`, or a failure naming what never happened. */
 const stateWhere = (
@@ -230,6 +280,7 @@ describe.sequential('Hard fork crossing @fork', () => {
   let enactment: Awaited<ReturnType<ForkFixture['enactFork']>>;
   let postFork: FacadeState;
   let receiver: utils.WalletInit | undefined;
+  let preForkReceiver: utils.WalletInit | undefined;
   let twin: utils.WalletInit;
   let twinTracked: rx.Observable<Tracked>;
   let twinSubscription: rx.Subscription;
@@ -267,9 +318,16 @@ describe.sequential('Hard fork crossing @fork', () => {
     const configuration = {
       ...fixture.getWalletConfig(),
       ...fixture.getDustWalletConfig(),
-      // Version-keyed proving wins over the fixture's single `provingServerUrl`; named here so the
-      // wallet's post-fork proving routes exactly as an application crossing the fork would set it up.
-      provingServers: [{ sinceVersion: V9_NATIVE_FORK_VERSION, url: new URL(fixture.getProverUri()) }],
+      // Version-keyed proving wins over the fixture's single `provingServerUrl`, and names both epochs, because that
+      // is what an application crossing the fork actually has to configure: no proof server serves both ledger
+      // versions, so a wallet that spends on each side of the boundary needs one entry per side.
+      provers: [
+        {
+          sinceVersion: ProtocolVersion.MinSupportedVersion,
+          backend: { kind: 'server', url: new URL(fixture.getPreForkProverUri()) },
+        },
+        { sinceVersion: V9_NATIVE_FORK_VERSION, backend: { kind: 'server', url: new URL(fixture.getProverUri()) } },
+      ] as const satisfies DefaultConfiguration['provers'],
     };
     unshieldedKeystore = createKeystore({ kind: 'schnorr', secret: seeds.unshielded }, fixture.getNetworkId());
 
@@ -310,6 +368,7 @@ describe.sequential('Hard fork crossing @fork', () => {
     await wallet?.stop();
     await twin?.wallet.stop();
     await receiver?.wallet.stop();
+    await preForkReceiver?.wallet.stop();
   }, 60_000);
 
   test('syncs to the pre-fork tip on the old ledger', async () => {
@@ -349,6 +408,62 @@ describe.sequential('Hard fork crossing @fork', () => {
       expect(rootsEqual(eventsState.dust.state.state, twinState.dust.state.state)).toBe(true);
     },
     CROSSING_TIMEOUT_MS,
+  );
+
+  test(
+    'spends before the fork, proving at the pre-fork proof server',
+    async () => {
+      // The half of proving no other lane can reach. Below the boundary the wallet builds pre-fork bytes, and only the
+      // pre-fork ledger can frame a proving request for them and only a pre-fork proof server can answer it — so what
+      // this proves is that the version-keyed backends were honoured, not merely accepted by configuration. The same
+      // wallet proves at the other server after the fork, which is the acceptance criterion for the pair.
+      preForkReceiver = await utils.initWalletWithSeed(PRE_FORK_RECEIVER_SEED, fixture);
+      const receiverBefore = await within(
+        'the pre-fork receiver to sync',
+        CROSSING_TIMEOUT_MS,
+        preForkReceiver.wallet.waitForSyncedState(),
+      );
+      expect(receiverBefore.unshielded.balances[NIGHT] ?? 0n).toBe(0n);
+
+      const before = await wallet.waitForSyncedState();
+      expect(before.activeProtocolVersion).toBeLessThan(V9_NATIVE_FORK_VERSION);
+      const nightBefore = before.unshielded.balances[NIGHT];
+
+      // Dust accrues with time, and this chain is seconds old: for the first half-minute of it there is not enough for
+      // the wallet to pay for anything, and it says so by refusing to balance. What a transfer costs cannot be asked
+      // before there is a transfer to price, so "enough has accrued" is expressed as the build succeeding, retried
+      // until it does. That the wallet leaves the inputs of a build it could not pay for booked is why the first
+      // attempts cost it coins it does not get back — enough of them remain for the one that succeeds.
+      const receiverAddress = await preForkReceiver.wallet.unshielded.getAddress();
+      const recipe = await onceEnoughDustHasBeenGenerated(() =>
+        wallet.transferTransaction(
+          [{ type: 'unshielded', outputs: [{ type: NIGHT, amount: TRANSFER_AMOUNT, receiverAddress }] }],
+          { ttl: new Date(Date.now() + TTL_MS) },
+        ),
+      );
+      const signed = await wallet.signRecipe(recipe, unshieldedKeystore.signDataAsync);
+      const finalizedTx = await wallet.finalizeRecipe(signed);
+
+      // The proof came back as the pre-fork ledger's transaction, which is only true if the pre-fork backend produced
+      // it: the current ledger's classes are a different type and would have been unwrapped as one.
+      expect(carried<preForkLedger.FinalizedTransaction>(finalizedTx)).toBeInstanceOf(preForkLedger.Transaction);
+
+      const txId = await wallet.submitTransaction(finalizedTx);
+      logger.info(`pre-fork unshielded transfer submitted: ${txId}`);
+
+      // The receiver's arrival, not the sender's bookkeeping, is what says the chain took the transaction: the sender
+      // books a spend the moment it submits one, and the coins the earlier attempts booked make its own balances a
+      // poor witness. An empty account seeing exactly what was sent to it is decided by inclusion and nothing else.
+      const receiverAfter = await stateWhere(
+        'the pre-fork receiver to see the transferred Night',
+        preForkReceiver.wallet,
+        (state) => state.isSynced && (state.unshielded.balances[NIGHT] ?? 0n) > 0n,
+      );
+      logger.info(`AFTER PRE-FORK SPEND ${summarize(receiverAfter)}`);
+      expect(receiverAfter.unshielded.balances[NIGHT]).toBe(TRANSFER_AMOUNT);
+      expect(nightBefore).toBe(preFork.unshielded.balances[NIGHT]);
+    },
+    SPEND_TIMEOUT_MS + 5 * 60 * 1000,
   );
 
   test('enacts the ledger 8 to 9 hard fork through governance', async () => {
@@ -415,7 +530,13 @@ describe.sequential('Hard fork crossing @fork', () => {
         ` post coins=${postFork.dust.totalCoins.length} balance=${postFork.dust.balance(new Date())}`,
     );
 
-    expect(postFork.unshielded.balances).toEqual(preFork.unshielded.balances);
+    // Everything the wallet had at the pre-fork tip, less the one transfer it made below the boundary — which is the
+    // only Night that legitimately left it there, and is stated rather than read back from the wallet so that what
+    // crossed is compared against what the chain was asked for.
+    expect(postFork.unshielded.balances).toEqual({
+      ...preFork.unshielded.balances,
+      [NIGHT]: preFork.unshielded.balances[NIGHT] - TRANSFER_AMOUNT,
+    });
     expect(postFork.shielded.balances).toEqual(preFork.shielded.balances);
     expect(postFork.pending.length).toBe(0);
   });

--- a/packages/e2e-tests/src/tests/hardFork.fork.test.ts
+++ b/packages/e2e-tests/src/tests/hardFork.fork.test.ts
@@ -25,7 +25,7 @@ import { inspect } from 'node:util';
 import { Cause, Either, Option, Runtime } from 'effect';
 import { describe, test, expect, beforeAll, afterAll } from 'vitest';
 // Both ledgers, because this file is the one that authors on both sides of the boundary: the spend before the fork is
-// the pre-fork ledger's transaction and everything from `re-registers its NIGHT` onwards is the post-fork ledger's.
+// ledger-v8's transaction and everything from `re-registers its NIGHT` onwards is ledger-v9's.
 import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
@@ -66,7 +66,7 @@ const FUNDED_SEED = '00000000000000000000000000000000000000000000000000000000000
 const RECEIVER_SEED = 'b7d32a5094ec502af45aa913b196530e155f17ef05bbf5d75e743c17c3824a82';
 
 /** A second empty account, for the spend made before the boundary: the post-fork receiver must still start at zero. */
-const PRE_FORK_RECEIVER_SEED = '4c1d1e0e9a2a4a3f8b5c6d7e8f90112233445566778899aabbccddeeff001122';
+const V8_RECEIVER_SEED = '4c1d1e0e9a2a4a3f8b5c6d7e8f90112233445566778899aabbccddeeff001122';
 
 /**
  * Native NIGHT. Written out rather than read from a ledger binding on purpose: the wallet holds this balance on both
@@ -324,7 +324,7 @@ describe.sequential('Hard fork crossing @fork', () => {
       provers: [
         {
           sinceVersion: ProtocolVersion.MinSupportedVersion,
-          backend: { kind: 'server', url: new URL(fixture.getPreForkProverUri()) },
+          backend: { kind: 'server', url: new URL(fixture.getV8ProverUri()) },
         },
         { sinceVersion: V9_NATIVE_FORK_VERSION, backend: { kind: 'server', url: new URL(fixture.getProverUri()) } },
       ] as const satisfies DefaultConfiguration['provers'],
@@ -411,13 +411,13 @@ describe.sequential('Hard fork crossing @fork', () => {
   );
 
   test(
-    'spends before the fork, proving at the pre-fork proof server',
+    'spends before the fork, proving at the ledger-v8 proof server',
     async () => {
-      // The half of proving no other lane can reach. Below the boundary the wallet builds pre-fork bytes, and only the
-      // pre-fork ledger can frame a proving request for them and only a pre-fork proof server can answer it — so what
+      // The half of proving no other lane can reach. Below the boundary the wallet builds ledger-v8 bytes, and only the
+      // ledger-v8 can frame a proving request for them and only a ledger-v8 proof server can answer it — so what
       // this proves is that the version-keyed backends were honoured, not merely accepted by configuration. The same
       // wallet proves at the other server after the fork, which is the acceptance criterion for the pair.
-      preForkReceiver = await utils.initWalletWithSeed(PRE_FORK_RECEIVER_SEED, fixture);
+      preForkReceiver = await utils.initWalletWithSeed(V8_RECEIVER_SEED, fixture);
       const receiverBefore = await within(
         'the pre-fork receiver to sync',
         CROSSING_TIMEOUT_MS,
@@ -444,8 +444,8 @@ describe.sequential('Hard fork crossing @fork', () => {
       const signed = await wallet.signRecipe(recipe, unshieldedKeystore.signDataAsync);
       const finalizedTx = await wallet.finalizeRecipe(signed);
 
-      // The proof came back as the pre-fork ledger's transaction, which is only true if the pre-fork backend produced
-      // it: the current ledger's classes are a different type and would have been unwrapped as one.
+      // The proof came back as ledger-v8's transaction, which is only true if the ledger-v8 backend produced
+      // it: ledger-v9's classes are a different type and would have been unwrapped as one.
       expect(carried<preForkLedger.FinalizedTransaction>(finalizedTx)).toBeInstanceOf(preForkLedger.Transaction);
 
       const txId = await wallet.submitTransaction(finalizedTx);

--- a/packages/e2e-tests/src/tests/transacting.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/transacting.undeployed.test.ts
@@ -36,7 +36,7 @@ import {
   type Transacting,
 } from '@midnightntwrk/wallet-sdk-shielded/v2';
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { Effect, Either, pipe } from 'effect';
+import { Effect, pipe } from 'effect';
 import * as fc from 'fast-check';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
@@ -45,7 +45,8 @@ import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnightntw
 import * as rx from 'rxjs';
 import { DockerComposeEnvironment, type StartedDockerComposeEnvironment } from 'testcontainers';
 import {
-  makeDefaultVersionedProvingServiceEffect,
+  makeServerProvingServiceEffect,
+  singleVersionProvingServiceEffect,
   type DefaultProvingConfiguration,
   type VersionedProvingServiceEffect,
   type UnboundTransaction,
@@ -76,6 +77,9 @@ const shieldedTokenType = ledger.shieldedToken().raw;
 describe.skip('Wallet transacting', () => {
   let startedEnvironment: StartedDockerComposeEnvironment;
   let configuration: DefaultV2Configuration & Submission.DefaultSubmissionConfiguration & DefaultProvingConfiguration;
+  // Named separately from the configuration it also goes into: this suite builds a single current-ledger wallet, so it
+  // wants one current-ledger backend for every version rather than a boundary-aware registry.
+  let provingServerUrl: URL;
 
   beforeEach(async () => {
     const environmentId = randomUUID();
@@ -94,13 +98,14 @@ describe.skip('Wallet transacting', () => {
 
     startedEnvironment = await environment.up();
 
+    provingServerUrl = new URL(
+      `http://localhost:${startedEnvironment.getContainer(`proof-server_${environmentId}`).getMappedPort(6300)}`,
+    );
     configuration = {
       indexerClientConnection: {
         indexerHttpUrl: `http://localhost:${startedEnvironment.getContainer(`indexer_${environmentId}`).getMappedPort(8088)}/api/v4/graphql`,
       },
-      provingServerUrl: new URL(
-        `http://localhost:${startedEnvironment.getContainer(`proof-server_${environmentId}`).getMappedPort(6300)}`,
-      ),
+      provingServerUrl,
       relayURL: new URL(
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
@@ -162,7 +167,7 @@ describe.skip('Wallet transacting', () => {
 
   beforeEach(async () => {
     submissionService = Submission.makeDefaultSubmissionServiceEffect<ledger.FinalizedTransaction>(configuration);
-    provingService = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(configuration));
+    provingService = singleVersionProvingServiceEffect(makeServerProvingServiceEffect({ provingServerUrl }));
     Wallet = WalletBuilder.init()
       .withVariant(ProtocolVersion.MinSupportedVersion, new V2Builder().withDefaults())
       .build(configuration);

--- a/packages/facade/README.md
+++ b/packages/facade/README.md
@@ -40,6 +40,38 @@ const facade = new WalletFacade(shieldedWallet, unshieldedWallet, dustWallet);
 await facade.start(shieldedSecretKeys, dustSecretKey);
 ```
 
+### Configuring where proving happens
+
+A transaction is proved by the backend registered for the protocol version its own bytes were authored at, never by the
+version the chain has since reached. Backends are named ascending by the version each starts serving:
+
+```typescript
+import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+
+const configuration = {
+  // ... the rest of the wallet configuration, including `forkVersion`
+  provers: [
+    // Below the boundary: a proof server built against the pre-fork ledger.
+    {
+      sinceVersion: ProtocolVersion.MinSupportedVersion,
+      backend: { kind: 'server', url: new URL('http://localhost:6301') },
+    },
+    // From the boundary: proving in this process, with the published circuits.
+    { sinceVersion: forkVersion, backend: { kind: 'wasm' } },
+  ],
+};
+```
+
+Two shorthands remain: `provingServers: [{ sinceVersion, url }]` is the same list with every entry a server, and
+`provingServerUrl: url` is one server for every version. Both are read only when `provers` is absent.
+
+A backend whose range spans `configuration.forkVersion` — which `provingServerUrl` always does — is split at the
+boundary and driven by each ledger version in turn, so the same description means the right thing on both sides. A proof
+server, though, is built against one ledger version: no published image serves both, so a chain with history below the
+boundary wants an entry per side. The in-process prover works on bytes and does serve both.
+
+A version no backend covers fails with `UnsupportedProvingVersionError`, naming the version.
+
 ### Observing Combined State
 
 ```typescript

--- a/packages/facade/README.md
+++ b/packages/facade/README.md
@@ -51,7 +51,7 @@ import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 const configuration = {
   // ... the rest of the wallet configuration, including `forkVersion`
   provers: [
-    // Below the boundary: a proof server built against the pre-fork ledger.
+    // Below the boundary: a proof server built against ledger-v8.
     {
       sinceVersion: ProtocolVersion.MinSupportedVersion,
       backend: { kind: 'server', url: new URL('http://localhost:6301') },

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -17,10 +17,11 @@ import {
   type SubmissionService,
 } from '@midnightntwrk/wallet-sdk-capabilities';
 import {
+  type AnyVersionUnboundTransaction,
+  type AnyVersionUnprovenTransaction,
   type DefaultProvingConfiguration,
   makeDefaultVersionedProvingService,
   type VersionedProvingService,
-  type UnboundTransaction,
 } from '@midnightntwrk/wallet-sdk-capabilities/proving';
 import {
   type DefaultDustConfiguration,
@@ -726,7 +727,9 @@ export type InitParams<TConfig extends DefaultConfiguration> = {
   clock?: (config: TConfig) => MaybePromise<Clock.Clock>;
   submissionService?: (config: TConfig) => MaybePromise<SubmissionService<FinalizedTx>>;
   pendingTransactionsService?: (config: TConfig) => MaybePromise<PendingTransactionsService<FinalizedTx>>;
-  provingService?: (config: TConfig) => MaybePromise<VersionedProvingService<UnboundTransaction>>;
+  provingService?: (
+    config: TConfig,
+  ) => MaybePromise<VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>>;
   /**
    * Optional factory for the block-data fetcher used by validation. Defaults to an HTTP indexer-backed fetcher built
    * from `configuration.indexerClientConnection`. Override for simulator-based tests with
@@ -772,10 +775,20 @@ export class WalletFacade {
     });
   }
 
-  private static makeDefaultProvingService<TConfig extends DefaultProvingConfiguration>(
+  /**
+   * Builds the proving service a configuration describes.
+   *
+   * @remarks
+   *   Handed the same fork version the wallets are built with, because a proving backend is chosen by the epoch a
+   *   transaction belongs to and the two ends of that question must not be able to compute the boundary differently.
+   */
+  private static makeDefaultProvingService<TConfig extends DefaultConfiguration>(
     config: TConfig,
-  ): VersionedProvingService<UnboundTransaction> {
-    return Either.getOrThrowWith(makeDefaultVersionedProvingService(config), (error) => new Error(error.message));
+  ): VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction> {
+    return Either.getOrThrowWith(
+      makeDefaultVersionedProvingService(config, config.forkVersion),
+      (error) => new Error(error.message),
+    );
   }
 
   /**
@@ -889,7 +902,7 @@ export class WalletFacade {
   readonly dust: DustWalletAPI;
   readonly submissionService: SubmissionService<FinalizedTx>;
   readonly pendingTransactionsService: PendingTransactionsService<FinalizedTx>;
-  readonly provingService: VersionedProvingService<UnboundTransaction>;
+  readonly provingService: VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>;
   readonly validationService: VersionedValidationService<AnyVersionValidatableTransaction, AnyLedgerParameters>;
   #txHistoryStorage: TransactionHistoryStorage.TransactionHistoryStorage<WalletEntry>;
   readonly clock: Clock.Clock;
@@ -919,7 +932,7 @@ export class WalletFacade {
     dustWallet: DustWalletAPI,
     submissionService: SubmissionService<FinalizedTx>,
     pendingTransactionsService: PendingTransactionsService<FinalizedTx>,
-    provingService: VersionedProvingService<UnboundTransaction>,
+    provingService: VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>,
     validationService: VersionedValidationService<AnyVersionValidatableTransaction, AnyLedgerParameters>,
     txHistoryStorage: TransactionHistoryStorage.TransactionHistoryStorage<WalletEntry>,
     forkVersion: ProtocolVersion.ProtocolVersion,

--- a/packages/facade/test/versionedProving.test.ts
+++ b/packages/facade/test/versionedProving.test.ts
@@ -193,14 +193,14 @@ describe('Proving with the backend configured for the epoch a transaction belong
   };
 
   /**
-   * A pre-fork transaction with nothing in it that needs a proof, stamped below the boundary.
+   * A ledger-v8 transaction with nothing in it that needs a proof, stamped below the boundary.
    *
    * @remarks
    *   Nothing to prove means no backend is ever reached over the network, which is what lets these tests name proof
    *   servers that do not exist. What is observable is the only thing that matters here: which ledger version drove the
    *   proving, and therefore which ledger version's transaction comes back.
    */
-  const aPreForkTransaction = () =>
+  const aV8Transaction = () =>
     WalletTransaction.adopt(
       'Unproven',
       preForkLedger.Transaction.fromParts(
@@ -212,7 +212,7 @@ describe('Proving with the backend configured for the epoch a transaction belong
       PRE_FORK,
     );
 
-  /** A current-ledger transaction wearing a pre-fork stamp: the stamp the facade reads, the bytes it does not. */
+  /** A ledger-v9 transaction wearing a pre-fork stamp: the stamp the facade reads, the bytes it does not. */
   const aMisstampedCurrentLedgerTransaction = () =>
     WalletTransaction.adopt(
       'Unproven',
@@ -243,7 +243,7 @@ describe('Proving with the backend configured for the epoch a transaction belong
       WalletTransaction.unwrapWithin<unknown>(finalized, ProtocolVersion.epochOf(PRE_FORK, V9_NATIVE_FORK_VERSION)),
     );
 
-  const preForkServerAndPostForkWasm: Partial<DefaultConfiguration> = {
+  const v8ServerAndV9Wasm: Partial<DefaultConfiguration> = {
     provers: [
       {
         sinceVersion: ProtocolVersion.MinSupportedVersion,
@@ -253,10 +253,10 @@ describe('Proving with the backend configured for the epoch a transaction belong
     ],
   };
 
-  it('proves a transaction built below the fork with the pre-fork ledger', async () => {
-    const facade = await started(preForkServerAndPostForkWasm);
+  it('proves a transaction built below the fork with ledger-v8', async () => {
+    const facade = await started(v8ServerAndV9Wasm);
 
-    const finalized = await facade.finalizeTransaction(aPreForkTransaction());
+    const finalized = await facade.finalizeTransaction(aV8Transaction());
 
     expect(provenBy(finalized)).toBeInstanceOf(preForkLedger.Transaction);
   });
@@ -266,13 +266,13 @@ describe('Proving with the backend configured for the epoch a transaction belong
     // boundary is that the facade hands proving the same fork version it hands its wallets.
     const facade = await started({ provingServerUrl: new URL('http://only-prover:6300') });
 
-    const finalized = await facade.finalizeTransaction(aPreForkTransaction());
+    const finalized = await facade.finalizeTransaction(aV8Transaction());
 
     expect(provenBy(finalized)).toBeInstanceOf(preForkLedger.Transaction);
   });
 
-  it('refuses a current-ledger transaction wearing a pre-fork stamp, rather than handing it to a ledger that cannot read it', async () => {
-    const facade = await started(preForkServerAndPostForkWasm);
+  it('refuses a ledger-v9 transaction wearing a pre-fork stamp, rather than handing it to a ledger that cannot read it', async () => {
+    const facade = await started(v8ServerAndV9Wasm);
 
     const failure = await facade.finalizeTransaction(aMisstampedCurrentLedgerTransaction()).then(
       () => undefined,
@@ -292,7 +292,7 @@ describe('Proving with the backend configured for the epoch a transaction belong
       ],
     });
 
-    const failure = await facade.finalizeTransaction(aPreForkTransaction()).then(
+    const failure = await facade.finalizeTransaction(aV8Transaction()).then(
       () => undefined,
       (error: unknown) => error,
     );

--- a/packages/facade/test/versionedProving.test.ts
+++ b/packages/facade/test/versionedProving.test.ts
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import {
   InMemoryTransactionHistoryStorage,
@@ -21,10 +22,16 @@ import {
   ProtocolVersionMismatchError,
   WalletTransaction,
 } from '@midnightntwrk/wallet-sdk-abstractions';
-import type { UnboundTransaction, VersionedProvingService } from '@midnightntwrk/wallet-sdk-capabilities/proving';
+import {
+  ProvingEpochMismatchError,
+  UnsupportedProvingVersionError,
+  type UnboundTransaction,
+  type VersionedProvingService,
+} from '@midnightntwrk/wallet-sdk-capabilities/proving';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
+import { Cause, Either, Option, Runtime } from 'effect';
 import * as rx from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -146,5 +153,151 @@ describe('Proving a transaction at the version it was built for', () => {
 
     expect(failure).toBeInstanceOf(ProtocolVersionMismatchError);
     expect(prover.askedFor).toStrictEqual([]);
+  });
+});
+
+describe('Proving with the backend configured for the epoch a transaction belongs to', () => {
+  const facades: WalletFacade[] = [];
+
+  afterEach(async () => {
+    await Promise.allSettled(facades.splice(0).map((facade) => facade.stop()));
+  });
+
+  /** A facade built with the default proving service, so what is under test is the wiring rather than a stand-in. */
+  const started = async (proving: Partial<DefaultConfiguration>): Promise<WalletFacade> => {
+    const configuration: DefaultConfiguration = {
+      networkId: NetworkId.NetworkId.Undeployed,
+      forkVersion: V9_NATIVE_FORK_VERSION,
+      relayURL: new URL('http://localhost:9944'),
+      indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
+      costParameters: { feeBlocksMargin: 0 },
+      txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
+      ...proving,
+    };
+    const seed = '0000000000000000000000000000000000000000000000000000000000000001';
+    const unshieldedKeystore = createKeystore(
+      { kind: 'schnorr', secret: getUnshieldedSeed(seed) },
+      configuration.networkId,
+    );
+
+    const facade = await WalletFacade.init({
+      configuration,
+      shielded: () => ShieldedWallet(configuration).startWithSeed(getShieldedSeed(seed)),
+      unshielded: () => UnshieldedWallet(configuration).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
+      dust: () =>
+        DustWallet(configuration).startWithSeed(getDustSeed(seed), ledger.LedgerParameters.initialParameters().dust),
+    });
+    facades.push(facade);
+    return facade;
+    // The wallets are not started, for the same reason as above: this suite has no indexer to subscribe to.
+  };
+
+  /**
+   * A pre-fork transaction with nothing in it that needs a proof, stamped below the boundary.
+   *
+   * @remarks
+   *   Nothing to prove means no backend is ever reached over the network, which is what lets these tests name proof
+   *   servers that do not exist. What is observable is the only thing that matters here: which ledger version drove the
+   *   proving, and therefore which ledger version's transaction comes back.
+   */
+  const aPreForkTransaction = () =>
+    WalletTransaction.adopt(
+      'Unproven',
+      preForkLedger.Transaction.fromParts(
+        NetworkId.NetworkId.Undeployed,
+        undefined,
+        undefined,
+        preForkLedger.Intent.new(new Date(Date.now() + 60_000)),
+      ),
+      PRE_FORK,
+    );
+
+  /** A current-ledger transaction wearing a pre-fork stamp: the stamp the facade reads, the bytes it does not. */
+  const aMisstampedCurrentLedgerTransaction = () =>
+    WalletTransaction.adopt(
+      'Unproven',
+      ledger.Transaction.fromParts(
+        NetworkId.NetworkId.Undeployed,
+        undefined,
+        undefined,
+        ledger.Intent.new(new Date(Date.now() + 60_000)),
+      ),
+      PRE_FORK,
+    );
+
+  /**
+   * The error a rejected facade call actually reports.
+   *
+   * @remarks
+   *   Proving is the one facade path whose failures come back through an Effect runtime, so they arrive wrapped rather
+   *   than as themselves. What the caller is entitled to is inside; this is where the test looks for it, rather than
+   *   loosening what it asserts about the failure.
+   */
+  const reported = (error: unknown): unknown =>
+    Runtime.isFiberFailure(error)
+      ? Option.getOrElse(Cause.failureOption(error[Runtime.FiberFailureCauseId]), () => error)
+      : error;
+
+  const provenBy = (finalized: WalletTransaction<WalletTransaction.Stage>) =>
+    Either.getOrThrow(
+      WalletTransaction.unwrapWithin<unknown>(finalized, ProtocolVersion.epochOf(PRE_FORK, V9_NATIVE_FORK_VERSION)),
+    );
+
+  const preForkServerAndPostForkWasm: Partial<DefaultConfiguration> = {
+    provers: [
+      {
+        sinceVersion: ProtocolVersion.MinSupportedVersion,
+        backend: { kind: 'server', url: new URL('http://pre-fork-prover:6300') },
+      },
+      { sinceVersion: V9_NATIVE_FORK_VERSION, backend: { kind: 'wasm' } },
+    ],
+  };
+
+  it('proves a transaction built below the fork with the pre-fork ledger', async () => {
+    const facade = await started(preForkServerAndPostForkWasm);
+
+    const finalized = await facade.finalizeTransaction(aPreForkTransaction());
+
+    expect(provenBy(finalized)).toBeInstanceOf(preForkLedger.Transaction);
+  });
+
+  it('splits the single-server configuration at the fork version the wallet was configured with', async () => {
+    // Naming one server for every version says nothing about ledger versions, and cannot. What makes it right below the
+    // boundary is that the facade hands proving the same fork version it hands its wallets.
+    const facade = await started({ provingServerUrl: new URL('http://only-prover:6300') });
+
+    const finalized = await facade.finalizeTransaction(aPreForkTransaction());
+
+    expect(provenBy(finalized)).toBeInstanceOf(preForkLedger.Transaction);
+  });
+
+  it('refuses a current-ledger transaction wearing a pre-fork stamp, rather than handing it to a ledger that cannot read it', async () => {
+    const facade = await started(preForkServerAndPostForkWasm);
+
+    const failure = await facade.finalizeTransaction(aMisstampedCurrentLedgerTransaction()).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(reported(failure)).toBeInstanceOf(ProvingEpochMismatchError);
+  });
+
+  it('refuses a transaction from a version no backend was configured for, naming that version', async () => {
+    const facade = await started({
+      provers: [
+        {
+          sinceVersion: V9_NATIVE_FORK_VERSION,
+          backend: { kind: 'server', url: new URL('http://post-fork-prover:6300') },
+        },
+      ],
+    });
+
+    const failure = await facade.finalizeTransaction(aPreForkTransaction()).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(reported(failure)).toBeInstanceOf(UnsupportedProvingVersionError);
+    expect((reported(failure) as UnsupportedProvingVersionError).protocolVersion).toStrictEqual(PRE_FORK);
   });
 });

--- a/packages/prover-client/README.md
+++ b/packages/prover-client/README.md
@@ -58,8 +58,8 @@ framed and read back by that same version. `HttpProverClient` therefore offers o
 ```typescript
 const client = await Effect.runPromise(HttpProverClient.create({ url: proofServerUrl }));
 
-client.asProvingProvider(); // frames with @midnightntwrk/ledger-v9 (the current ledger)
-client.asPreForkProvingProvider(); // frames with @midnight-ntwrk/ledger-v8 (the pre-fork ledger)
+client.asV9ProvingProvider(); // frames with @midnightntwrk/ledger-v9; asProvingProvider() is the same provider
+client.asV8ProvingProvider(); // frames with @midnight-ntwrk/ledger-v8
 ```
 
 `WasmProver` offers both names too, and returns the same provider for each: the in-process prover drives a zkir runtime

--- a/packages/prover-client/README.md
+++ b/packages/prover-client/README.md
@@ -50,6 +50,34 @@ class HttpProverClient {
 }
 ```
 
+### Proving providers, per ledger version
+
+A proof preimage is produced by the ledger version that built the transaction, and the request carrying it has to be
+framed and read back by that same version. `HttpProverClient` therefore offers one provider per ledger version:
+
+```typescript
+const client = await Effect.runPromise(HttpProverClient.create({ url: proofServerUrl }));
+
+client.asProvingProvider(); // frames with @midnightntwrk/ledger-v9 (the current ledger)
+client.asPreForkProvingProvider(); // frames with @midnight-ntwrk/ledger-v8 (the pre-fork ledger)
+```
+
+`WasmProver` offers both names too, and returns the same provider for each: the in-process prover drives a zkir runtime
+over bytes and never looks at a ledger version.
+
+Its key material is read from a published bucket, one line per circuit generation rather than per ledger:
+
+```typescript
+WasmProver.makeDefaultKeyMaterialProvider(); // the line both ledger versions accept
+WasmProver.makeDefaultKeyMaterialProvider({ circuits: 8 }); // an explicit override
+```
+
+The default is what both ledger versions accept today; `circuits` exists so an operator whose bucket says otherwise can
+say so, not because a fork implies a change of line.
+
+> This package depends on both ledger runtimes, `@midnight-ntwrk/ledger-v8` and `@midnightntwrk/ledger-v9`. Both are
+> WASM modules, so a direct consumer bundling this package ships both.
+
 ## Exports
 
 ### Default Export

--- a/packages/prover-client/package.json
+++ b/packages/prover-client/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@effect/platform": "^0.96.0",
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnight-ntwrk/zkir-v2": "^2.1.0",
     "@midnightntwrk/ledger-v9": "1.0.0-rc.4",
     "@midnightntwrk/wallet-sdk-utilities": "1.2.1",

--- a/packages/prover-client/src/effect/HttpProverClient.ts
+++ b/packages/prover-client/src/effect/HttpProverClient.ts
@@ -40,13 +40,13 @@ type PayloadFraming = Readonly<{
   parseCheckResult: (result: Uint8Array) => (bigint | undefined)[];
 }>;
 
-const currentLedgerFraming: PayloadFraming = {
+const v9Framing: PayloadFraming = {
   createProvingPayload: (preimage, binding) => ledger.createProvingPayload(preimage, binding),
   createCheckPayload: (preimage) => ledger.createCheckPayload(preimage),
   parseCheckResult: (result) => ledger.parseCheckResult(result),
 };
 
-const preForkFraming: PayloadFraming = {
+const v8Framing: PayloadFraming = {
   createProvingPayload: (preimage, binding) => preForkLedger.createProvingPayload(preimage, binding),
   createCheckPayload: (preimage) => preForkLedger.createCheckPayload(preimage),
   parseCheckResult: (result) => preForkLedger.parseCheckResult(result),
@@ -181,7 +181,7 @@ class HttpProverClientImpl implements Context.Tag.Service<ProverClient> {
     costModel: ledger.CostModel,
   ): Effect.Effect<ledger.Transaction<S, ledger.Proof, B>, ClientError | ServerError> {
     return pipe(
-      Effect.succeed(this.serverProverProvider(currentLedgerFraming)),
+      Effect.succeed(this.serverProverProvider(v9Framing)),
       Effect.flatMap((provider) =>
         Effect.tryPromise({
           try: () => transaction.prove(provider, costModel),
@@ -195,10 +195,14 @@ class HttpProverClientImpl implements Context.Tag.Service<ProverClient> {
   }
 
   asProvingProvider(): ledger.ProvingProvider {
-    return this.serverProverProvider(currentLedgerFraming);
+    return this.serverProverProvider(v9Framing);
   }
 
-  asPreForkProvingProvider(): preForkLedger.ProvingProvider {
-    return this.serverProverProvider(preForkFraming);
+  asV9ProvingProvider(): ledger.ProvingProvider {
+    return this.asProvingProvider();
+  }
+
+  asV8ProvingProvider(): preForkLedger.ProvingProvider {
+    return this.serverProverProvider(v8Framing);
   }
 }

--- a/packages/prover-client/src/effect/HttpProverClient.ts
+++ b/packages/prover-client/src/effect/HttpProverClient.ts
@@ -20,10 +20,37 @@ import {
   ServerError,
 } from '@midnightntwrk/wallet-sdk-utilities/networking';
 import { BlobOps, EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
 
 const PROVE_TX_PATH = '/prove';
 const CHECK_TX_PATH = '/check';
+
+/**
+ * How one ledger version frames a proof server request and reads its reply.
+ *
+ * @remarks
+ *   The only thing that differs between the two ledger versions' providers, so it is the only thing named. A preimage is
+ *   produced by one ledger version and has to be framed by that same one; that the two framings agree byte for byte on
+ *   today's preimages is a coincidence of the current releases, not a property to build on.
+ */
+type PayloadFraming = Readonly<{
+  createProvingPayload: (serializedPreimage: Uint8Array, overwriteBindingInput: bigint | undefined) => Uint8Array;
+  createCheckPayload: (serializedPreimage: Uint8Array) => Uint8Array;
+  parseCheckResult: (result: Uint8Array) => (bigint | undefined)[];
+}>;
+
+const currentLedgerFraming: PayloadFraming = {
+  createProvingPayload: (preimage, binding) => ledger.createProvingPayload(preimage, binding),
+  createCheckPayload: (preimage) => ledger.createCheckPayload(preimage),
+  parseCheckResult: (result) => ledger.parseCheckResult(result),
+};
+
+const preForkFraming: PayloadFraming = {
+  createProvingPayload: (preimage, binding) => preForkLedger.createProvingPayload(preimage, binding),
+  createCheckPayload: (preimage) => preForkLedger.createCheckPayload(preimage),
+  parseCheckResult: (result) => preForkLedger.parseCheckResult(result),
+};
 
 /**
  * Creates a layer for a {@link ProverClient} that sends requests to a Proof Server over HTTP.
@@ -126,12 +153,12 @@ class HttpProverClientImpl implements Context.Tag.Service<ProverClient> {
     );
   }
 
-  private serverProverProvider = (): ledger.ProvingProvider => ({
+  private serverProverProvider = (framing: PayloadFraming): ledger.ProvingProvider => ({
     check: async (serializedPreimage: Uint8Array, _keyLocation: string): Promise<(bigint | undefined)[]> =>
       pipe(
-        Effect.succeed(ledger.createCheckPayload(serializedPreimage)),
+        Effect.succeed(framing.createCheckPayload(serializedPreimage)),
         Effect.flatMap((tx) => this.request(CHECK_TX_PATH, tx, 'Failed to check')),
-        Effect.map((response) => ledger.parseCheckResult(response)),
+        Effect.map((response) => framing.parseCheckResult(response)),
         Effect.runPromise,
       ),
     prove: async (
@@ -140,7 +167,7 @@ class HttpProverClientImpl implements Context.Tag.Service<ProverClient> {
       overwriteBindingInput?: bigint,
     ): Promise<Uint8Array> =>
       pipe(
-        Effect.succeed(ledger.createProvingPayload(serializedPreimage, overwriteBindingInput)),
+        Effect.succeed(framing.createProvingPayload(serializedPreimage, overwriteBindingInput)),
         Effect.flatMap((tx) => this.request(PROVE_TX_PATH, tx, 'Failed to prove')),
         Effect.runPromise,
       ),
@@ -154,7 +181,7 @@ class HttpProverClientImpl implements Context.Tag.Service<ProverClient> {
     costModel: ledger.CostModel,
   ): Effect.Effect<ledger.Transaction<S, ledger.Proof, B>, ClientError | ServerError> {
     return pipe(
-      Effect.succeed(this.serverProverProvider()),
+      Effect.succeed(this.serverProverProvider(currentLedgerFraming)),
       Effect.flatMap((provider) =>
         Effect.tryPromise({
           try: () => transaction.prove(provider, costModel),
@@ -167,7 +194,11 @@ class HttpProverClientImpl implements Context.Tag.Service<ProverClient> {
     );
   }
 
-  asProvingProvider() {
-    return this.serverProverProvider();
+  asProvingProvider(): ledger.ProvingProvider {
+    return this.serverProverProvider(currentLedgerFraming);
+  }
+
+  asPreForkProvingProvider(): preForkLedger.ProvingProvider {
+    return this.serverProverProvider(preForkFraming);
   }
 }

--- a/packages/prover-client/src/effect/ProverClient.ts
+++ b/packages/prover-client/src/effect/ProverClient.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { type Effect, Context } from 'effect';
+import type * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import type * as ledger from '@midnightntwrk/ledger-v9';
 import { type ClientError, type ServerError } from '@midnightntwrk/wallet-sdk-utilities/networking';
 import type { KeyMaterialProvider } from '@midnight-ntwrk/zkir-v2';
@@ -47,6 +48,18 @@ export declare namespace ProverClient {
       costModel?: ledger.CostModel,
     ): Effect.Effect<ledger.Transaction<S, ledger.Proof, B>, ClientError | ServerError>;
 
+    /** A proving provider that frames its requests with the current ledger version. */
     asProvingProvider(): ledger.ProvingProvider;
+
+    /**
+     * A proving provider that frames its requests with the pre-fork ledger version.
+     *
+     * @remarks
+     *   A preimage is produced by the ledger version that built the transaction, and has to be framed and read back by
+     *   that same version — so a client serving a pre-fork transaction is asked for this provider rather than the
+     *   other. An in-process prover has nothing to distinguish: it works on bytes, and offers the same provider for
+     *   both.
+     */
+    asPreForkProvingProvider(): preForkLedger.ProvingProvider;
   }
 }

--- a/packages/prover-client/src/effect/ProverClient.ts
+++ b/packages/prover-client/src/effect/ProverClient.ts
@@ -48,18 +48,21 @@ export declare namespace ProverClient {
       costModel?: ledger.CostModel,
     ): Effect.Effect<ledger.Transaction<S, ledger.Proof, B>, ClientError | ServerError>;
 
-    /** A proving provider that frames its requests with the current ledger version. */
+    /** A proving provider that frames its requests with ledger-v9. */
     asProvingProvider(): ledger.ProvingProvider;
 
+    /** The same provider as {@link asProvingProvider}, named for the ledger version it frames with. */
+    asV9ProvingProvider(): ledger.ProvingProvider;
+
     /**
-     * A proving provider that frames its requests with the pre-fork ledger version.
+     * A proving provider that frames its requests with ledger-v8.
      *
      * @remarks
      *   A preimage is produced by the ledger version that built the transaction, and has to be framed and read back by
-     *   that same version — so a client serving a pre-fork transaction is asked for this provider rather than the
+     *   that same version — so a client serving a ledger-v8 transaction is asked for this provider rather than the
      *   other. An in-process prover has nothing to distinguish: it works on bytes, and offers the same provider for
      *   both.
      */
-    asPreForkProvingProvider(): preForkLedger.ProvingProvider;
+    asV8ProvingProvider(): preForkLedger.ProvingProvider;
   }
 }

--- a/packages/prover-client/src/effect/WasmProver.ts
+++ b/packages/prover-client/src/effect/WasmProver.ts
@@ -193,12 +193,38 @@ class WasmProverImpl implements Context.Tag.Service<ProverClient> {
   asProvingProvider() {
     return this.wasmProverProvider();
   }
+
+  /**
+   * The same provider {@link asProvingProvider} returns.
+   *
+   * @remarks
+   *   The in-process prover drives a zkir runtime over bytes and never looks at a ledger version, so there is nothing for
+   *   a pre-fork variant to do differently. It is offered under both names because the caller choosing a backend for an
+   *   epoch should not have to know which backends care about the epoch and which do not.
+   */
+  asPreForkProvingProvider() {
+    return this.wasmProverProvider();
+  }
 }
 
-export const makeDefaultKeyMaterialProvider = (): KeyMaterialProvider => {
+/** Which line of the key-material bucket to read: the circuits the keys were generated for. */
+export type KeyMaterialConfig = {
+  /**
+   * The circuit line to read.
+   *
+   * @remarks
+   *   Not a ledger version, despite reading like one. Line 9 is what both ledger versions the SDK carries accept today —
+   *   the pre-fork ledger's own line predates the zkir runtime they share and its verifier keys are rejected outright —
+   *   which is why it is the default on both sides. The setting exists so an operator whose bucket says otherwise can
+   *   say so, not because a fork implies a change of line.
+   */
+  circuits?: 8 | 9;
+};
+
+export const makeDefaultKeyMaterialProvider = (config?: KeyMaterialConfig): KeyMaterialProvider => {
   const cache = new Map<string, ProvingKeyMaterial | Uint8Array>();
   const s3 = 'https://midnight-s3-fileshare-dev-eu-west-1.s3.eu-west-1.amazonaws.com';
-  const ver = 9;
+  const ver = config?.circuits ?? 9;
 
   const fetchWithRetry = async (url: string, retries = 5): Promise<Response> => {
     for (let i = 0; i < retries; i++) {

--- a/packages/prover-client/src/effect/WasmProver.ts
+++ b/packages/prover-client/src/effect/WasmProver.ts
@@ -199,10 +199,14 @@ class WasmProverImpl implements Context.Tag.Service<ProverClient> {
    *
    * @remarks
    *   The in-process prover drives a zkir runtime over bytes and never looks at a ledger version, so there is nothing for
-   *   a pre-fork variant to do differently. It is offered under both names because the caller choosing a backend for an
-   *   epoch should not have to know which backends care about the epoch and which do not.
+   *   a ledger-v8 variant to do differently. It is offered under both names because the caller choosing a backend for
+   *   an epoch should not have to know which backends care about the epoch and which do not.
    */
-  asPreForkProvingProvider() {
+  asV9ProvingProvider() {
+    return this.wasmProverProvider();
+  }
+
+  asV8ProvingProvider() {
     return this.wasmProverProvider();
   }
 }
@@ -214,9 +218,9 @@ export type KeyMaterialConfig = {
    *
    * @remarks
    *   Not a ledger version, despite reading like one. Line 9 is what both ledger versions the SDK carries accept today —
-   *   the pre-fork ledger's own line predates the zkir runtime they share and its verifier keys are rejected outright —
-   *   which is why it is the default on both sides. The setting exists so an operator whose bucket says otherwise can
-   *   say so, not because a fork implies a change of line.
+   *   ledger-v8's own line predates the zkir runtime they share and its verifier keys are rejected outright — which is
+   *   why it is the default on both sides. The setting exists so an operator whose bucket says otherwise can say so,
+   *   not because a fork implies a change of line.
    */
   circuits?: 8 | 9;
 };

--- a/packages/prover-client/src/effect/test/httpProverClient.test.ts
+++ b/packages/prover-client/src/effect/test/httpProverClient.test.ts
@@ -1,0 +1,169 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * What the HTTP prover client puts on the wire, per ledger version.
+ *
+ * @remarks
+ *   A proof server speaks in payloads the ledger frames, so the client has one framing per ledger version and picks by
+ *   which provider was asked for. The two framings happen to agree byte for byte on the preimages today's ledgers
+ *   produce — which is exactly why this is worth pinning down rather than left to coincidence: what makes the request
+ *   right is that the ledger which built the preimage also framed it, not that the other one would have agreed.
+ *
+ *   The requests are observed by standing in for `fetch`, because the client runs each request on its own runtime with
+ *   its own HTTP layer, so there is no context a test could provide one through.
+ */
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as HttpProverClient from '../HttpProverClient.js';
+
+const PROVER_URL = new URL('http://prover.test:6300');
+
+/** A request the client made, as the stand-in for `fetch` saw it. */
+type ObservedRequest = Readonly<{ url: string; method: string; body: Uint8Array }>;
+
+/** A check result the ledger's own parser reads as `[42n]`: the tagged, SCALE-encoded `vec(option(u64))`. */
+const aCheckResponseBody = new Uint8Array(
+  Buffer.concat([Buffer.from('midnight:vec(option(u64)):', 'utf8'), Buffer.from([0x04, 0x01, 42 << 2])]),
+);
+
+/**
+ * A proof preimage as one ledger version's own transaction produces it.
+ *
+ * @remarks
+ *   Taken from the ledger rather than written down as a fixture: the payload helpers refuse anything that is not a real
+ *   preimage, and a preimage is only ever produced by the ledger version whose framing is under test. Proving is
+ *   abandoned as soon as the first one has been seen — no proof is wanted here, only the bytes the ledger would have
+ *   sent to a prover.
+ */
+const firstPreimageOf = async (
+  prove: (provider: {
+    check: () => Promise<(bigint | undefined)[]>;
+    prove: (preimage: Uint8Array) => Promise<Uint8Array>;
+    lookupKey: () => Promise<undefined>;
+  }) => Promise<unknown>,
+): Promise<Uint8Array> => {
+  const seen: Uint8Array[] = [];
+  await prove({
+    check: () => Promise.resolve([]),
+    prove: (preimage: Uint8Array) => {
+      seen.push(preimage);
+      return Promise.reject(new Error('enough: the preimage has been seen'));
+    },
+    lookupKey: () => Promise.resolve(undefined),
+  }).then(
+    () => undefined,
+    () => undefined,
+  );
+
+  const preimage = seen.at(0);
+  if (preimage === undefined) throw new Error('the ledger asked for no proof');
+  return preimage;
+};
+
+const aPreForkPreimage = (): Promise<Uint8Array> => {
+  const shielded = preForkLedger.shieldedToken();
+  const coin = preForkLedger.createShieldedCoinInfo(shielded.raw, 1_000n);
+  const output = preForkLedger.ZswapOutput.new(
+    coin,
+    0,
+    preForkLedger.sampleCoinPublicKey(),
+    preForkLedger.sampleEncryptionPublicKey(),
+  );
+  const transaction = preForkLedger.Transaction.fromParts(
+    'undeployed',
+    preForkLedger.ZswapOffer.fromOutput(output, shielded.raw, 1_000n),
+  );
+  return firstPreimageOf((provider) => transaction.prove(provider, preForkLedger.CostModel.initialCostModel()));
+};
+
+const aCurrentLedgerPreimage = (): Promise<Uint8Array> => {
+  const shielded = ledger.shieldedToken();
+  const coin = ledger.createShieldedCoinInfo(shielded.raw, 1_000n);
+  const output = ledger.ZswapOutput.new(coin, 0, ledger.sampleCoinPublicKey(), ledger.sampleEncryptionPublicKey());
+  const transaction = ledger.Transaction.fromParts(
+    'undeployed',
+    ledger.ZswapOffer.fromOutput(output, shielded.raw, 1_000n),
+  );
+  return firstPreimageOf((provider) => transaction.prove(provider, ledger.CostModel.initialCostModel()));
+};
+
+describe('What the HTTP prover client sends to a proof server', () => {
+  const observed: ObservedRequest[] = [];
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    observed.length = 0;
+    globalThis.fetch = (input: string | URL | Request, init?: RequestInit) => {
+      observed.push({
+        url: input instanceof Request ? input.url : input.toString(),
+        method: init?.method ?? 'GET',
+        // Type cast required because: the client always sends a raw byte body, which `RequestInit` types only as the
+        // whole `BodyInit` union.
+        body: new Uint8Array(init?.body as Uint8Array),
+      });
+      return Promise.resolve(new Response(aCheckResponseBody, { status: 200 }));
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  const client = () => Effect.runSync(HttpProverClient.create({ url: PROVER_URL }));
+
+  it('frames a pre-fork proving request with the pre-fork ledger, and posts it to /prove', async () => {
+    const preimage = await aPreForkPreimage();
+
+    const proof = await client().asPreForkProvingProvider().prove(preimage, 'midnight/zswap/output', 7n);
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0].url).toBe('http://prover.test:6300/prove');
+    expect(observed[0].method).toBe('POST');
+    expect(observed[0].body).toStrictEqual(preForkLedger.createProvingPayload(preimage, 7n));
+    expect(proof).toStrictEqual(aCheckResponseBody);
+  });
+
+  it('frames a pre-fork check request with the pre-fork ledger, posts it to /check, and reads the reply with it', async () => {
+    const preimage = await aPreForkPreimage();
+
+    const result = await client().asPreForkProvingProvider().check(preimage, 'midnight/zswap/output');
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0].url).toBe('http://prover.test:6300/check');
+    expect(observed[0].body).toStrictEqual(preForkLedger.createCheckPayload(preimage));
+    expect(result).toStrictEqual(preForkLedger.parseCheckResult(aCheckResponseBody));
+  });
+
+  it('frames a current-ledger proving request with the current ledger, unchanged', async () => {
+    const preimage = await aCurrentLedgerPreimage();
+
+    await client().asProvingProvider().prove(preimage, 'midnight/zswap/output', 7n);
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0].url).toBe('http://prover.test:6300/prove');
+    expect(observed[0].body).toStrictEqual(ledger.createProvingPayload(preimage, 7n));
+  });
+
+  it('frames a current-ledger check request with the current ledger, unchanged', async () => {
+    const preimage = await aCurrentLedgerPreimage();
+
+    const result = await client().asProvingProvider().check(preimage, 'midnight/zswap/output');
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0].url).toBe('http://prover.test:6300/check');
+    expect(observed[0].body).toStrictEqual(ledger.createCheckPayload(preimage));
+    expect(result).toStrictEqual(ledger.parseCheckResult(aCheckResponseBody));
+  });
+});

--- a/packages/prover-client/src/effect/test/httpProverClient.test.ts
+++ b/packages/prover-client/src/effect/test/httpProverClient.test.ts
@@ -72,7 +72,7 @@ const firstPreimageOf = async (
   return preimage;
 };
 
-const aPreForkPreimage = (): Promise<Uint8Array> => {
+const aV8Preimage = (): Promise<Uint8Array> => {
   const shielded = preForkLedger.shieldedToken();
   const coin = preForkLedger.createShieldedCoinInfo(shielded.raw, 1_000n);
   const output = preForkLedger.ZswapOutput.new(
@@ -123,10 +123,10 @@ describe('What the HTTP prover client sends to a proof server', () => {
 
   const client = () => Effect.runSync(HttpProverClient.create({ url: PROVER_URL }));
 
-  it('frames a pre-fork proving request with the pre-fork ledger, and posts it to /prove', async () => {
-    const preimage = await aPreForkPreimage();
+  it('frames a ledger-v8 proving request with it, and posts it to /prove', async () => {
+    const preimage = await aV8Preimage();
 
-    const proof = await client().asPreForkProvingProvider().prove(preimage, 'midnight/zswap/output', 7n);
+    const proof = await client().asV8ProvingProvider().prove(preimage, 'midnight/zswap/output', 7n);
 
     expect(observed).toHaveLength(1);
     expect(observed[0].url).toBe('http://prover.test:6300/prove');
@@ -135,10 +135,10 @@ describe('What the HTTP prover client sends to a proof server', () => {
     expect(proof).toStrictEqual(aCheckResponseBody);
   });
 
-  it('frames a pre-fork check request with the pre-fork ledger, posts it to /check, and reads the reply with it', async () => {
-    const preimage = await aPreForkPreimage();
+  it('frames a ledger-v8 check request with it, posts it to /check, and reads the reply with it', async () => {
+    const preimage = await aV8Preimage();
 
-    const result = await client().asPreForkProvingProvider().check(preimage, 'midnight/zswap/output');
+    const result = await client().asV8ProvingProvider().check(preimage, 'midnight/zswap/output');
 
     expect(observed).toHaveLength(1);
     expect(observed[0].url).toBe('http://prover.test:6300/check');
@@ -146,7 +146,7 @@ describe('What the HTTP prover client sends to a proof server', () => {
     expect(result).toStrictEqual(preForkLedger.parseCheckResult(aCheckResponseBody));
   });
 
-  it('frames a current-ledger proving request with the current ledger, unchanged', async () => {
+  it('frames a current-ledger proving request with ledger-v9, unchanged', async () => {
     const preimage = await aCurrentLedgerPreimage();
 
     await client().asProvingProvider().prove(preimage, 'midnight/zswap/output', 7n);
@@ -156,7 +156,7 @@ describe('What the HTTP prover client sends to a proof server', () => {
     expect(observed[0].body).toStrictEqual(ledger.createProvingPayload(preimage, 7n));
   });
 
-  it('frames a current-ledger check request with the current ledger, unchanged', async () => {
+  it('frames a current-ledger check request with ledger-v9, unchanged', async () => {
     const preimage = await aCurrentLedgerPreimage();
 
     const result = await client().asProvingProvider().check(preimage, 'midnight/zswap/output');

--- a/packages/prover-client/src/effect/test/preForkWasmProver.integration.test.ts
+++ b/packages/prover-client/src/effect/test/preForkWasmProver.integration.test.ts
@@ -1,0 +1,85 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * Whether the bundled in-process prover can prove a _pre-fork_ transaction, and with which key material.
+ *
+ * @remarks
+ *   The zkir runtime the worker drives is shared by both ledger lines, so nothing about the proving loop itself is
+ *   version-specific — but the circuits the keys were generated for are, and the bucket has a line per circuit
+ *   generation rather than per ledger. Which line pairs with `@midnight-ntwrk/ledger-v8` is therefore an empirical
+ *   question, and this is where it is answered: by proving a pre-fork transaction with each line and asking the
+ *   pre-fork ledger, under a strictness that verifies native proofs, which one it accepts.
+ *
+ *   The answer today is line 9 — the same line the current ledger uses — which is why
+ *   `makePreForkWasmProvingServiceEffect` applies no override. Line 8 predates the shared runtime: its verifier keys
+ *   carry a header one generation old and are rejected before any proof is attempted. Should the bucket be refreshed,
+ *   the second test here is what says so.
+ *
+ *   Network is needed (the key material comes from S3); Docker is not.
+ */
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { Effect } from 'effect';
+import { describe, expect, it } from 'vitest';
+import * as WasmProver from '../WasmProver.js';
+
+const timeoutMinutes = (mins: number) => 1_000 * 60 * mins;
+
+const aPreForkTransaction = (spendCoinAmount: bigint): ledger.UnprovenTransaction => {
+  const shieldedTokenType = ledger.shieldedToken();
+  const spendCoin = ledger.createShieldedCoinInfo(shieldedTokenType.raw, spendCoinAmount);
+  const output = ledger.ZswapOutput.new(spendCoin, 0, ledger.sampleCoinPublicKey(), ledger.sampleEncryptionPublicKey());
+  const offer = ledger.ZswapOffer.fromOutput(output, shieldedTokenType.raw, spendCoinAmount);
+  return ledger.Transaction.fromParts('undeployed', offer);
+};
+
+const proveWith = (
+  circuits: 8 | 9,
+): Promise<ledger.Transaction<ledger.SignatureEnabled, ledger.Proof, ledger.PreBinding>> =>
+  Effect.runPromise(
+    WasmProver.create({ keyMaterialProvider: WasmProver.makeDefaultKeyMaterialProvider({ circuits }) }),
+  ).then((prover) =>
+    aPreForkTransaction(1_000n).prove(prover.asPreForkProvingProvider(), ledger.CostModel.initialCostModel()),
+  );
+
+/** Checks the proof the way a node would: the pre-fork ledger itself, verifying native proofs. */
+const verifyNatively = (
+  transaction: ledger.Transaction<ledger.SignatureEnabled, ledger.Proof, ledger.PreBinding>,
+): void => {
+  const strictness = new ledger.WellFormedStrictness();
+  strictness.enforceBalancing = false;
+  strictness.verifyNativeProofs = true;
+  strictness.verifyContractProofs = false;
+  strictness.enforceLimits = false;
+  strictness.verifySignatures = false;
+  transaction.wellFormed(ledger.LedgerState.blank('undeployed'), strictness, new Date(0));
+};
+
+describe('the bundled in-process prover, on the pre-fork ledger', () => {
+  it(
+    'proves a pre-fork transaction with the key material it defaults to, and the pre-fork ledger verifies the proof',
+    async () => {
+      const proven = await proveWith(9);
+
+      expect(() => verifyNatively(proven)).not.toThrow();
+    },
+    timeoutMinutes(10),
+  );
+
+  it(
+    'cannot use the line named after the pre-fork ledger, whose verifier keys predate the shared zkir runtime',
+    async () => {
+      await expect(proveWith(8)).rejects.toThrow(/verifier-key\[v5\]/);
+    },
+    timeoutMinutes(10),
+  );
+});

--- a/packages/prover-client/src/effect/test/v8WasmProver.integration.test.ts
+++ b/packages/prover-client/src/effect/test/v8WasmProver.integration.test.ts
@@ -17,13 +17,12 @@
  *   The zkir runtime the worker drives is shared by both ledger lines, so nothing about the proving loop itself is
  *   version-specific — but the circuits the keys were generated for are, and the bucket has a line per circuit
  *   generation rather than per ledger. Which line pairs with `@midnight-ntwrk/ledger-v8` is therefore an empirical
- *   question, and this is where it is answered: by proving a pre-fork transaction with each line and asking the
- *   pre-fork ledger, under a strictness that verifies native proofs, which one it accepts.
+ *   question, and this is where it is answered: by proving a ledger-v8 transaction with each line and asking the
+ *   ledger-v8, under a strictness that verifies native proofs, which one it accepts.
  *
- *   The answer today is line 9 — the same line the current ledger uses — which is why
- *   `makePreForkWasmProvingServiceEffect` applies no override. Line 8 predates the shared runtime: its verifier keys
- *   carry a header one generation old and are rejected before any proof is attempted. Should the bucket be refreshed,
- *   the second test here is what says so.
+ *   The answer today is line 9 — the same line ledger-v9 uses — which is why `makeV8WasmProvingServiceEffect` applies no
+ *   override. Line 8 predates the shared runtime: its verifier keys carry a header one generation old and are rejected
+ *   before any proof is attempted. Should the bucket be refreshed, the second test here is what says so.
  *
  *   Network is needed (the key material comes from S3); Docker is not.
  */
@@ -34,7 +33,7 @@ import * as WasmProver from '../WasmProver.js';
 
 const timeoutMinutes = (mins: number) => 1_000 * 60 * mins;
 
-const aPreForkTransaction = (spendCoinAmount: bigint): ledger.UnprovenTransaction => {
+const aV8Transaction = (spendCoinAmount: bigint): ledger.UnprovenTransaction => {
   const shieldedTokenType = ledger.shieldedToken();
   const spendCoin = ledger.createShieldedCoinInfo(shieldedTokenType.raw, spendCoinAmount);
   const output = ledger.ZswapOutput.new(spendCoin, 0, ledger.sampleCoinPublicKey(), ledger.sampleEncryptionPublicKey());
@@ -47,11 +46,9 @@ const proveWith = (
 ): Promise<ledger.Transaction<ledger.SignatureEnabled, ledger.Proof, ledger.PreBinding>> =>
   Effect.runPromise(
     WasmProver.create({ keyMaterialProvider: WasmProver.makeDefaultKeyMaterialProvider({ circuits }) }),
-  ).then((prover) =>
-    aPreForkTransaction(1_000n).prove(prover.asPreForkProvingProvider(), ledger.CostModel.initialCostModel()),
-  );
+  ).then((prover) => aV8Transaction(1_000n).prove(prover.asV8ProvingProvider(), ledger.CostModel.initialCostModel()));
 
-/** Checks the proof the way a node would: the pre-fork ledger itself, verifying native proofs. */
+/** Checks the proof the way a node would: ledger-v8 itself, verifying native proofs. */
 const verifyNatively = (
   transaction: ledger.Transaction<ledger.SignatureEnabled, ledger.Proof, ledger.PreBinding>,
 ): void => {
@@ -64,9 +61,9 @@ const verifyNatively = (
   transaction.wellFormed(ledger.LedgerState.blank('undeployed'), strictness, new Date(0));
 };
 
-describe('the bundled in-process prover, on the pre-fork ledger', () => {
+describe('the bundled in-process prover, on ledger-v8', () => {
   it(
-    'proves a pre-fork transaction with the key material it defaults to, and the pre-fork ledger verifies the proof',
+    'proves a ledger-v8 transaction with the key material it defaults to, and ledger-v8 verifies the proof',
     async () => {
       const proven = await proveWith(9);
 
@@ -76,7 +73,7 @@ describe('the bundled in-process prover, on the pre-fork ledger', () => {
   );
 
   it(
-    'cannot use the line named after the pre-fork ledger, whose verifier keys predate the shared zkir runtime',
+    'cannot use the line named after ledger-v8, whose verifier keys predate the shared zkir runtime',
     async () => {
       await expect(proveWith(8)).rejects.toThrow(/verifier-key\[v5\]/);
     },

--- a/packages/prover-client/src/effect/test/wasmProverKeyMaterial.test.ts
+++ b/packages/prover-client/src/effect/test/wasmProverKeyMaterial.test.ts
@@ -1,0 +1,87 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * Which line of the key-material bucket the bundled provider reads.
+ *
+ * @remarks
+ *   The line is a property of the circuits the keys were generated for, not of the ledger version driving the proof, so
+ *   it has to be nameable. Which line pairs with which ledger is settled empirically in
+ *   `preForkWasmProver.integration.test.ts`; this file only pins down that naming a line reads that line, and that
+ *   naming none reads the one both ledgers accept.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as WasmProver from '../WasmProver.js';
+
+const S3 = 'https://midnight-s3-fileshare-dev-eu-west-1.s3.eu-west-1.amazonaws.com';
+
+describe('Where the bundled prover looks for its key material', () => {
+  const requested: string[] = [];
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    requested.length = 0;
+    globalThis.fetch = (input: string | URL | Request) => {
+      requested.push(input instanceof Request ? input.url : input.toString());
+      return Promise.resolve(new Response(new Uint8Array([1, 2, 3]), { status: 200 }));
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('reads the line it is asked for', async () => {
+    const provider = WasmProver.makeDefaultKeyMaterialProvider({ circuits: 8 });
+
+    const material = await provider.lookupKey('midnight/zswap/spend');
+
+    expect(requested).toStrictEqual([
+      `${S3}/zswap/8/spend.prover`,
+      `${S3}/zswap/8/spend.verifier`,
+      `${S3}/zswap/8/spend.bzkir`,
+    ]);
+    expect(material).toStrictEqual({
+      proverKey: new Uint8Array([1, 2, 3]),
+      verifierKey: new Uint8Array([1, 2, 3]),
+      ir: new Uint8Array([1, 2, 3]),
+    });
+  });
+
+  it('reads the line both ledger versions accept when it is asked for none', async () => {
+    const provider = WasmProver.makeDefaultKeyMaterialProvider();
+
+    await provider.lookupKey('midnight/dust/spend');
+
+    expect(requested).toStrictEqual([
+      `${S3}/dust/9/spend.prover`,
+      `${S3}/dust/9/spend.verifier`,
+      `${S3}/dust/9/spend.bzkir`,
+    ]);
+  });
+
+  it('has nothing to offer for a key location it does not know', async () => {
+    const provider = WasmProver.makeDefaultKeyMaterialProvider({ circuits: 8 });
+
+    await expect(provider.lookupKey('midnight/unheard-of')).resolves.toBeUndefined();
+    expect(requested).toStrictEqual([]);
+  });
+
+  it('reads the proving parameters once, whichever line it was asked for', async () => {
+    const provider = WasmProver.makeDefaultKeyMaterialProvider({ circuits: 8 });
+
+    await provider.getParams(14);
+    await provider.getParams(14);
+
+    expect(requested).toStrictEqual([`${S3}/bls_midnight_2p14`]);
+  });
+});

--- a/packages/prover-client/src/effect/test/wasmProverKeyMaterial.test.ts
+++ b/packages/prover-client/src/effect/test/wasmProverKeyMaterial.test.ts
@@ -16,8 +16,8 @@
  * @remarks
  *   The line is a property of the circuits the keys were generated for, not of the ledger version driving the proof, so
  *   it has to be nameable. Which line pairs with which ledger is settled empirically in
- *   `preForkWasmProver.integration.test.ts`; this file only pins down that naming a line reads that line, and that
- *   naming none reads the one both ledgers accept.
+ *   `v8WasmProver.integration.test.ts`; this file only pins down that naming a line reads that line, and that naming
+ *   none reads the one both ledgers accept.
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import * as WasmProver from '../WasmProver.js';

--- a/packages/wallet-integration-tests/package.json
+++ b/packages/wallet-integration-tests/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@midnight-ntwrk/ledger-v8": "^8.1.0",
     "@midnightntwrk/ledger-v9": "1.0.0-rc.4",
     "@midnightntwrk/wallet-sdk-abstractions": "^3.0.0-beta.0",
     "@midnightntwrk/wallet-sdk-address-format": "^4.0.0-beta.2",

--- a/packages/wallet-integration-tests/test/proving.integration.test.ts
+++ b/packages/wallet-integration-tests/test/proving.integration.test.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 import {
   type ProvingServiceEffect,
-  makePreForkServerProvingServiceEffect,
+  makeV8ServerProvingServiceEffect,
   makeWasmProvingServiceEffect,
   fromProvingProvider,
   makeServerProvingServiceEffect,
@@ -28,7 +28,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { getNonDustImbalance } from './utils.js';
 
 const PROOF_SERVER_IMAGE: string = 'ghcr.io/midnight-ntwrk/proof-server:9.0.0-rc.7';
-/** The proof server of the epoch before the boundary: no image serves both sides, so the pre-fork case needs its own. */
+/** The proof server of the epoch before the boundary: no image serves both sides, so the ledger-v8 case needs its own. */
 const PRE_FORK_PROOF_SERVER_IMAGE: string = 'ghcr.io/midnight-ntwrk/proof-server:8.1.0';
 const PROOF_SERVER_PORT: number = 6300;
 
@@ -165,13 +165,13 @@ describe('Server Proving Service', () => {
  * Proving a transaction of the epoch before the boundary, at the proof server of that epoch.
  *
  * @remarks
- *   The other end of the routing the SDK already did: the pre-fork backend is not a variation on the current one, it is a
- *   different ledger version driving the proof, and no proof server serves both sides. What is checked here is the only
- *   thing that finally settles it — the pre-fork ledger accepting, under a strictness that verifies native proofs, what
- *   the pre-fork prover produced.
+ *   The other end of the routing the SDK already did: the ledger-v8 backend is not a variation on the current one, it is
+ *   a different ledger version driving the proof, and no proof server serves both sides. What is checked here is the
+ *   only thing that finally settles it — ledger-v8 accepting, under a strictness that verifies native proofs, what the
+ *   ledger-v8 prover produced.
  */
-describe('Pre-fork Server Proving', () => {
-  const preForkProofServer = Effect.acquireRelease(
+describe('Ledger-v8 Server Proving', () => {
+  const v8ProofServer = Effect.acquireRelease(
     Effect.tryPromise({
       try: () =>
         new GenericContainer(PRE_FORK_PROOF_SERVER_IMAGE)
@@ -188,19 +188,19 @@ describe('Pre-fork Server Proving', () => {
     Effect.retry(Schedule.spaced(Duration.millis(10))),
   );
 
-  const aPreForkTransaction = (): preForkLedger.UnprovenTransaction => {
+  const aV8Transaction = (): preForkLedger.UnprovenTransaction => {
     const recipient = preForkLedger.ZswapSecretKeys.fromSeed(Buffer.alloc(32, 0));
-    const preForkShieldedTokenType = preForkLedger.shieldedToken().raw;
-    const coin = preForkLedger.createShieldedCoinInfo(preForkShieldedTokenType, 42n);
+    const v8ShieldedTokenType = preForkLedger.shieldedToken().raw;
+    const coin = preForkLedger.createShieldedCoinInfo(v8ShieldedTokenType, 42n);
     const output = preForkLedger.ZswapOutput.new(coin, 0, recipient.coinPublicKey, recipient.encryptionPublicKey);
-    const offer = preForkLedger.ZswapOffer.fromOutput(output, preForkShieldedTokenType, 42n);
+    const offer = preForkLedger.ZswapOffer.fromOutput(output, v8ShieldedTokenType, 42n);
     return preForkLedger.Transaction.fromParts(NetworkId.NetworkId.Undeployed, offer);
   };
 
-  it('proves a pre-fork transaction at a pre-fork proof server, and the pre-fork ledger verifies the proof', async () => {
+  it('proves a ledger-v8 transaction at a ledger-v8 proof server, and ledger-v8 verifies the proof', async () => {
     const proven = await Effect.gen(function* () {
-      const provingServerUrl = yield* preForkProofServer;
-      return yield* makePreForkServerProvingServiceEffect({ provingServerUrl }).prove(aPreForkTransaction());
+      const provingServerUrl = yield* v8ProofServer;
+      return yield* makeV8ServerProvingServiceEffect({ provingServerUrl }).prove(aV8Transaction());
     }).pipe(Effect.scoped, Effect.runPromise);
 
     expect(proven).toBeInstanceOf(preForkLedger.Transaction);

--- a/packages/wallet-integration-tests/test/proving.integration.test.ts
+++ b/packages/wallet-integration-tests/test/proving.integration.test.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 import {
   type ProvingServiceEffect,
+  makePreForkServerProvingServiceEffect,
   makeWasmProvingServiceEffect,
   fromProvingProvider,
   makeServerProvingServiceEffect,
@@ -19,6 +20,7 @@ import {
 } from '@midnightntwrk/wallet-sdk-capabilities/proving';
 import { HttpProverClient, WasmProver } from '@midnightntwrk/wallet-sdk-prover-client/effect';
 import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { Effect, Either, Schedule, Duration, type Scope, pipe } from 'effect';
 import { GenericContainer, Wait } from 'testcontainers';
@@ -26,6 +28,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { getNonDustImbalance } from './utils.js';
 
 const PROOF_SERVER_IMAGE: string = 'ghcr.io/midnight-ntwrk/proof-server:9.0.0-rc.7';
+/** The proof server of the epoch before the boundary: no image serves both sides, so the pre-fork case needs its own. */
+const PRE_FORK_PROOF_SERVER_IMAGE: string = 'ghcr.io/midnight-ntwrk/proof-server:8.1.0';
 const PROOF_SERVER_PORT: number = 6300;
 
 vi.setConfig({ testTimeout: 300_000, hookTimeout: 300_000 });
@@ -154,5 +158,61 @@ describe('Server Proving Service', () => {
         expect(error).toBeInstanceOf(ProvingError);
       },
     });
+  });
+});
+
+/**
+ * Proving a transaction of the epoch before the boundary, at the proof server of that epoch.
+ *
+ * @remarks
+ *   The other end of the routing the SDK already did: the pre-fork backend is not a variation on the current one, it is a
+ *   different ledger version driving the proof, and no proof server serves both sides. What is checked here is the only
+ *   thing that finally settles it — the pre-fork ledger accepting, under a strictness that verifies native proofs, what
+ *   the pre-fork prover produced.
+ */
+describe('Pre-fork Server Proving', () => {
+  const preForkProofServer = Effect.acquireRelease(
+    Effect.tryPromise({
+      try: () =>
+        new GenericContainer(PRE_FORK_PROOF_SERVER_IMAGE)
+          .withExposedPorts(PROOF_SERVER_PORT)
+          .withWaitStrategy(Wait.forListeningPorts())
+          .withStartupTimeout(120_000)
+          .withReuse()
+          .start(),
+      catch: (error) => Effect.fail(error),
+    }),
+    (container) => Effect.promise(() => container.stop()),
+  ).pipe(
+    Effect.map((container) => new URL(`http://localhost:${container.getMappedPort(PROOF_SERVER_PORT)}`)),
+    Effect.retry(Schedule.spaced(Duration.millis(10))),
+  );
+
+  const aPreForkTransaction = (): preForkLedger.UnprovenTransaction => {
+    const recipient = preForkLedger.ZswapSecretKeys.fromSeed(Buffer.alloc(32, 0));
+    const preForkShieldedTokenType = preForkLedger.shieldedToken().raw;
+    const coin = preForkLedger.createShieldedCoinInfo(preForkShieldedTokenType, 42n);
+    const output = preForkLedger.ZswapOutput.new(coin, 0, recipient.coinPublicKey, recipient.encryptionPublicKey);
+    const offer = preForkLedger.ZswapOffer.fromOutput(output, preForkShieldedTokenType, 42n);
+    return preForkLedger.Transaction.fromParts(NetworkId.NetworkId.Undeployed, offer);
+  };
+
+  it('proves a pre-fork transaction at a pre-fork proof server, and the pre-fork ledger verifies the proof', async () => {
+    const proven = await Effect.gen(function* () {
+      const provingServerUrl = yield* preForkProofServer;
+      return yield* makePreForkServerProvingServiceEffect({ provingServerUrl }).prove(aPreForkTransaction());
+    }).pipe(Effect.scoped, Effect.runPromise);
+
+    expect(proven).toBeInstanceOf(preForkLedger.Transaction);
+
+    const strictness = new preForkLedger.WellFormedStrictness();
+    strictness.enforceBalancing = false;
+    strictness.verifyNativeProofs = true;
+    strictness.verifyContractProofs = false;
+    strictness.enforceLimits = false;
+    strictness.verifySignatures = false;
+    expect(() =>
+      proven.wellFormed(preForkLedger.LedgerState.blank(NetworkId.NetworkId.Undeployed), strictness, new Date(0)),
+    ).not.toThrow();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,6 +2407,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@midnight-ntwrk/wallet-integration-tests@workspace:packages/wallet-integration-tests"
   dependencies:
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.4"
     "@midnightntwrk/wallet-sdk-abstractions": "npm:^3.0.0-beta.0"
     "@midnightntwrk/wallet-sdk-address-format": "npm:^4.0.0-beta.2"
@@ -2455,6 +2456,7 @@ __metadata:
   resolution: "@midnight/wallet-e2e-tests@workspace:packages/e2e-tests"
   dependencies:
     "@cardano-sdk/key-management": "npm:0.29.18"
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.4"
     "@midnightntwrk/wallet-sdk-abstractions": "workspace:*"
     "@midnightntwrk/wallet-sdk-address-format": "workspace:*"
@@ -2679,6 +2681,7 @@ __metadata:
   resolution: "@midnightntwrk/wallet-sdk-prover-client@workspace:packages/prover-client"
   dependencies:
     "@effect/platform": "npm:^0.96.0"
+    "@midnight-ntwrk/ledger-v8": "npm:^8.1.0"
     "@midnight-ntwrk/zkir-v2": "npm:^2.1.0"
     "@midnightntwrk/ledger-v9": "npm:1.0.0-rc.4"
     "@midnightntwrk/wallet-sdk-utilities": "npm:1.2.1"


### PR DESCRIPTION
## Summary

Proving on either side of the protocol boundary. Routing a transaction to a prover by the version stamped on it already worked (#715); every backend, however, was bound to ledger-v9: `fromProvingProviderEffect` drove `Transaction.prove` with the v9 cost model, `HttpProverClient` framed requests with v9 payload helpers, and `WasmProver` read key material at a fixed circuit line. A pre-fork `provingServers` entry was accepted by configuration and could not be honoured (`expected instance of CostModel` at the wasm-bindgen boundary).

- **`provers` configuration**: `{ sinceVersion, backend: { kind: 'server', url } | { kind: 'wasm', keyMaterialProvider? } }`, ascending. `provingServers` and `provingServerUrl` unchanged; precedence `provers` > `provingServers` > `provingServerUrl`. A range spanning `forkVersion` is split at the boundary so each side is driven by its own ledger.
- **Ledger-v8 twin** in `capabilities/proving/v8ProvingService.ts` (`V8UnprovenTransaction`, `makeV8ServerProvingServiceEffect`, `makeV8WasmProvingServiceEffect`; ledger-v8 cost model and types), composed by `versionedProving.ts` mirroring how validation already does it. Each registered backend refuses the other ledger's object with `ProvingEpochMismatchError`.
- **`prover-client`**: `HttpProverClient.asV8ProvingProvider()` with ledger-v8 payload framing (`asV9ProvingProvider()` names the existing one); `WasmProver.makeDefaultKeyMaterialProvider({ circuits?: 8 | 9 })` replaces the hard-coded line. Gains `@midnight-ntwrk/ledger-v8` as a runtime dependency (it had it on `main`).
- **Facade**: `InitParams.provingService` widened to `VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>`; the default factory receives `configuration.forkVersion`.
- **Fork lane**: a second `proof-server-v8` service (`8.1.0`, `PROOF_SERVER_V8_TAG`) in the fork compose and workflow, and the hard-fork e2e now spends **before** the fork through the ledger-v8 prover, crosses, and spends after through the ledger-v9 one, in the same wallet.
- Snippets, READMEs and changeset (capabilities major: default factory signature; prover-client/facade/wallet-sdk minor).

The new surface is named by ledger version (`V8*`/`v8*`, `V9*`), matching `ledger/v8`, `ledger/v9`, `startWithKeys({ v8, v9 })` and the `V8`/`V9` simulators; "pre-fork"/"post-fork" is kept only for phases of the chain's timeline.

## Findings worth knowing

- **Key material**: the S3 line named after ledger 8 (`zswap/8/*`) is refused by the shared zkir runtime (`expected header tag 'midnight:verifier-key[v6]:', got '[v5]'`). Line 9 proves for ledger-v8 too and its own `wellFormed` with native-proof verification accepts the result, matching what `main` did. So in-process proving works on both sides with the same published circuits; a regression test asserts both directions.
- **The real breakage was the cost model, not the framing**: v8 and v9 `createProvingPayload`/`createCheckPayload` are byte-identical for today's preimages. Per-ledger framing is kept as a structural guarantee.
- A fresh pre-fork chain has generated almost no dust, so the pre-fork spend in the e2e retries until the build can pay for itself. A build that cannot pay leaves its unshielded inputs booked and the release is not prompt, so that test asserts on the receiver. That booking behaviour is pre-existing and may deserve a follow-up.

## Verification

`yarn dist --force`, `yarn typecheck --force`, `yarn lint`, `yarn format:check`, `yarn changeset status` all green. Unit tests for capabilities, prover-client, facade green (new: 14 versioned-proving, 8 prover-client, 4 facade). Integration: pre-fork WASM spike and pre-fork server case against `proof-server:8.1.0` green. Fork lane run locally: 13/13, including `spends before the fork, proving at the ledger-v8 proof server`. The two changed docs snippets were run against the compose stack: `hard-fork-support` passes; `wasm-prover` runs correctly but its snapshot on `v2` is stale (genesis intent hashes from the node image bump in #715), which #717 regenerates. Merge #717 first and this branch picks it up.

Implemented by an Opus agent from `.context/plans/proving-per-version.md`, reviewed before commit.
