### PR TITLE
feat(proving)!: name a proving backend per ledger version, with the ranges taken from the fork schedule

### DIFF
--- a/.changeset/fork-schedule.md
+++ b/.changeset/fork-schedule.md
@@ -28,6 +28,6 @@ BREAKING CHANGE — replace the field in every configuration you build:
 { forks: { v9: ProtocolVersion.V9NativeForkVersion }, ... }
 ```
 
-Factories that take a single boundary directly (`makeDefaultVersionedProvingService(configuration, forkVersion)`,
-`defaultLedgerParametersCodecs(forkVersion)`, `ProtocolVersion.epochOf`) are unchanged; the facade passes
-`configuration.forks.v9` to them.
+Factories that take a single boundary directly (`defaultLedgerParametersCodecs(forkVersion)`, `ProtocolVersion.epochOf`)
+are unchanged; the facade passes `configuration.forks.v9` to them. Proving takes the whole schedule, since its backends
+are keyed the same way — see the proving changeset.

--- a/.changeset/hard-fork-ready-snippets.md
+++ b/.changeset/hard-fork-ready-snippets.md
@@ -3,7 +3,7 @@
 
 Make the documentation snippets hard-fork ready. Every snippet now imports only from `@midnightntwrk/wallet-sdk` and
 its subpaths; every wallet is configured to run on ledger-v8 below `forks.v9` and on ledger-v9 from it — proving
-included, with a proof server per ledger version under `provers` (the in-process prover needs one entry, since the
+included, with a proof server per ledger version under `provers` (the in-process prover under both keys, since the
 same backend serves both); the examples that author their own transactions pick the ledger — `./ledger/v8` below
 `forks.v9`, `./ledger/v9` from it — by the protocol version the wallets are acting at and seal the handle with that
 version, so they run on a pre-fork chain and follow it across the fork instead of stamping version 0, which a wallet

--- a/.changeset/hard-fork-support.md
+++ b/.changeset/hard-fork-support.md
@@ -59,8 +59,8 @@ no longer import a ledger package.
   reason. The unshielded `revertTransaction` ignores a handle from the other side of the fork.
 - Facade recipes (`FinalizedTransactionRecipe`, `UnboundTransactionRecipe`, `UnprovenTransactionRecipe`) gain a required
   `protocolVersion`, and `BlockData` gains a required `protocolVersion`.
-- Proving, validation and block ledger-parameter reads route on the transaction's version. Configure proof servers as
-  `provingServers: [{ sinceVersion, url }]`; `provingServerUrl` remains for a single server. Both fields of
+- Proving, validation and block ledger-parameter reads route on the transaction's version. Configure a proving backend
+  per ledger version as `provers: { v8, v9 }`; `provingServerUrl` remains for a single server. Both fields of
   `DefaultProvingConfiguration` are optional and a configuration with neither fails with `ProvingConfigurationError`.
   `defaultLedgerParametersCodecs(forkVersion)` is the version-routed codec set.
 

--- a/.changeset/provers-by-ledger.md
+++ b/.changeset/provers-by-ledger.md
@@ -1,0 +1,36 @@
+---
+'@midnightntwrk/wallet-sdk-capabilities': major
+'@midnightntwrk/wallet-sdk-facade': major
+'@midnightntwrk/wallet-sdk': major
+---
+
+feat(proving)!: name a proving backend per ledger version, with the ranges taken from the fork schedule
+
+`provers` is a map keyed by ledger version, the way `forks` is, in place of a list of backends each carrying the protocol
+version it starts serving. The boundary between two backends is the chain's fork schedule, and it is now read from
+`forks` alone. A `provers` entry could restate it, and a `sinceVersion` that drifted from `forks.v9` framed the versions
+in between with one ledger and sent them to a server built for the other, which nothing caught at configuration time.
+
+```ts
+// before
+{
+  forks: { v9 },
+  provers: [
+    { sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'server', url: v8ProofServer } },
+    { sinceVersion: v9, backend: { kind: 'wasm' } },
+  ],
+}
+// after
+{ forks: { v9 }, provers: { v8: { kind: 'server', url: v8ProofServer }, v9: { kind: 'wasm' } } }
+```
+
+`v9` is required, because every new transaction is proved with it. `v8` may be left out on a chain whose pre-fork history
+the wallet never authors for; a transaction stamped there then fails with `UnsupportedProvingVersionError`. The next hard
+fork adds a key (`v10`) rather than changing the shape. `provingServerUrl` remains the shorthand for one proof server under
+every key; `provingServers` is gone, since it carried the same `sinceVersion`.
+
+BREAKING CHANGE (`@midnightntwrk/wallet-sdk-capabilities`) — `ProvingBackends` replaces `ProverActivation` and
+`ProvingServerActivation`; `resolveProvingServers` is removed and `resolveProvingBackends(configuration)` returns the
+`ProvingBackends` map rather than a registry; `makeDefaultProvingServices`, `makeDefaultVersionedProvingServiceEffect`
+and `makeDefaultVersionedProvingService` take the `ProtocolVersion.ForkSchedule` as their second argument in place of a
+single fork version. The facade passes `configuration.forks` for you.

--- a/.changeset/proving-per-version.md
+++ b/.changeset/proving-per-version.md
@@ -13,33 +13,30 @@ ledger-v8 transaction ledger-v9's cost model fails at the wasm-bindgen boundary 
 CostModel`. There is now a backend per ledger version, and the registration that says which serves which range of
 protocol versions.
 
-Proving backends are configured with `provers`, which — unlike `provingServers` — can also name the in-process prover:
+Proving backends are configured with `provers`, a backend per ledger version, which — unlike a proof server URL — can
+also name the in-process prover:
 
 ```ts
 const configuration = {
-  forkVersion,
-  provers: [
-    { sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'server', url: v8ProofServer } },
-    { sinceVersion: forkVersion, backend: { kind: 'wasm' } },
-  ],
+  forks: { v9 },
+  provers: { v8: { kind: 'server', url: v8ProofServer }, v9: { kind: 'wasm' } },
 };
 ```
 
-`provingServers` and `provingServerUrl` are unchanged and still supported; precedence is `provers` > `provingServers` >
-`provingServerUrl`, and naming none is still a `ProvingConfigurationError`. A backend whose range spans `forkVersion` —
-which `provingServerUrl` always does — is split at the boundary and driven by each ledger version in turn, so the same
-description frames correctly on both sides. Whether one proof server can in fact prove both is an operational fact
-about that server, not something the SDK can enforce: no published image serves both today, so a chain with history
-below the boundary wants an entry per side. The in-process prover works on bytes and does serve both, with the same
-published circuits.
+`provingServerUrl` is unchanged and still supported as the shorthand for one proof server under every key; `provers`
+wins when both are given, and naming neither is still a `ProvingConfigurationError`. The single URL is driven by each
+ledger version on its own side of `forks.v9`, so the same description frames correctly on both sides. Whether one proof
+server can in fact prove both is an operational fact about that server, not something the SDK can enforce: no published
+image serves both today, so a chain with history below the boundary wants `provers` with a server per side. The
+in-process prover works on bytes and does serve both, with the same published circuits.
 
 Each registered backend refuses the other ledger version's transaction with a new `ProvingEpochMismatchError` naming
 the epoch it serves, rather than passing a foreign object to a ledger that cannot read it.
 
 BREAKING CHANGE (`@midnightntwrk/wallet-sdk-capabilities`) — `makeDefaultVersionedProvingService` and
-`makeDefaultVersionedProvingServiceEffect` take the chain's fork version as a second argument, and a new
-`makeDefaultProvingServices(configuration, forkVersion)` exposes the registry they build. The facade passes
-`configuration.forks.v9` for you; only a direct caller of these factories is affected. `ProvingServiceEffect`'s error
+`makeDefaultVersionedProvingServiceEffect` take the chain's fork schedule as a second argument, and a new
+`makeDefaultProvingServices(configuration, forks)` exposes the registry they build. The facade passes
+`configuration.forks` for you; only a direct caller of these factories is affected. `ProvingServiceEffect`'s error
 channel widens from `ProvingError` to `ProvingFailure` (`ProvingError | ProvingEpochMismatchError`) — existing
 implementations stay assignable. The facade's `InitParams.provingService` widens to
 `VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>`, which existing ledger-v9

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,8 @@ Contains working code examples for common wallet operations:
 - `dust-fast-sync.ts` - Wallet initialization with projections-based dust fast sync
 - `designation.ts` / `redesignation.ts` / `deregistration.ts` - Registering Night for dust generation, and undoing it
 - `dust-sponsorship.ts` - Paying another party's fees
