### PR TITLE
feat(sdk)!: state the fork schedule as a map keyed by ledger version

### DIFF
--- a/.changeset/fold-fork-constant.md
+++ b/.changeset/fold-fork-constant.md
@@ -9,4 +9,4 @@ package (and through the umbrella package's `ProtocolVersion`), next to `MinSupp
 It is the same value the shielded package published as `V9_NATIVE_FORK_VERSION` — a property of the chain, not of one
 wallet, which is why it moves. The shielded export stays as a deprecated alias of the new constant, so existing imports
 keep working; it will be removed in a later release. As before, it is a named value and not a default: every wallet's
-`forkVersion` remains required.
+`forks.v9` remains required.

--- a/.changeset/fork-schedule.md
+++ b/.changeset/fork-schedule.md
@@ -1,0 +1,33 @@
+---
+'@midnightntwrk/wallet-sdk-abstractions': minor
+'@midnightntwrk/wallet-sdk-capabilities': major
+'@midnightntwrk/wallet-sdk-shielded': major
+'@midnightntwrk/wallet-sdk-unshielded-wallet': major
+'@midnightntwrk/wallet-sdk-dust-wallet': major
+'@midnightntwrk/wallet-sdk-facade': major
+'@midnightntwrk/wallet-sdk-testkit': major
+'@midnightntwrk/wallet-sdk': major
+---
+
+feat(sdk)!: state the fork schedule as a map keyed by ledger version
+
+The wallet, facade and block-data-fetcher configurations take `forks: { v9 }` — the protocol version from which
+ledger-v9 reads the chain — in place of the single `forkVersion`. The value and its meaning are unchanged; only the shape
+is. A single number could name one boundary and no more, so the next hard fork would have changed the shape of every
+application's configuration. A map keyed by ledger version adds a key (`v10`) instead, which is why the change is made
+now, while 2.0 is still in beta. The type is `ProtocolVersion.ForkSchedule` in the abstractions package; ledger-v8 begins
+at `MinSupportedVersion` and has no entry, and every entry stays required with no default, for the same reason as before:
+where a chain forks is a fact about the chain, not the SDK.
+
+BREAKING CHANGE — replace the field in every configuration you build:
+
+```ts
+// before
+{ forkVersion: ProtocolVersion.V9NativeForkVersion, ... }
+// after
+{ forks: { v9: ProtocolVersion.V9NativeForkVersion }, ... }
+```
+
+Factories that take a single boundary directly (`makeDefaultVersionedProvingService(configuration, forkVersion)`,
+`defaultLedgerParametersCodecs(forkVersion)`, `ProtocolVersion.epochOf`) are unchanged; the facade passes
+`configuration.forks.v9` to them.

--- a/.changeset/hard-fork-ready-snippets.md
+++ b/.changeset/hard-fork-ready-snippets.md
@@ -2,10 +2,10 @@
 ---
 
 Make the documentation snippets hard-fork ready. Every snippet now imports only from `@midnightntwrk/wallet-sdk` and
-its subpaths; every wallet is configured to run on ledger-v8 below `forkVersion` and on ledger-v9 from it — proving
+its subpaths; every wallet is configured to run on ledger-v8 below `forks.v9` and on ledger-v9 from it — proving
 included, with a proof server per ledger version under `provers` (the in-process prover needs one entry, since the
 same backend serves both); the examples that author their own transactions pick the ledger — `./ledger/v8` below
-`forkVersion`, `./ledger/v9` from it — by the protocol version the wallets are acting at and seal the handle with that
+`forks.v9`, `./ledger/v9` from it — by the protocol version the wallets are acting at and seal the handle with that
 version, so they run on a pre-fork chain and follow it across the fork instead of stamping version 0, which a wallet
 past the fork refuses; and the projections fast-sync example is composed either side of the boundary — ledger-v8 event
 replay below it, projections from it — with `withStartAuxDefaults()` restated after `withSync`, which drops it, so a

--- a/.changeset/hard-fork-support.md
+++ b/.changeset/hard-fork-support.md
@@ -23,7 +23,7 @@ no longer import a ledger package.
 
 ### Breaking: configuration and starting
 
-- `forkVersion` is required in the shielded, dust, unshielded and facade configurations: the protocol version at which
+- `forks.v9` is required in the shielded, dust, unshielded and facade configurations: the protocol version at which
   the chain switches ledgers. There is no default. `ProtocolVersion.V9NativeForkVersion`, from the abstractions package, is
   the value a 2.x chain reports (2000000); the final mainnet constant is not fixed yet, so supply it per environment.
 - `chainVersionProbe` is a new optional setting on all three wallets. By default a wallet asks the indexer, on every

--- a/.changeset/proving-per-version.md
+++ b/.changeset/proving-per-version.md
@@ -39,7 +39,7 @@ the epoch it serves, rather than passing a foreign object to a ledger that canno
 BREAKING CHANGE (`@midnightntwrk/wallet-sdk-capabilities`) — `makeDefaultVersionedProvingService` and
 `makeDefaultVersionedProvingServiceEffect` take the chain's fork version as a second argument, and a new
 `makeDefaultProvingServices(configuration, forkVersion)` exposes the registry they build. The facade passes
-`configuration.forkVersion` for you; only a direct caller of these factories is affected. `ProvingServiceEffect`'s error
+`configuration.forks.v9` for you; only a direct caller of these factories is affected. `ProvingServiceEffect`'s error
 channel widens from `ProvingError` to `ProvingFailure` (`ProvingError | ProvingEpochMismatchError`) — existing
 implementations stay assignable. The facade's `InitParams.provingService` widens to
 `VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>`, which existing ledger-v9

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,8 +304,8 @@ Capabilities operate on state synchronously; services provide data that capabili
 Each of the three wallet packages holds **two variants of the same wallet**, one per ledger version, in sibling
 directories under `src/`:
 
-- **`src/v1`** - the **pre-fork** variant, on `@midnight-ntwrk/ledger-v8`. Active below the chain's `forkVersion`.
-- **`src/v2`** - the **current** variant, on `@midnightntwrk/ledger-v9`. Active from `forkVersion` upwards.
+- **`src/v1`** - the **pre-fork** variant, on `@midnight-ntwrk/ledger-v8`. Active below the chain's `forks.v9`.
+- **`src/v2`** - the **current** variant, on `@midnightntwrk/ledger-v9`. Active from `forks.v9` upwards.
 
 The two trees are near-identical modulo the ledger import: same file names, same exports with `V1`/`V2` in their names.
 
@@ -320,7 +320,7 @@ each is documented where it is excluded. Do not "fix" a missing `v1` counterpart
 them.
 
 **The wallet layer above the twins is single.** `ShieldedWallet` / `DustWallet` / `UnshieldedWallet` each register both
-variants and hand over at `configuration.forkVersion`; the package's own `Default*Configuration` is declared by the
+variants and hand over at `configuration.forks.v9`; the package's own `Default*Configuration` is declared by the
 package, not aliased to either variant's. `Custom*Wallet(configuration, builder)` is the single-variant composition.
 
 ### State Management

--- a/apps/test-website/src/wallet.ts
+++ b/apps/test-website/src/wallet.ts
@@ -55,7 +55,7 @@ export const configurationFor = (network: KnownNetwork): Configuration => ({
   networkId: network,
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: V9_NATIVE_FORK_VERSION,
+  forks: { v9: V9_NATIVE_FORK_VERSION },
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/abstractions/src/ProtocolVersion.ts
+++ b/packages/abstractions/src/ProtocolVersion.ts
@@ -80,11 +80,30 @@ export const MaxSupportedVersion = ProtocolVersion(BigInt(Number.MAX_SAFE_INTEGE
  *   reaches the post-fork variant on any v9-native chain.
  *
  *   Offered as a named value so applications and test suites pointed at a v9-native chain do not each invent a magic
- *   number. It is **not** a default: every wallet's `forkVersion` stays required, because the right value is a property
- *   of the chain an application points at. The final mainnet fork constant is still an open question; when it is fixed
- *   it will join this one here.
+ *   number. It is **not** a default: every wallet's `forks.v9` stays required, because the right value is a property of
+ *   the chain an application points at. The final mainnet fork constant is still an open question; when it is fixed it
+ *   will join this one here.
  */
 export const V9NativeForkVersion: ProtocolVersion = ProtocolVersion(2_000_000n);
+
+/**
+ * Where each ledger version after the first begins on a chain, by protocol version.
+ *
+ * @remarks
+ *   One key per ledger version the SDK can run, minus the first: ledger-v8 begins at {@link MinSupportedVersion} and needs
+ *   no entry. `v9` is the protocol version from which ledger-v9 reads the chain — {@link V9NativeForkVersion} on a chain
+ *   born on ledger-v9, and whatever version the hand-over is enacted at on a chain with pre-fork history. The next hard
+ *   fork adds a key (`v10`) rather than changing this shape, which is what lets an application's configuration outlive
+ *   the fork.
+ *
+ *   Every entry is required and none is defaulted, for the same reason a single fork version was: where a chain forks is
+ *   a fact about the chain rather than the SDK, and a wrong guess does not degrade — it decides which ledger version
+ *   reads the chain.
+ */
+export type ForkSchedule = Readonly<{
+  /** The protocol version from which ledger-v9 reads the chain. */
+  v9: ProtocolVersion;
+}>;
 
 /**
  * The range of protocol versions on the same side of a protocol boundary as a given version.

--- a/packages/abstractions/src/test/protocolVersion.test.ts
+++ b/packages/abstractions/src/test/protocolVersion.test.ts
@@ -55,3 +55,17 @@ describe('ProtocolVersion', () => {
     },
   );
 });
+
+describe('ForkSchedule', () => {
+  it('names where each ledger version after the first begins, keyed by ledger version', () => {
+    const schedule: ProtocolVersion.ForkSchedule = { v9: ProtocolVersion.V9NativeForkVersion };
+    expect(schedule.v9).toBe(ProtocolVersion.V9NativeForkVersion);
+  });
+
+  it('has no entry for ledger-v8, which begins at MinSupportedVersion', () => {
+    // A type-level fact stated as a value: were `v8` a key, this annotation would be `true` and the assignment would
+    // not compile.
+    const v8Scheduled: 'v8' extends keyof ProtocolVersion.ForkSchedule ? true : false = false;
+    expect(v8Scheduled).toBe(false);
+  });
+});

--- a/packages/capabilities/README.md
+++ b/packages/capabilities/README.md
@@ -99,7 +99,7 @@ try {
 
 A proving backend is written against one ledger version — it drives that version's `Transaction.prove` with that
 version's cost model, and frames its proof-server requests with that version's payload helpers. Which backend answers
-for which protocol version is therefore a registration, and it is made from the same `forkVersion` the wallets are built
+for which protocol version is therefore a registration, and it is made from the same `forks.v9` the wallets are built
 with:
 
 ```typescript
@@ -110,18 +110,18 @@ const service = makeDefaultVersionedProvingService(
   {
     provers: [
       { sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'server', url: v8ProofServer } },
-      { sinceVersion: forkVersion, backend: { kind: 'wasm' } },
+      { sinceVersion: forks.v9, backend: { kind: 'wasm' } },
     ],
   },
-  forkVersion,
+  forks.v9,
 ); // Either<VersionedProvingService, ProvingConfigurationError>
 ```
 
 - `provers` > `provingServers` > `provingServerUrl`; naming none is a `ProvingConfigurationError`, as is naming them out
   of order.
-- A range that spans `forkVersion` is split at it, so each side is driven by its own ledger version. That is what makes
-  the single-URL form frame correctly on both sides; whether one server can actually prove both is an operational fact
-  about that server, not something the SDK enforces.
+- A range that spans `forks.v9` is split at it, so each side is driven by its own ledger version. That is what makes the
+  single-URL form frame correctly on both sides; whether one server can actually prove both is an operational fact about
+  that server, not something the SDK enforces.
 - Each registered backend refuses the other ledger version's transaction with `ProvingEpochMismatchError` rather than
   handing it to a ledger that cannot read it.
 - `makeServerProvingServiceEffect` / `makeWasmProvingServiceEffect` build a single current-ledger backend;

--- a/packages/capabilities/src/validation/blockData.ts
+++ b/packages/capabilities/src/validation/blockData.ts
@@ -70,8 +70,8 @@ export type DefaultBlockDataFetcherConfiguration = {
   indexerClientConnection: {
     indexerHttpUrl: string;
   };
-  /** The protocol version at which this chain hands over to the current ledger version. */
-  forkVersion: ProtocolVersion.ProtocolVersion;
+  /** Where each ledger version begins on this chain — see {@link ProtocolVersion.ForkSchedule}. */
+  forks: ProtocolVersion.ForkSchedule;
   /** The ledger parameters codecs blocks are read with; defaults to {@link defaultLedgerParametersCodecs}. */
   ledgerParametersCodecs?: LedgerParametersCodec.LedgerParametersCodecs<AnyLedgerParameters>;
 };
@@ -119,7 +119,7 @@ export const blockDataFrom = (
  */
 export const makeDefaultBlockDataFetcher = (config: DefaultBlockDataFetcherConfiguration): BlockDataFetcher => {
   const url = config.indexerClientConnection.indexerHttpUrl;
-  const codecs = config.ledgerParametersCodecs ?? defaultLedgerParametersCodecs(config.forkVersion);
+  const codecs = config.ledgerParametersCodecs ?? defaultLedgerParametersCodecs(config.forks.v9);
   return () =>
     Effect.runPromise(
       Effect.gen(function* () {

--- a/packages/docs-snippets/src/snippets/balancing.ts
+++ b/packages/docs-snippets/src/snippets/balancing.ts
@@ -46,7 +46,7 @@ const makeTransactionBlueprint = (state: FacadeState) => {
   };
   return WalletTransaction.adopt(
     'Unproven',
-    authoredFor < configuration.forkVersion ? authorPreFork() : authorPostFork(),
+    authoredFor < configuration.forks.v9 ? authorPreFork() : authorPostFork(),
     authoredFor,
   );
 };

--- a/packages/docs-snippets/src/snippets/dust-fast-sync.ts
+++ b/packages/docs-snippets/src/snippets/dust-fast-sync.ts
@@ -38,7 +38,7 @@ import { pick } from 'lodash-es';
 const INDEXER_PORT = Number.parseInt(process.env['INDEXER_PORT'] ?? '8088', 10);
 const NODE_PORT = Number.parseInt(process.env['NODE_PORT'] ?? '9944', 10);
 const PROOF_SERVER_PORT = Number.parseInt(process.env['PROOF_SERVER_PORT'] ?? '6300', 10);
-// The proof server built against ledger-v8, for the chain's history below `forkVersion`. Never contacted on a chain
+// The proof server built against ledger-v8, for the chain's history below `forks.v9`. Never contacted on a chain
 // that has been post-fork since genesis, like the one this runs against.
 const V8_PROOF_SERVER_PORT = Number.parseInt(process.env['V8_PROOF_SERVER_PORT'] ?? '6301', 10);
 const INDEXER_HTTP_URL = `http://localhost:${INDEXER_PORT}/api/v4/graphql`;
@@ -48,12 +48,12 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: ProtocolVersion.V9NativeForkVersion,
+  forks: { v9: ProtocolVersion.V9NativeForkVersion },
   costParameters: {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  // One proof server per ledger version: the one built against ledger-v8 answers below `forkVersion`, the one built
+  // One proof server per ledger version: the one built against ledger-v8 answers below `forks.v9`, the one built
   // against ledger-v9 from it. A transaction is proved by the entry for the version its bytes were authored at, so the
   // wallet proves on either side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
   provers: [
@@ -82,7 +82,7 @@ const configuration: DefaultConfiguration = {
 // so the wallet hides among roughly 2^anonymityLevel candidate nullifiers (default 7). Raising
 // it improves privacy but downloads more non-matching candidates to filter out locally.
 //
-// Note the composition. `DustWallet(config)` registers the event-replay variant either side of `forkVersion`, and
+// Note the composition. `DustWallet(config)` registers the event-replay variant either side of `forks.v9`, and
 // only the ledger-v9 side has a projections path — it rests on `DustLocalState` APIs no ledger-v8 has, permanently. So
 // the fast-syncing wallet is put together from its two halves by hand, the way the shipped one is: the ledger-v8
 // replay variant below the boundary, exactly as shipped, and from the boundary a ledger-v9 variant whose sync is the

--- a/packages/docs-snippets/src/snippets/dust-sponsorship.ts
+++ b/packages/docs-snippets/src/snippets/dust-sponsorship.ts
@@ -100,7 +100,7 @@ const prepareTransactionToBalance = async (state: FacadeState): Promise<UnboundT
       v9.LedgerParameters.initialParameters().transactionCostModel.runtimeCostModel,
     );
   };
-  const proven = await (authoredFor < configuration.forkVersion ? authorPreFork() : authorPostFork());
+  const proven = await (authoredFor < configuration.forks.v9 ? authorPreFork() : authorPostFork());
   // A transaction an application built for itself is handed to the wallet as a handle, saying which ledger version
   // made it.
   return WalletTransaction.adopt('Unbound', proven, authoredFor);

--- a/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
+++ b/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
@@ -31,7 +31,7 @@ import { pick } from 'lodash-es';
 const INDEXER_PORT = Number.parseInt(process.env['INDEXER_PORT'] ?? '8088', 10);
 const NODE_PORT = Number.parseInt(process.env['NODE_PORT'] ?? '9944', 10);
 const PROOF_SERVER_PORT = Number.parseInt(process.env['PROOF_SERVER_PORT'] ?? '6300', 10);
-// The proof server built against ledger-v8, for the chain's history below `forkVersion`. Never contacted on a chain
+// The proof server built against ledger-v8, for the chain's history below `forks.v9`. Never contacted on a chain
 // that has been post-fork since genesis, like the one this runs against.
 const V8_PROOF_SERVER_PORT = Number.parseInt(process.env['V8_PROOF_SERVER_PORT'] ?? '6301', 10);
 const INDEXER_HTTP_URL = `http://localhost:${INDEXER_PORT}/api/v4/graphql`;
@@ -41,12 +41,12 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: ProtocolVersion.V9NativeForkVersion,
+  forks: { v9: ProtocolVersion.V9NativeForkVersion },
   costParameters: {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  // One proof server per ledger version: the one built against ledger-v8 answers below `forkVersion`, the one built
+  // One proof server per ledger version: the one built against ledger-v8 answers below `forks.v9`, the one built
   // against ledger-v9 from it. A transaction is proved by the entry for the version its bytes were authored at, so the
   // wallet proves on either side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
   provers: [

--- a/packages/docs-snippets/src/snippets/hard-fork-support.ts
+++ b/packages/docs-snippets/src/snippets/hard-fork-support.ts
@@ -14,7 +14,7 @@
 /*
  * The wallet across a hard fork.
  *
- * The SDK runs one ledger version below the chain's `forkVersion` and another from it, and each of the three wallets
+ * The SDK runs one ledger version below the chain's `forks.v9` and another from it, and each of the three wallets
  * registers a variant either side. Nothing here is a migration an application performs: a wallet started from a seed
  * follows the chain across the boundary on its own. What an application does have to do is say where the boundary is,
  * read which side of it the wallets are on, and — if it authors its own transactions — author for the right side.
@@ -67,7 +67,7 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: ProtocolVersion.V9NativeForkVersion,
+  forks: { v9: ProtocolVersion.V9NativeForkVersion },
   costParameters: {
     feeBlocksMargin: 5,
   },
@@ -78,11 +78,11 @@ const configuration: DefaultConfiguration = {
   // built those bytes is the one that frames the proving request.
   //
   // Two entries, because a proof server is built against one ledger version and no published image serves both: the
-  // pre-fork half of a chain that has history below `forkVersion` needs its own deployment. On a chain that has been
+  // pre-fork half of a chain that has history below `forks.v9` needs its own deployment. On a chain that has been
   // post-fork since genesis — like the one this runs against — the first entry is simply never reached.
   //
   // `provingServerUrl: url` is the shortest form and means one server for every version; the SDK splits its range at
-  // `forkVersion` so each side is framed by its own ledger, which makes it correct but rarely what an operator wants,
+  // `forks.v9` so each side is framed by its own ledger, which makes it correct but rarely what an operator wants,
   // since the one URL then has to answer for both. `provingServers: [...]` is the same list as below with every entry
   // a server.
   provers: [

--- a/packages/docs-snippets/src/snippets/initialization.ts
+++ b/packages/docs-snippets/src/snippets/initialization.ts
@@ -30,7 +30,7 @@ import { pick } from 'lodash-es';
 const INDEXER_PORT = Number.parseInt(process.env['INDEXER_PORT'] ?? '8088', 10);
 const NODE_PORT = Number.parseInt(process.env['NODE_PORT'] ?? '9944', 10);
 const PROOF_SERVER_PORT = Number.parseInt(process.env['PROOF_SERVER_PORT'] ?? '6300', 10);
-// The proof server built against ledger-v8, for the chain's history below `forkVersion`. Never contacted on a chain
+// The proof server built against ledger-v8, for the chain's history below `forks.v9`. Never contacted on a chain
 // that has been post-fork since genesis, like the one this runs against.
 const V8_PROOF_SERVER_PORT = Number.parseInt(process.env['V8_PROOF_SERVER_PORT'] ?? '6301', 10);
 const INDEXER_HTTP_URL = `http://localhost:${INDEXER_PORT}/api/v4/graphql`;
@@ -40,12 +40,12 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: ProtocolVersion.V9NativeForkVersion,
+  forks: { v9: ProtocolVersion.V9NativeForkVersion },
   costParameters: {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  // One proof server per ledger version: the one built against ledger-v8 answers below `forkVersion`, the one built
+  // One proof server per ledger version: the one built against ledger-v8 answers below `forks.v9`, the one built
   // against ledger-v9 from it. A transaction is proved by the entry for the version its bytes were authored at, so the
   // wallet proves on either side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
   provers: [

--- a/packages/docs-snippets/src/snippets/wasm-prover.ts
+++ b/packages/docs-snippets/src/snippets/wasm-prover.ts
@@ -15,7 +15,7 @@
  *
  * The bundled prover drives a zkir runtime over bytes and never looks at a ledger version, so — unlike a proof server,
  * which is built against one — the same backend serves both epochs. One `provers` entry starting at the minimum
- * supported version therefore covers the whole timeline: the SDK splits its range at `forkVersion` and drives each side
+ * supported version therefore covers the whole timeline: the SDK splits its range at `forks.v9` and drives each side
  * with its own ledger.
  */
 import {
@@ -44,7 +44,7 @@ const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: ProtocolVersion.V9NativeForkVersion,
+  forks: { v9: ProtocolVersion.V9NativeForkVersion },
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/well-formed-validation.ts
+++ b/packages/docs-snippets/src/snippets/well-formed-validation.ts
@@ -47,7 +47,7 @@ const buildUnprovenTransaction = (state: FacadeState) => {
   // The version also picks which prover and validator answer for these bytes further down.
   return WalletTransaction.adopt(
     'Unproven',
-    authoredFor < configuration.forkVersion ? authorPreFork() : authorPostFork(),
+    authoredFor < configuration.forks.v9 ? authorPreFork() : authorPostFork(),
     authoredFor,
   );
 };

--- a/packages/docs-snippets/src/utils.ts
+++ b/packages/docs-snippets/src/utils.ts
@@ -31,7 +31,7 @@ import { type Buffer } from 'buffer';
 const INDEXER_PORT = Number.parseInt(process.env['INDEXER_PORT'] ?? '8088', 10);
 const NODE_PORT = Number.parseInt(process.env['NODE_PORT'] ?? '9944', 10);
 const PROOF_SERVER_PORT = Number.parseInt(process.env['PROOF_SERVER_PORT'] ?? '6300', 10);
-// The proof server built against ledger-v8, for the chain's history below `forkVersion`. Never contacted on a chain
+// The proof server built against ledger-v8, for the chain's history below `forks.v9`. Never contacted on a chain
 // that has been post-fork since genesis, like the one this runs against.
 const V8_PROOF_SERVER_PORT = Number.parseInt(process.env['V8_PROOF_SERVER_PORT'] ?? '6301', 10);
 const INDEXER_HTTP_URL = `http://localhost:${INDEXER_PORT}/api/v4/graphql`;
@@ -41,12 +41,12 @@ export const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forkVersion: ProtocolVersion.V9NativeForkVersion,
+  forks: { v9: ProtocolVersion.V9NativeForkVersion },
   costParameters: {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  // One proof server per ledger version: the one built against ledger-v8 answers below `forkVersion`, the one built
+  // One proof server per ledger version: the one built against ledger-v8 answers below `forks.v9`, the one built
   // against ledger-v9 from it. A transaction is proved by the entry for the version its bytes were authored at, so the
   // wallet proves on either side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
   provers: [

--- a/packages/dust-wallet/src/DustWallet.ts
+++ b/packages/dust-wallet/src/DustWallet.ts
@@ -134,8 +134,8 @@ export type SelfConfiguredDustVariant<TVariant extends Variant.AnyVariant, TConf
 /** What a forking dust wallet needs to know about itself, whatever its variants are built from. */
 export type ForkingDustConfiguration = {
   networkId: NetworkId;
-  /** The protocol version at which the chain hands over from the pre-fork ledger version to the post-fork one. */
-  forkVersion: ProtocolVersion.ProtocolVersion;
+  /** Where each ledger version begins on this chain — see {@link ProtocolVersion.ForkSchedule}. */
+  forks: ProtocolVersion.ForkSchedule;
   /**
    * How the wallet asks the chain which protocol version it is on, before it chooses a variant to start at.
    *
@@ -348,7 +348,7 @@ export const asPostForkDustParameters = (parameters: DustGenerationRates): ledge
  * Builds a dust wallet class over a variant either side of a protocol boundary.
  *
  * @remarks
- *   The boundary is `configuration.forkVersion` and nothing else: the pre-fork variant is registered from the minimum
+ *   The boundary is `configuration.forks.v9` and nothing else: the pre-fork variant is registered from the minimum
  *   supported version and the post-fork one from the fork version, so the version at which the runtime hands over and
  *   the version at which each variant stops applying are the same number, taken from one place.
  *
@@ -357,7 +357,7 @@ export const asPostForkDustParameters = (parameters: DustGenerationRates): ledge
  * @example
  *   ```typescript
  *   const Wallet = CustomForkingDustWallet(
- *     { forkVersion },
+ *     { forks },
  *     { builder: new V1Builder().withDefaults(), configuration: preForkConfiguration },
  *     { builder: new V2Builder().withDefaults().withMigration(...), configuration: postForkConfiguration },
  *   );
@@ -393,7 +393,7 @@ export function CustomForkingDustWallet<
 
   const BaseWallet: WalletLike.BaseWalletClass<Variants> = WalletBuilder.init()
     .withVariant(ProtocolVersion.MinSupportedVersion, preForkBuilder, preFork.configuration)
-    .withVariant(configuration.forkVersion, postForkBuilder, postFork.configuration)
+    .withVariant(configuration.forks.v9, postForkBuilder, postFork.configuration)
     .build();
 
   const variants = BaseWallet.allVariantsRecord();
@@ -470,8 +470,8 @@ export function CustomForkingDustWallet<
    *   The stamp is the floor of the variant's epoch: every decision it is later read for asks which side of the boundary
    *   the bytes belong to, and the floor answers that the same way as any other version in the same epoch.
    */
-  const preForkEpoch = ProtocolVersion.epochOf(ProtocolVersion.MinSupportedVersion, configuration.forkVersion);
-  const postForkEpoch = ProtocolVersion.epochOf(configuration.forkVersion, configuration.forkVersion);
+  const preForkEpoch = ProtocolVersion.epochOf(ProtocolVersion.MinSupportedVersion, configuration.forks.v9);
+  const postForkEpoch = ProtocolVersion.epochOf(configuration.forks.v9, configuration.forks.v9);
   const [preForkStamp] = preForkEpoch;
   const [postForkStamp] = postForkEpoch;
 
@@ -1074,7 +1074,7 @@ export type DustWallet = ForkingDustWallet<PreForkSyncUpdate, PostForkSyncUpdate
 export type DustWalletClass = ForkingDustWalletClass<PreForkSyncUpdate, PostForkSyncUpdate, DefaultDustConfiguration>;
 
 /**
- * Builds the dust wallet this package ships: the default variant either side of `configuration.forkVersion`.
+ * Builds the dust wallet this package ships: the default variant either side of `configuration.forks.v9`.
  *
  * @remarks
  *   Both variants read the chain through the indexer's dust event subscription and record transaction history in the same

--- a/packages/dust-wallet/src/DustWalletAPI.ts
+++ b/packages/dust-wallet/src/DustWalletAPI.ts
@@ -343,19 +343,22 @@ export type DefaultDustConfiguration = {
   indexerClientConnection: { indexerHttpUrl: string };
   transactionDetailsRetryWindow?: Duration.DurationInput;
   /**
-   * The protocol version at which this chain hands over from the pre-fork ledger to the post-fork one.
+   * Where each ledger version begins on this chain: under `v9`, the protocol version at which it hands over from
+   * ledger-v8 to ledger-v9.
    *
    * @remarks
-   *   Required, and deliberately without a default: the wallet registers one variant either side of it, so a wrong value
-   *   does not degrade — it decides which ledger version reads the chain. Below this version the pre-fork variant is
-   *   active; from it, the post-fork one. The SDK cannot guess it, because it is a property of the chain the
+   *   Required, and deliberately without a default: the wallet registers one variant either side of the boundary, so a
+   *   wrong value does not degrade — it decides which ledger version reads the chain. Below `forks.v9` the pre-fork
+   *   variant is active; from it, the post-fork one. The SDK cannot guess it, because it is a property of the chain the
    *   application points at, not of the SDK.
    *
-   *   A node reporting a 2.x runtime version reports protocol version `2000000`, which is therefore the value for a
-   *   ledger-v9-native chain — published as `ProtocolVersion.V9NativeForkVersion`. The final mainnet fork constant is
-   *   not yet fixed; it will join that one once it is, and this field keeps working unchanged.
+   *   A map keyed by ledger version rather than a single number, so the next hard fork adds a key instead of changing the
+   *   shape of every application's configuration — see {@link ProtocolVersion.ForkSchedule}. A node reporting a 2.x
+   *   runtime version reports protocol version `2000000`, which is therefore the value for a ledger-v9-native chain —
+   *   published as `ProtocolVersion.V9NativeForkVersion`. The final mainnet fork constant is not yet fixed; it will
+   *   join that one once it is, and this field keeps working unchanged.
    */
-  forkVersion: ProtocolVersion.ProtocolVersion;
+  forks: ProtocolVersion.ForkSchedule;
   /**
    * How the wallet asks the chain which protocol version its timeline starts under, before it chooses a variant to
    * start at.

--- a/packages/dust-wallet/src/test/configuration.test.ts
+++ b/packages/dust-wallet/src/test/configuration.test.ts
@@ -34,7 +34,7 @@ describe('DefaultDustConfiguration', () => {
           txHistoryStorage: V2TransactionHistory.DustHistoryStorage;
           indexerClientConnection: { indexerHttpUrl: string };
           transactionDetailsRetryWindow?: Duration.DurationInput;
-          forkVersion: ProtocolVersion.ProtocolVersion;
+          forks: ProtocolVersion.ForkSchedule;
           chainVersionProbe?: ChainVersionProbe;
         }
       >
@@ -54,9 +54,9 @@ describe('DefaultDustConfiguration', () => {
     // interchangeable, not the WASM instance.)
     type _2 = Expect<CanAssign<DefaultDustConfiguration, DefaultV1Configuration>>;
 
-    // `forkVersion` is the wallet layer's alone: neither variant knows there is another one.
-    type _3 = Expect<Equal<'forkVersion' extends keyof DefaultV1Configuration ? true : false, false>>;
-    type _4 = Expect<Equal<'forkVersion' extends keyof DefaultV2Configuration ? true : false, false>>;
+    // `forks` is the wallet layer's alone: neither variant knows there is another one.
+    type _3 = Expect<Equal<'forks' extends keyof DefaultV1Configuration ? true : false, false>>;
+    type _4 = Expect<Equal<'forks' extends keyof DefaultV2Configuration ? true : false, false>>;
 
     // And so is the question of where to start, for the same reason: a variant that does not know there is another
     // one has no use for the answer.

--- a/packages/dust-wallet/src/test/forkHarness.ts
+++ b/packages/dust-wallet/src/test/forkHarness.ts
@@ -399,7 +399,7 @@ export const makeForkWallet = (config: ForkWalletConfig): Effect.Effect<ForkWall
     .withMigration(() => capturingCrossLedgerMigration(dustParameters.postFork, captured));
 
   const WalletClass = CustomForkingDustWallet(
-    { networkId, forkVersion, ...(chainVersionProbe !== undefined ? { chainVersionProbe } : {}) },
+    { networkId, forks: { v9: forkVersion }, ...(chainVersionProbe !== undefined ? { chainVersionProbe } : {}) },
     {
       builder: preForkBuilder,
       configuration: {

--- a/packages/dust-wallet/src/test/forkSchedule.test.ts
+++ b/packages/dust-wallet/src/test/forkSchedule.test.ts
@@ -1,0 +1,52 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Where the boundary between the two variants lies is configured as `forks.v9`, not as a single fork version.
+ *
+ * @remarks
+ *   A map keyed by ledger version, so the next hard fork adds a key rather than changing the configuration's shape. What
+ *   is pinned here is the one thing the map decides today: below `forks.v9` the ledger-v8 variant owns the chain, from
+ *   it the ledger-v9 variant does.
+ */
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Variant } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { type DefaultDustConfiguration } from '../DustWalletAPI.js';
+import { DustWallet } from '../DustWallet.js';
+import { V1Tag } from '../v1/index.js';
+import { TransactionHistory, V2Tag } from '../v2/index.js';
+
+const v9 = ProtocolVersion.ProtocolVersion(7n);
+
+const configuration: DefaultDustConfiguration = {
+  networkId: NetworkId.NetworkId.Undeployed,
+  indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.DustTransactionHistoryEntrySchema),
+  costParameters: { feeBlocksMargin: 0 },
+  forks: { v9 },
+};
+
+describe('DustWallet forks', () => {
+  it('hands the chain to the ledger-v9 variant from forks.v9, and leaves everything below it to ledger-v8', () => {
+    const Wallet = DustWallet(configuration);
+    const tagAt = (version: bigint) =>
+      Variant.getVersionedVariantTag(Option.getOrThrow(Wallet.variantFor(ProtocolVersion.ProtocolVersion(version))));
+
+    expect(tagAt(0n)).toBe(V1Tag);
+    expect(tagAt(6n)).toBe(V1Tag);
+    expect(tagAt(7n)).toBe(V2Tag);
+    expect(tagAt(2_000_000n)).toBe(V2Tag);
+  });
+});

--- a/packages/dust-wallet/src/test/tryRestore.test.ts
+++ b/packages/dust-wallet/src/test/tryRestore.test.ts
@@ -29,7 +29,7 @@ const configuration: DefaultDustConfiguration = {
   indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.DustTransactionHistoryEntrySchema),
   costParameters: { feeBlocksMargin: 0 },
-  forkVersion: ProtocolVersion.ProtocolVersion(2_000_000n),
+  forks: { v9: ProtocolVersion.ProtocolVersion(2_000_000n) },
 };
 
 /** A snapshot declaring a protocol version far beyond anything this build registers a variant for. */

--- a/packages/e2e-tests/src/tests/dustDeregistration.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dustDeregistration.undeployed.test.ts
@@ -83,7 +83,7 @@ describe('Dust Deregistration', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/dustRegistration.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dustRegistration.undeployed.test.ts
@@ -91,7 +91,7 @@ describe('Dust Registration', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/emptyWallet.universal.test.ts
+++ b/packages/e2e-tests/src/tests/emptyWallet.universal.test.ts
@@ -130,7 +130,7 @@ describe('Fresh wallet with empty state', () => {
         },
         txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
         // The same boundary the shielded configuration names, taken from the one place this fixture defines it.
-        forkVersion: fixture.getWalletConfig().forkVersion,
+        forks: fixture.getWalletConfig().forks,
       }).startWithPublicKey(PublicKey.fromKeyStore(wallet.unshieldedKeystore));
     } catch (error) {
       expect(error).toBeUndefined();

--- a/packages/e2e-tests/src/tests/facadeTransfer.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/facadeTransfer.undeployed.test.ts
@@ -92,7 +92,7 @@ describe('Wallet Facade Transfer', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/helpers/walletInit.ts
+++ b/packages/e2e-tests/src/tests/helpers/walletInit.ts
@@ -94,7 +94,7 @@ const restoreUnshieldedWallet = async (
         },
         txHistoryStorage,
         // The same boundary the shielded configuration names, taken from the one place this fixture defines it.
-        forkVersion: fixture.getWalletConfig().forkVersion,
+        forks: fixture.getWalletConfig().forks,
       }).startWithPublicKey(PublicKey.fromKeyStore(keyStore));
       logger.info(`Restored unshielded wallet from ${path}`);
       return wallet;

--- a/packages/e2e-tests/src/tests/multipleWallets.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/multipleWallets.undeployed.test.ts
@@ -69,7 +69,7 @@ describe('Syncing', () => {
           },
           txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
           // The same boundary the shielded configuration names, taken from the one place this fixture defines it.
-          forkVersion: fixture.getWalletConfig().forkVersion,
+          forks: fixture.getWalletConfig().forks,
         }).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystores[i]));
       }
 

--- a/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
@@ -99,7 +99,7 @@ describe('Optional Balancing', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/smoke.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/smoke.undeployed.test.ts
@@ -252,7 +252,7 @@ describe('Smoke tests', () => {
         },
         txHistoryStorage: unshieldedTxHistoryStorage,
         // The same boundary the shielded configuration names, taken from the one place this fixture defines it.
-        forkVersion: fixture.getWalletConfig().forkVersion,
+        forks: fixture.getWalletConfig().forks,
       }).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeyStore));
       await initialWallet.start();
       logger.info(`Waiting to sync...`);
@@ -278,7 +278,7 @@ describe('Smoke tests', () => {
         },
         txHistoryStorage: restoredTxHistoryStorage,
         // The same boundary the shielded configuration names, taken from the one place this fixture defines it.
-        forkVersion: fixture.getWalletConfig().forkVersion,
+        forks: fixture.getWalletConfig().forks,
       }).restore(serializedState);
 
       await restoredWallet.start();

--- a/packages/e2e-tests/src/tests/swap.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/swap.undeployed.test.ts
@@ -95,7 +95,7 @@ describe('Swaps', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/test-fixture.ts
+++ b/packages/e2e-tests/src/tests/test-fixture.ts
@@ -249,7 +249,7 @@ export class TestContainersFixture {
       // Every environment these suites run against is on the ledger-v9-native node line, which reports
       // this protocol version, so the wallet reaches its post-fork variant. Defined once here rather than
       // at each construction site; the final mainnet fork constant is still an open question.
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
     };
   }
 

--- a/packages/facade/README.md
+++ b/packages/facade/README.md
@@ -49,7 +49,7 @@ version the chain has since reached. Backends are named ascending by the version
 import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 
 const configuration = {
-  // ... the rest of the wallet configuration, including `forkVersion`
+  // ... the rest of the wallet configuration, including `forks`
   provers: [
     // Below the boundary: a proof server built against ledger-v8.
     {
@@ -57,7 +57,7 @@ const configuration = {
       backend: { kind: 'server', url: new URL('http://localhost:6301') },
     },
     // From the boundary: proving in this process, with the published circuits.
-    { sinceVersion: forkVersion, backend: { kind: 'wasm' } },
+    { sinceVersion: forks.v9, backend: { kind: 'wasm' } },
   ],
 };
 ```
@@ -65,10 +65,10 @@ const configuration = {
 Two shorthands remain: `provingServers: [{ sinceVersion, url }]` is the same list with every entry a server, and
 `provingServerUrl: url` is one server for every version. Both are read only when `provers` is absent.
 
-A backend whose range spans `configuration.forkVersion` — which `provingServerUrl` always does — is split at the
-boundary and driven by each ledger version in turn, so the same description means the right thing on both sides. A proof
-server, though, is built against one ledger version: no published image serves both, so a chain with history below the
-boundary wants an entry per side. The in-process prover works on bytes and does serve both.
+A backend whose range spans `configuration.forks.v9` — which `provingServerUrl` always does — is split at the boundary
+and driven by each ledger version in turn, so the same description means the right thing on both sides. A proof server,
+though, is built against one ledger version: no published image serves both, so a chain with history below the boundary
+wants an entry per side. The in-process prover works on bytes and does serve both.
 
 A version no backend covers fails with `UnsupportedProvingVersionError`, naming the version.
 

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -767,11 +767,11 @@ export class WalletFacade {
   }
 
   private static makeDefaultPendingTransactionsService<
-    TConfig extends DefaultPendingTransactionsServiceConfiguration & { forkVersion: ProtocolVersion.ProtocolVersion },
+    TConfig extends DefaultPendingTransactionsServiceConfiguration & { forks: ProtocolVersion.ForkSchedule },
   >(config: TConfig): Promise<PendingTransactionsServiceImpl<FinalizedTx>> {
     return PendingTransactionsServiceImpl.init<FinalizedTx>({
       configuration: config,
-      txTraits: finalizedTransactionTraits(config.forkVersion),
+      txTraits: finalizedTransactionTraits(config.forks.v9),
     });
   }
 
@@ -786,7 +786,7 @@ export class WalletFacade {
     config: TConfig,
   ): VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction> {
     return Either.getOrThrowWith(
-      makeDefaultVersionedProvingService(config, config.forkVersion),
+      makeDefaultVersionedProvingService(config, config.forks.v9),
       (error) => new Error(error.message),
     );
   }
@@ -880,7 +880,7 @@ export class WalletFacade {
               networkId: initParams.configuration.networkId,
               clock,
             },
-            initParams.configuration.forkVersion,
+            initParams.configuration.forks.v9,
           ),
     );
     return new WalletFacade(
@@ -892,7 +892,7 @@ export class WalletFacade {
       provingService,
       validationService,
       initParams.configuration.txHistoryStorage,
-      initParams.configuration.forkVersion,
+      initParams.configuration.forks.v9,
       clock,
     );
   }

--- a/packages/facade/test/forkSchedule.test.ts
+++ b/packages/facade/test/forkSchedule.test.ts
@@ -1,0 +1,28 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** The facade asks for the fork schedule in the shape the wallets do, and for nothing the wallets no longer take. */
+import { type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type Equal, type Expect } from '@midnightntwrk/wallet-sdk-utilities/types';
+import { describe, it } from 'vitest';
+import { type DefaultConfiguration } from '../src/index.js';
+
+describe('DefaultConfiguration', () => {
+  it('states where each ledger version begins as `forks`, one key per ledger version after the first', () => {
+    type _1 = Expect<Equal<DefaultConfiguration['forks'], ProtocolVersion.ForkSchedule>>;
+  });
+
+  it('no longer takes a single fork version', () => {
+    type _1 = Expect<Equal<'forkVersion' extends keyof DefaultConfiguration ? true : false, false>>;
+  });
+});

--- a/packages/facade/test/lateVerdictAcrossFork.test.ts
+++ b/packages/facade/test/lateVerdictAcrossFork.test.ts
@@ -139,7 +139,7 @@ describe('a verdict that arrives after the wallets have crossed the boundary', (
   beforeEach(async () => {
     configuration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion,
+      forks: { v9: forkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServerUrl: new URL('http://localhost:6300'),

--- a/packages/facade/test/orphanOnFork.test.ts
+++ b/packages/facade/test/orphanOnFork.test.ts
@@ -101,7 +101,7 @@ describe('A pending transaction the fork left behind', () => {
   beforeEach(async () => {
     configuration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServerUrl: new URL('http://localhost:6300'),
@@ -212,7 +212,7 @@ describe('A pending transaction the fork left behind', () => {
     );
     expect(rejected[0].identifiers).toStrictEqual(
       Option.getOrThrow(
-        ProtocolVersion.select(finalizedTransactionTraits(configuration.forkVersion), finalized.protocolVersion),
+        ProtocolVersion.select(finalizedTransactionTraits(configuration.forks.v9), finalized.protocolVersion),
       ).ids(finalized),
     );
   });

--- a/packages/facade/test/pendingTransactions.test.ts
+++ b/packages/facade/test/pendingTransactions.test.ts
@@ -47,7 +47,7 @@ describe('Wallet Facade handling pending transactions', () => {
   beforeEach(async () => {
     configuration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',

--- a/packages/facade/test/protocolPhaseWiring.test.ts
+++ b/packages/facade/test/protocolPhaseWiring.test.ts
@@ -121,7 +121,7 @@ describe('three wallets that disagree about which side of the boundary the chain
   beforeEach(async () => {
     const configuration: DefaultConfiguration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion,
+      forks: { v9: forkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServerUrl: new URL('http://localhost:6300'),

--- a/packages/facade/test/submission.test.ts
+++ b/packages/facade/test/submission.test.ts
@@ -64,7 +64,7 @@ describe('Facade submission', () => {
     })();
     const configuration: DefaultConfiguration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -111,7 +111,7 @@ describe('Facade submission', () => {
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -192,7 +192,7 @@ describe('Facade submission', () => {
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -260,7 +260,7 @@ describe('Facade transaction history reads return entries regardless of lifecycl
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServerUrl: new URL('http://localhost:6300'),

--- a/packages/facade/test/utils/helpers.ts
+++ b/packages/facade/test/utils/helpers.ts
@@ -326,7 +326,7 @@ export const makeSimulatorFacade = (
           ...config,
           // A simulator that runs only the current ledger version has never had two epochs, whatever protocol version
           // its blocks report — so the boundary is at the bottom and everything it produces is post-fork.
-          forkVersion: ProtocolVersion.MinSupportedVersion,
+          forks: { v9: ProtocolVersion.MinSupportedVersion },
           // Dummy values - not used in simulation mode
           indexerClientConnection: { indexerHttpUrl: 'http://unused' },
           relayURL: new URL('ws://unused'),

--- a/packages/facade/test/versionedProving.test.ts
+++ b/packages/facade/test/versionedProving.test.ts
@@ -71,7 +71,7 @@ describe('Proving a transaction at the version it was built for', () => {
   beforeEach(async () => {
     configuration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServers: [{ sinceVersion: ProtocolVersion.MinSupportedVersion, url: new URL('http://localhost:6300') }],
@@ -167,7 +167,7 @@ describe('Proving with the backend configured for the epoch a transaction belong
   const started = async (proving: Partial<DefaultConfiguration>): Promise<WalletFacade> => {
     const configuration: DefaultConfiguration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       costParameters: { feeBlocksMargin: 0 },

--- a/packages/shielded-wallet/README.md
+++ b/packages/shielded-wallet/README.md
@@ -40,7 +40,7 @@ const configuration = {
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so it is supplied per environment.
-  forkVersion: ProtocolVersion.V9NativeForkVersion,
+  forks: { v9: ProtocolVersion.V9NativeForkVersion },
 };
 
 // Create secret keys from a shielded seed

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -131,8 +131,8 @@ export type SelfConfiguredShieldedVariant<
 /** What a forking shielded wallet needs to know about itself, whatever its variants are built from. */
 export type ForkingShieldedConfiguration = {
   networkId: NetworkId.NetworkId;
-  /** The protocol version at which the chain hands over from the pre-fork ledger version to the post-fork one. */
-  forkVersion: ProtocolVersion.ProtocolVersion;
+  /** Where each ledger version begins on this chain — see {@link ProtocolVersion.ForkSchedule}. */
+  forks: ProtocolVersion.ForkSchedule;
   /**
    * How the wallet asks the chain which protocol version it is on, before it chooses a variant to start at.
    *
@@ -287,7 +287,7 @@ export interface ForkingShieldedWalletClass<
  * Builds a shielded wallet class over a variant either side of a protocol boundary.
  *
  * @remarks
- *   The boundary is `configuration.forkVersion` and nothing else: the pre-fork variant is registered from the minimum
+ *   The boundary is `configuration.forks.v9` and nothing else: the pre-fork variant is registered from the minimum
  *   supported version and the post-fork one from the fork version, so the version at which the runtime hands over and
  *   the version at which each variant stops applying are the same number, taken from one place.
  *
@@ -296,7 +296,7 @@ export interface ForkingShieldedWalletClass<
  * @example
  *   ```typescript
  *   const Wallet = CustomForkingShieldedWallet(
- *     { networkId, forkVersion },
+ *     { networkId, forks },
  *     { builder: new V1Builder().withDefaults(), configuration: preForkConfiguration },
  *     { builder: new V2Builder().withDefaults().withMigration(makeCrossLedgerMigration), configuration: postForkConfiguration },
  *   );
@@ -335,7 +335,7 @@ export function CustomForkingShieldedWallet<
 
   const BaseWallet: WalletLike.BaseWalletClass<Variants> = WalletBuilder.init()
     .withVariant(ProtocolVersion.MinSupportedVersion, preForkBuilder, preFork.configuration)
-    .withVariant(configuration.forkVersion, postForkBuilder, postFork.configuration)
+    .withVariant(configuration.forks.v9, postForkBuilder, postFork.configuration)
     .build();
 
   const variants = BaseWallet.allVariantsRecord();
@@ -411,10 +411,10 @@ export function CustomForkingShieldedWallet<
    *   rather than the block height the chain happened to be at. Every decision the stamp is later read for asks which
    *   side of the boundary the bytes belong to: which prover proves them, which validator checks them, which variant
    *   may unwrap them. The epoch floor is the one value guaranteed to answer that the same way as any other version in
-   *   the same epoch, and it is derived here from the same `forkVersion` the variants are registered at.
+   *   the same epoch, and it is derived here from the same `forks.v9` the variants are registered at.
    */
-  const preForkEpoch = ProtocolVersion.epochOf(ProtocolVersion.MinSupportedVersion, configuration.forkVersion);
-  const postForkEpoch = ProtocolVersion.epochOf(configuration.forkVersion, configuration.forkVersion);
+  const preForkEpoch = ProtocolVersion.epochOf(ProtocolVersion.MinSupportedVersion, configuration.forks.v9);
+  const postForkEpoch = ProtocolVersion.epochOf(configuration.forks.v9, configuration.forks.v9);
   const [preForkStamp] = preForkEpoch;
   const [postForkStamp] = postForkEpoch;
 
@@ -860,7 +860,7 @@ export type ShieldedWalletClass = ForkingShieldedWalletClass<
 >;
 
 /**
- * Builds the shielded wallet this package ships: the default variant either side of `configuration.forkVersion`.
+ * Builds the shielded wallet this package ships: the default variant either side of `configuration.forks.v9`.
  *
  * @remarks
  *   Both variants read the chain through the indexer and record transaction history in the same storage; each is built

--- a/packages/shielded-wallet/src/ShieldedWalletAPI.ts
+++ b/packages/shielded-wallet/src/ShieldedWalletAPI.ts
@@ -246,19 +246,22 @@ export type DefaultShieldedConfiguration = {
   txHistoryStorage: ShieldedHistoryStorage;
   transactionDetailsRetryWindow?: Duration.DurationInput;
   /**
-   * The protocol version at which this chain hands over from the pre-fork ledger to the post-fork one.
+   * Where each ledger version begins on this chain: under `v9`, the protocol version at which it hands over from
+   * ledger-v8 to ledger-v9.
    *
    * @remarks
-   *   Required, and deliberately without a default: the wallet registers one variant either side of it, so a wrong value
-   *   does not degrade — it decides which ledger version reads the chain. Below this version the pre-fork variant is
-   *   active; from it, the post-fork one. The SDK cannot guess it, because it is a property of the chain the
+   *   Required, and deliberately without a default: the wallet registers one variant either side of the boundary, so a
+   *   wrong value does not degrade — it decides which ledger version reads the chain. Below `forks.v9` the pre-fork
+   *   variant is active; from it, the post-fork one. The SDK cannot guess it, because it is a property of the chain the
    *   application points at, not of the SDK.
    *
-   *   A node reporting a 2.x runtime version reports protocol version `2000000`, which is therefore the value for a
-   *   ledger-v9-native chain. The final mainnet fork constant is not yet fixed; a `ProtocolVersion.Forks.*` default
-   *   will ship once it is, and this field keeps working unchanged.
+   *   A map keyed by ledger version rather than a single number, so the next hard fork adds a key instead of changing the
+   *   shape of every application's configuration — see {@link ProtocolVersion.ForkSchedule}. A node reporting a 2.x
+   *   runtime version reports protocol version `2000000`, which is therefore the value for a ledger-v9-native chain —
+   *   published as `ProtocolVersion.V9NativeForkVersion`. The final mainnet fork constant is not yet fixed; it will
+   *   join that one once it is, and this field keeps working unchanged.
    */
-  forkVersion: ProtocolVersion.ProtocolVersion;
+  forks: ProtocolVersion.ForkSchedule;
   /**
    * How the wallet asks the chain which protocol version its timeline starts under, before it chooses a variant to
    * start at.

--- a/packages/shielded-wallet/src/test/configuration.test.ts
+++ b/packages/shielded-wallet/src/test/configuration.test.ts
@@ -34,7 +34,7 @@ describe('DefaultShieldedConfiguration', () => {
           batchUpdates?: V2Sync.BatchUpdatesConfig;
           txHistoryStorage: V2TransactionHistory.ShieldedHistoryStorage;
           transactionDetailsRetryWindow?: Duration.DurationInput;
-          forkVersion: ProtocolVersion.ProtocolVersion;
+          forks: ProtocolVersion.ForkSchedule;
           chainVersionProbe?: ChainVersionProbe;
         }
       >
@@ -49,9 +49,9 @@ describe('DefaultShieldedConfiguration', () => {
     type _1 = Expect<CanAssign<DefaultShieldedConfiguration, DefaultV2Configuration>>;
     type _2 = Expect<CanAssign<DefaultShieldedConfiguration, DefaultV1Configuration>>;
 
-    // `forkVersion` is the wallet layer's alone: neither variant knows there is another one.
-    type _3 = Expect<Equal<'forkVersion' extends keyof DefaultV1Configuration ? true : false, false>>;
-    type _4 = Expect<Equal<'forkVersion' extends keyof DefaultV2Configuration ? true : false, false>>;
+    // `forks` is the wallet layer's alone: neither variant knows there is another one.
+    type _3 = Expect<Equal<'forks' extends keyof DefaultV1Configuration ? true : false, false>>;
+    type _4 = Expect<Equal<'forks' extends keyof DefaultV2Configuration ? true : false, false>>;
 
     // And so is the question of where to start, for the same reason: a variant that does not know there is another
     // one has no use for the answer.

--- a/packages/shielded-wallet/src/test/forkHarness.ts
+++ b/packages/shielded-wallet/src/test/forkHarness.ts
@@ -307,7 +307,7 @@ export const makeForkWallet = (config: ForkWalletConfig): Effect.Effect<ForkWall
     .withMigration(() => capturingCrossLedgerMigration(captured));
 
   const WalletClass = CustomForkingShieldedWallet(
-    { networkId, forkVersion, ...(chainVersionProbe !== undefined ? { chainVersionProbe } : {}) },
+    { networkId, forks: { v9: forkVersion }, ...(chainVersionProbe !== undefined ? { chainVersionProbe } : {}) },
     { builder: preForkBuilder, configuration: { networkId, simulator: preFork } },
     { builder: postForkBuilder, configuration: { networkId, postFork } },
   );

--- a/packages/shielded-wallet/src/test/forkSchedule.test.ts
+++ b/packages/shielded-wallet/src/test/forkSchedule.test.ts
@@ -1,0 +1,51 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Where the boundary between the two variants lies is configured as `forks.v9`, not as a single fork version.
+ *
+ * @remarks
+ *   A map keyed by ledger version, so the next hard fork adds a key rather than changing the configuration's shape. What
+ *   is pinned here is the one thing the map decides today: below `forks.v9` the ledger-v8 variant owns the chain, from
+ *   it the ledger-v9 variant does.
+ */
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Variant } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { type DefaultShieldedConfiguration } from '../ShieldedWalletAPI.js';
+import { ShieldedWallet } from '../ShieldedWallet.js';
+import { V1Tag } from '../v1/index.js';
+import { TransactionHistory, V2Tag } from '../v2/index.js';
+
+const v9 = ProtocolVersion.ProtocolVersion(7n);
+
+const configuration: DefaultShieldedConfiguration = {
+  networkId: NetworkId.NetworkId.Undeployed,
+  indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
+  forks: { v9 },
+};
+
+describe('ShieldedWallet forks', () => {
+  it('hands the chain to the ledger-v9 variant from forks.v9, and leaves everything below it to ledger-v8', () => {
+    const Wallet = ShieldedWallet(configuration);
+    const tagAt = (version: bigint) =>
+      Variant.getVersionedVariantTag(Option.getOrThrow(Wallet.variantFor(ProtocolVersion.ProtocolVersion(version))));
+
+    expect(tagAt(0n)).toBe(V1Tag);
+    expect(tagAt(6n)).toBe(V1Tag);
+    expect(tagAt(7n)).toBe(V2Tag);
+    expect(tagAt(2_000_000n)).toBe(V2Tag);
+  });
+});

--- a/packages/shielded-wallet/src/test/shieldedWallet.test.ts
+++ b/packages/shielded-wallet/src/test/shieldedWallet.test.ts
@@ -22,7 +22,7 @@ const configuration: DefaultShieldedConfiguration = {
   networkId: NetworkId.NetworkId.Undeployed,
   indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
-  forkVersion: ProtocolVersion.V9NativeForkVersion,
+  forks: { v9: ProtocolVersion.V9NativeForkVersion },
 };
 
 /**

--- a/packages/shielded-wallet/src/test/tryRestore.test.ts
+++ b/packages/shielded-wallet/src/test/tryRestore.test.ts
@@ -33,7 +33,7 @@ const configuration: DefaultShieldedConfiguration = {
   networkId: NetworkId.NetworkId.Undeployed,
   indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
-  forkVersion: ProtocolVersion.V9NativeForkVersion,
+  forks: { v9: ProtocolVersion.V9NativeForkVersion },
 };
 
 /** A snapshot declaring a protocol version far beyond anything this build registers a variant for. */

--- a/packages/unshielded-wallet/README.md
+++ b/packages/unshielded-wallet/README.md
@@ -38,7 +38,7 @@ const configuration = {
   txHistoryStorage: new InMemoryTransactionHistoryStorage(),
   // The protocol version this chain hands over to the post-fork ledger at. A 2.x node reports 2000000;
   // the final mainnet fork constant is not yet fixed, so it is supplied per environment.
-  forkVersion: ProtocolVersion.V9NativeForkVersion,
+  forks: { v9: ProtocolVersion.V9NativeForkVersion },
 };
 
 // Create a keystore from a random unshielded seed
@@ -126,10 +126,10 @@ Variant internals are published under two subpaths, one per ledger version:
 - Current (ledger-v9) variant internals via `@midnightntwrk/wallet-sdk-unshielded-wallet/v2`
 - Pre-fork (ledger-v8) variant internals via `@midnightntwrk/wallet-sdk-unshielded-wallet/v1`
 
-The production wallet registers both variants and hands over at `forkVersion`; `./v1` is the pre-fork half on its own,
-for code that needs the ledger that produced pre-fork history. The two are not interchangeable — `./v1` has no ECDSA
-support (ledger-v8 has a single signature scheme) and carries its own ledger-v8 `createKeystore`, whose secret is a
-plain `Uint8Array` rather than the root export's `{kind, secret}`.
+The production wallet registers both variants and hands over at `forks.v9`; `./v1` is the pre-fork half on its own, for
+code that needs the ledger that produced pre-fork history. The two are not interchangeable — `./v1` has no ECDSA support
+(ledger-v8 has a single signature scheme) and carries its own ledger-v8 `createKeystore`, whose secret is a plain
+`Uint8Array` rather than the root export's `{kind, secret}`.
 
 ```typescript
 import { V2Builder, RunningV2Variant } from '@midnightntwrk/wallet-sdk-unshielded-wallet/v2';

--- a/packages/unshielded-wallet/src/UnshieldedWallet.ts
+++ b/packages/unshielded-wallet/src/UnshieldedWallet.ts
@@ -128,8 +128,8 @@ export type SelfConfiguredUnshieldedVariant<
 /** What a forking unshielded wallet needs to know about itself, whatever its variants are built from. */
 export type ForkingUnshieldedConfiguration = {
   networkId: NetworkId.NetworkId;
-  /** The protocol version at which the chain hands over from the pre-fork ledger version to the post-fork one. */
-  forkVersion: ProtocolVersion.ProtocolVersion;
+  /** Where each ledger version begins on this chain — see {@link ProtocolVersion.ForkSchedule}. */
+  forks: ProtocolVersion.ForkSchedule;
   /**
    * How the wallet asks the chain which protocol version it is on, before it chooses a variant to start at.
    *
@@ -237,7 +237,7 @@ export const asPreForkPublicKey = (publicKey: PublicKey): Option.Option<PreForkP
  * Builds an unshielded wallet class over a variant either side of a protocol boundary.
  *
  * @remarks
- *   The boundary is `configuration.forkVersion` and nothing else: the pre-fork variant is registered from the minimum
+ *   The boundary is `configuration.forks.v9` and nothing else: the pre-fork variant is registered from the minimum
  *   supported version and the post-fork one from the fork version, so the version at which the runtime hands over and
  *   the version at which each variant stops applying are the same number, taken from one place.
  *
@@ -245,7 +245,7 @@ export const asPreForkPublicKey = (publicKey: PublicKey): Option.Option<PreForkP
  * @example
  *   ```typescript
  *   const Wallet = CustomForkingUnshieldedWallet(
- *     { networkId, forkVersion },
+ *     { networkId, forks },
  *     { builder: new V1Builder().withDefaults(), configuration: preForkConfiguration },
  *     { builder: new V2Builder().withDefaults().withMigration(...), configuration: postForkConfiguration },
  *   );
@@ -284,7 +284,7 @@ export function CustomForkingUnshieldedWallet<
 
   const BaseWallet: WalletLike.BaseWalletClass<Variants> = WalletBuilder.init()
     .withVariant(ProtocolVersion.MinSupportedVersion, preForkBuilder, preFork.configuration)
-    .withVariant(configuration.forkVersion, postForkBuilder, postFork.configuration)
+    .withVariant(configuration.forks.v9, postForkBuilder, postFork.configuration)
     .build();
 
   const variants = BaseWallet.allVariantsRecord();
@@ -296,8 +296,8 @@ export function CustomForkingUnshieldedWallet<
    *   The stamp is the floor of the variant's epoch: every decision it is later read for asks which side of the boundary
    *   the bytes belong to, and the floor answers that the same way as any other version in the same epoch.
    */
-  const preForkEpoch = ProtocolVersion.epochOf(ProtocolVersion.MinSupportedVersion, configuration.forkVersion);
-  const postForkEpoch = ProtocolVersion.epochOf(configuration.forkVersion, configuration.forkVersion);
+  const preForkEpoch = ProtocolVersion.epochOf(ProtocolVersion.MinSupportedVersion, configuration.forks.v9);
+  const postForkEpoch = ProtocolVersion.epochOf(configuration.forks.v9, configuration.forks.v9);
   const [preForkStamp] = preForkEpoch;
   const [postForkStamp] = postForkEpoch;
 
@@ -439,7 +439,7 @@ export function CustomForkingUnshieldedWallet<
               variants[V2Tag],
               CoreWallet.withProtocolVersion(
                 CoreWallet.init(publicKey, configuration.networkId),
-                configuration.forkVersion,
+                configuration.forks.v9,
               ),
             ),
           ),
@@ -775,7 +775,7 @@ export type UnshieldedWalletClass = ForkingUnshieldedWalletClass<
 >;
 
 /**
- * Builds the unshielded wallet this package ships: the default variant either side of `configuration.forkVersion`.
+ * Builds the unshielded wallet this package ships: the default variant either side of `configuration.forks.v9`.
  *
  * @remarks
  *   Both variants read the chain through the indexer's unshielded-transaction subscription and record transaction history

--- a/packages/unshielded-wallet/src/UnshieldedWalletAPI.ts
+++ b/packages/unshielded-wallet/src/UnshieldedWalletAPI.ts
@@ -168,19 +168,22 @@ export type DefaultUnshieldedConfiguration = {
   indexerClientConnection: IndexerClientConnection;
   txHistoryStorage: UnshieldedHistoryStorage;
   /**
-   * The protocol version at which this chain hands over from the pre-fork ledger to the post-fork one.
+   * Where each ledger version begins on this chain: under `v9`, the protocol version at which it hands over from
+   * ledger-v8 to ledger-v9.
    *
    * @remarks
-   *   Required, and deliberately without a default: the wallet registers one variant either side of it, so a wrong value
-   *   does not degrade — it decides which ledger version reads the chain. Below this version the pre-fork variant is
-   *   active; from it, the post-fork one. The SDK cannot guess it, because it is a property of the chain the
+   *   Required, and deliberately without a default: the wallet registers one variant either side of the boundary, so a
+   *   wrong value does not degrade — it decides which ledger version reads the chain. Below `forks.v9` the pre-fork
+   *   variant is active; from it, the post-fork one. The SDK cannot guess it, because it is a property of the chain the
    *   application points at, not of the SDK.
    *
-   *   A node reporting a 2.x runtime version reports protocol version `2000000`, which is therefore the value for a
-   *   ledger-v9-native chain — published as `ProtocolVersion.V9NativeForkVersion`. The final mainnet fork constant is
-   *   not yet fixed; it will join that one once it is, and this field keeps working unchanged.
+   *   A map keyed by ledger version rather than a single number, so the next hard fork adds a key instead of changing the
+   *   shape of every application's configuration — see {@link ProtocolVersion.ForkSchedule}. A node reporting a 2.x
+   *   runtime version reports protocol version `2000000`, which is therefore the value for a ledger-v9-native chain —
+   *   published as `ProtocolVersion.V9NativeForkVersion`. The final mainnet fork constant is not yet fixed; it will
+   *   join that one once it is, and this field keeps working unchanged.
    */
-  forkVersion: ProtocolVersion.ProtocolVersion;
+  forks: ProtocolVersion.ForkSchedule;
   /**
    * How the wallet asks the chain which protocol version its timeline starts under, before it chooses a variant to
    * start at.

--- a/packages/unshielded-wallet/src/test/configuration.test.ts
+++ b/packages/unshielded-wallet/src/test/configuration.test.ts
@@ -31,7 +31,7 @@ describe('DefaultUnshieldedConfiguration', () => {
           networkId: NetworkId.NetworkId;
           indexerClientConnection: V2Sync.IndexerClientConnection;
           txHistoryStorage: V2TransactionHistory.UnshieldedHistoryStorage;
-          forkVersion: ProtocolVersion.ProtocolVersion;
+          forks: ProtocolVersion.ForkSchedule;
           chainVersionProbe?: ChainVersionProbe;
         }
       >
@@ -48,9 +48,9 @@ describe('DefaultUnshieldedConfiguration', () => {
     // here so a divergence shows up as a compile error rather than as a wallet that cannot be built for one of them.
     type _2 = Expect<CanAssign<DefaultUnshieldedConfiguration, DefaultV1Configuration>>;
 
-    // `forkVersion` is the wallet layer's alone: neither variant knows there is another one.
-    type _3 = Expect<Equal<'forkVersion' extends keyof DefaultV1Configuration ? true : false, false>>;
-    type _4 = Expect<Equal<'forkVersion' extends keyof DefaultV2Configuration ? true : false, false>>;
+    // `forks` is the wallet layer's alone: neither variant knows there is another one.
+    type _3 = Expect<Equal<'forks' extends keyof DefaultV1Configuration ? true : false, false>>;
+    type _4 = Expect<Equal<'forks' extends keyof DefaultV2Configuration ? true : false, false>>;
 
     // And so is the question of where to start, for the same reason: a variant that does not know there is another
     // one has no use for the answer.

--- a/packages/unshielded-wallet/src/test/forkHarness.ts
+++ b/packages/unshielded-wallet/src/test/forkHarness.ts
@@ -317,7 +317,7 @@ export const makeForkWallet = (config: ForkWalletConfig): Effect.Effect<ForkWall
   const WalletClass = CustomForkingUnshieldedWallet(
     {
       networkId,
-      forkVersion: config.forkVersion,
+      forks: { v9: config.forkVersion },
       ...(config.chainVersionProbe !== undefined ? { chainVersionProbe: config.chainVersionProbe } : {}),
     },
     { builder: preForkBuilder, configuration: variantConfiguration },

--- a/packages/unshielded-wallet/src/test/forkSchedule.test.ts
+++ b/packages/unshielded-wallet/src/test/forkSchedule.test.ts
@@ -1,0 +1,51 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Where the boundary between the two variants lies is configured as `forks.v9`, not as a single fork version.
+ *
+ * @remarks
+ *   A map keyed by ledger version, so the next hard fork adds a key rather than changing the configuration's shape. What
+ *   is pinned here is the one thing the map decides today: below `forks.v9` the ledger-v8 variant owns the chain, from
+ *   it the ledger-v9 variant does.
+ */
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Variant } from '@midnightntwrk/wallet-sdk-runtime/abstractions';
+import { Option } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { type DefaultUnshieldedConfiguration } from '../UnshieldedWalletAPI.js';
+import { UnshieldedWallet } from '../UnshieldedWallet.js';
+import { V1Tag } from '../v1/index.js';
+import { TransactionHistory, V2Tag } from '../v2/index.js';
+
+const v9 = ProtocolVersion.ProtocolVersion(7n);
+
+const configuration: DefaultUnshieldedConfiguration = {
+  networkId: NetworkId.NetworkId.Undeployed,
+  indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.UnshieldedTransactionHistoryEntrySchema),
+  forks: { v9 },
+};
+
+describe('UnshieldedWallet forks', () => {
+  it('hands the chain to the ledger-v9 variant from forks.v9, and leaves everything below it to ledger-v8', () => {
+    const Wallet = UnshieldedWallet(configuration);
+    const tagAt = (version: bigint) =>
+      Variant.getVersionedVariantTag(Option.getOrThrow(Wallet.variantFor(ProtocolVersion.ProtocolVersion(version))));
+
+    expect(tagAt(0n)).toBe(V1Tag);
+    expect(tagAt(6n)).toBe(V1Tag);
+    expect(tagAt(7n)).toBe(V2Tag);
+    expect(tagAt(2_000_000n)).toBe(V2Tag);
+  });
+});

--- a/packages/unshielded-wallet/src/test/tryRestore.test.ts
+++ b/packages/unshielded-wallet/src/test/tryRestore.test.ts
@@ -28,7 +28,7 @@ const configuration: DefaultUnshieldedConfiguration = {
   networkId: NetworkId.NetworkId.Undeployed,
   indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.UnshieldedTransactionHistoryEntrySchema),
-  forkVersion: ProtocolVersion.ProtocolVersion(2_000_000n),
+  forks: { v9: ProtocolVersion.ProtocolVersion(2_000_000n) },
 };
 
 /** A snapshot declaring a protocol version far beyond anything this build registers a variant for. */

