### PR TITLE
refactor(abstractions,shielded): fold the v9-native fork version into ProtocolVersion

### DIFF
--- a/.changeset/fold-fork-constant.md
+++ b/.changeset/fold-fork-constant.md
@@ -1,0 +1,12 @@
+---
+'@midnightntwrk/wallet-sdk-abstractions': minor
+'@midnightntwrk/wallet-sdk-shielded': minor
+'@midnightntwrk/wallet-sdk-testkit': patch
+---
+
+The v9-native fork version lives with the version type: `ProtocolVersion.V9NativeForkVersion` in the abstractions
+package (and through the umbrella package's `ProtocolVersion`), next to `MinSupportedVersion` and `MaxSupportedVersion`.
+It is the same value the shielded package published as `V9_NATIVE_FORK_VERSION` — a property of the chain, not of one
+wallet, which is why it moves. The shielded export stays as a deprecated alias of the new constant, so existing imports
+keep working; it will be removed in a later release. As before, it is a named value and not a default: every wallet's
+`forkVersion` remains required.

--- a/.changeset/hard-fork-support.md
+++ b/.changeset/hard-fork-support.md
@@ -24,8 +24,8 @@ no longer import a ledger package.
 ### Breaking: configuration and starting
 
 - `forkVersion` is required in the shielded, dust, unshielded and facade configurations: the protocol version at which
-  the chain switches ledgers. There is no default. `V9_NATIVE_FORK_VERSION`, exported from the shielded package, is the
-  value a 2.x chain reports (2000000); the final mainnet constant is not fixed yet, so supply it per environment.
+  the chain switches ledgers. There is no default. `ProtocolVersion.V9NativeForkVersion`, from the abstractions package, is
+  the value a 2.x chain reports (2000000); the final mainnet constant is not fixed yet, so supply it per environment.
 - `chainVersionProbe` is a new optional setting on all three wallets. By default a wallet asks the indexer, on every
   start, which protocol version the chain's first block was produced under, with a 5-second timeout, and starts on the
   matching side. A failed probe never fails a start: the wallet starts pre-fork and crosses on its first synced update.
@@ -79,7 +79,7 @@ no longer import a ledger package.
   `SchemeMismatchError`; `Simulator` on `./v1` is the ledger-v8 simulator only. Both subpaths gain a `Migration`
   namespace, and their builders gain `withStartAux`, `withStartAuxDefaults`, `withMigration` and
   `withMigrationDefaults`.
-- Root entry points keep their names and gain the forking wallet types, `V9_NATIVE_FORK_VERSION`, `DustGenerationRates`
+- Root entry points keep their names and gain the forking wallet types, `ProtocolVersion.V9NativeForkVersion`, `DustGenerationRates`
   with `asPreForkDustParameters` and `asPostForkDustParameters`, and snapshot inspection: `Restore` (shielded) and
   `UnshieldedRestore` namespaces, and the dust `peekProtocolVersion` and `UnsupportedSnapshotVersionError`.
 - Existing snapshots restore; `restore` and the new `tryRestore` route on the protocol version a snapshot declares, and

--- a/packages/abstractions/src/ProtocolVersion.ts
+++ b/packages/abstractions/src/ProtocolVersion.ts
@@ -71,6 +71,22 @@ export const MinSupportedVersion = ProtocolVersion(0n);
 export const MaxSupportedVersion = ProtocolVersion(BigInt(Number.MAX_SAFE_INTEGER));
 
 /**
+ * The protocol version a ledger-v9-native chain hands over at, for the current node line.
+ *
+ * @remarks
+ *   Measured, not assumed: a `midnight-node` 2.x reports protocol version `2000000` on its ledger events — the runtime
+ *   version, scaled, rather than a small ordinal or the ledger major. A chain of the previous node line reports a
+ *   1.x-encoded value, which is below this, so a wallet configured with it stays on the pre-fork variant there and
+ *   reaches the post-fork variant on any v9-native chain.
+ *
+ *   Offered as a named value so applications and test suites pointed at a v9-native chain do not each invent a magic
+ *   number. It is **not** a default: every wallet's `forkVersion` stays required, because the right value is a property
+ *   of the chain an application points at. The final mainnet fork constant is still an open question; when it is fixed
+ *   it will join this one here.
+ */
+export const V9NativeForkVersion: ProtocolVersion = ProtocolVersion(2_000_000n);
+
+/**
  * The range of protocol versions on the same side of a protocol boundary as a given version.
  *
  * @remarks

--- a/packages/abstractions/src/test/protocolVersion.test.ts
+++ b/packages/abstractions/src/test/protocolVersion.test.ts
@@ -29,6 +29,18 @@ describe('ProtocolVersion', () => {
     });
   });
 
+  describe('V9NativeForkVersion', () => {
+    it('is the version a midnight-node 2.x reports on its ledger events, 2000000', () => {
+      expect(ProtocolVersion.V9NativeForkVersion).toBe(2_000_000n);
+      expect(ProtocolVersion.is(ProtocolVersion.V9NativeForkVersion)).toBeTruthy();
+    });
+
+    it('lies strictly inside the supported range, so it splits it into two non-empty epochs', () => {
+      expect(ProtocolVersion.V9NativeForkVersion).toBeGreaterThan(ProtocolVersion.MinSupportedVersion);
+      expect(ProtocolVersion.V9NativeForkVersion).toBeLessThan(ProtocolVersion.MaxSupportedVersion);
+    });
+  });
+
   it.each([ProtocolVersion.MinSupportedVersion, ProtocolVersion.MaxSupportedVersion])(
     'should be encodable and decodable',
     (input) => {

--- a/packages/docs-snippets/src/snippets/dust-fast-sync.ts
+++ b/packages/docs-snippets/src/snippets/dust-fast-sync.ts
@@ -27,7 +27,6 @@ import {
   UnshieldedWallet,
   mergeWalletEntries,
   ProtocolVersion,
-  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { makeIndexerChainVersionProbe } from '@midnightntwrk/wallet-sdk/capabilities';
 import { V1Builder } from '@midnightntwrk/wallet-sdk/dust/v1';
@@ -49,7 +48,7 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
   costParameters: {
     feeBlocksMargin: 5,
   },
@@ -63,7 +62,7 @@ const configuration: DefaultConfiguration = {
       backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
     },
     {
-      sinceVersion: V9_NATIVE_FORK_VERSION,
+      sinceVersion: ProtocolVersion.V9NativeForkVersion,
       backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
     },
   ],

--- a/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
+++ b/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
@@ -24,7 +24,6 @@ import {
   UnshieldedWallet,
   mergeWalletEntries,
   ProtocolVersion,
-  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import { pick } from 'lodash-es';
@@ -42,7 +41,7 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
   costParameters: {
     feeBlocksMargin: 5,
   },
@@ -56,7 +55,7 @@ const configuration: DefaultConfiguration = {
       backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
     },
     {
-      sinceVersion: V9_NATIVE_FORK_VERSION,
+      sinceVersion: ProtocolVersion.V9NativeForkVersion,
       backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
     },
   ],

--- a/packages/docs-snippets/src/snippets/hard-fork-support.ts
+++ b/packages/docs-snippets/src/snippets/hard-fork-support.ts
@@ -46,7 +46,6 @@ import {
   WalletEntrySchema,
   WalletFacade,
   WalletSeeds,
-  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import { Either } from 'effect';
@@ -68,7 +67,7 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
   costParameters: {
     feeBlocksMargin: 5,
   },
@@ -92,7 +91,7 @@ const configuration: DefaultConfiguration = {
       backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
     },
     {
-      sinceVersion: V9_NATIVE_FORK_VERSION,
+      sinceVersion: ProtocolVersion.V9NativeForkVersion,
       backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
     },
   ],

--- a/packages/docs-snippets/src/snippets/initialization.ts
+++ b/packages/docs-snippets/src/snippets/initialization.ts
@@ -23,7 +23,6 @@ import {
   UnshieldedWallet,
   mergeWalletEntries,
   ProtocolVersion,
-  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import { pick } from 'lodash-es';
@@ -41,7 +40,7 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
   costParameters: {
     feeBlocksMargin: 5,
   },
@@ -55,7 +54,7 @@ const configuration: DefaultConfiguration = {
       backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
     },
     {
-      sinceVersion: V9_NATIVE_FORK_VERSION,
+      sinceVersion: ProtocolVersion.V9NativeForkVersion,
       backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
     },
   ],

--- a/packages/docs-snippets/src/snippets/wasm-prover.ts
+++ b/packages/docs-snippets/src/snippets/wasm-prover.ts
@@ -31,7 +31,6 @@ import {
   PublicKey,
   UnshieldedWallet,
   mergeWalletEntries,
-  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import { pick } from 'lodash-es';
@@ -45,7 +44,7 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/utils.ts
+++ b/packages/docs-snippets/src/utils.ts
@@ -25,7 +25,6 @@ import {
   WalletSeeds,
   mergeWalletEntries,
   ProtocolVersion,
-  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk';
 import { type Buffer } from 'buffer';
 
@@ -42,7 +41,7 @@ export const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
   costParameters: {
     feeBlocksMargin: 5,
   },
@@ -56,7 +55,7 @@ export const configuration: DefaultConfiguration = {
       backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
     },
     {
-      sinceVersion: V9_NATIVE_FORK_VERSION,
+      sinceVersion: ProtocolVersion.V9NativeForkVersion,
       backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
     },
   ],

--- a/packages/dust-wallet/src/DustWallet.ts
+++ b/packages/dust-wallet/src/DustWallet.ts
@@ -368,9 +368,8 @@ export type DefaultDustConfiguration = {
    *   application points at, not of the SDK.
    *
    *   A node reporting a 2.x runtime version reports protocol version `2000000`, which is therefore the value for a
-   *   ledger-v9-native chain — the shielded package publishes it as `V9_NATIVE_FORK_VERSION`. The final mainnet fork
-   *   constant is not yet fixed; a `ProtocolVersion.Forks.*` default will ship once it is, and this field keeps working
-   *   unchanged.
+   *   ledger-v9-native chain — published as `ProtocolVersion.V9NativeForkVersion`. The final mainnet fork constant is
+   *   not yet fixed; it will join that one once it is, and this field keeps working unchanged.
    */
   forkVersion: ProtocolVersion.ProtocolVersion;
   /**

--- a/packages/e2e-tests/src/tests/dustDeregistration.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dustDeregistration.undeployed.test.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
@@ -27,7 +27,7 @@ import {
   isFinalizedWalletEntry,
   mergeWalletEntries,
 } from '@midnightntwrk/wallet-sdk-facade';
-import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, InMemoryTransactionHistoryStorage, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { makeDefaultSubmissionService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { carried } from './helpers/transactions.js';
@@ -83,7 +83,7 @@ describe('Dust Deregistration', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/dustRegistration.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dustRegistration.undeployed.test.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import * as crypto from 'node:crypto';
 import { randomUUID } from 'node:crypto';
@@ -37,7 +37,7 @@ import {
   isFinalizedWalletEntry,
   mergeWalletEntries,
 } from '@midnightntwrk/wallet-sdk-facade';
-import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, InMemoryTransactionHistoryStorage, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { ArrayOps, DateOps } from '@midnightntwrk/wallet-sdk-utilities';
 import { carried } from './helpers/transactions.js';
@@ -91,7 +91,7 @@ describe('Dust Registration', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/facadeTransfer.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/facadeTransfer.undeployed.test.ts
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, InMemoryTransactionHistoryStorage, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { PublicKey, UnshieldedWallet, createKeystore } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnightntwrk/wallet-sdk-utilities/testing';
 import { pipe } from 'effect';
@@ -92,7 +92,7 @@ describe('Wallet Facade Transfer', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/hardFork.fork.test.ts
+++ b/packages/e2e-tests/src/tests/hardFork.fork.test.ts
@@ -30,7 +30,7 @@ import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type WalletSeeds as WalletSeedsType, WalletSeeds } from '@midnightntwrk/wallet-sdk-hd';
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import {
   createKeystore,
   PublicKey,
@@ -265,7 +265,7 @@ const projectionsTwinDustWallet = (configuration: DefaultDustConfiguration) => {
 const hasCrossed = (state: FacadeState | undefined): boolean =>
   state !== undefined &&
   state.protocol._tag === 'Settled' &&
-  state.activeProtocolVersion >= V9_NATIVE_FORK_VERSION &&
+  state.activeProtocolVersion >= ProtocolVersion.V9NativeForkVersion &&
   state.isSynced;
 
 describe.sequential('Hard fork crossing @fork', () => {
@@ -326,7 +326,10 @@ describe.sequential('Hard fork crossing @fork', () => {
           sinceVersion: ProtocolVersion.MinSupportedVersion,
           backend: { kind: 'server', url: new URL(fixture.getV8ProverUri()) },
         },
-        { sinceVersion: V9_NATIVE_FORK_VERSION, backend: { kind: 'server', url: new URL(fixture.getProverUri()) } },
+        {
+          sinceVersion: ProtocolVersion.V9NativeForkVersion,
+          backend: { kind: 'server', url: new URL(fixture.getProverUri()) },
+        },
       ] as const satisfies DefaultConfiguration['provers'],
     };
     unshieldedKeystore = createKeystore({ kind: 'schnorr', secret: seeds.unshielded }, fixture.getNetworkId());
@@ -376,7 +379,7 @@ describe.sequential('Hard fork crossing @fork', () => {
     logger.info(`PRE-FORK SYNCED ${summarize(preFork)}`);
 
     expect(preFork.protocol._tag).toBe('Settled');
-    expect(preFork.activeProtocolVersion).toBeLessThan(V9_NATIVE_FORK_VERSION);
+    expect(preFork.activeProtocolVersion).toBeLessThan(ProtocolVersion.V9NativeForkVersion);
 
     const specVersion = await fixture.specVersionAtHead();
     expect(specVersion).toBe(PRE_FORK_SPEC_VERSION);
@@ -403,7 +406,7 @@ describe.sequential('Hard fork crossing @fork', () => {
           ` ${twinState.dust.state.progress.highestIndex}`,
       );
 
-      expect(twinState.protocolVersion.dust).toBeLessThan(V9_NATIVE_FORK_VERSION);
+      expect(twinState.protocolVersion.dust).toBeLessThan(ProtocolVersion.V9NativeForkVersion);
       expect(sameDustCoins(eventsState.dust.state.state, twinState.dust.state.state)).toBe(true);
       expect(rootsEqual(eventsState.dust.state.state, twinState.dust.state.state)).toBe(true);
     },
@@ -426,7 +429,7 @@ describe.sequential('Hard fork crossing @fork', () => {
       expect(receiverBefore.unshielded.balances[NIGHT] ?? 0n).toBe(0n);
 
       const before = await wallet.waitForSyncedState();
-      expect(before.activeProtocolVersion).toBeLessThan(V9_NATIVE_FORK_VERSION);
+      expect(before.activeProtocolVersion).toBeLessThan(ProtocolVersion.V9NativeForkVersion);
       const nightBefore = before.unshielded.balances[NIGHT];
 
       // Dust accrues with time, and this chain is seconds old: for the first half-minute of it there is not enough for
@@ -487,7 +490,7 @@ describe.sequential('Hard fork crossing @fork', () => {
     logger.info(`phase transitions observed: ${observed.phases.join('  ->  ')}`);
 
     expect(postFork.protocol._tag).toBe('Settled');
-    expect(postFork.activeProtocolVersion).toBeGreaterThanOrEqual(V9_NATIVE_FORK_VERSION);
+    expect(postFork.activeProtocolVersion).toBeGreaterThanOrEqual(ProtocolVersion.V9NativeForkVersion);
     expect(postFork.isSynced).toBe(true);
 
     // The wallets do not cross together: each learns of the change when its own synchronization
@@ -515,7 +518,7 @@ describe.sequential('Hard fork crossing @fork', () => {
       logDustCounts('B post-fork', eventsState, twinState);
 
       expect(twinState.protocol._tag).toBe('Settled');
-      expect(twinState.activeProtocolVersion).toBeGreaterThanOrEqual(V9_NATIVE_FORK_VERSION);
+      expect(twinState.activeProtocolVersion).toBeGreaterThanOrEqual(ProtocolVersion.V9NativeForkVersion);
       expect(twinState.isSynced).toBe(true);
       // The twin's post-fork variant has exactly one synchronization — the projections one — so a settled post-fork
       // state is itself the proof that the projections path ran, and ran on a state produced by the migration.

--- a/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
@@ -25,7 +25,7 @@ import {
   WalletFacade,
   mergeWalletEntries,
 } from '@midnightntwrk/wallet-sdk-facade';
-import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { makeWasmProvingService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { pipe } from 'effect';
@@ -99,7 +99,7 @@ describe('Optional Balancing', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/swap.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/swap.undeployed.test.ts
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { NetworkId, InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import { NetworkId, InMemoryTransactionHistoryStorage, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { V2Builder } from '@midnightntwrk/wallet-sdk-shielded/v2';
-import { CustomShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { CustomShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { PublicKey, UnshieldedWallet, createKeystore } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnightntwrk/wallet-sdk-utilities/testing';
@@ -95,7 +95,7 @@ describe('Swaps', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/test-fixture.ts
+++ b/packages/e2e-tests/src/tests/test-fixture.ts
@@ -11,14 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { type DefaultShieldedConfiguration, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { type DefaultShieldedConfiguration } from '@midnightntwrk/wallet-sdk-shielded';
 import { exit } from 'process';
 import { randomUUID } from 'node:crypto';
 import { DockerComposeEnvironment, type StartedDockerComposeEnvironment, Wait } from 'testcontainers';
 import { type StartedGenericContainer } from 'testcontainers/build/generic-container/started-generic-container';
 import { type MidnightNetwork, sleep } from './helpers/network.js';
 import { logger } from './logger.js';
-import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { WalletEntrySchema, mergeWalletEntries } from '@midnightntwrk/wallet-sdk-facade';
 import { type DefaultV2Configuration as DefaultDustV2Configuration } from '@midnightntwrk/wallet-sdk-dust-wallet/v2';
 import { buildTestEnvironmentVariables, getComposeDirectory } from '@midnightntwrk/wallet-sdk-utilities/testing';
@@ -249,7 +249,7 @@ export class TestContainersFixture {
       // Every environment these suites run against is on the ledger-v9-native node line, which reports
       // this protocol version, so the wallet reaches its post-fork variant. Defined once here rather than
       // at each construction site; the final mainnet fork constant is still an open question.
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
     };
   }
 

--- a/packages/facade/test/lateVerdictAcrossFork.test.ts
+++ b/packages/facade/test/lateVerdictAcrossFork.test.ts
@@ -41,7 +41,7 @@ import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pend
 import type { PendingTransactionsService } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import type { SubmissionService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { DustWallet, type DustWalletState } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import { ShieldedWallet, type ShieldedWalletState, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet, type ShieldedWalletState } from '@midnightntwrk/wallet-sdk-shielded';
 import {
   createKeystore,
   PublicKey,
@@ -72,7 +72,7 @@ import {
 } from './utils/index.js';
 
 /** The boundary this chain forks at. */
-const forkVersion = V9_NATIVE_FORK_VERSION;
+const forkVersion = ProtocolVersion.V9NativeForkVersion;
 
 /** Where the three wallets are before it: one epoch, ordinary drift within it. */
 const beforeFork = ProtocolVersion.ProtocolVersion(3n);

--- a/packages/facade/test/orphanOnFork.test.ts
+++ b/packages/facade/test/orphanOnFork.test.ts
@@ -25,7 +25,7 @@ import {
 import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import type { PendingTransactionsService } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { DateTime, Option } from 'effect';
 import * as rx from 'rxjs';
@@ -101,7 +101,7 @@ describe('A pending transaction the fork left behind', () => {
   beforeEach(async () => {
     configuration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServerUrl: new URL('http://localhost:6300'),
@@ -191,7 +191,7 @@ describe('A pending transaction the fork left behind', () => {
           result: {
             status: 'ORPHANED_BY_FORK',
             authoredFor: ProtocolVersion.MinSupportedVersion,
-            chainNow: V9_NATIVE_FORK_VERSION,
+            chainNow: ProtocolVersion.V9NativeForkVersion,
           },
         },
       ],

--- a/packages/facade/test/pendingTransactions.test.ts
+++ b/packages/facade/test/pendingTransactions.test.ts
@@ -21,7 +21,7 @@ import {
   WalletTransaction,
 } from '@midnightntwrk/wallet-sdk-abstractions';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
@@ -47,7 +47,7 @@ describe('Wallet Facade handling pending transactions', () => {
   beforeEach(async () => {
     configuration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',

--- a/packages/facade/test/protocolPhaseWiring.test.ts
+++ b/packages/facade/test/protocolPhaseWiring.test.ts
@@ -42,7 +42,7 @@ import {
 import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import type { PendingTransactionsService } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import { DustWallet, type DustWalletState } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import { ShieldedWallet, type ShieldedWalletState, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet, type ShieldedWalletState } from '@midnightntwrk/wallet-sdk-shielded';
 import {
   createKeystore,
   PublicKey,
@@ -66,7 +66,7 @@ import {
 } from './utils/index.js';
 
 /** The boundary the facade reads `protocol` against. */
-const forkVersion = V9_NATIVE_FORK_VERSION;
+const forkVersion = ProtocolVersion.V9NativeForkVersion;
 
 /** Three versions below the boundary, all different: ordinary drift within one epoch. */
 const beforeFork = {

--- a/packages/facade/test/submission.test.ts
+++ b/packages/facade/test/submission.test.ts
@@ -20,7 +20,7 @@ import {
 } from '@midnightntwrk/wallet-sdk-abstractions';
 import { type SubmissionService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { Either } from 'effect';
 import * as crypto from 'node:crypto';
@@ -64,7 +64,7 @@ describe('Facade submission', () => {
     })();
     const configuration: DefaultConfiguration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -111,7 +111,7 @@ describe('Facade submission', () => {
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -192,7 +192,7 @@ describe('Facade submission', () => {
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -260,7 +260,7 @@ describe('Facade transaction history reads return entries regardless of lifecycl
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServerUrl: new URL('http://localhost:6300'),

--- a/packages/facade/test/versionedProving.test.ts
+++ b/packages/facade/test/versionedProving.test.ts
@@ -29,7 +29,7 @@ import {
   type VersionedProvingService,
 } from '@midnightntwrk/wallet-sdk-capabilities/proving';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { Cause, Either, Option, Runtime } from 'effect';
 import * as rx from 'rxjs';
@@ -71,7 +71,7 @@ describe('Proving a transaction at the version it was built for', () => {
   beforeEach(async () => {
     configuration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServers: [{ sinceVersion: ProtocolVersion.MinSupportedVersion, url: new URL('http://localhost:6300') }],
@@ -146,7 +146,7 @@ describe('Proving a transaction at the version it was built for', () => {
   });
 
   it('refuses a transaction built on the other side of the boundary, without asking any prover', async () => {
-    const failure = await facade.finalizeTransaction(anyTransaction(V9_NATIVE_FORK_VERSION)).then(
+    const failure = await facade.finalizeTransaction(anyTransaction(ProtocolVersion.V9NativeForkVersion)).then(
       () => undefined,
       (error: unknown) => error,
     );
@@ -167,7 +167,7 @@ describe('Proving with the backend configured for the epoch a transaction belong
   const started = async (proving: Partial<DefaultConfiguration>): Promise<WalletFacade> => {
     const configuration: DefaultConfiguration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       costParameters: { feeBlocksMargin: 0 },
@@ -240,7 +240,10 @@ describe('Proving with the backend configured for the epoch a transaction belong
 
   const provenBy = (finalized: WalletTransaction<WalletTransaction.Stage>) =>
     Either.getOrThrow(
-      WalletTransaction.unwrapWithin<unknown>(finalized, ProtocolVersion.epochOf(PRE_FORK, V9_NATIVE_FORK_VERSION)),
+      WalletTransaction.unwrapWithin<unknown>(
+        finalized,
+        ProtocolVersion.epochOf(PRE_FORK, ProtocolVersion.V9NativeForkVersion),
+      ),
     );
 
   const v8ServerAndV9Wasm: Partial<DefaultConfiguration> = {
@@ -249,7 +252,7 @@ describe('Proving with the backend configured for the epoch a transaction belong
         sinceVersion: ProtocolVersion.MinSupportedVersion,
         backend: { kind: 'server', url: new URL('http://pre-fork-prover:6300') },
       },
-      { sinceVersion: V9_NATIVE_FORK_VERSION, backend: { kind: 'wasm' } },
+      { sinceVersion: ProtocolVersion.V9NativeForkVersion, backend: { kind: 'wasm' } },
     ],
   };
 
@@ -286,7 +289,7 @@ describe('Proving with the backend configured for the epoch a transaction belong
     const facade = await started({
       provers: [
         {
-          sinceVersion: V9_NATIVE_FORK_VERSION,
+          sinceVersion: ProtocolVersion.V9NativeForkVersion,
           backend: { kind: 'server', url: new URL('http://post-fork-prover:6300') },
         },
       ],

--- a/packages/shielded-wallet/README.md
+++ b/packages/shielded-wallet/README.md
@@ -24,8 +24,8 @@ while maintaining verifiability. It provides:
 ### Starting the Wallet
 
 ```typescript
-import { ShieldedWallet, V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
-import { InMemoryTransactionHistoryStorage } from '@midnightntwrk/wallet-sdk-abstractions';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
+import { InMemoryTransactionHistoryStorage, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { TransactionHistory } from '@midnightntwrk/wallet-sdk-shielded/v2';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { randomBytes } from 'node:crypto';
@@ -40,7 +40,7 @@ const configuration = {
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so it is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
 };
 
 // Create secret keys from a shielded seed

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -237,20 +237,13 @@ export type CustomizedShieldedWallet<
   WalletLike.WalletLike<[Variant.VersionedVariant<V2Variant<TSerialized, TSyncUpdate, TTransaction, TStartAux>>]>;
 
 /**
- * The protocol version a ledger-v9-native chain hands over at, for the current node line.
+ * The protocol version a ledger-v9-native chain hands over at.
  *
- * @remarks
- *   Measured, not assumed: a `midnight-node` 2.x reports protocol version `2000000` on its ledger events — the runtime
- *   version, scaled, rather than a small ordinal or the ledger major. A chain of the previous node line reports a
- *   1.x-encoded value, which is below this, so a wallet configured with it stays on the pre-fork variant there and
- *   reaches the post-fork variant on any v9-native chain.
- *
- *   Offered as a named value so applications and test suites pointed at a v9-native chain do not each invent a magic
- *   number. It is **not** a default: {@link DefaultShieldedConfiguration.forkVersion} stays required, because the right
- *   value is a property of the chain an application points at. The final mainnet fork constant is still an open
- *   question; when it is fixed a `ProtocolVersion.Forks.*` value will join this one.
+ * @deprecated Use {@link ProtocolVersion.V9NativeForkVersion} from `@midnightntwrk/wallet-sdk-abstractions` (or the
+ *   umbrella package) — the value is a property of the chain, not of the shielded wallet, and lives with the version
+ *   type now. This alias is the same value and will be removed in a later release.
  */
-export const V9_NATIVE_FORK_VERSION: ProtocolVersion.ProtocolVersion = ProtocolVersion.ProtocolVersion(2_000_000n);
+export const V9_NATIVE_FORK_VERSION: ProtocolVersion.ProtocolVersion = ProtocolVersion.V9NativeForkVersion;
 
 /**
  * The configuration a default {@link ShieldedWallet} is built from.

--- a/packages/shielded-wallet/src/test/shieldedWallet.test.ts
+++ b/packages/shielded-wallet/src/test/shieldedWallet.test.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as ledger from '@midnightntwrk/ledger-v9';
-import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { Effect, Scope, Stream } from 'effect';
 import { describe, expect, it } from 'vitest';
 import {
@@ -167,5 +167,11 @@ describe('CustomShieldedWallet post-migration sync restart', () => {
 
     expect(recorder.watchers).toEqual([]);
     expect(recorder.resumed).toEqual([]);
+  });
+});
+
+describe('V9_NATIVE_FORK_VERSION', () => {
+  it('is the same value as ProtocolVersion.V9NativeForkVersion, kept only so existing imports keep working', () => {
+    expect(V9_NATIVE_FORK_VERSION).toBe(ProtocolVersion.V9NativeForkVersion);
   });
 });

--- a/packages/shielded-wallet/src/test/shieldedWallet.test.ts
+++ b/packages/shielded-wallet/src/test/shieldedWallet.test.ts
@@ -26,7 +26,7 @@ const configuration: DefaultShieldedConfiguration = {
   networkId: NetworkId.NetworkId.Undeployed,
   indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
 };
 
 /**

--- a/packages/shielded-wallet/src/test/tryRestore.test.ts
+++ b/packages/shielded-wallet/src/test/tryRestore.test.ts
@@ -25,7 +25,7 @@ import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@
 import { Either } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { UnsupportedSnapshotVersionError } from '../Restore.js';
-import { type DefaultShieldedConfiguration, V9_NATIVE_FORK_VERSION } from '../ShieldedWallet.js';
+import { type DefaultShieldedConfiguration } from '../ShieldedWallet.js';
 import { ShieldedWallet } from '../ForkingShieldedWallet.js';
 import { TransactionHistory } from '../v2/index.js';
 
@@ -33,7 +33,7 @@ const configuration: DefaultShieldedConfiguration = {
   networkId: NetworkId.NetworkId.Undeployed,
   indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
 };
 
 /** A snapshot declaring a protocol version far beyond anything this build registers a variant for. */

--- a/packages/unshielded-wallet/README.md
+++ b/packages/unshielded-wallet/README.md
@@ -25,8 +25,7 @@ Unlike shielded transactions, unshielded operations do not use zero-knowledge pr
 
 ```typescript
 import { UnshieldedWallet, createKeystore, PublicKey } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
-import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
-import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { randomBytes } from 'node:crypto';
 
 // Configuration for the wallet
@@ -39,7 +38,7 @@ const configuration = {
   txHistoryStorage: new InMemoryTransactionHistoryStorage(),
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so it is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forkVersion: ProtocolVersion.V9NativeForkVersion,
 };
 
 // Create a keystore from a random unshielded seed

--- a/packages/unshielded-wallet/src/UnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/UnshieldedWallet.ts
@@ -183,9 +183,8 @@ export type DefaultUnshieldedConfiguration = {
    *   application points at, not of the SDK.
    *
    *   A node reporting a 2.x runtime version reports protocol version `2000000`, which is therefore the value for a
-   *   ledger-v9-native chain — the shielded package publishes it as `V9_NATIVE_FORK_VERSION`. The final mainnet fork
-   *   constant is not yet fixed; a `ProtocolVersion.Forks.*` default will ship once it is, and this field keeps working
-   *   unchanged.
+   *   ledger-v9-native chain — published as `ProtocolVersion.V9NativeForkVersion`. The final mainnet fork constant is
+   *   not yet fixed; it will join that one once it is, and this field keeps working unchanged.
    */
   forkVersion: ProtocolVersion.ProtocolVersion;
   /**

--- a/packages/unshielded-wallet/test/testUtils.ts
+++ b/packages/unshielded-wallet/test/testUtils.ts
@@ -126,9 +126,8 @@ export const createWalletConfig = (
     networkId: NetworkId.NetworkId.Undeployed,
     txHistoryStorage: new InMemoryTransactionHistoryStorage(UnshieldedEntrySchema),
     // The ledger-v9-native node line these suites run against reports this protocol version, so the wallet reaches its
-    // post-fork variant. Spelled out rather than imported: it is published as `V9_NATIVE_FORK_VERSION` by the shielded
-    // package, which this one does not depend on.
-    forkVersion: ProtocolVersion.ProtocolVersion(2_000_000n),
+    // post-fork variant.
+    forkVersion: ProtocolVersion.V9NativeForkVersion,
   };
 
   return { ...defaultConfig, ...overrides };

--- a/packages/wallet-integration-tests/test/serializationAndRestoration.integration.test.ts
+++ b/packages/wallet-integration-tests/test/serializationAndRestoration.integration.test.ts
@@ -15,7 +15,6 @@ import {
   type ShieldedWalletClass,
   type ShieldedWalletState,
   type DefaultShieldedConfiguration,
-  V9_NATIVE_FORK_VERSION,
 } from '@midnightntwrk/wallet-sdk-shielded';
 import { UnshieldedWallet, createKeystore, PublicKey } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import * as ledger from '@midnightntwrk/ledger-v9';
@@ -29,7 +28,7 @@ import { firstValueFrom } from 'rxjs';
 import * as rx from 'rxjs';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getShieldedSeed, getUnshieldedSeed } from './utils.js';
-import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { WalletEntrySchema, mergeWalletEntries } from '@midnightntwrk/wallet-sdk-facade';
 
 vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
@@ -58,7 +57,7 @@ describe('Wallet serialization and restoration', () => {
     indexerPort = startedEnvironment.getContainer(`indexer_${environmentId}`).getMappedPort(8088);
 
     shieldedConfiguration = {
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       indexerClientConnection: {
         indexerHttpUrl: `http://localhost:${indexerPort}/api/v4/graphql`,
       },
@@ -69,7 +68,7 @@ describe('Wallet serialization and restoration', () => {
     unshieldedConfiguration = {
       // The same boundary the shielded configuration names, for the same reason: this stack runs the
       // ledger-v9-native node line, so the unshielded wallet reaches its post-fork variant too.
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
       indexerClientConnection: {
         indexerWsUrl: `ws://localhost:${indexerPort}/api/v4/graphql/ws`,
         indexerHttpUrl: `http://localhost:${indexerPort}/api/v4/graphql`,

--- a/packages/wallet-sdk-testkit/src/environment.ts
+++ b/packages/wallet-sdk-testkit/src/environment.ts
@@ -10,8 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { InMemoryTransactionHistoryStorage, NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
-import { V9_NATIVE_FORK_VERSION } from '@midnightntwrk/wallet-sdk-shielded';
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { WalletEntrySchema, mergeWalletEntries } from '@midnightntwrk/wallet-sdk-facade';
 import {
   type DustWalletConfiguration,
@@ -89,7 +88,7 @@ export const makeEnvironment = (
       // Every environment this testkit drives runs the ledger-v9-native node line, which reports this
       // protocol version, so the wallet reaches its post-fork variant. Defined once here rather than at
       // each construction site; the final mainnet fork constant is still an open question.
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
     };
   },
   getDustWalletConfig(): DustWalletConfiguration {
@@ -104,7 +103,7 @@ export const makeEnvironment = (
       },
       // The same boundary the shielded configuration names, for the same reason: this testkit's environments all run
       // the ledger-v9-native node line, so the dust wallet reaches its post-fork variant too.
-      forkVersion: V9_NATIVE_FORK_VERSION,
+      forkVersion: ProtocolVersion.V9NativeForkVersion,
     };
   },
   down: options.down ?? (async () => {}),


### PR DESCRIPTION
## Summary

Stacked on #717. Folds the v9-native fork version into the version type, as its own doc comment anticipated.

- **`ProtocolVersion.V9NativeForkVersion`** joins `MinSupportedVersion` and `MaxSupportedVersion` in `@midnightntwrk/wallet-sdk-abstractions`, reachable through the umbrella package's `ProtocolVersion` too. Same value as before, 2000000, the version a `midnight-node` 2.x reports on its ledger events. Its doc comment moved with it.
- **The shielded `V9_NATIVE_FORK_VERSION` stays as a deprecated alias** of the new constant, so existing imports keep working. It goes in a later release.
- **Every in-repo use moves to the new name**: the three wallet packages' docs, facade and shielded tests, testkit, e2e and integration tests, the two READMEs, the six snippets, and the consolidated hard-fork release note. The unshielded test utilities, which had spelled the number out because they could not import from shielded, now import it. The dust and unshielded docs no longer point at "the shielded package publishes it".
- **Still a named value, not a default.** `forkVersion` remains required on every wallet, because the right value is a property of the chain an application points at.

## Tests

Red first: `protocolVersion.test.ts` asserts the constant's value and that it lies strictly inside the supported range; `shieldedWallet.test.ts` asserts the alias is the same value.

## Verification

`yarn dist`, `yarn typecheck`, `yarn lint`, `yarn test:unit` (all packages; three dust files timed out once under full parallel load and pass on their own and as a package), Effect diagnostics on every changed file, `yarn changeset status`. Snippets typecheck and lint; their output cannot change from a rename, and #717 ran the full lane on the same tree.