-- `hard-fork-support.ts` - Hard-fork-ready initialization: fork version, version-keyed proving, protocol phase, orphaned
-  transactions
+- `hard-fork-support.ts` - Hard-fork-ready initialization: fork schedule, a proving backend per ledger version, protocol
+  phase, orphaned transactions
 - `wasm-prover.ts` - In-process proving
 - `well-formed-validation.ts` - Validating a transaction before submission
 - `terms-and-conditions.ts` - Fetching terms and conditions

--- a/packages/capabilities/README.md
+++ b/packages/capabilities/README.md
@@ -98,30 +98,24 @@ try {
 ### Proving, either side of a protocol boundary
 
 A proving backend is written against one ledger version — it drives that version's `Transaction.prove` with that
-version's cost model, and frames its proof-server requests with that version's payload helpers. Which backend answers
-for which protocol version is therefore a registration, and it is made from the same `forks.v9` the wallets are built
-with:
+version's cost model, and frames its proof-server requests with that version's payload helpers. Backends are therefore
+named per ledger version, keyed the way `forks` is, and the range each serves is read off the same fork schedule the
+wallets are built with:
 
 ```typescript
-import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { makeDefaultVersionedProvingService } from '@midnightntwrk/wallet-sdk-capabilities/proving';
 
 const service = makeDefaultVersionedProvingService(
-  {
-    provers: [
-      { sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'server', url: v8ProofServer } },
-      { sinceVersion: forks.v9, backend: { kind: 'wasm' } },
-    ],
-  },
-  forks.v9,
+  { provers: { v8: { kind: 'server', url: v8ProofServer }, v9: { kind: 'wasm' } } },
+  forks,
 ); // Either<VersionedProvingService, ProvingConfigurationError>
 ```
 
-- `provers` > `provingServers` > `provingServerUrl`; naming none is a `ProvingConfigurationError`, as is naming them out
-  of order.
-- A range that spans `forks.v9` is split at it, so each side is driven by its own ledger version. That is what makes the
-  single-URL form frame correctly on both sides; whether one server can actually prove both is an operational fact about
-  that server, not something the SDK enforces.
+- `provers` wins over `provingServerUrl`; naming neither is a `ProvingConfigurationError`. `v9` is required and `v8` is
+  optional: a version below `forks.v9` with no `v8` backend fails with `UnsupportedProvingVersionError`.
+- `provingServerUrl` is one server under every key, driven by each ledger version on its own side of `forks.v9`. That is
+  what makes the single-URL form frame correctly on both sides; whether one server can actually prove both is an
+  operational fact about that server, not something the SDK enforces.
 - Each registered backend refuses the other ledger version's transaction with `ProvingEpochMismatchError` rather than
   handing it to a ledger that cannot read it.
 - `makeServerProvingServiceEffect` / `makeWasmProvingServiceEffect` build a single current-ledger backend;

--- a/packages/capabilities/src/proving/provingService.ts
+++ b/packages/capabilities/src/proving/provingService.ts
@@ -190,54 +190,56 @@ export type WasmProvingConfiguration = {
   keyMaterialProvider?: KeyMaterialProvider;
 };
 
-/** A proof server together with the protocol version it starts serving. */
-export type ProvingServerActivation = Readonly<{
-  sinceVersion: ProtocolVersion.ProtocolVersion;
-  url: URL;
-}>;
-
 /**
  * Where proving happens: at a proof server over HTTP, or in this process.
  *
  * @remarks
- *   Deliberately says nothing about a ledger version. Which ledger drives a backend follows from the protocol versions it
- *   is registered for, so the same description can be registered on either side of a fork and mean the right thing both
- *   times.
+ *   Deliberately says nothing about a ledger version. Which ledger drives a backend follows from the key it is registered
+ *   under in {@link ProvingBackends}, so the same description can be named for either side of a fork and mean the right
+ *   thing both times.
  */
 export type ProvingBackend =
   Readonly<{ kind: 'server'; url: URL }> | Readonly<{ kind: 'wasm'; keyMaterialProvider?: KeyMaterialProvider }>;
 
-/** A proving backend together with the protocol version it starts serving. */
-export type ProverActivation = Readonly<{
-  sinceVersion: ProtocolVersion.ProtocolVersion;
-  backend: ProvingBackend;
+/**
+ * Which proving backend proves the transactions each ledger version authors.
+ *
+ * @remarks
+ *   Keyed the way {@link ProtocolVersion.ForkSchedule} is, so a configuration states each boundary once: `v8` proves below
+ *   `forks.v9` and `v9` from it, and where one ends and the next begins is read off the schedule rather than restated
+ *   here. The newest ledger version's backend is required, because it is what every new transaction is proved with; an
+ *   older one may be left out on a chain whose history below the boundary the wallet will never author for, and a
+ *   transaction stamped there then fails with {@link UnsupportedProvingVersionError}. The next hard fork adds a key
+ *   (`v10`) rather than changing this shape.
+ */
+export type ProvingBackends = Readonly<{
+  /** Proves the transactions ledger-v8 authored, below `forks.v9`. */
+  v8?: ProvingBackend;
+  /** Proves the transactions ledger-v9 authored, from `forks.v9`. */
+  v9: ProvingBackend;
 }>;
 
 /**
- * Which proving backend serves which protocol version.
+ * Which proving backend serves which ledger version.
  *
  * @remarks
- *   The three settings are alternatives, not a set: `provers` is the general form, `provingServers` is the shorthand for
- *   "these proof servers", and `provingServerUrl` the shorthand for "this one proof server, for every version". Giving
- *   more than one is not an error — `provers` wins, then `provingServers` — but naming none is, because there is then
- *   nothing to prove with.
+ *   The two settings are alternatives, not a set: `provers` is the general form and `provingServerUrl` the shorthand for
+ *   "this one proof server, for every ledger version". Giving both is not an error — `provers` wins — but naming
+ *   neither is, because there is then nothing to prove with.
  *
- *   A backend registered across a protocol boundary (which is what `provingServerUrl` always is, and what a `provers`
- *   list with a single entry at the minimum version is) is split at that boundary and driven by each ledger version in
- *   turn. That is what makes one URL frame its requests correctly on both sides. Whether a given proof server can in
- *   fact serve both is an operational fact about that server, not something the SDK can know or enforce — today's
- *   images serve one side each, so a chain that spans a fork wants two entries.
+ *   The single URL is registered once per ledger version and driven by each in turn, which is what makes it frame its
+ *   requests correctly on both sides of a fork. Whether a given proof server can in fact serve both is an operational
+ *   fact about that server, not something the SDK can know or enforce — today's images serve one side each, so a chain
+ *   that spans a fork wants `provers` with a server per side.
  */
 export type DefaultProvingConfiguration = {
-  /** One proof server for every protocol version. */
+  /** One proof server for every ledger version. */
   provingServerUrl?: URL;
-  /** Proof servers keyed by the protocol version each one starts serving, in ascending order. */
-  provingServers?: readonly ProvingServerActivation[];
-  /** Proving backends keyed by the protocol version each one starts serving, in ascending order. */
-  provers?: readonly ProverActivation[];
+  /** A proving backend per ledger version. */
+  provers?: ProvingBackends;
 };
 
-/** Raised when the proving configuration names no proof server, or names them out of order. */
+/** Raised when the proving configuration names no backend at all. */
 export class ProvingConfigurationError extends Data.TaggedError(
   '@midnightntwrk/wallet-sdk-capabilities/proving/provingService/ProvingConfigurationError',
 )<{
@@ -248,72 +250,40 @@ export class ProvingConfigurationError extends Data.TaggedError(
 const noBackendNamed = () =>
   new ProvingConfigurationError({
     message:
-      "Missing required configuration: set 'provers' (or 'provingServers', or 'provingServerUrl'), or provide a custom provingService in init parameters.",
-  });
-
-const outOfOrder = (cause: unknown) =>
-  new ProvingConfigurationError({
-    message: 'Proving backends must be listed in strictly ascending order of the version each starts serving.',
-    cause,
+      "Missing required configuration: set 'provers' (or 'provingServerUrl'), or provide a custom provingService in init parameters.",
   });
 
 /**
- * Reads a proving configuration as the proof servers it names, keyed by protocol version.
+ * Reads a proving configuration as the backend it names for each ledger version.
  *
  * @remarks
- *   The server-only view of {@link resolveProvingBackends}, which is what a caller that can only talk to a proof server
- *   wants. A configuration that names in-process backends is not readable this way, and says so.
+ *   Where the precedence between the two settings is decided, once, so that reading a configuration and building services
+ *   from it cannot disagree about which one was meant. Says nothing about protocol versions: which range each backend
+ *   serves is the fork schedule's to say, and `makeDefaultProvingServices` reads it there.
  * @param configuration The proving configuration.
- * @returns The proof server URLs by version range, or the reason the configuration names none.
- */
-export const resolveProvingServers = (
-  configuration: DefaultProvingConfiguration,
-): Either.Either<ProtocolVersion.Registry<URL>, ProvingConfigurationError> => {
-  const activations =
-    configuration.provingServers !== undefined && configuration.provingServers.length > 0
-      ? configuration.provingServers.map(({ sinceVersion, url }) => ({ sinceVersion, value: url }))
-      : configuration.provingServerUrl !== undefined
-        ? [{ sinceVersion: ProtocolVersion.MinSupportedVersion, value: configuration.provingServerUrl }]
-        : [];
-
-  return activations.length === 0
-    ? Either.left(noBackendNamed())
-    : ProtocolVersion.makeRegistryFromActivations(activations).pipe(Either.mapLeft(outOfOrder));
-};
-
-/**
- * Reads a proving configuration as the backends it names, keyed by protocol version.
- *
- * @remarks
- *   Where the precedence between the three settings is decided, once, so that reading a configuration and building
- *   services from it cannot disagree about which one was meant.
- * @param configuration The proving configuration.
- * @returns The backends by version range, or the reason the configuration names none.
+ * @returns The backend per ledger version, or the reason the configuration names none.
  */
 export const resolveProvingBackends = (
   configuration: DefaultProvingConfiguration,
-): Either.Either<ProtocolVersion.Registry<ProvingBackend>, ProvingConfigurationError> =>
-  configuration.provers !== undefined && configuration.provers.length > 0
-    ? ProtocolVersion.makeRegistryFromActivations(
-        configuration.provers.map(({ sinceVersion, backend }) => ({ sinceVersion, value: backend })),
-      ).pipe(Either.mapLeft(outOfOrder))
-    : resolveProvingServers(configuration).pipe(
-        Either.map((servers) => ({
-          entries: servers.entries.map((entry) => ({
-            range: entry.range,
-            value: { kind: 'server', url: entry.value } as const,
-          })),
-        })),
-      );
+): Either.Either<ProvingBackends, ProvingConfigurationError> =>
+  configuration.provers !== undefined
+    ? Either.right(configuration.provers)
+    : configuration.provingServerUrl !== undefined
+      ? Either.right({
+          v8: { kind: 'server', url: configuration.provingServerUrl },
+          v9: { kind: 'server', url: configuration.provingServerUrl },
+        })
+      : Either.left(noBackendNamed());
 
 /**
  * Registers the in-process WASM prover, driven by ledger-v9, from a given protocol version upwards.
  *
  * @remarks
  *   Every entry here is ledger-v9's backend, so `sinceVersion` should not be below a protocol boundary: what a version
- *   below it needs is the ledger-v8 driver, which `makeDefaultProvingServices` registers from the fork version it is
- *   given. Registering nothing below is what turns that into an {@link UnsupportedProvingVersionError} naming the
- *   version, rather than a ledger-v8 transaction handed to a ledger that cannot read it.
+ *   below it needs is the ledger-v8 driver, which `makeDefaultProvingServices` registers for the epoch the fork
+ *   schedule it is given places below `forks.v9`. Registering nothing below is what turns that into an
+ *   {@link UnsupportedProvingVersionError} naming the version, rather than a ledger-v8 transaction handed to a ledger
+ *   that cannot read it.
  * @param sinceVersion The first protocol version to register the bundled prover for.
  * @param configuration Optional key material override.
  * @returns The proving backends, keyed by version.

--- a/packages/capabilities/src/proving/test/versionedProving.test.ts
+++ b/packages/capabilities/src/proving/test/versionedProving.test.ts
@@ -13,14 +13,24 @@
 import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { type Equal, type Expect } from '@midnightntwrk/wallet-sdk-utilities/types';
 import { Cause, Effect, Either, Exit, Option } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { fromV8ProvingProvider } from '../v8ProvingService.js';
-import { ProvingConfigurationError, ProvingEpochMismatchError, resolveProvingBackends } from '../provingService.js';
+import {
+  ProvingConfigurationError,
+  ProvingEpochMismatchError,
+  resolveProvingBackends,
+  UnsupportedProvingVersionError,
+  type DefaultProvingConfiguration,
+  type ProvingBackend,
+  type ProvingBackends,
+} from '../provingService.js';
 import { makeDefaultProvingServices, makeDefaultVersionedProvingServiceEffect } from '../versionedProving.js';
 
 const version = (value: bigint): ProtocolVersion.ProtocolVersion => ProtocolVersion.ProtocolVersion(value);
 const FORK = version(2_000_000n);
+const FORKS: ProtocolVersion.ForkSchedule = { v9: FORK };
 const BEFORE_FORK = version(5n);
 
 /**
@@ -70,14 +80,14 @@ describe('Proving with ledger-v8', () => {
 
 describe('Composing proving backends either side of the protocol boundary', () => {
   const bothSides = {
-    provers: [
-      { sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'server', url: unusedServer('pre-fork') } },
-      { sinceVersion: FORK, backend: { kind: 'server', url: unusedServer('post-fork') } },
-    ],
+    provers: {
+      v8: { kind: 'server', url: unusedServer('pre-fork') },
+      v9: { kind: 'server', url: unusedServer('post-fork') },
+    },
   } as const;
 
   it('proves a transaction stamped below the fork with ledger-v8', async () => {
-    const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORK));
+    const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORKS));
 
     const proven = await Effect.runPromise(router.prove(aV8Transaction(), BEFORE_FORK));
 
@@ -86,7 +96,7 @@ describe('Composing proving backends either side of the protocol boundary', () =
   });
 
   it('proves a transaction stamped at the fork with ledger-v9', async () => {
-    const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORK));
+    const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORKS));
 
     const proven = await Effect.runPromise(router.prove(aCurrentLedgerTransaction(), FORK));
 
@@ -94,10 +104,26 @@ describe('Composing proving backends either side of the protocol boundary', () =
     expect(proven).not.toBeInstanceOf(preForkLedger.Transaction);
   });
 
-  it('splits a backend whose range straddles the fork, so each side is driven by its own ledger', async () => {
+  it('takes the range each backend serves from the fork schedule, and from nowhere else', () => {
+    // The configuration names a backend per ledger version and says nothing about protocol versions; where one ledger
+    // version ends and the next begins is the chain's fork schedule, stated once. Moving the boundary moves the ranges.
+    const atTheNativeFork = Either.getOrThrow(makeDefaultProvingServices(bothSides, FORKS));
+    expect(atTheNativeFork.entries.map((entry) => entry.range)).toStrictEqual([
+      ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, FORK),
+      ProtocolVersion.makeRange(FORK, ProtocolVersion.MaxSupportedVersion),
+    ]);
+
+    const atSeven = Either.getOrThrow(makeDefaultProvingServices(bothSides, { v9: version(7n) }));
+    expect(atSeven.entries.map((entry) => entry.range)).toStrictEqual([
+      ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, version(7n)),
+      ProtocolVersion.makeRange(version(7n), ProtocolVersion.MaxSupportedVersion),
+    ]);
+  });
+
+  it('drives the single-server shorthand with each ledger version on its own side of the fork', async () => {
     // One server for every version says nothing about ledger versions, and cannot: the two epochs frame their proving
-    // requests differently. Splitting the range at the boundary is what makes the same URL mean the right thing twice.
-    const services = Either.getOrThrow(makeDefaultProvingServices({ provingServerUrl: unusedServer('only') }, FORK));
+    // requests differently. Registering the same URL once per side is what makes it mean the right thing twice.
+    const services = Either.getOrThrow(makeDefaultProvingServices({ provingServerUrl: unusedServer('only') }, FORKS));
 
     expect(services.entries.map((entry) => entry.range)).toStrictEqual([
       ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, FORK),
@@ -105,7 +131,7 @@ describe('Composing proving backends either side of the protocol boundary', () =
     ]);
 
     const router = Either.getOrThrow(
-      makeDefaultVersionedProvingServiceEffect({ provingServerUrl: unusedServer('only') }, FORK),
+      makeDefaultVersionedProvingServiceEffect({ provingServerUrl: unusedServer('only') }, FORKS),
     );
     expect(await Effect.runPromise(router.prove(aV8Transaction(), BEFORE_FORK))).toBeInstanceOf(
       preForkLedger.Transaction,
@@ -113,28 +139,45 @@ describe('Composing proving backends either side of the protocol boundary', () =
     expect(await Effect.runPromise(router.prove(aCurrentLedgerTransaction(), FORK))).toBeInstanceOf(ledger.Transaction);
   });
 
-  it('registers a single epoch for a chain whose boundary is at or below the minimum supported version', async () => {
-    const services = Either.getOrThrow(
-      makeDefaultProvingServices({ provingServerUrl: unusedServer('only') }, ProtocolVersion.MinSupportedVersion),
-    );
+  it('registers nothing below the fork when no ledger-v8 backend is named, and says so for a transaction stamped there', async () => {
+    const postForkOnly = { provers: { v9: { kind: 'server', url: unusedServer('post-fork') } } } as const;
 
+    const services = Either.getOrThrow(makeDefaultProvingServices(postForkOnly, FORKS));
     expect(services.entries.map((entry) => entry.range)).toStrictEqual([
-      ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, ProtocolVersion.MaxSupportedVersion),
+      ProtocolVersion.makeRange(FORK, ProtocolVersion.MaxSupportedVersion),
     ]);
 
-    const router = Either.getOrThrow(
-      makeDefaultVersionedProvingServiceEffect(
-        { provingServerUrl: unusedServer('only') },
-        ProtocolVersion.MinSupportedVersion,
+    const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(postForkOnly, FORKS));
+    const error = await failureOf(router.prove(aV8Transaction(), BEFORE_FORK));
+    expect(error).toBeInstanceOf(UnsupportedProvingVersionError);
+    expect((error as UnsupportedProvingVersionError).protocolVersion).toStrictEqual(BEFORE_FORK);
+  });
+
+  it('registers a single ledger-v9 epoch for a chain whose boundary is at or below the minimum supported version', async () => {
+    // Such a chain has no history ledger-v8 authored, so a ledger-v8 backend has no epoch to serve, whether it was named
+    // outright or implied by the single-server shorthand.
+    const bornOnV9: ProtocolVersion.ForkSchedule = { v9: ProtocolVersion.MinSupportedVersion };
+    const wholeTimeline = [
+      ProtocolVersion.makeRange(ProtocolVersion.MinSupportedVersion, ProtocolVersion.MaxSupportedVersion),
+    ];
+
+    expect(
+      Either.getOrThrow(makeDefaultProvingServices(bothSides, bornOnV9)).entries.map((entry) => entry.range),
+    ).toStrictEqual(wholeTimeline);
+    expect(
+      Either.getOrThrow(makeDefaultProvingServices({ provingServerUrl: unusedServer('only') }, bornOnV9)).entries.map(
+        (entry) => entry.range,
       ),
-    );
+    ).toStrictEqual(wholeTimeline);
+
+    const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, bornOnV9));
     expect(await Effect.runPromise(router.prove(aCurrentLedgerTransaction(), BEFORE_FORK))).toBeInstanceOf(
       ledger.Transaction,
     );
   });
 
   it('refuses a transaction from the other side of the boundary, naming the epoch the backend serves', async () => {
-    const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORK));
+    const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORKS));
 
     const error = await failureOf(router.prove(aCurrentLedgerTransaction(), BEFORE_FORK));
 
@@ -145,7 +188,7 @@ describe('Composing proving backends either side of the protocol boundary', () =
   });
 
   it('refuses a ledger-v8 transaction handed to ledger-v9, naming the epoch that backend serves', async () => {
-    const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORK));
+    const router = Either.getOrThrow(makeDefaultVersionedProvingServiceEffect(bothSides, FORKS));
 
     const error = await failureOf(router.prove(aV8Transaction(), FORK));
 
@@ -156,61 +199,35 @@ describe('Composing proving backends either side of the protocol boundary', () =
   });
 });
 
-describe('Reading which backend serves which protocol version', () => {
-  it('reads the version-keyed backends as the versions they each start serving', () => {
-    const registry = Either.getOrThrow(
+describe('Reading which backend proves for which ledger version', () => {
+  it('reads the backends keyed by ledger version as given', () => {
+    const backends = Either.getOrThrow(
       resolveProvingBackends({
-        provers: [
-          { sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'server', url: unusedServer('pre') } },
-          { sinceVersion: FORK, backend: { kind: 'wasm' } },
-        ],
+        provers: { v8: { kind: 'server', url: unusedServer('pre') }, v9: { kind: 'wasm' } },
       }),
     );
 
-    expect(ProtocolVersion.select(registry, BEFORE_FORK)).toStrictEqual(
-      Option.some({ kind: 'server', url: unusedServer('pre') }),
-    );
-    expect(ProtocolVersion.select(registry, FORK)).toStrictEqual(Option.some({ kind: 'wasm' }));
+    expect(backends).toStrictEqual({ v8: { kind: 'server', url: unusedServer('pre') }, v9: { kind: 'wasm' } });
   });
 
-  it('prefers the version-keyed backends over both server shorthands', () => {
-    const registry = Either.getOrThrow(
-      resolveProvingBackends({
-        provingServerUrl: unusedServer('ignored'),
-        provingServers: [{ sinceVersion: ProtocolVersion.MinSupportedVersion, url: unusedServer('also-ignored') }],
-        provers: [
-          {
-            sinceVersion: ProtocolVersion.MinSupportedVersion,
-            backend: { kind: 'server', url: unusedServer('named') },
-          },
-        ],
-      }),
-    );
+  it('reads the single-server shorthand as that server for every ledger version', () => {
+    const backends = Either.getOrThrow(resolveProvingBackends({ provingServerUrl: unusedServer('only') }));
 
-    expect(ProtocolVersion.select(registry, FORK)).toStrictEqual(
-      Option.some({ kind: 'server', url: unusedServer('named') }),
-    );
+    expect(backends).toStrictEqual({
+      v8: { kind: 'server', url: unusedServer('only') },
+      v9: { kind: 'server', url: unusedServer('only') },
+    });
   });
 
-  it('prefers the version-keyed server list over the single-server shorthand', () => {
-    const registry = Either.getOrThrow(
+  it('prefers the backends keyed by ledger version over the single-server shorthand', () => {
+    const backends = Either.getOrThrow(
       resolveProvingBackends({
         provingServerUrl: unusedServer('ignored'),
-        provingServers: [{ sinceVersion: ProtocolVersion.MinSupportedVersion, url: unusedServer('listed') }],
+        provers: { v9: { kind: 'server', url: unusedServer('named') } },
       }),
     );
 
-    expect(ProtocolVersion.select(registry, FORK)).toStrictEqual(
-      Option.some({ kind: 'server', url: unusedServer('listed') }),
-    );
-  });
-
-  it('reads the single-server shorthand as one server for every version', () => {
-    const registry = Either.getOrThrow(resolveProvingBackends({ provingServerUrl: unusedServer('only') }));
-
-    expect(ProtocolVersion.select(registry, ProtocolVersion.MinSupportedVersion)).toStrictEqual(
-      Option.some({ kind: 'server', url: unusedServer('only') }),
-    );
+    expect(backends).toStrictEqual({ v9: { kind: 'server', url: unusedServer('named') } });
   });
 
   it('refuses a configuration that names no backend at all', () => {
@@ -220,22 +237,19 @@ describe('Reading which backend serves which protocol version', () => {
     expect(Either.getLeft(failure).pipe(Option.getOrThrow)).toBeInstanceOf(ProvingConfigurationError);
   });
 
-  it('refuses backends that are not in ascending version order', () => {
-    const failure = resolveProvingBackends({
-      provers: [
-        { sinceVersion: FORK, backend: { kind: 'server', url: unusedServer('later') } },
-        {
-          sinceVersion: ProtocolVersion.MinSupportedVersion,
-          backend: { kind: 'server', url: unusedServer('earlier') },
-        },
-      ],
-    });
-
-    expect(Either.isLeft(failure)).toBe(true);
-    expect(Either.getLeft(failure).pipe(Option.getOrThrow)).toBeInstanceOf(ProvingConfigurationError);
+  it('keys the backends the way the fork schedule is keyed, plus the ledger version the schedule leaves implicit', () => {
+    // The two maps must not be able to drift: every ledger version the schedule can place a boundary for is one a
+    // backend can be named for, and ledger-v8, which begins at the minimum supported version, is the one key beyond.
+    type _1 = Expect<Equal<Exclude<keyof ProvingBackends, 'v8'>, keyof ProtocolVersion.ForkSchedule>>;
   });
 
-  it('refuses an empty list of backends, rather than reading it as no configuration at all', () => {
-    expect(Either.isLeft(makeDefaultProvingServices({ provers: [] }, FORK))).toBe(true);
+  it('requires the newest ledger version to have a backend and leaves the older one optional', () => {
+    type _1 = Expect<Equal<ProvingBackends['v9'], ProvingBackend>>;
+    type _2 = Expect<Equal<Pick<ProvingBackends, 'v8'>, { readonly v8?: ProvingBackend }>>;
+  });
+
+  it('no longer takes backends keyed by the protocol version each starts serving', () => {
+    type _1 = Expect<Equal<'provingServers' extends keyof DefaultProvingConfiguration ? true : false, false>>;
+    type _2 = Expect<Equal<DefaultProvingConfiguration['provers'], ProvingBackends | undefined>>;
   });
 });

--- a/packages/capabilities/src/proving/test/versionedProvingService.test.ts
+++ b/packages/capabilities/src/proving/test/versionedProvingService.test.ts
@@ -15,7 +15,6 @@ import { Cause, Effect, Either, Exit, Option } from 'effect';
 import { describe, expect, it } from 'vitest';
 import {
   makeVersionedProvingServiceEffect,
-  resolveProvingServers,
   singleVersionProvingServiceEffect,
   UnsupportedProvingVersionError,
   type ProvingServiceEffect,
@@ -75,58 +74,5 @@ describe('Routing a transaction to the prover for the version it was built for',
 
     await expect(Effect.runPromise(anywhere.prove('tx', version(0n)))).resolves.toBe('only:tx');
     await expect(Effect.runPromise(anywhere.prove('tx', FORK))).resolves.toBe('only:tx');
-  });
-});
-
-describe('Configuring which proof server serves which protocol version', () => {
-  it('reads a list of servers as the versions they each start serving', () => {
-    const registry = Either.getOrThrow(
-      resolveProvingServers({
-        provingServers: [
-          { sinceVersion: ProtocolVersion.MinSupportedVersion, url: new URL('http://pre-fork:6300') },
-          { sinceVersion: FORK, url: new URL('http://post-fork:6300') },
-        ],
-      }),
-    );
-
-    expect(ProtocolVersion.select(registry, version(5n))).toStrictEqual(Option.some(new URL('http://pre-fork:6300')));
-    expect(ProtocolVersion.select(registry, FORK)).toStrictEqual(Option.some(new URL('http://post-fork:6300')));
-  });
-
-  it('reads the single-server configuration as one server for every version', () => {
-    const registry = Either.getOrThrow(resolveProvingServers({ provingServerUrl: new URL('http://only:6300') }));
-
-    expect(ProtocolVersion.select(registry, ProtocolVersion.MinSupportedVersion)).toStrictEqual(
-      Option.some(new URL('http://only:6300')),
-    );
-    expect(ProtocolVersion.select(registry, FORK)).toStrictEqual(Option.some(new URL('http://only:6300')));
-  });
-
-  it('prefers the version-keyed list when both are given', () => {
-    const registry = Either.getOrThrow(
-      resolveProvingServers({
-        provingServerUrl: new URL('http://ignored:6300'),
-        provingServers: [{ sinceVersion: ProtocolVersion.MinSupportedVersion, url: new URL('http://listed:6300') }],
-      }),
-    );
-
-    expect(ProtocolVersion.select(registry, FORK)).toStrictEqual(Option.some(new URL('http://listed:6300')));
-  });
-
-  it('refuses a configuration that names no proof server at all', () => {
-    expect(Either.isLeft(resolveProvingServers({}))).toBe(true);
-  });
-
-  it('refuses a server list that is not in ascending version order', () => {
-    expect(
-      Either.isLeft(
-        resolveProvingServers({
-          provingServers: [
-            { sinceVersion: FORK, url: new URL('http://later:6300') },
-            { sinceVersion: ProtocolVersion.MinSupportedVersion, url: new URL('http://earlier:6300') },
-          ],
-        }),
-      ),
-    ).toBe(true);
   });
 });

--- a/packages/capabilities/src/proving/versionedProving.ts
+++ b/packages/capabilities/src/proving/versionedProving.ts
@@ -18,13 +18,13 @@
  * @remarks
  *   The routing already existed and the backends already existed; what this module supplies is the only thing neither
  *   could: the registration that says which range of protocol versions each backend answers for, taken from the same
- *   fork version the wallets are built with. Written the same way validation's `versionedValidation.ts` is, because it
+ *   fork schedule the wallets are built with. Written the same way validation's `versionedValidation.ts` is, because it
  *   is the same problem.
  */
 import * as preForkLedger from '@midnight-ntwrk/ledger-v8';
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
-import { Effect, Either } from 'effect';
+import { Effect, Either, Option } from 'effect';
 import {
   makeV8ServerProvingServiceEffect,
   makeV8WasmProvingServiceEffect,
@@ -112,97 +112,98 @@ const isV9Transaction = (transaction: AnyVersionUnprovenTransaction): transactio
 const wasmConfigurationOf = (backend: Extract<ProvingBackend, { kind: 'wasm' }>): WasmProvingConfiguration =>
   backend.keyMaterialProvider === undefined ? {} : { keyMaterialProvider: backend.keyMaterialProvider };
 
-/** Builds the backend a description names, on the ledger version the epoch it is registered for belongs to. */
-const makeBackend = (
+/** Builds the backend a description names, driven by ledger-v8, for the epoch below `forks.v9`. */
+const makeV8Backend = (
   backend: ProvingBackend,
   epoch: ProtocolVersion.ProtocolVersion.Range,
-  forkVersion: ProtocolVersion.ProtocolVersion,
 ): VersionProvingServiceEffect =>
-  epoch[1] <= forkVersion
-    ? onlyFrom(
-        backend.kind === 'server'
-          ? makeV8ServerProvingServiceEffect({ provingServerUrl: backend.url })
-          : makeV8WasmProvingServiceEffect(wasmConfigurationOf(backend)),
-        isV8Transaction,
-        epoch,
-      )
-    : onlyFrom(
-        backend.kind === 'server'
-          ? makeServerProvingServiceEffect({ provingServerUrl: backend.url })
-          : makeWasmProvingServiceEffect(wasmConfigurationOf(backend)),
-        isV9Transaction,
-        epoch,
-      );
+  onlyFrom(
+    backend.kind === 'server'
+      ? makeV8ServerProvingServiceEffect({ provingServerUrl: backend.url })
+      : makeV8WasmProvingServiceEffect(wasmConfigurationOf(backend)),
+    isV8Transaction,
+    epoch,
+  );
+
+/** Builds the backend a description names, driven by ledger-v9, for the epoch from `forks.v9`. */
+const makeV9Backend = (
+  backend: ProvingBackend,
+  epoch: ProtocolVersion.ProtocolVersion.Range,
+): VersionProvingServiceEffect =>
+  onlyFrom(
+    backend.kind === 'server'
+      ? makeServerProvingServiceEffect({ provingServerUrl: backend.url })
+      : makeWasmProvingServiceEffect(wasmConfigurationOf(backend)),
+    isV9Transaction,
+    epoch,
+  );
 
 /**
- * Splits a registered range at the protocol boundary, so no single entry spans two ledger versions.
+ * The range of protocol versions each ledger version reads on a chain, from where the chain says the hand-over is.
  *
  * @remarks
- *   A range that straddles the boundary is a description of _where_ to prove that says nothing about _which_ ledger
- *   frames the request — and both are needed. Splitting it keeps the operator's answer to the first question and lets
- *   the boundary answer the second, which is what makes "one proof server for every version" mean the right thing on
- *   both sides rather than ledger-v9's thing on both.
+ *   A chain whose boundary is at or below the minimum supported version has no history ledger-v8 authored, so there is no
+ *   pre-fork epoch on it and a ledger-v8 backend has nothing to serve.
  */
-const splitAtFork = (
-  entry: ProtocolVersion.RegistryEntry<ProvingBackend>,
-  forkVersion: ProtocolVersion.ProtocolVersion,
-): readonly ProtocolVersion.RegistryEntry<ProvingBackend>[] => {
-  const [start, end] = entry.range;
-  return start < forkVersion && forkVersion < end
-    ? [
-        { range: ProtocolVersion.makeRange(start, forkVersion), value: entry.value },
-        { range: ProtocolVersion.makeRange(forkVersion, end), value: entry.value },
-      ]
-    : [entry];
-};
+const epochsOf = (forks: ProtocolVersion.ForkSchedule) => ({
+  v8:
+    forks.v9 > ProtocolVersion.MinSupportedVersion
+      ? Option.some(ProtocolVersion.epochOf(ProtocolVersion.MinSupportedVersion, forks.v9))
+      : Option.none(),
+  v9: ProtocolVersion.epochOf(forks.v9, forks.v9),
+});
 
 /**
  * Registers a proving backend either side of the protocol boundary.
  *
+ * @remarks
+ *   The configuration names a backend per ledger version and the fork schedule says where each ledger version begins; the
+ *   range a backend serves is the meeting of the two, computed here and nowhere else, so the wallets and their provers
+ *   cannot place the boundary differently.
  * @param configuration The proving configuration.
- * @param forkVersion The protocol version at which the chain hands over to ledger-v9.
+ * @param forks Where each ledger version begins on the chain.
  * @returns The backends and the version ranges they serve, or the reason the configuration names none.
  */
 export const makeDefaultProvingServices = (
   configuration: DefaultProvingConfiguration,
-  forkVersion: ProtocolVersion.ProtocolVersion,
+  forks: ProtocolVersion.ForkSchedule,
 ): Either.Either<
   ProvingServices<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>,
   ProvingConfigurationError
 > =>
   resolveProvingBackends(configuration).pipe(
-    Either.map((backends) => ({
-      // A chain whose boundary is at or below the minimum supported version has no pre-fork epoch to register for, so
-      // nothing is split and every range is ledger-v9's.
-      entries: backends.entries
-        .flatMap((entry) =>
-          forkVersion > ProtocolVersion.MinSupportedVersion ? splitAtFork(entry, forkVersion) : [entry],
-        )
-        .map((entry) => ({ range: entry.range, value: makeBackend(entry.value, entry.range, forkVersion) })),
-    })),
+    Either.map((backends) => {
+      const epochs = epochsOf(forks);
+      const preFork = Option.all([Option.fromNullable(backends.v8), epochs.v8]).pipe(
+        Option.map(([backend, range]) => ({ range, value: makeV8Backend(backend, range) })),
+      );
+      return {
+        entries: [...Option.toArray(preFork), { range: epochs.v9, value: makeV9Backend(backends.v9, epochs.v9) }],
+      };
+    }),
   );
 
 /**
  * Builds the version-routed proving service an SDK spanning a protocol boundary proves with.
  *
  * @param configuration The proving configuration.
- * @param forkVersion The protocol version at which the chain hands over to ledger-v9.
+ * @param forks Where each ledger version begins on the chain.
  * @returns A proving service that routes on the version a transaction was built for, or the reason the configuration
  *   names no backend.
  */
 export const makeDefaultVersionedProvingServiceEffect = (
   configuration: DefaultProvingConfiguration,
-  forkVersion: ProtocolVersion.ProtocolVersion,
+  forks: ProtocolVersion.ForkSchedule,
 ): Either.Either<
   VersionedProvingServiceEffect<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>,
   ProvingConfigurationError
-> => makeDefaultProvingServices(configuration, forkVersion).pipe(Either.map(makeVersionedProvingServiceEffect));
+> => makeDefaultProvingServices(configuration, forks).pipe(Either.map(makeVersionedProvingServiceEffect));
 
 /** The promise-facing surface of {@link makeDefaultVersionedProvingServiceEffect}, for the facade to expose. */
 export const makeDefaultVersionedProvingService = (
   configuration: DefaultProvingConfiguration,
-  forkVersion: ProtocolVersion.ProtocolVersion,
+  forks: ProtocolVersion.ForkSchedule,
 ): Either.Either<
   VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>,
   ProvingConfigurationError
-> => makeDefaultVersionedProvingServiceEffect(configuration, forkVersion).pipe(Either.map(wrapVersionedEffectService));
+> => makeDefaultVersionedProvingServiceEffect(configuration, forks).pipe(Either.map(wrapVersionedEffectService));

--- a/packages/docs-snippets/src/snippets/dust-fast-sync.ts
+++ b/packages/docs-snippets/src/snippets/dust-fast-sync.ts
@@ -53,19 +53,13 @@ const configuration: DefaultConfiguration = {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  // One proof server per ledger version: the one built against ledger-v8 answers below `forks.v9`, the one built
-  // against ledger-v9 from it. A transaction is proved by the entry for the version its bytes were authored at, so the
-  // wallet proves on either side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
-  provers: [
-    {
-      sinceVersion: ProtocolVersion.MinSupportedVersion,
-      backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
-    },
-    {
-      sinceVersion: ProtocolVersion.V9NativeForkVersion,
-      backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
-    },
-  ],
+  // One proof server per ledger version, keyed the way `forks` is: `v8` answers below `forks.v9`, `v9` from it. A
+  // transaction is proved by the backend for the ledger version that authored its bytes, so the wallet proves on either
+  // side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
+  provers: {
+    v8: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
+    v9: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
+  },
   indexerClientConnection: {
     indexerHttpUrl: INDEXER_HTTP_URL,
     indexerWsUrl: INDEXER_WS_URL,

--- a/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
+++ b/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
@@ -46,19 +46,13 @@ const configuration: DefaultConfiguration = {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  // One proof server per ledger version: the one built against ledger-v8 answers below `forks.v9`, the one built
-  // against ledger-v9 from it. A transaction is proved by the entry for the version its bytes were authored at, so the
-  // wallet proves on either side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
-  provers: [
-    {
-      sinceVersion: ProtocolVersion.MinSupportedVersion,
-      backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
-    },
-    {
-      sinceVersion: ProtocolVersion.V9NativeForkVersion,
-      backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
-    },
-  ],
+  // One proof server per ledger version, keyed the way `forks` is: `v8` answers below `forks.v9`, `v9` from it. A
+  // transaction is proved by the backend for the ledger version that authored its bytes, so the wallet proves on either
+  // side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
+  provers: {
+    v8: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
+    v9: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
+  },
   indexerClientConnection: {
     indexerHttpUrl: INDEXER_HTTP_URL,
     indexerWsUrl: INDEXER_WS_URL,

--- a/packages/docs-snippets/src/snippets/hard-fork-support.ts
+++ b/packages/docs-snippets/src/snippets/hard-fork-support.ts
@@ -21,7 +21,7 @@
  *
  * This file is the copy-paste shape, in the order the code runs:
  *
- * 1. version-keyed proving configuration (`provers`)
+ * 1. a proving backend per ledger version (`provers`)
  * 2. the seed-first start, which is the primary and the only one that crosses a fork
  * 3. reading the protocol phase off the state (`Settled` / `Crossing`)
  * 4. finding transactions the fork orphaned (`PendingStatus.Orphaned`)
@@ -60,7 +60,7 @@ const INDEXER_HTTP_URL = `http://localhost:${INDEXER_PORT}/api/v4/graphql`;
 const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 // ---------------------------------------------------------------------------------------------------------------------
-// 1. Version-keyed proving configuration
+// 1. A proving backend per ledger version
 // ---------------------------------------------------------------------------------------------------------------------
 
 const configuration: DefaultConfiguration = {
@@ -72,29 +72,23 @@ const configuration: DefaultConfiguration = {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  // Proving backends keyed by the protocol version each starts serving, in ascending order. A transaction is proved by
-  // the backend registered for the version its own bytes were authored at, so a fork landing between building a
-  // transaction and proving it cannot send it to the wrong prover — and, just as importantly, the ledger version that
-  // built those bytes is the one that frames the proving request.
+  // Proving backends keyed by ledger version, the way `forks` is: `v8` proves below `forks.v9`, `v9` from it, and the
+  // boundary is read off `forks` rather than restated here. A transaction is proved by the backend for the ledger
+  // version that authored its bytes, so a fork landing between building a transaction and proving it cannot send it to
+  // the wrong prover — and, just as importantly, the ledger version that built those bytes is the one that frames the
+  // proving request.
   //
   // Two entries, because a proof server is built against one ledger version and no published image serves both: the
   // pre-fork half of a chain that has history below `forks.v9` needs its own deployment. On a chain that has been
-  // post-fork since genesis — like the one this runs against — the first entry is simply never reached.
+  // post-fork since genesis — like the one this runs against — the `v8` entry is simply never reached.
   //
-  // `provingServerUrl: url` is the shortest form and means one server for every version; the SDK splits its range at
-  // `forks.v9` so each side is framed by its own ledger, which makes it correct but rarely what an operator wants,
-  // since the one URL then has to answer for both. `provingServers: [...]` is the same list as below with every entry
-  // a server.
-  provers: [
-    {
-      sinceVersion: ProtocolVersion.MinSupportedVersion,
-      backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
-    },
-    {
-      sinceVersion: ProtocolVersion.V9NativeForkVersion,
-      backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
-    },
-  ],
+  // `provingServerUrl: url` is the shortest form and means one server under every key; the SDK drives it with each
+  // ledger version on its own side of `forks.v9`, which makes it correct but rarely what an operator wants, since the
+  // one URL then has to answer for both.
+  provers: {
+    v8: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
+    v9: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
+  },
   indexerClientConnection: {
     indexerHttpUrl: INDEXER_HTTP_URL,
     indexerWsUrl: INDEXER_WS_URL,

--- a/packages/docs-snippets/src/snippets/initialization.ts
+++ b/packages/docs-snippets/src/snippets/initialization.ts
@@ -45,19 +45,13 @@ const configuration: DefaultConfiguration = {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  // One proof server per ledger version: the one built against ledger-v8 answers below `forks.v9`, the one built
-  // against ledger-v9 from it. A transaction is proved by the entry for the version its bytes were authored at, so the
-  // wallet proves on either side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
-  provers: [
-    {
-      sinceVersion: ProtocolVersion.MinSupportedVersion,
-      backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
-    },
-    {
-      sinceVersion: ProtocolVersion.V9NativeForkVersion,
-      backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
-    },
-  ],
+  // One proof server per ledger version, keyed the way `forks` is: `v8` answers below `forks.v9`, `v9` from it. A
+  // transaction is proved by the backend for the ledger version that authored its bytes, so the wallet proves on either
+  // side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
+  provers: {
+    v8: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
+    v9: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
+  },
   indexerClientConnection: {
     indexerHttpUrl: INDEXER_HTTP_URL,
     indexerWsUrl: INDEXER_WS_URL,

--- a/packages/docs-snippets/src/snippets/wasm-prover.ts
+++ b/packages/docs-snippets/src/snippets/wasm-prover.ts
@@ -14,9 +14,9 @@
  * Proving in this process, either side of a protocol boundary.
  *
  * The bundled prover drives a zkir runtime over bytes and never looks at a ledger version, so — unlike a proof server,
- * which is built against one — the same backend serves both epochs. One `provers` entry starting at the minimum
- * supported version therefore covers the whole timeline: the SDK splits its range at `forks.v9` and drives each side
- * with its own ledger.
+ * which is built against one — the same description serves both ledger versions. Naming it under both `v8` and `v9`
+ * covers the whole timeline: the SDK drives each side with its own ledger, and where one side ends and the other
+ * begins is `forks.v9`, stated once.
  */
 import {
   WalletSeeds,
@@ -49,9 +49,9 @@ const configuration: DefaultConfiguration = {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  // The in-process prover, for every protocol version. `keyMaterialProvider` can be supplied here to point the prover
+  // The in-process prover, for every ledger version. `keyMaterialProvider` can be supplied here to point the prover
   // at key material of your own; left out, it reads the published circuits, which both ledger versions accept.
-  provers: [{ sinceVersion: ProtocolVersion.MinSupportedVersion, backend: { kind: 'wasm' } }],
+  provers: { v8: { kind: 'wasm' }, v9: { kind: 'wasm' } },
   indexerClientConnection: {
     indexerHttpUrl: INDEXER_HTTP_URL,
     indexerWsUrl: INDEXER_WS_URL,

--- a/packages/docs-snippets/src/utils.ts
+++ b/packages/docs-snippets/src/utils.ts
@@ -46,19 +46,13 @@ export const configuration: DefaultConfiguration = {
     feeBlocksMargin: 5,
   },
   relayURL: new URL(`ws://localhost:${NODE_PORT}`),
-  // One proof server per ledger version: the one built against ledger-v8 answers below `forks.v9`, the one built
-  // against ledger-v9 from it. A transaction is proved by the entry for the version its bytes were authored at, so the
-  // wallet proves on either side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
-  provers: [
-    {
-      sinceVersion: ProtocolVersion.MinSupportedVersion,
-      backend: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
-    },
-    {
-      sinceVersion: ProtocolVersion.V9NativeForkVersion,
-      backend: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
-    },
-  ],
+  // One proof server per ledger version, keyed the way `forks` is: `v8` answers below `forks.v9`, `v9` from it. A
+  // transaction is proved by the backend for the ledger version that authored its bytes, so the wallet proves on either
+  // side of the fork and across it. `hard-fork-support.ts` explains the shape in full.
+  provers: {
+    v8: { kind: 'server', url: new URL(`http://localhost:${V8_PROOF_SERVER_PORT}`) },
+    v9: { kind: 'server', url: new URL(`http://localhost:${PROOF_SERVER_PORT}`) },
+  },
   indexerClientConnection: {
     indexerHttpUrl: INDEXER_HTTP_URL,
     indexerWsUrl: INDEXER_WS_URL,

--- a/packages/e2e-tests/src/tests/hardFork.fork.test.ts
+++ b/packages/e2e-tests/src/tests/hardFork.fork.test.ts
@@ -318,19 +318,13 @@ describe.sequential('Hard fork crossing @fork', () => {
     const configuration = {
       ...fixture.getWalletConfig(),
       ...fixture.getDustWalletConfig(),
-      // Version-keyed proving wins over the fixture's single `provingServerUrl`, and names both epochs, because that
+      // A backend per ledger version wins over the fixture's single `provingServerUrl`, and names both, because that
       // is what an application crossing the fork actually has to configure: no proof server serves both ledger
-      // versions, so a wallet that spends on each side of the boundary needs one entry per side.
-      provers: [
-        {
-          sinceVersion: ProtocolVersion.MinSupportedVersion,
-          backend: { kind: 'server', url: new URL(fixture.getV8ProverUri()) },
-        },
-        {
-          sinceVersion: ProtocolVersion.V9NativeForkVersion,
-          backend: { kind: 'server', url: new URL(fixture.getProverUri()) },
-        },
-      ] as const satisfies DefaultConfiguration['provers'],
+      // versions, so a wallet that spends on each side of the boundary needs one per side.
+      provers: {
+        v8: { kind: 'server', url: new URL(fixture.getV8ProverUri()) },
+        v9: { kind: 'server', url: new URL(fixture.getProverUri()) },
+      } satisfies DefaultConfiguration['provers'],
     };
     unshieldedKeystore = createKeystore({ kind: 'schnorr', secret: seeds.unshielded }, fixture.getNetworkId());
 
@@ -418,8 +412,8 @@ describe.sequential('Hard fork crossing @fork', () => {
     async () => {
       // The half of proving no other lane can reach. Below the boundary the wallet builds ledger-v8 bytes, and only the
       // ledger-v8 can frame a proving request for them and only a ledger-v8 proof server can answer it — so what
-      // this proves is that the version-keyed backends were honoured, not merely accepted by configuration. The same
-      // wallet proves at the other server after the fork, which is the acceptance criterion for the pair.
+      // this proves is that the backends keyed by ledger version were honoured, not merely accepted by configuration.
+      // The same wallet proves at the other server after the fork, which is the acceptance criterion for the pair.
       preForkReceiver = await utils.initWalletWithSeed(V8_RECEIVER_SEED, fixture);
       const receiverBefore = await within(
         'the pre-fork receiver to sync',

--- a/packages/facade/README.md
+++ b/packages/facade/README.md
@@ -42,35 +42,31 @@ await facade.start(shieldedSecretKeys, dustSecretKey);
 
 ### Configuring where proving happens
 
-A transaction is proved by the backend registered for the protocol version its own bytes were authored at, never by the
-version the chain has since reached. Backends are named ascending by the version each starts serving:
+A transaction is proved by the backend for the ledger version that authored its bytes, never by the version the chain
+has since reached. Backends are named per ledger version, keyed the way `forks` is, and the range each serves is read
+off `forks` rather than restated:
 
 ```typescript
-import { ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
-
 const configuration = {
-  // ... the rest of the wallet configuration, including `forks`
-  provers: [
-    // Below the boundary: a proof server built against ledger-v8.
-    {
-      sinceVersion: ProtocolVersion.MinSupportedVersion,
-      backend: { kind: 'server', url: new URL('http://localhost:6301') },
-    },
-    // From the boundary: proving in this process, with the published circuits.
-    { sinceVersion: forks.v9, backend: { kind: 'wasm' } },
-  ],
+  // ... the rest of the wallet configuration, including `forks: { v9 }`
+  provers: {
+    // Below `forks.v9`: a proof server built against ledger-v8.
+    v8: { kind: 'server', url: new URL('http://localhost:6301') },
+    // From `forks.v9`: proving in this process, with the published circuits.
+    v9: { kind: 'wasm' },
+  },
 };
 ```
 
-Two shorthands remain: `provingServers: [{ sinceVersion, url }]` is the same list with every entry a server, and
-`provingServerUrl: url` is one server for every version. Both are read only when `provers` is absent.
+`v9` is required, because it is what every new transaction is proved with. `v8` may be left out on a chain whose history
+below the boundary the wallet never authors for; a transaction stamped there then fails with
+`UnsupportedProvingVersionError`, naming the version.
 
-A backend whose range spans `configuration.forks.v9` — which `provingServerUrl` always does — is split at the boundary
-and driven by each ledger version in turn, so the same description means the right thing on both sides. A proof server,
-though, is built against one ledger version: no published image serves both, so a chain with history below the boundary
-wants an entry per side. The in-process prover works on bytes and does serve both.
-
-A version no backend covers fails with `UnsupportedProvingVersionError`, naming the version.
+One shorthand remains: `provingServerUrl: url` is one proof server under every key, read only when `provers` is absent.
+The SDK drives it with each ledger version on its own side of `forks.v9`, so the same URL frames its requests correctly
+on both. A proof server, though, is built against one ledger version: no published image serves both, so a chain with
+history below the boundary wants `provers` with a server per side. The in-process prover works on bytes and does serve
+both, under both keys.
 
 ### Observing Combined State
 

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -779,14 +779,14 @@ export class WalletFacade {
    * Builds the proving service a configuration describes.
    *
    * @remarks
-   *   Handed the same fork version the wallets are built with, because a proving backend is chosen by the epoch a
+   *   Handed the same fork schedule the wallets are built with, because a proving backend is chosen by the epoch a
    *   transaction belongs to and the two ends of that question must not be able to compute the boundary differently.
    */
   private static makeDefaultProvingService<TConfig extends DefaultConfiguration>(
     config: TConfig,
   ): VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction> {
     return Either.getOrThrowWith(
-      makeDefaultVersionedProvingService(config, config.forks.v9),
+      makeDefaultVersionedProvingService(config, config.forks),
       (error) => new Error(error.message),
     );
   }

--- a/packages/facade/test/versionedProving.test.ts
+++ b/packages/facade/test/versionedProving.test.ts
@@ -25,12 +25,14 @@ import {
 import {
   ProvingEpochMismatchError,
   UnsupportedProvingVersionError,
+  type ProvingBackends,
   type UnboundTransaction,
   type VersionedProvingService,
 } from '@midnightntwrk/wallet-sdk-capabilities/proving';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
+import { type Equal, type Expect } from '@midnightntwrk/wallet-sdk-utilities/types';
 import { Cause, Either, Option, Runtime } from 'effect';
 import * as rx from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -74,7 +76,7 @@ describe('Proving a transaction at the version it was built for', () => {
       forks: { v9: ProtocolVersion.V9NativeForkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
-      provingServers: [{ sinceVersion: ProtocolVersion.MinSupportedVersion, url: new URL('http://localhost:6300') }],
+      provingServerUrl: new URL('http://localhost:6300'),
       costParameters: { feeBlocksMargin: 0 },
       txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
     };
@@ -247,13 +249,7 @@ describe('Proving with the backend configured for the epoch a transaction belong
     );
 
   const v8ServerAndV9Wasm: Partial<DefaultConfiguration> = {
-    provers: [
-      {
-        sinceVersion: ProtocolVersion.MinSupportedVersion,
-        backend: { kind: 'server', url: new URL('http://pre-fork-prover:6300') },
-      },
-      { sinceVersion: ProtocolVersion.V9NativeForkVersion, backend: { kind: 'wasm' } },
-    ],
+    provers: { v8: { kind: 'server', url: new URL('http://pre-fork-prover:6300') }, v9: { kind: 'wasm' } },
   };
 
   it('proves a transaction built below the fork with ledger-v8', async () => {
@@ -264,9 +260,9 @@ describe('Proving with the backend configured for the epoch a transaction belong
     expect(provenBy(finalized)).toBeInstanceOf(preForkLedger.Transaction);
   });
 
-  it('splits the single-server configuration at the fork version the wallet was configured with', async () => {
+  it('drives the single-server configuration with ledger-v8 below the fork the wallet was configured with', async () => {
     // Naming one server for every version says nothing about ledger versions, and cannot. What makes it right below the
-    // boundary is that the facade hands proving the same fork version it hands its wallets.
+    // boundary is that the facade hands proving the same fork schedule it hands its wallets.
     const facade = await started({ provingServerUrl: new URL('http://only-prover:6300') });
 
     const finalized = await facade.finalizeTransaction(aV8Transaction());
@@ -287,12 +283,7 @@ describe('Proving with the backend configured for the epoch a transaction belong
 
   it('refuses a transaction from a version no backend was configured for, naming that version', async () => {
     const facade = await started({
-      provers: [
-        {
-          sinceVersion: ProtocolVersion.V9NativeForkVersion,
-          backend: { kind: 'server', url: new URL('http://post-fork-prover:6300') },
-        },
-      ],
+      provers: { v9: { kind: 'server', url: new URL('http://post-fork-prover:6300') } },
     });
 
     const failure = await facade.finalizeTransaction(aV8Transaction()).then(
@@ -302,5 +293,15 @@ describe('Proving with the backend configured for the epoch a transaction belong
 
     expect(reported(failure)).toBeInstanceOf(UnsupportedProvingVersionError);
     expect((reported(failure) as UnsupportedProvingVersionError).protocolVersion).toStrictEqual(PRE_FORK);
+  });
+});
+
+describe('DefaultConfiguration', () => {
+  it('names a proving backend per ledger version, keyed the way `forks` is', () => {
+    type _1 = Expect<Equal<DefaultConfiguration['provers'], ProvingBackends | undefined>>;
+  });
+
+  it('no longer takes proof servers keyed by the protocol version each starts serving', () => {
+    type _1 = Expect<Equal<'provingServers' extends keyof DefaultConfiguration ? true : false, false>>;
   });
 });


### PR DESCRIPTION
# Description

After #721 a configuration states the fork once, as `forks.v9`. Proving still restated it: every `provers` entry carried a `sinceVersion`, and in the common case the ledger-v9 entry's `sinceVersion` was the same number as `forks.v9`. The two were not independent. The SDK split every prover range at `forks.v9` and chose the ledger driver by which side of it a range fell on, so a prover's `sinceVersion` only said which URL applied from where. If the two drifted, the versions between them were framed by one ledger and sent to a server built for the other, and nothing caught it at configuration time.

This PR keys `provers` by ledger version, the way `forks` and the key material already are, and reads the range each backend serves off the fork schedule. The boundary is now stated in one place.

**Stacked on #721**, which is stacked on #720; GitHub retargets it as each base merges.

# Proposed Solution

- `ProvingBackends` in the capabilities package: `Readonly<{ v8?: ProvingBackend; v9: ProvingBackend }>`. `v9` is required because every new transaction is proved with it; `v8` is optional for a chain whose pre-fork history the wallet never authors for, and a transaction stamped there then fails with `UnsupportedProvingVersionError`. The next fork adds a key.
- `DefaultProvingConfiguration` is `provers?: ProvingBackends` plus the unchanged `provingServerUrl` shorthand, which is read as the same server under both keys. `provingServers` is removed, since it carried the same `sinceVersion`.
- `resolveProvingBackends(configuration)` decides precedence only and returns the keyed map. `makeDefaultProvingServices(configuration, forks)` takes the `ProtocolVersion.ForkSchedule`, computes each ledger version's epoch from it, and builds the ledger-v8 backend for the epoch below `forks.v9` and the ledger-v9 backend from it. `splitAtFork` and the side-of-fork driver choice are gone, because nothing can straddle the boundary any more.
- `makeDefaultVersionedProvingService` and its Effect twin take the schedule as their second argument; the facade passes `configuration.forks`.

Alternative considered: keeping the list and validating that its `sinceVersion`s coincide with `forks`. That turns a footgun into an error rather than removing the second statement of the boundary, and it cannot say which ledger a URL was built against, which is the fact the key now carries.

# Important Changes Introduced

- **Breaking for every configuration that names `provers` or `provingServers`**: the changeset carries the migration. `provingServerUrl` configurations are unaffected.
- **Breaking for direct callers of the capabilities factories**: `ProverActivation`, `ProvingServerActivation` and `resolveProvingServers` are removed; `resolveProvingBackends` returns `ProvingBackends`; the three `makeDefault*Proving*` factories take a `ForkSchedule`.
- Tests came first: commit `c7f5f5f0` rewrites the capabilities and facade proving tests to the new contract, including a test that moving `forks.v9` moves the prover ranges with no other input, and fails typecheck on its own; commit `f92d5fdc` makes it pass without touching the tests.
- Docs snippets, the fork e2e test, both READMEs and CLAUDE.md are updated. The pending 2.0 release notes that described the list form (`proving-per-version`, `hard-fork-support`, `hard-fork-ready-snippets`, `fork-schedule`) are aligned so the final CHANGELOG does not document a shape that never shipped.

# Testing

- `yarn typecheck` across the whole repository: 37 tasks pass, including e2e and docs-snippets.
- `yarn lint` (58 tasks) and `yarn format:check` (22 tasks): pass.
- `yarn test:unit` on capabilities and facade: 17 test files each, all passing, including the rewritten proving tests.
- Effect language service diagnostics on the three edited source modules: no new findings. The one pre-existing error in `provingService.ts` is the `ProvingError` tag, which this PR does not touch.
- To see the red state, check out `c7f5f5f0` and run `yarn typecheck --filter=@midnightntwrk/wallet-sdk-capabilities`.
- The fork e2e lane (`hardFork.fork.test.ts`) is updated but not run locally; it needs the fork docker stack.