--- a/packages/unshielded-wallet/test/testUtils.ts
+++ b/packages/unshielded-wallet/test/testUtils.ts
@@ -127,7 +127,7 @@ export const createWalletConfig = (
     txHistoryStorage: new InMemoryTransactionHistoryStorage(UnshieldedEntrySchema),
     // The ledger-v9-native node line these suites run against reports this protocol version, so the wallet reaches its
     // post-fork variant.
-    forkVersion: ProtocolVersion.V9NativeForkVersion,
+    forks: { v9: ProtocolVersion.V9NativeForkVersion },
   };
 
   return { ...defaultConfig, ...overrides };

--- a/packages/wallet-integration-tests/test/serializationAndRestoration.integration.test.ts
+++ b/packages/wallet-integration-tests/test/serializationAndRestoration.integration.test.ts
@@ -57,7 +57,7 @@ describe('Wallet serialization and restoration', () => {
     indexerPort = startedEnvironment.getContainer(`indexer_${environmentId}`).getMappedPort(8088);
 
     shieldedConfiguration = {
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       indexerClientConnection: {
         indexerHttpUrl: `http://localhost:${indexerPort}/api/v4/graphql`,
       },
@@ -68,7 +68,7 @@ describe('Wallet serialization and restoration', () => {
     unshieldedConfiguration = {
       // The same boundary the shielded configuration names, for the same reason: this stack runs the
       // ledger-v9-native node line, so the unshielded wallet reaches its post-fork variant too.
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       indexerClientConnection: {
         indexerWsUrl: `ws://localhost:${indexerPort}/api/v4/graphql/ws`,
         indexerHttpUrl: `http://localhost:${indexerPort}/api/v4/graphql`,

--- a/packages/wallet-sdk-testkit/src/environment.ts
+++ b/packages/wallet-sdk-testkit/src/environment.ts
@@ -88,7 +88,7 @@ export const makeEnvironment = (
       // Every environment this testkit drives runs the ledger-v9-native node line, which reports this
       // protocol version, so the wallet reaches its post-fork variant. Defined once here rather than at
       // each construction site; the final mainnet fork constant is still an open question.
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
     };
   },
   getDustWalletConfig(): DustWalletConfiguration {
@@ -103,7 +103,7 @@ export const makeEnvironment = (
       },
       // The same boundary the shielded configuration names, for the same reason: this testkit's environments all run
       // the ledger-v9-native node line, so the dust wallet reaches its post-fork variant too.
-      forkVersion: ProtocolVersion.V9NativeForkVersion,
+      forks: { v9: ProtocolVersion.V9NativeForkVersion },
     };
   },
   down: options.down ?? (async () => {}),

--- a/packages/wallet-sdk-testkit/src/types.ts
+++ b/packages/wallet-sdk-testkit/src/types.ts
@@ -38,7 +38,7 @@ export interface ResolvedEndpoints {
 }
 
 /** Shielded + submission + proving configuration consumed by `ShieldedWallet`/`WalletFacade`. */
-// The shielded wallet's own configuration rather than its post-fork variant's: it carries `forkVersion`,
+// The shielded wallet's own configuration rather than its post-fork variant's: it carries `forks`,
 // which says where this chain hands over from one ledger version to the other, and neither variant knows
 // there is another one.
 export type WalletConfiguration = DefaultShieldedConfiguration &
@@ -46,7 +46,7 @@ export type WalletConfiguration = DefaultShieldedConfiguration &
   DefaultProvingConfiguration;
 
 /** Dust wallet configuration consumed by `DustWallet`. */
-// The dust wallet's own configuration rather than its post-fork variant's: it carries `forkVersion`, which says
+// The dust wallet's own configuration rather than its post-fork variant's: it carries `forks`, which says
 // where this chain hands over from one ledger version to the other, and neither variant knows there is another one.
 export type DustWalletConfiguration = DefaultDustConfiguration;
 

--- a/packages/wallet-sdk-testkit/src/wallet.ts
+++ b/packages/wallet-sdk-testkit/src/wallet.ts
@@ -107,7 +107,7 @@ const restoreUnshieldedWallet = async (
         },
         txHistoryStorage,
         // The same boundary the shielded configuration names, taken from the one place this environment defines it.
-        forkVersion: env.getWalletConfig().forkVersion,
+        forks: env.getWalletConfig().forks,
       }).startWithPublicKey(PublicKey.fromKeyStore(keyStore));
       logger.info(`Restored unshielded wallet from ${path}`);
       return wallet;


### PR DESCRIPTION
# Description

Every wallet configuration, and the facade's, took the fork as a single number: `forkVersion`, the protocol version at which the chain hands over from ledger-v8 to ledger-v9. That shape can name one boundary and no more. When the next hard fork comes it needs a second boundary, and a scalar would force a shape change on every application configuration in the field.

This PR replaces it with a map keyed by ledger version, `forks: { v9 }`, so the next fork adds a key (`v10`) instead of changing the shape. The value and its meaning are unchanged; the SDK still does not default it, because where a chain forks is a fact about the chain, not the SDK. The change is made now, while 2.0 is still in beta.

**Stacked on #720** (the file rename); GitHub retargets it to `v2` once that merges.

# Proposed Solution

- `ProtocolVersion.ForkSchedule` in the abstractions package: `Readonly<{ v9: ProtocolVersion }>`. Ledger-v8 begins at `MinSupportedVersion` and has no entry.
- The three wallet configurations, the three forking factories, the facade's `DefaultConfiguration`, and the capabilities' block-data-fetcher configuration take `forks` and read `forks.v9` where they read `forkVersion`.
- Internal factories that take a single boundary directly (`makeDefaultVersionedProvingService`, `defaultLedgerParametersCodecs`, `ProtocolVersion.epochOf`, the facade's internals) are unchanged; the facade hands them `configuration.forks.v9`. The two-variant internals of the forking wallets are also unchanged: a third ledger needs a new compiled variant tree anyway, and internals can change without breaking applications, whereas the configuration shape cannot.

Alternatives considered: deriving the boundary from the chain (events carry a protocol version number, not a ledger identity, so the mapping has to come from configuration); an ordered list of boundaries (a keyed map is self-documenting and matches the `{ v8, v9 }` key shapes already used for key material).

# Important Changes Introduced

- **Breaking for every configuration**: `forkVersion: X` becomes `forks: { v9: X }`. The changeset carries the migration. Pending 2.0 release notes that named `forkVersion` as a configuration field are updated to the new name so the final CHANGELOG is not self-contradictory.
- Tests came first: commit `a13c328f` adds the contract (a hand-over test per wallet, a type test on the facade configuration, a type test on `ForkSchedule`, and the existing configuration type tests updated) and fails typecheck on its own; commit `049b67b8` makes it pass without touching the tests.
- Configuration literals in tests, e2e suites, docs snippets, the testkit, the test website, and READMEs are updated. Fork-simulator settings and test-harness parameters that take a single version are unchanged, since they describe one simulated fork, not an application configuration.
- Follow-up in #724, stacked on this PR: `provers[].sinceVersion` restated the same boundary as `forks.v9`; that PR keys `provers` by ledger version and reads each backend's range off `forks`.

# Testing

- `yarn typecheck` across the whole repository: 37 tasks pass, including every test project.
- `yarn lint` and `yarn format:check` across the whole repository: pass.
- `yarn test:unit` on abstractions, capabilities, dust, shielded, unshielded and facade: 7, 17, 32, 32, 28 and 17 test files pass respectively, including the new `forkSchedule` tests.
- Effect language service diagnostics on every edited source module: clean.
- To see the red state, check out `a13c328f` and run `yarn typecheck --filter=@midnightntwrk/wallet-sdk-dust-wallet`.

