### PR TITLE
ci(prover-client): build the package before its own tests, which spawn dist/proof-worker.js

### DIFF
--- a/.changeset/prover-client-test-dist.md
+++ b/.changeset/prover-client-test-dist.md
@@ -1,0 +1,8 @@
+---
+---
+
+Build the prover-client package before running its own tests. The in-process prover spawns its worker from the package's
+`dist/proof-worker.js`, so a test that reaches it needs the package built, not only its upstream dependencies. The `test`
+task already declared that; `test:unit` and `test:integration`, added when the suite was split, did not, and on a fresh
+CI runner `v8WasmProver.integration.test.ts` failed to find the worker and hung to its timeout. Tooling only — no API
+changes.

--- a/packages/prover-client/turbo.json
+++ b/packages/prover-client/turbo.json
@@ -3,6 +3,12 @@
   "tasks": {
     "test": {
       "dependsOn": ["dist"]
+    },
+    "test:unit": {
+      "dependsOn": ["dist"]
+    },
+    "test:integration": {
+      "dependsOn": ["dist"]
     }
   }
 }


### PR DESCRIPTION
# Description

`Integration Tests / packages/prover-client/src/effect/test/v8WasmProver.integration.test.ts` has failed on every PR since #718 introduced it, taking 21 minutes to do so. The in-process prover spawns its worker from the package's own build output, `dist/proof-worker.js`. The integration matrix runs each file on a fresh runner with `turbo run test:integration --filter=./packages/prover-client`, whose graph is `utilities#dist`, `prover-client#typecheck` and `prover-client#test:integration`: `^dist` builds upstream packages only, so the package's own `dist` never exists and the worker fails to load:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../packages/prover-client/dist/proof-worker.js'
```

The `web-worker` shim logs that failure inside the worker thread rather than raising it to the parent, so the launcher waits out its 10-minute guard and each of the two tests hits the 10-minute test timeout.

The other proving jobs pass because they live downstream of prover-client, where `^dist` does build it. Locally the file passes whenever a previous build left `dist` in place, which is why this never showed up on a developer machine.

# Proposed Solution

`packages/prover-client/turbo.json` already makes `test` depend on the package's own `dist`. That override predates the unit/integration split, so `test:unit` and `test:integration` never inherited it. This PR adds the same dependency to both. Turbo's dry run for the CI command now lists `prover-client#dist`.

Not included: making the launcher reject as soon as the worker dies, so a broken worker fails in seconds instead of 10 minutes. That is a runtime change that needs the worker URL to be injectable to test properly, and it is worth doing separately.

# Testing

- Deleted `packages/prover-client/dist` and ran the exact CI command, `yarn turbo run test:integration --filter=./packages/prover-client -- v8WasmProver.integration.test.ts`: turbo builds `prover-client:dist` first and both tests pass in 55 seconds.
- `yarn turbo run test:integration --filter=./packages/prover-client --dry=json` lists `@midnightntwrk/wallet-sdk-prover-client#dist` in the task graph; before the change it did not.
- Empty changeset, since no published package changes.
