### PR TITLE
feat(facade): preset the fork schedule, so a configuration need not say where the chain hands over to ledger-v9

### DIFF
--- a/.changeset/facade-preset-fork-schedule.md
+++ b/.changeset/facade-preset-fork-schedule.md
@@ -1,0 +1,22 @@
+---
+'@midnightntwrk/wallet-sdk-facade': minor
+'@midnightntwrk/wallet-sdk': minor
+---
+
+feat(facade): preset the fork schedule, so a configuration need not say where the chain hands over to ledger-v9
+
+`forks` may now be left out of the facade's `DefaultConfiguration`. `WalletFacade.init` then fills in
+`DefaultForkSchedule` — `ProtocolVersion.V9NativeForkSchedule`, ledger-v9 from the version a 2.x node reports — and
+hands the completed configuration to every factory in `InitParams`, wallets and services alike. A configuration that
+does name `forks` is handed exactly what it named.
+
+The wallet packages are unchanged: `ShieldedWallet`, `UnshieldedWallet` and `DustWallet` still require `forks`, because
+where a chain forks is a fact about the chain. The facade is the one place a preset decides nothing the SDK had not
+already decided — every application was copying the same constant into its configuration — which is why the preset
+lives there and nowhere lower.
+
+What a factory is handed is typed `ResolvedConfiguration<TConfig>`: the configuration as given, with `forks` always
+present. `shielded: (config) => ShieldedWallet(config)` keeps compiling as before. Code outside a factory that needs the
+configuration the facade will use — to build a wallet package directly, or to read `forks` back and author a transaction
+for the right ledger version — calls `WalletFacade.resolveConfiguration(configuration)`, which returns that same
+`ResolvedConfiguration`. `init` accepts the result as it is, so a configuration can be resolved once and serve both.

--- a/.changeset/fold-fork-constant.md
+++ b/.changeset/fold-fork-constant.md
@@ -8,5 +8,10 @@ The v9-native fork version lives with the version type: `ProtocolVersion.V9Nativ
 package (and through the umbrella package's `ProtocolVersion`), next to `MinSupportedVersion` and `MaxSupportedVersion`.
 It is the same value the shielded package published as `V9_NATIVE_FORK_VERSION` — a property of the chain, not of one
 wallet, which is why it moves. The shielded export stays as a deprecated alias of the new constant, so existing imports
-keep working; it will be removed in a later release. As before, it is a named value and not a default: every wallet's
-`forks.v9` remains required.
+keep working; it will be removed in a later release. As before, each wallet package requires `forks.v9` rather than
+presetting it; the facade presets it as `DefaultForkSchedule`, the same value — see its own changeset.
+
+`ProtocolVersion.V9NativeForkSchedule` sits next to it: the fork schedule of a chain born on ledger-v9,
+`{ v9: V9NativeForkVersion }`, named once so that a configuration pointed at such a chain writes
+`forks: ProtocolVersion.V9NativeForkSchedule` rather than the literal. It is the value the facade's
+`DefaultForkSchedule` presets.

--- a/.changeset/fork-schedule.md
+++ b/.changeset/fork-schedule.md
@@ -16,8 +16,9 @@ ledger-v9 reads the chain — in place of the single `forkVersion`. The value an
 is. A single number could name one boundary and no more, so the next hard fork would have changed the shape of every
 application's configuration. A map keyed by ledger version adds a key (`v10`) instead, which is why the change is made
 now, while 2.0 is still in beta. The type is `ProtocolVersion.ForkSchedule` in the abstractions package; ledger-v8 begins
-at `MinSupportedVersion` and has no entry, and every entry stays required with no default, for the same reason as before:
-where a chain forks is a fact about the chain, not the SDK.
+at `MinSupportedVersion` and has no entry, and every entry stays required in the wallet packages, for the same reason as
+before: where a chain forks is a fact about the chain, not the SDK. The facade presets `DefaultForkSchedule` when `forks`
+is left out — see its own changeset.
 
 BREAKING CHANGE — replace the field in every configuration you build:
 

--- a/.changeset/hard-fork-support.md
+++ b/.changeset/hard-fork-support.md
@@ -23,9 +23,10 @@ no longer import a ledger package.
 
 ### Breaking: configuration and starting
 
-- `forks.v9` is required in the shielded, dust, unshielded and facade configurations: the protocol version at which
-  the chain switches ledgers. There is no default. `ProtocolVersion.V9NativeForkVersion`, from the abstractions package, is
-  the value a 2.x chain reports (2000000); the final mainnet constant is not fixed yet, so supply it per environment.
+- `forks.v9` is required in the shielded, dust and unshielded configurations: the protocol version at which the chain
+  switches ledgers. There is no default in the wallet packages. `ProtocolVersion.V9NativeForkVersion`, from the
+  abstractions package, is the value a 2.x chain reports (2000000); the final mainnet constant is not fixed yet, so
+  supply it per environment. The facade presets this value when `forks` is left out — see the facade changeset.
 - `chainVersionProbe` is a new optional setting on all three wallets. By default a wallet asks the indexer, on every
   start, which protocol version the chain's first block was produced under, with a 5-second timeout, and starts on the
   matching side. A failed probe never fails a start: the wallet starts on V1 and crosses on its first synced update.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,7 +321,11 @@ them.
 
 **The wallet layer above the twins is single.** `ShieldedWallet` / `DustWallet` / `UnshieldedWallet` each register both
 variants and hand over at `configuration.forks.v9`; the package's own `Default*Configuration` is declared by the
-package, not aliased to either variant's. `Custom*Wallet(configuration, builder)` is the single-variant composition.
+package, not aliased to either variant's. `Custom*Wallet(configuration, builder)` is the single-variant composition. The
+wallet packages require `forks`; only the facade presets it (`DefaultForkSchedule`), handing every factory in
+`InitParams` a `ResolvedConfiguration` with it filled in, and `WalletFacade.resolveConfiguration` gives code outside a
+factory the same one. Do not push the preset down into the wallets or remove it from the facade — the facade README says
+why it sits exactly there.
 
 ### Naming the two sides of a fork
 

--- a/packages/abstractions/src/ProtocolVersion.ts
+++ b/packages/abstractions/src/ProtocolVersion.ts
@@ -80,9 +80,8 @@ export const MaxSupportedVersion = ProtocolVersion(BigInt(Number.MAX_SAFE_INTEGE
  *   the V2 variant on any v9-native chain.
  *
  *   Offered as a named value so applications and test suites pointed at a v9-native chain do not each invent a magic
- *   number. It is **not** a default: every wallet's `forks.v9` stays required, because the right value is a property of
- *   the chain an application points at. The final mainnet fork constant is still an open question; when it is fixed it
- *   will join this one here.
+ *   number; {@link V9NativeForkSchedule} is the schedule built from it. The final mainnet fork constant is still an open
+ *   question; when it is fixed it will join this one here.
  */
 export const V9NativeForkVersion: ProtocolVersion = ProtocolVersion(2_000_000n);
 
@@ -96,14 +95,26 @@ export const V9NativeForkVersion: ProtocolVersion = ProtocolVersion(2_000_000n);
  *   hard fork adds a key (`v10`) rather than changing this shape, which is what lets an application's configuration
  *   outlive the fork.
  *
- *   Every entry is required and none is defaulted, for the same reason a single fork version was: where a chain forks is
+ *   Every entry is required in the wallet packages, for the same reason a single fork version was: where a chain forks is
  *   a fact about the chain rather than the SDK, and a wrong guess does not degrade — it decides which ledger version
- *   reads the chain.
+ *   reads the chain. {@link V9NativeForkSchedule} names the schedule of a chain born on ledger-v9; only the facade
+ *   presets one, `DefaultForkSchedule`, and says there why.
  */
 export type ForkSchedule = Readonly<{
   /** The protocol version from which ledger-v9 reads the chain. */
   v9: ProtocolVersion;
 }>;
+
+/**
+ * The fork schedule of a chain born on ledger-v9: ledger-v9 from {@link V9NativeForkVersion}, and nothing else.
+ *
+ * @remarks
+ *   Offered as a named value for the same reason {@link V9NativeForkVersion} is: so applications and test suites pointed
+ *   at a v9-native chain do not each write the schedule out by hand. A named value and not a default — the wallet
+ *   packages still require `forks`. The facade's `DefaultForkSchedule` is this value, under the name of what the facade
+ *   presets.
+ */
+export const V9NativeForkSchedule: ForkSchedule = { v9: V9NativeForkVersion };
 
 /**
  * The range of protocol versions on the same side of a protocol boundary as a given version.

--- a/packages/abstractions/src/test/protocolVersion.test.ts
+++ b/packages/abstractions/src/test/protocolVersion.test.ts
@@ -69,3 +69,14 @@ describe('ForkSchedule', () => {
     expect(v8Scheduled).toBe(false);
   });
 });
+
+describe('V9NativeForkSchedule', () => {
+  it('has ledger-v9 begin at V9NativeForkVersion, and says nothing else', () => {
+    expect(ProtocolVersion.V9NativeForkSchedule).toStrictEqual({ v9: ProtocolVersion.V9NativeForkVersion });
+  });
+
+  it('is a ForkSchedule, so a configuration can name it where it would otherwise write the literal', () => {
+    const schedule: ProtocolVersion.ForkSchedule = ProtocolVersion.V9NativeForkSchedule;
+    expect(schedule.v9).toBe(ProtocolVersion.V9NativeForkVersion);
+  });
+});

--- a/packages/docs-snippets/src/snippets/dust-fast-sync.ts
+++ b/packages/docs-snippets/src/snippets/dust-fast-sync.ts
@@ -26,7 +26,6 @@ import {
   PublicKey,
   UnshieldedWallet,
   mergeWalletEntries,
-  ProtocolVersion,
 } from '@midnightntwrk/wallet-sdk';
 import { makeIndexerChainVersionProbe } from '@midnightntwrk/wallet-sdk/capabilities';
 import { V1Builder } from '@midnightntwrk/wallet-sdk/dust/v1';
@@ -46,9 +45,8 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
-  // The protocol version this chain hands over to ledger-v9 at. A 2.x node reports 2000000;
-  // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forks: { v9: ProtocolVersion.V9NativeForkVersion },
+  // `forks` is left out: the facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A
+  // chain that hands over elsewhere states its own `forks` here, which wins.
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/dust-fast-sync.ts
+++ b/packages/docs-snippets/src/snippets/dust-fast-sync.ts
@@ -45,8 +45,8 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
-  // `forks` is left out: the facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A
-  // chain that hands over elsewhere states its own `forks` here, which wins.
+  // The facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A chain that hands over
+  // elsewhere states its own `forks` here, which wins.
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/dust-fast-sync.ts
+++ b/packages/docs-snippets/src/snippets/dust-fast-sync.ts
@@ -45,8 +45,6 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
-  // The facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A chain that hands over
-  // elsewhere states its own `forks` here, which wins.
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
+++ b/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
@@ -38,8 +38,8 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
-  // `forks` is left out: the facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A
-  // chain that hands over elsewhere states its own `forks` here, which wins.
+  // The facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A chain that hands over
+  // elsewhere states its own `forks` here, which wins.
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
+++ b/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
@@ -38,8 +38,6 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
-  // The facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A chain that hands over
-  // elsewhere states its own `forks` here, which wins.
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
+++ b/packages/docs-snippets/src/snippets/ecdsa-initialization.ts
@@ -23,7 +23,6 @@ import {
   PublicKey,
   UnshieldedWallet,
   mergeWalletEntries,
-  ProtocolVersion,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import { pick } from 'lodash-es';
@@ -39,9 +38,8 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
-  // The protocol version this chain hands over to ledger-v9 at. A 2.x node reports 2000000;
-  // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forks: { v9: ProtocolVersion.V9NativeForkVersion },
+  // `forks` is left out: the facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A
+  // chain that hands over elsewhere states its own `forks` here, which wins.
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/hard-fork-support.ts
+++ b/packages/docs-snippets/src/snippets/hard-fork-support.ts
@@ -16,8 +16,9 @@
  *
  * The SDK runs one ledger version below the chain's `forks.v9` and another from it, and each of the three wallets
  * registers a variant either side. Nothing here is a migration an application performs: a wallet started from a seed
- * follows the chain across the boundary on its own. What an application does have to do is say where the boundary is,
- * read which side of it the wallets are on, and — if it authors its own transactions — author for the right side.
+ * follows the chain across the boundary on its own. What an application does have to do is read which side of the
+ * boundary the wallets are on and — if it authors its own transactions — author for the right side. Where the boundary
+ * is, the facade presets; only a chain that hands over elsewhere has to say so.
  *
  * This file is the copy-paste shape, in the order the code runs:
  *
@@ -35,8 +36,6 @@
  */
 import {
   createKeystore,
-  type DefaultConfiguration,
-  ProtocolVersion,
   DustWallet,
   InMemoryTransactionHistoryStorage,
   mergeWalletEntries,
@@ -63,11 +62,12 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 // 1. A proving backend per ledger version
 // ---------------------------------------------------------------------------------------------------------------------
 
-const configuration: DefaultConfiguration = {
+// Resolved up front, which fills in what the facade presets: `forks`, as `DefaultForkSchedule` — ledger-v9 from the
+// version a 2.x node reports. `WalletFacade.init` does the same for the factories it calls; it is done here as well
+// because step 5 uses a wallet package on its own, which has no preset and requires `forks`. A chain that hands over
+// elsewhere states its own `forks: { v9: ... }` in this object, which wins.
+const configuration = WalletFacade.resolveConfiguration({
   networkId: 'undeployed',
-  // The protocol version this chain hands over to ledger-v9 at. A 2.x node reports 2000000;
-  // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forks: { v9: ProtocolVersion.V9NativeForkVersion },
   costParameters: {
     feeBlocksMargin: 5,
   },
@@ -94,7 +94,7 @@ const configuration: DefaultConfiguration = {
     indexerWsUrl: INDEXER_WS_URL,
   },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
-};
+});
 
 // ---------------------------------------------------------------------------------------------------------------------
 // 2. The seed-first start

--- a/packages/docs-snippets/src/snippets/initialization.ts
+++ b/packages/docs-snippets/src/snippets/initialization.ts
@@ -37,8 +37,6 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
-  // The facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A chain that hands over
-  // elsewhere states its own `forks` here, which wins.
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/initialization.ts
+++ b/packages/docs-snippets/src/snippets/initialization.ts
@@ -37,8 +37,8 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
-  // `forks` is left out: the facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A
-  // chain that hands over elsewhere states its own `forks` here, which wins.
+  // The facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A chain that hands over
+  // elsewhere states its own `forks` here, which wins.
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/initialization.ts
+++ b/packages/docs-snippets/src/snippets/initialization.ts
@@ -22,7 +22,6 @@ import {
   PublicKey,
   UnshieldedWallet,
   mergeWalletEntries,
-  ProtocolVersion,
 } from '@midnightntwrk/wallet-sdk';
 import { Buffer } from 'buffer';
 import { pick } from 'lodash-es';
@@ -38,9 +37,8 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
-  // The protocol version this chain hands over to ledger-v9 at. A 2.x node reports 2000000;
-  // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forks: { v9: ProtocolVersion.V9NativeForkVersion },
+  // `forks` is left out: the facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A
+  // chain that hands over elsewhere states its own `forks` here, which wins.
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/wasm-prover.ts
+++ b/packages/docs-snippets/src/snippets/wasm-prover.ts
@@ -16,14 +16,13 @@
  * The bundled prover drives a zkir runtime over bytes and never looks at a ledger version, so — unlike a proof server,
  * which is built against one — the same description serves both ledger versions. Naming it under both `v8` and `v9`
  * covers the whole timeline: the SDK drives each side with its own ledger, and where one side ends and the other
- * begins is `forks.v9`, stated once.
+ * begins is `forks.v9`, which the facade presets.
  */
 import {
   WalletSeeds,
   type DefaultConfiguration,
   DustWallet,
   InMemoryTransactionHistoryStorage,
-  ProtocolVersion,
   WalletEntrySchema,
   WalletFacade,
   ShieldedWallet,
@@ -42,9 +41,8 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
-  // The protocol version this chain hands over to ledger-v9 at. A 2.x node reports 2000000;
-  // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forks: { v9: ProtocolVersion.V9NativeForkVersion },
+  // `forks` is left out: the facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A
+  // chain that hands over elsewhere states its own `forks` here, which wins.
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/wasm-prover.ts
+++ b/packages/docs-snippets/src/snippets/wasm-prover.ts
@@ -41,8 +41,6 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
-  // The facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A chain that hands over
-  // elsewhere states its own `forks` here, which wins.
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/snippets/wasm-prover.ts
+++ b/packages/docs-snippets/src/snippets/wasm-prover.ts
@@ -41,8 +41,8 @@ const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
 const configuration: DefaultConfiguration = {
   networkId: 'undeployed',
-  // `forks` is left out: the facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A
-  // chain that hands over elsewhere states its own `forks` here, which wins.
+  // The facade presets `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports. A chain that hands over
+  // elsewhere states its own `forks` here, which wins.
   costParameters: {
     feeBlocksMargin: 5,
   },

--- a/packages/docs-snippets/src/utils.ts
+++ b/packages/docs-snippets/src/utils.ts
@@ -12,7 +12,6 @@
 // limitations under the License.
 import type * as ledger from '@midnightntwrk/wallet-sdk/ledger/v9';
 import {
-  type DefaultConfiguration,
   DustWallet,
   InMemoryTransactionHistoryStorage,
   WalletEntrySchema,
@@ -24,7 +23,6 @@ import {
   type UnshieldedKeystore,
   WalletSeeds,
   mergeWalletEntries,
-  ProtocolVersion,
 } from '@midnightntwrk/wallet-sdk';
 import { type Buffer } from 'buffer';
 
@@ -37,11 +35,11 @@ const V8_PROOF_SERVER_PORT = Number.parseInt(process.env['V8_PROOF_SERVER_PORT']
 const INDEXER_HTTP_URL = `http://localhost:${INDEXER_PORT}/api/v4/graphql`;
 const INDEXER_WS_URL = `ws://localhost:${INDEXER_PORT}/api/v4/graphql/ws`;
 
-export const configuration: DefaultConfiguration = {
+// Resolved up front rather than left to `WalletFacade.init`, which does the same for the factories it calls: the
+// snippets read `forks` back to choose which ledger version authors a transaction, and `init` takes the resolved
+// configuration as it is.
+export const configuration = WalletFacade.resolveConfiguration({
   networkId: 'undeployed',
-  // The protocol version this chain hands over to ledger-v9 at. A 2.x node reports 2000000;
-  // the final mainnet fork constant is not yet fixed, so this is supplied per environment.
-  forks: { v9: ProtocolVersion.V9NativeForkVersion },
   costParameters: {
     feeBlocksMargin: 5,
   },
@@ -58,7 +56,7 @@ export const configuration: DefaultConfiguration = {
     indexerWsUrl: INDEXER_WS_URL,
   },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
-};
+});
 
 export const initWalletWithSeed = async (
   seed: Buffer,

--- a/packages/e2e-tests/src/tests/dustDeregistration.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dustDeregistration.undeployed.test.ts
@@ -83,7 +83,7 @@ describe('Dust Deregistration', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
+      forks: ProtocolVersion.V9NativeForkSchedule,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/dustRegistration.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/dustRegistration.undeployed.test.ts
@@ -91,7 +91,7 @@ describe('Dust Registration', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
+      forks: ProtocolVersion.V9NativeForkSchedule,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/facadeTransfer.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/facadeTransfer.undeployed.test.ts
@@ -92,7 +92,7 @@ describe('Wallet Facade Transfer', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
+      forks: ProtocolVersion.V9NativeForkSchedule,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/optionalBalancing.undeployed.test.ts
@@ -99,7 +99,7 @@ describe('Optional Balancing', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
+      forks: ProtocolVersion.V9NativeForkSchedule,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/swap.undeployed.test.ts
+++ b/packages/e2e-tests/src/tests/swap.undeployed.test.ts
@@ -95,7 +95,7 @@ describe('Swaps', () => {
         `ws://127.0.0.1:${startedEnvironment.getContainer(`node_${environmentId}`).getMappedPort(9944)}`,
       ),
       networkId: NetworkId.NetworkId.Undeployed,
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
+      forks: ProtocolVersion.V9NativeForkSchedule,
       costParameters: {
         feeBlocksMargin: 5,
       },

--- a/packages/e2e-tests/src/tests/test-fixture.ts
+++ b/packages/e2e-tests/src/tests/test-fixture.ts
@@ -246,10 +246,9 @@ export class TestContainersFixture {
       relayURL: new URL(this.getNodeUri()),
       networkId: this.getNetworkId(),
       txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
-      // Every environment these suites run against is on the ledger-v9-native node line, which reports
-      // this protocol version, so the wallet reaches its V2 variant. Defined once here rather than
-      // at each construction site; the final mainnet fork constant is still an open question.
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
+      // Every environment these suites run against is on the ledger-v9-native node line, so the wallet reaches its V2
+      // variant; the final mainnet fork constant is still an open question.
+      forks: ProtocolVersion.V9NativeForkSchedule,
     };
   }
 

--- a/packages/facade/README.md
+++ b/packages/facade/README.md
@@ -40,6 +40,18 @@ const facade = new WalletFacade(shieldedWallet, unshieldedWallet, dustWallet);
 await facade.start(shieldedSecretKeys, dustSecretKey);
 ```
 
+### Where the chain forks
+
+Every configuration in the SDK carries `forks`, the protocol version from which each ledger version after the first
+reads the chain. The wallet packages require it, because where a chain forks is a fact about the chain. The facade
+presets it: left out of the configuration handed to `WalletFacade.init`, `forks` becomes `DefaultForkSchedule` —
+`ProtocolVersion.V9NativeForkSchedule`, ledger-v9 from the version a 2.x node reports — and every factory in
+`InitParams` is handed the configuration with it filled in, typed `ResolvedConfiguration`. That is why
+`shielded: (config) => ShieldedWallet(config)` compiles against a wallet package that requires the field. Code outside a
+factory that needs the same configuration — to build a wallet package directly, or to read `forks` back — gets it from
+`WalletFacade.resolveConfiguration(configuration)`, and may hand the result to `init` as it is. A chain that hands over
+elsewhere states its own `forks`, which wins.
+
 ### Configuring where proving happens
 
 A transaction is proved by the backend for the ledger version that authored its bytes, never by the version the chain
@@ -48,7 +60,7 @@ off `forks` rather than restated:
 
 ```typescript
 const configuration = {
-  // ... the rest of the wallet configuration, including `forks: { v9 }`
+  // ... the rest of the wallet configuration; `forks` may be left out, the facade presets `DefaultForkSchedule`
   provers: {
     // Below `forks.v9`: a proof server built against ledger-v8.
     v8: { kind: 'server', url: new URL('http://localhost:6301') },

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -705,12 +705,54 @@ export type FetchTermsAndConditionsConfiguration = {
   };
 };
 
-export type DefaultConfiguration = DefaultUnshieldedConfiguration &
+/**
+ * The fork schedule the facade presets when a configuration names none: {@link ProtocolVersion.V9NativeForkSchedule},
+ * ledger-v9 from the version a 2.x node reports.
+ *
+ * @remarks
+ *   Where a chain forks is a fact about the chain, which is why each wallet package requires `forks` and presets nothing.
+ *   The facade is the one place a preset decides nothing the SDK has not already decided: every chain the 2.x node line
+ *   runs hands over at this version, so an application copying the constant into its configuration only restates it. A
+ *   chain that hands over elsewhere states its own `forks`, which wins.
+ */
+export const DefaultForkSchedule: ProtocolVersion.ForkSchedule = ProtocolVersion.V9NativeForkSchedule;
+
+/** What the three wallets and the default services are built from, as the wallet packages take it. */
+type WalletsConfiguration = DefaultUnshieldedConfiguration &
   DefaultShieldedConfiguration &
   DefaultDustConfiguration &
   DefaultSubmissionConfiguration &
   DefaultPendingTransactionsServiceConfiguration &
   DefaultProvingConfiguration;
+
+/**
+ * The configuration {@link WalletFacade.init} takes: what the three wallets and the default services are built from.
+ *
+ * @remarks
+ *   The one difference from the wallets' own configurations is that `forks` may be left out — see
+ *   {@link DefaultForkSchedule} for what is then preset, and {@link ResolvedConfiguration} for what a factory is handed.
+ */
+export type DefaultConfiguration = Omit<WalletsConfiguration, 'forks'> & {
+  /**
+   * Where each ledger version begins on this chain — see {@link ProtocolVersion.ForkSchedule}. Left out, the facade
+   * presets {@link DefaultForkSchedule}.
+   */
+  forks?: ProtocolVersion.ForkSchedule;
+};
+
+/**
+ * A {@link DefaultConfiguration} with what the facade presets filled in: `forks` is always present, the schedule the
+ * configuration named or {@link DefaultForkSchedule}.
+ *
+ * @remarks
+ *   What every factory in {@link InitParams} is handed, so that a wallet can be built from it directly: the wallet
+ *   packages require `forks`, and this is what lets `shielded: (config) => ShieldedWallet(config)` compile. Code
+ *   outside a factory gets the same from {@link WalletFacade.resolveConfiguration}.
+ * @typeParam TConfig The configuration as given, which may extend {@link DefaultConfiguration} with settings of its own.
+ */
+export type ResolvedConfiguration<TConfig extends DefaultConfiguration = DefaultConfiguration> = TConfig & {
+  forks: ProtocolVersion.ForkSchedule;
+};
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -718,30 +760,32 @@ type MaybePromise<T> = T | Promise<T>;
  * Parameters object for {@link WalletFacade.init}. It features configuration and bunch of initializers for the wallets
  * and services, all of them are in a form of a function that takes the configuration and returns proper implementation,
  * either synchronously or wrapped in a Promise. Services are optional to provide ({@link WalletFacade.init} will provide
- * default implementations), but all 3 wallets: shielded, unshielded and Dust one need to be present
+ * default implementations), but all 3 wallets: shielded, unshielded and Dust one need to be present.
  */
 export type InitParams<TConfig extends DefaultConfiguration> = {
   configuration: TConfig;
   /** Optional factory for the clock abstraction. Defaults to system clock (`() => new Date()`). */
-  clock?: (config: TConfig) => MaybePromise<Clock.Clock>;
-  submissionService?: (config: TConfig) => MaybePromise<SubmissionService<FinalizedTx>>;
-  pendingTransactionsService?: (config: TConfig) => MaybePromise<PendingTransactionsService<FinalizedTx>>;
+  clock?: (config: ResolvedConfiguration<TConfig>) => MaybePromise<Clock.Clock>;
+  submissionService?: (config: ResolvedConfiguration<TConfig>) => MaybePromise<SubmissionService<FinalizedTx>>;
+  pendingTransactionsService?: (
+    config: ResolvedConfiguration<TConfig>,
+  ) => MaybePromise<PendingTransactionsService<FinalizedTx>>;
   provingService?: (
-    config: TConfig,
+    config: ResolvedConfiguration<TConfig>,
   ) => MaybePromise<VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction>>;
   /**
    * Optional factory for the block-data fetcher used by validation. Defaults to an HTTP indexer-backed fetcher built
    * from `configuration.indexerClientConnection`. Override for simulator-based tests with
    * `makeSimulatorBlockDataFetcher(simulator)` from `@midnightntwrk/wallet-sdk-capabilities/validation`.
    */
-  fetchBlockData?: (config: TConfig) => MaybePromise<BlockDataFetcher>;
+  fetchBlockData?: (config: ResolvedConfiguration<TConfig>) => MaybePromise<BlockDataFetcher>;
   validationService?: (
-    config: TConfig,
+    config: ResolvedConfiguration<TConfig>,
     deps: { fetchBlockData: BlockDataFetcher; clock: Clock.Clock },
   ) => MaybePromise<VersionedValidationService<AnyVersionValidatableTransaction, AnyLedgerParameters>>;
-  shielded: (config: TConfig) => MaybePromise<ShieldedWalletAPI>;
-  unshielded: (config: TConfig) => MaybePromise<UnshieldedWalletAPI>;
-  dust: (config: TConfig) => MaybePromise<DustWalletAPI>;
+  shielded: (config: ResolvedConfiguration<TConfig>) => MaybePromise<ShieldedWalletAPI>;
+  unshielded: (config: ResolvedConfiguration<TConfig>) => MaybePromise<UnshieldedWalletAPI>;
+  dust: (config: ResolvedConfiguration<TConfig>) => MaybePromise<DustWalletAPI>;
 };
 
 // `BlockData` is not re-exported from the facade to avoid a name collision with the
@@ -782,12 +826,38 @@ export class WalletFacade {
    *   transaction belongs to and the two ends of that question must not be able to compute the boundary differently.
    */
   private static makeDefaultProvingService<TConfig extends DefaultConfiguration>(
-    config: TConfig,
+    config: ResolvedConfiguration<TConfig>,
   ): VersionedProvingService<AnyVersionUnboundTransaction, AnyVersionUnprovenTransaction> {
     return Either.getOrThrowWith(
       makeDefaultVersionedProvingService(config, config.forks),
       (error) => new Error(error.message),
     );
+  }
+
+  /**
+   * Fills in what the facade presets — `forks`, as {@link DefaultForkSchedule} — so that the result is a configuration a
+   * wallet package can be built from.
+   *
+   * @remarks
+   *   {@link WalletFacade.init} does this itself, once and before anything is built, so the wallets, the default services
+   *   and the facade's own boundary cannot be given different schedules, and no factory needs to call it. It is public
+   *   for code outside a factory that needs the configuration the facade will use: an application building a wallet
+   *   package directly, or reading `forks` back to author a transaction for the right ledger version. Resolving twice
+   *   is the same as resolving once, so `init` may be handed the result.
+   * @example
+   *   ```typescript
+   *   const configuration = WalletFacade.resolveConfiguration({ networkId: 'undeployed', ... });
+   *   const facade = await WalletFacade.init({ configuration, shielded: (config) => ShieldedWallet(config), ... });
+   *   const authoredForV9 = protocolVersion >= configuration.forks.v9;
+   *   ```;
+   *
+   * @param configuration The configuration as given, with or without `forks`.
+   * @returns The same configuration with `forks` present: the schedule it named, or {@link DefaultForkSchedule}.
+   */
+  static resolveConfiguration<TConfig extends DefaultConfiguration>(
+    configuration: TConfig,
+  ): ResolvedConfiguration<TConfig> {
+    return { ...configuration, forks: configuration.forks ?? DefaultForkSchedule };
   }
 
   /**
@@ -827,7 +897,9 @@ export class WalletFacade {
    * and initialization of necessary components. Specifically - it requires following fields:
    *
    * - `configuration` - holding a configuration, which needs to extend {@link DefaultConfiguration} - this way allows to
-   *   convey use-case-specific settings in the same way, as the SDK works by default
+   *   convey use-case-specific settings in the same way, as the SDK works by default. `forks` may be left out; every
+   *   factory below is handed a {@link ResolvedConfiguration}, which always has it — what
+   *   {@link WalletFacade.resolveConfiguration} returns
    * - `shielded` - a function taking the configuration and returning shielded wallet (or a promise with such)
    *   implementing {@link ShieldedWalletAPI}
    * - `unshielded` - a function taking the configuration and returning unshielded wallet (or a promise with such)
@@ -845,42 +917,39 @@ export class WalletFacade {
    * - `clock` - needs to implement {@link Clock.Clock} for getting current time, default uses system clock
    */
   static async init<TConfig extends DefaultConfiguration>(initParams: InitParams<TConfig>): Promise<WalletFacade> {
+    const configuration = WalletFacade.resolveConfiguration(initParams.configuration);
     const submissionService = await Promise.resolve(
       initParams.submissionService
-        ? initParams.submissionService(initParams.configuration)
-        : WalletFacade.makeDefaultSubmissionService(initParams.configuration),
+        ? initParams.submissionService(configuration)
+        : WalletFacade.makeDefaultSubmissionService(configuration),
     );
     const pendingTransactionsService = await Promise.resolve(
       initParams.pendingTransactionsService
-        ? initParams.pendingTransactionsService(initParams.configuration)
-        : WalletFacade.makeDefaultPendingTransactionsService(initParams.configuration),
+        ? initParams.pendingTransactionsService(configuration)
+        : WalletFacade.makeDefaultPendingTransactionsService(configuration),
     );
     const provingService = await Promise.resolve(
       initParams.provingService
-        ? initParams.provingService(initParams.configuration)
-        : WalletFacade.makeDefaultProvingService(initParams.configuration),
+        ? initParams.provingService(configuration)
+        : WalletFacade.makeDefaultProvingService(configuration),
     );
-    const shielded = await Promise.resolve(initParams.shielded(initParams.configuration));
-    const unshielded = await Promise.resolve(initParams.unshielded(initParams.configuration));
-    const dust = await Promise.resolve(initParams.dust(initParams.configuration));
-    const clock = await Promise.resolve(
-      initParams.clock ? initParams.clock(initParams.configuration) : Clock.systemClock,
-    );
+    const shielded = await Promise.resolve(initParams.shielded(configuration));
+    const unshielded = await Promise.resolve(initParams.unshielded(configuration));
+    const dust = await Promise.resolve(initParams.dust(configuration));
+    const clock = await Promise.resolve(initParams.clock ? initParams.clock(configuration) : Clock.systemClock);
     const fetchBlockData: BlockDataFetcher = await Promise.resolve(
-      initParams.fetchBlockData
-        ? initParams.fetchBlockData(initParams.configuration)
-        : makeDefaultBlockDataFetcher(initParams.configuration),
+      initParams.fetchBlockData ? initParams.fetchBlockData(configuration) : makeDefaultBlockDataFetcher(configuration),
     );
     const validationService = await Promise.resolve(
       initParams.validationService
-        ? initParams.validationService(initParams.configuration, { fetchBlockData, clock })
+        ? initParams.validationService(configuration, { fetchBlockData, clock })
         : makeDefaultVersionedValidationService(
             {
               fetchBlockData,
-              networkId: initParams.configuration.networkId,
+              networkId: configuration.networkId,
               clock,
             },
-            initParams.configuration.forks.v9,
+            configuration.forks.v9,
           ),
     );
     return new WalletFacade(
@@ -891,8 +960,8 @@ export class WalletFacade {
       pendingTransactionsService,
       provingService,
       validationService,
-      initParams.configuration.txHistoryStorage,
-      initParams.configuration.forks.v9,
+      configuration.txHistoryStorage,
+      configuration.forks.v9,
       clock,
     );
   }

--- a/packages/facade/test/forkSchedule.test.ts
+++ b/packages/facade/test/forkSchedule.test.ts
@@ -11,18 +11,233 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/** The facade asks for the fork schedule in the shape the wallets do, and for nothing the wallets no longer take. */
-import { type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+/**
+ * The facade asks for the fork schedule in the shape the wallets do, for nothing the wallets no longer take — and,
+ * alone among the SDK's configurations, lets it be left out: it then presets {@link DefaultForkSchedule} and hands the
+ * filled-in configuration to every factory. Why the preset sits in the facade and nowhere lower is documented on the
+ * constant.
+ */
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
+import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
+import { PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
+import { Clock } from '@midnightntwrk/wallet-sdk-utilities';
 import { type Equal, type Expect } from '@midnightntwrk/wallet-sdk-utilities/types';
-import { describe, it } from 'vitest';
-import { type DefaultConfiguration } from '../src/index.js';
+import * as rx from 'rxjs';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  type BlockDataFetcher,
+  type DefaultConfiguration,
+  DefaultForkSchedule,
+  type InitParams,
+  type ResolvedConfiguration,
+  WalletEntrySchema,
+  WalletFacade,
+  mergeWalletEntries,
+} from '../src/index.js';
+
+import {
+  createV8MockProvingService,
+  deriveWalletKeys,
+  drivenBy,
+  dustAt,
+  shieldedAt,
+  SilentPendingTransactions,
+  unshieldedAt,
+} from './utils/index.js';
+
+/** A configuration that says nothing about where the chain forks. */
+const configuration = {
+  networkId: NetworkId.NetworkId.Undeployed,
+  relayURL: new URL('http://localhost:9944'),
+  indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
+  provingServerUrl: new URL('http://localhost:6300'),
+  costParameters: { feeBlocksMargin: 0 },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
+} satisfies DefaultConfiguration;
 
 describe('DefaultConfiguration', () => {
   it('states where each ledger version begins as `forks`, one key per ledger version after the first', () => {
-    type _1 = Expect<Equal<DefaultConfiguration['forks'], ProtocolVersion.ForkSchedule>>;
+    type _1 = Expect<Equal<DefaultConfiguration['forks'], ProtocolVersion.ForkSchedule | undefined>>;
+  });
+
+  it('lets `forks` be left out, which no wallet configuration does', () => {
+    type _1 = Expect<Equal<Pick<DefaultConfiguration, 'forks'>, { forks?: ProtocolVersion.ForkSchedule }>>;
+    type _2 = Expect<Equal<InitParams<DefaultConfiguration>['configuration'], DefaultConfiguration>>;
   });
 
   it('no longer takes a single fork version', () => {
     type _1 = Expect<Equal<'forkVersion' extends keyof DefaultConfiguration ? true : false, false>>;
+  });
+});
+
+describe('DefaultForkSchedule', () => {
+  it('has ledger-v9 begin at the version a 2.x node reports, and says nothing else', () => {
+    expect(DefaultForkSchedule).toStrictEqual({ v9: ProtocolVersion.V9NativeForkVersion });
+  });
+
+  it('is the schedule of a chain born on ledger-v9, as the abstractions package names it', () => {
+    expect(DefaultForkSchedule).toBe(ProtocolVersion.V9NativeForkSchedule);
+  });
+});
+
+describe('ResolvedConfiguration', () => {
+  it('is the configuration given, with `forks` always present', () => {
+    type _1 = Expect<Equal<ResolvedConfiguration['forks'], ProtocolVersion.ForkSchedule>>;
+
+    type Custom = DefaultConfiguration & { readonly appSetting: string };
+    type _2 = Expect<Equal<ResolvedConfiguration<Custom>['appSetting'], string>>;
+    type _3 = Expect<Equal<ResolvedConfiguration<Custom>['forks'], ProtocolVersion.ForkSchedule>>;
+  });
+
+  it('is what every factory in InitParams is handed', () => {
+    type Factories = Required<Omit<InitParams<DefaultConfiguration>, 'configuration'>>;
+    // `Parameters` distributes over the union of factories, and a union of identical types is one type: a factory handed
+    // anything else would keep the union apart. Derived from `InitParams`, so a factory added later is covered too.
+    type _1 = Expect<Equal<Parameters<Factories[keyof Factories]>[0], ResolvedConfiguration>>;
+  });
+});
+
+describe('WalletFacade.resolveConfiguration', () => {
+  it('fills in `DefaultForkSchedule` when the configuration names no `forks`', () => {
+    const resolved = WalletFacade.resolveConfiguration(configuration);
+
+    expect(resolved).toStrictEqual({ ...configuration, forks: DefaultForkSchedule });
+    expect(resolved.forks).toBe(DefaultForkSchedule);
+  });
+
+  it('leaves the `forks` a configuration does name untouched', () => {
+    const forks: ProtocolVersion.ForkSchedule = { v9: ProtocolVersion.ProtocolVersion(7n) };
+
+    const resolved = WalletFacade.resolveConfiguration({ ...configuration, forks });
+
+    expect(resolved.forks).toBe(forks);
+  });
+
+  it('keeps the settings a configuration adds, and types the result as `ResolvedConfiguration` of them', () => {
+    const custom = { ...configuration, appSetting: 'kept' };
+
+    const resolved = WalletFacade.resolveConfiguration(custom);
+
+    type _1 = Expect<Equal<typeof resolved, ResolvedConfiguration<typeof custom>>>;
+    expect(resolved.appSetting).toBe('kept');
+  });
+
+  it('is idempotent, so `init` may be handed a configuration that is already resolved', () => {
+    const once = WalletFacade.resolveConfiguration(configuration);
+
+    expect(WalletFacade.resolveConfiguration(once)).toStrictEqual(once);
+  });
+});
+
+describe('WalletFacade.init', () => {
+  const facades: WalletFacade[] = [];
+
+  afterEach(async () => {
+    await Promise.allSettled(facades.splice(0).map((facade) => facade.stop()));
+  });
+
+  const keys = deriveWalletKeys(
+    '0000000000000000000000000000000000000000000000000000000000000003',
+    configuration.networkId,
+  );
+
+  /** Services the facade never reaches here, present so that their factories are handed a configuration too. */
+  const unusedSubmission: WalletFacade['submissionService'] = {
+    submitTransaction: (): Promise<never> => Promise.reject(new Error('not under test')),
+    close: () => Promise.resolve(),
+  };
+  const unusedBlockData: BlockDataFetcher = () => Promise.reject(new Error('not under test'));
+  const unusedValidation: WalletFacade['validationService'] = { validateTx: () => Promise.resolve() };
+
+  /** One per factory in {@link InitParams}: the three wallets and the six services. */
+  const factoryCount = 9;
+
+  /**
+   * Builds a facade from the configuration each factory is handed, and returns what each was handed.
+   *
+   * @remarks
+   *   The wallets are real and shipped, built the way an application builds them — from the factory's own argument — and
+   *   never started, since this suite has no indexer to subscribe to.
+   */
+  const initRecording = async (given: DefaultConfiguration): Promise<readonly ResolvedConfiguration[]> => {
+    const handed: ResolvedConfiguration[] = [];
+    const recording =
+      <T>(make: (config: ResolvedConfiguration) => T) =>
+      (config: ResolvedConfiguration): T => {
+        handed.push(config);
+        return make(config);
+      };
+
+    const facade = await WalletFacade.init({
+      configuration: given,
+      shielded: recording((config) => ShieldedWallet(config).startWithSeed(keys.seeds.shielded)),
+      unshielded: recording((config) =>
+        UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(keys.unshieldedKeystore)),
+      ),
+      dust: recording((config) => DustWallet(config).startWithSeed(keys.seeds.dust)),
+      clock: recording(() => Clock.systemClock),
+      submissionService: recording(() => unusedSubmission),
+      pendingTransactionsService: recording(() => new SilentPendingTransactions()),
+      provingService: recording(() => createV8MockProvingService()),
+      fetchBlockData: recording(() => unusedBlockData),
+      validationService: recording(() => unusedValidation),
+    });
+    facades.push(facade);
+    return handed;
+  };
+
+  it('hands every factory the configuration with `DefaultForkSchedule` filled in, when it names no `forks`', async () => {
+    const handed = await initRecording(configuration);
+
+    expect(handed).toHaveLength(factoryCount);
+    handed.forEach((config) => expect(config).toStrictEqual({ ...configuration, forks: DefaultForkSchedule }));
+  });
+
+  it('hands every factory the `forks` a configuration does name, untouched', async () => {
+    const forks: ProtocolVersion.ForkSchedule = { v9: ProtocolVersion.ProtocolVersion(7n) };
+
+    const handed = await initRecording({ ...configuration, forks });
+
+    expect(handed).toHaveLength(factoryCount);
+    handed.forEach((config) => expect(config.forks).toBe(forks));
+  });
+
+  it('reads the protocol phase against the preset boundary', async () => {
+    // Real, shipped wallets, never started, whose state streams this test drives (see `drivenStates.ts`). Built here
+    // rather than by the facade so the streams are in place before the facade subscribes to them; the schedule they
+    // are built with is immaterial, since what is under test is the boundary the facade reads their versions against.
+    const walletConfiguration = { ...configuration, forks: DefaultForkSchedule };
+    const shielded = await ShieldedWallet(walletConfiguration).startWithSeed(keys.seeds.shielded);
+    const unshielded = await UnshieldedWallet(walletConfiguration).startWithPublicKey(
+      PublicKey.fromKeyStore(keys.unshieldedKeystore),
+    );
+    const dust = await DustWallet(walletConfiguration).startWithSeed(keys.seeds.dust);
+    const boundary = ProtocolVersion.V9NativeForkVersion;
+    const below = ProtocolVersion.ProtocolVersion(boundary - 1n);
+    drivenBy(shielded, rx.of(shieldedAt(await rx.firstValueFrom(shielded.state), boundary)));
+    drivenBy(unshielded, rx.of(unshieldedAt(await rx.firstValueFrom(unshielded.state), below)));
+    drivenBy(dust, rx.of(dustAt(await rx.firstValueFrom(dust.state), below)));
+
+    const facade = await WalletFacade.init({
+      configuration,
+      shielded: () => shielded,
+      unshielded: () => unshielded,
+      dust: () => dust,
+      provingService: () => createV8MockProvingService(),
+      pendingTransactionsService: () => new SilentPendingTransactions(),
+    });
+    facades.push(facade);
+
+    const observed = await rx.firstValueFrom(facade.state());
+
+    // One wallet exactly at the version a 2.x node reports and two just below it is a crossing only if the boundary is
+    // there: read against the minimum or maximum supported version, the same three would be settled.
+    expect(observed.protocol).toStrictEqual({
+      _tag: 'Crossing',
+      from: below,
+      to: boundary,
+      behind: ['unshielded', 'dust'],
+    });
   });
 });

--- a/packages/facade/test/lateVerdictAcrossFork.test.ts
+++ b/packages/facade/test/lateVerdictAcrossFork.test.ts
@@ -37,8 +37,7 @@ import {
   WalletTransaction,
   type FinalizedTx,
 } from '@midnightntwrk/wallet-sdk-abstractions';
-import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
-import type { PendingTransactionsService } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
+import { type PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import type { SubmissionService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { DustWallet, type DustWalletState } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { ShieldedWallet, type ShieldedWalletState } from '@midnightntwrk/wallet-sdk-shielded';
@@ -52,7 +51,7 @@ import { DateTime, Option } from 'effect';
 import * as rx from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  type DefaultConfiguration,
+  type ResolvedConfiguration,
   WalletEntrySchema,
   WalletFacade,
   isPendingWalletEntry,
@@ -67,6 +66,7 @@ import {
   getShieldedSeed,
   getUnshieldedSeed,
   shieldedAt,
+  SilentPendingTransactions,
   sleep,
   unshieldedAt,
 } from './utils/index.js';
@@ -81,34 +81,11 @@ const v8Version = ProtocolVersion.ProtocolVersion(3n);
 const v9Version = ProtocolVersion.ProtocolVersion(forkVersion + 1n);
 
 /** A pending service the suite drives: the facade's reaction to a verdict is what is under test, not the polling. */
-class DrivenPendingTransactions implements PendingTransactionsService<FinalizedTx> {
+class DrivenPendingTransactions extends SilentPendingTransactions {
   readonly cleared: FinalizedTx[] = [];
-  readonly states = new rx.BehaviorSubject<PendingTransactions.PendingTransactions<FinalizedTx>>(
-    PendingTransactions.empty(),
-  );
 
-  start(): Promise<void> {
-    return Promise.resolve();
-  }
-
-  stop(): Promise<void> {
-    return Promise.resolve();
-  }
-
-  state(): rx.Observable<PendingTransactions.PendingTransactions<FinalizedTx>> {
-    return this.states.asObservable();
-  }
-
-  addPendingTransaction(): Promise<void> {
-    return Promise.resolve();
-  }
-
-  clear(tx: FinalizedTx): Promise<void> {
+  override clear(tx: FinalizedTx): Promise<void> {
     this.cleared.push(tx);
-    return Promise.resolve();
-  }
-
-  orphanBeyond(): Promise<void> {
     return Promise.resolve();
   }
 }
@@ -129,7 +106,7 @@ const acceptingSubmission: SubmissionService<FinalizedTx> = {
 };
 
 describe('a verdict that arrives after the wallets have crossed the boundary', () => {
-  let configuration: DefaultConfiguration;
+  let configuration: ResolvedConfiguration;
   let facade: WalletFacade;
   let pending: DrivenPendingTransactions;
   let shieldedStates: rx.BehaviorSubject<ShieldedWalletState>;

--- a/packages/facade/test/orphanOnFork.test.ts
+++ b/packages/facade/test/orphanOnFork.test.ts
@@ -22,18 +22,23 @@ import {
   WalletTransaction,
   type FinalizedTx,
 } from '@midnightntwrk/wallet-sdk-abstractions';
-import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
-import type { PendingTransactionsService } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { createKeystore, PublicKey, UnshieldedWallet } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { DateTime, Option } from 'effect';
 import * as rx from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { type DefaultConfiguration, WalletEntrySchema, WalletFacade, mergeWalletEntries } from '../src/index.js';
+import { type ResolvedConfiguration, WalletEntrySchema, WalletFacade, mergeWalletEntries } from '../src/index.js';
 import { finalizedTransactionTraits } from '../src/transaction.js';
 
-import { createV8MockProvingService, getDustSeed, getShieldedSeed, getUnshieldedSeed, sleep } from './utils/index.js';
+import {
+  createV8MockProvingService,
+  getDustSeed,
+  getShieldedSeed,
+  getUnshieldedSeed,
+  SilentPendingTransactions,
+  sleep,
+} from './utils/index.js';
 
 vi.setConfig({ testTimeout: 20_000, hookTimeout: 120_000 });
 
@@ -47,25 +52,10 @@ type Recorded = Readonly<{
  * A pending-transactions service the test drives directly: it records what the facade asks of it, and lets the test
  * push a pending state so the facade's reaction to an orphaned entry is observable without a real fork.
  */
-class RecordingPendingTransactions implements PendingTransactionsService<FinalizedTx> {
+class RecordingPendingTransactions extends SilentPendingTransactions {
   readonly recorded: Recorded = { added: [], cleared: [], orphanedBeyond: [] };
-  readonly states = new rx.BehaviorSubject<PendingTransactions.PendingTransactions<FinalizedTx>>(
-    PendingTransactions.empty(),
-  );
 
-  start(): Promise<void> {
-    return Promise.resolve();
-  }
-
-  stop(): Promise<void> {
-    return Promise.resolve();
-  }
-
-  state(): rx.Observable<PendingTransactions.PendingTransactions<FinalizedTx>> {
-    return this.states.asObservable();
-  }
-
-  addPendingTransaction(
+  override addPendingTransaction(
     tx: FinalizedTx,
     protocolVersion: Option.Option<ProtocolVersion.ProtocolVersion>,
   ): Promise<void> {
@@ -73,19 +63,19 @@ class RecordingPendingTransactions implements PendingTransactionsService<Finaliz
     return Promise.resolve();
   }
 
-  clear(tx: FinalizedTx): Promise<void> {
+  override clear(tx: FinalizedTx): Promise<void> {
     this.recorded.cleared.push(tx);
     return Promise.resolve();
   }
 
-  orphanBeyond(chainNow: ProtocolVersion.ProtocolVersion): Promise<void> {
+  override orphanBeyond(chainNow: ProtocolVersion.ProtocolVersion): Promise<void> {
     this.recorded.orphanedBeyond.push(chainNow);
     return Promise.resolve();
   }
 }
 
 describe('A pending transaction the fork left behind', () => {
-  let configuration: DefaultConfiguration;
+  let configuration: ResolvedConfiguration;
   let facade: WalletFacade;
   let shielded: ShieldedWallet;
   let unshielded: UnshieldedWallet;
@@ -93,15 +83,14 @@ describe('A pending transaction the fork left behind', () => {
   let pending: RecordingPendingTransactions;
 
   beforeEach(async () => {
-    configuration = {
+    configuration = WalletFacade.resolveConfiguration({
       networkId: NetworkId.NetworkId.Undeployed,
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServerUrl: new URL('http://localhost:6300'),
       costParameters: { feeBlocksMargin: 0 },
       txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
-    };
+    });
     const seed = '0000000000000000000000000000000000000000000000000000000000000001';
     const shieldedSeed = getShieldedSeed(seed);
     const unshieldedSeed = getUnshieldedSeed(seed);

--- a/packages/facade/test/pendingTransactions.test.ts
+++ b/packages/facade/test/pendingTransactions.test.ts
@@ -25,23 +25,22 @@ import { ShieldedWallet } from '@midnightntwrk/wallet-sdk-shielded';
 import { DustWallet } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import * as ledgerV8 from '@midnight-ntwrk/ledger-v8';
 import * as ledgerV9 from '@midnightntwrk/ledger-v9';
-import { type DefaultConfiguration, WalletEntrySchema, WalletFacade, mergeWalletEntries } from '../src/index.js';
+import { type ResolvedConfiguration, WalletEntrySchema, WalletFacade, mergeWalletEntries } from '../src/index.js';
 import { createV8MockProvingService, getDustSeed, getShieldedSeed, getUnshieldedSeed, sleep } from './utils/index.js';
 import * as rx from 'rxjs';
 
 vi.setConfig({ testTimeout: 20_000, hookTimeout: 120_000 });
 
 describe('Wallet Facade handling pending transactions', () => {
-  let configuration: DefaultConfiguration;
+  let configuration: ResolvedConfiguration;
 
   let facade: WalletFacade;
   let shielded: ShieldedWallet;
   let unshielded: UnshieldedWallet;
   let dust: DustWallet;
   beforeEach(async () => {
-    configuration = {
+    configuration = WalletFacade.resolveConfiguration({
       networkId: NetworkId.NetworkId.Undeployed,
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -51,7 +50,7 @@ describe('Wallet Facade handling pending transactions', () => {
         feeBlocksMargin: 0,
       },
       txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
-    };
+    });
     const seed = '0000000000000000000000000000000000000000000000000000000000000001';
     const shieldedSeed = getShieldedSeed(seed);
     const unshieldedSeed = getUnshieldedSeed(seed);

--- a/packages/facade/test/protocolPhaseWiring.test.ts
+++ b/packages/facade/test/protocolPhaseWiring.test.ts
@@ -33,14 +33,7 @@
  */
 
 import * as ledger from '@midnightntwrk/ledger-v9';
-import {
-  InMemoryTransactionHistoryStorage,
-  NetworkId,
-  ProtocolVersion,
-  type FinalizedTx,
-} from '@midnightntwrk/wallet-sdk-abstractions';
-import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
-import type { PendingTransactionsService } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
+import { InMemoryTransactionHistoryStorage, NetworkId, ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustWallet, type DustWalletState } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { ShieldedWallet, type ShieldedWalletState } from '@midnightntwrk/wallet-sdk-shielded';
 import {
@@ -52,7 +45,7 @@ import {
 import { Option } from 'effect';
 import * as rx from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { type DefaultConfiguration, WalletEntrySchema, WalletFacade, mergeWalletEntries } from '../src/index.js';
+import { type ResolvedConfiguration, WalletEntrySchema, WalletFacade, mergeWalletEntries } from '../src/index.js';
 
 import {
   createV8MockProvingService,
@@ -62,6 +55,7 @@ import {
   getShieldedSeed,
   getUnshieldedSeed,
   shieldedAt,
+  SilentPendingTransactions,
   unshieldedAt,
 } from './utils/index.js';
 
@@ -81,37 +75,6 @@ const v9Version = {
   dust: forkVersion,
 } as const;
 
-/** A pending service that answers and records, so the facade's own orphaning subscription has somewhere to go. */
-class SilentPendingTransactions implements PendingTransactionsService<FinalizedTx> {
-  readonly states = new rx.BehaviorSubject<PendingTransactions.PendingTransactions<FinalizedTx>>(
-    PendingTransactions.empty(),
-  );
-
-  start(): Promise<void> {
-    return Promise.resolve();
-  }
-
-  stop(): Promise<void> {
-    return Promise.resolve();
-  }
-
-  state(): rx.Observable<PendingTransactions.PendingTransactions<FinalizedTx>> {
-    return this.states.asObservable();
-  }
-
-  addPendingTransaction(): Promise<void> {
-    return Promise.resolve();
-  }
-
-  clear(): Promise<void> {
-    return Promise.resolve();
-  }
-
-  orphanBeyond(): Promise<void> {
-    return Promise.resolve();
-  }
-}
-
 describe('three wallets that disagree about which side of the boundary the chain is on', () => {
   let facade: WalletFacade;
   let shieldedStates: rx.BehaviorSubject<ShieldedWalletState>;
@@ -119,7 +82,7 @@ describe('three wallets that disagree about which side of the boundary the chain
   let dustStates: rx.BehaviorSubject<DustWalletState>;
 
   beforeEach(async () => {
-    const configuration: DefaultConfiguration = {
+    const configuration: ResolvedConfiguration = {
       networkId: NetworkId.NetworkId.Undeployed,
       forks: { v9: forkVersion },
       relayURL: new URL('http://localhost:9944'),

--- a/packages/facade/test/submission.test.ts
+++ b/packages/facade/test/submission.test.ts
@@ -64,7 +64,7 @@ describe('Facade submission', () => {
     })();
     const configuration: DefaultConfiguration = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
+      forks: ProtocolVersion.V9NativeForkSchedule,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -111,7 +111,7 @@ describe('Facade submission', () => {
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
+      forks: ProtocolVersion.V9NativeForkSchedule,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -192,7 +192,7 @@ describe('Facade submission', () => {
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
+      forks: ProtocolVersion.V9NativeForkSchedule,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: {
         indexerHttpUrl: 'http://localhost:8080',
@@ -260,7 +260,7 @@ describe('Facade transaction history reads return entries regardless of lifecycl
     const txHistoryStorage = new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries);
     const config = {
       networkId: NetworkId.NetworkId.Undeployed,
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
+      forks: ProtocolVersion.V9NativeForkSchedule,
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServerUrl: new URL('http://localhost:6300'),

--- a/packages/facade/test/utils/index.ts
+++ b/packages/facade/test/utils/index.ts
@@ -12,3 +12,4 @@
 // limitations under the License.
 export * from './helpers.js';
 export * from './drivenStates.js';
+export * from './silentPendingTransactions.js';

--- a/packages/facade/test/utils/silentPendingTransactions.ts
+++ b/packages/facade/test/utils/silentPendingTransactions.ts
@@ -1,0 +1,58 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { type FinalizedTx, type ProtocolVersion } from '@midnightntwrk/wallet-sdk-abstractions';
+import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
+import type { PendingTransactionsService } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
+import { type Option } from 'effect';
+import * as rx from 'rxjs';
+
+/**
+ * A pending service that answers and records nothing, so the facade's own orphaning subscription has somewhere to go.
+ *
+ * @remarks
+ *   Carries the service's full signatures so that a suite which needs one method to record can extend it and override
+ *   that method alone.
+ */
+export class SilentPendingTransactions implements PendingTransactionsService<FinalizedTx> {
+  readonly states = new rx.BehaviorSubject<PendingTransactions.PendingTransactions<FinalizedTx>>(
+    PendingTransactions.empty(),
+  );
+
+  start(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  stop(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  state(): rx.Observable<PendingTransactions.PendingTransactions<FinalizedTx>> {
+    return this.states.asObservable();
+  }
+
+  addPendingTransaction(
+    _tx: FinalizedTx,
+    _protocolVersion: Option.Option<ProtocolVersion.ProtocolVersion>,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  clear(_tx: FinalizedTx): Promise<void> {
+    return Promise.resolve();
+  }
+
+  orphanBeyond(_chainNow: ProtocolVersion.ProtocolVersion): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/packages/facade/test/versionedProving.test.ts
+++ b/packages/facade/test/versionedProving.test.ts
@@ -39,6 +39,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   type BalancingRecipe,
   type DefaultConfiguration,
+  type ResolvedConfiguration,
   WalletEntrySchema,
   WalletFacade,
   mergeWalletEntries,
@@ -66,20 +67,19 @@ class RecordingProver implements VersionedProvingService<V9UnboundTransaction> {
 }
 
 describe('Proving a transaction at the version it was built for', () => {
-  let configuration: DefaultConfiguration;
+  let configuration: ResolvedConfiguration;
   let facade: WalletFacade;
   let prover: RecordingProver;
 
   beforeEach(async () => {
-    configuration = {
+    configuration = WalletFacade.resolveConfiguration({
       networkId: NetworkId.NetworkId.Undeployed,
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       provingServerUrl: new URL('http://localhost:6300'),
       costParameters: { feeBlocksMargin: 0 },
       txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
-    };
+    });
     const seed = '0000000000000000000000000000000000000000000000000000000000000001';
     const shieldedSeed = getShieldedSeed(seed);
     const unshieldedSeed = getUnshieldedSeed(seed);
@@ -167,15 +167,14 @@ describe('Proving with the backend configured for the epoch a transaction belong
 
   /** A facade built with the default proving service, so what is under test is the wiring rather than a stand-in. */
   const started = async (proving: Partial<DefaultConfiguration>): Promise<WalletFacade> => {
-    const configuration: DefaultConfiguration = {
+    const configuration = WalletFacade.resolveConfiguration({
       networkId: NetworkId.NetworkId.Undeployed,
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
       relayURL: new URL('http://localhost:9944'),
       indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
       costParameters: { feeBlocksMargin: 0 },
       txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
       ...proving,
-    };
+    });
     const seed = '0000000000000000000000000000000000000000000000000000000000000001';
     const unshieldedKeystore = createKeystore(
       { kind: 'schnorr', secret: getUnshieldedSeed(seed) },

--- a/packages/shielded-wallet/README.md
+++ b/packages/shielded-wallet/README.md
@@ -38,9 +38,9 @@ const configuration = {
     indexerWsUrl: 'ws://localhost:8088/api/v4/graphql/ws',
   },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
-  // The protocol version this chain hands over to ledger-v9 at. A 2.x node reports 2000000;
-  // the final mainnet fork constant is not yet fixed, so it is supplied per environment.
-  forks: { v9: ProtocolVersion.V9NativeForkVersion },
+  // Where this chain hands over to ledger-v9: the schedule of a chain born on ledger-v9, as a 2.x node runs. The
+  // final mainnet fork constant is not yet fixed, so a chain that hands over elsewhere states `{ v9: ... }` here.
+  forks: ProtocolVersion.V9NativeForkSchedule,
 };
 
 // Create secret keys from a shielded seed

--- a/packages/shielded-wallet/src/test/shieldedWallet.test.ts
+++ b/packages/shielded-wallet/src/test/shieldedWallet.test.ts
@@ -22,7 +22,7 @@ const configuration: DefaultShieldedConfiguration = {
   networkId: NetworkId.NetworkId.Undeployed,
   indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
-  forks: { v9: ProtocolVersion.V9NativeForkVersion },
+  forks: ProtocolVersion.V9NativeForkSchedule,
 };
 
 /**

--- a/packages/shielded-wallet/src/test/tryRestore.test.ts
+++ b/packages/shielded-wallet/src/test/tryRestore.test.ts
@@ -33,7 +33,7 @@ const configuration: DefaultShieldedConfiguration = {
   networkId: NetworkId.NetworkId.Undeployed,
   indexerClientConnection: { indexerHttpUrl: 'http://localhost:8088/api/v4/graphql' },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(TransactionHistory.ShieldedTransactionHistoryEntrySchema),
-  forks: { v9: ProtocolVersion.V9NativeForkVersion },
+  forks: ProtocolVersion.V9NativeForkSchedule,
 };
 
 /** A snapshot declaring a protocol version far beyond anything this build registers a variant for. */

--- a/packages/unshielded-wallet/README.md
+++ b/packages/unshielded-wallet/README.md
@@ -36,9 +36,9 @@ const configuration = {
     indexerHttpUrl: 'http://localhost:8088/api/v4/graphql',
   },
   txHistoryStorage: new InMemoryTransactionHistoryStorage(),
-  // The protocol version this chain hands over to ledger-v9 at. A 2.x node reports 2000000;
-  // the final mainnet fork constant is not yet fixed, so it is supplied per environment.
-  forks: { v9: ProtocolVersion.V9NativeForkVersion },
+  // Where this chain hands over to ledger-v9: the schedule of a chain born on ledger-v9, as a 2.x node runs. The
+  // final mainnet fork constant is not yet fixed, so a chain that hands over elsewhere states `{ v9: ... }` here.
+  forks: ProtocolVersion.V9NativeForkSchedule,
 };
 
 // Create a keystore from a random unshielded seed

--- a/packages/unshielded-wallet/test/testUtils.ts
+++ b/packages/unshielded-wallet/test/testUtils.ts
@@ -127,7 +127,7 @@ export const createWalletConfig = (
     txHistoryStorage: new InMemoryTransactionHistoryStorage(UnshieldedEntrySchema),
     // The ledger-v9-native node line these suites run against reports this protocol version, so the wallet reaches its
     // V2 variant.
-    forks: { v9: ProtocolVersion.V9NativeForkVersion },
+    forks: ProtocolVersion.V9NativeForkSchedule,
   };
 
   return { ...defaultConfig, ...overrides };

--- a/packages/wallet-integration-tests/test/serializationAndRestoration.integration.test.ts
+++ b/packages/wallet-integration-tests/test/serializationAndRestoration.integration.test.ts
@@ -57,7 +57,7 @@ describe('Wallet serialization and restoration', () => {
     indexerPort = startedEnvironment.getContainer(`indexer_${environmentId}`).getMappedPort(8088);
 
     shieldedConfiguration = {
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
+      forks: ProtocolVersion.V9NativeForkSchedule,
       indexerClientConnection: {
         indexerHttpUrl: `http://localhost:${indexerPort}/api/v4/graphql`,
       },
@@ -68,7 +68,7 @@ describe('Wallet serialization and restoration', () => {
     unshieldedConfiguration = {
       // The same boundary the shielded configuration names, for the same reason: this stack runs the
       // ledger-v9-native node line, so the unshielded wallet reaches its V2 variant too.
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
+      forks: ProtocolVersion.V9NativeForkSchedule,
       indexerClientConnection: {
         indexerWsUrl: `ws://localhost:${indexerPort}/api/v4/graphql/ws`,
         indexerHttpUrl: `http://localhost:${indexerPort}/api/v4/graphql`,

--- a/packages/wallet-sdk-testkit/src/environment.ts
+++ b/packages/wallet-sdk-testkit/src/environment.ts
@@ -85,10 +85,9 @@ export const makeEnvironment = (
       relayURL: new URL(endpoints.nodeUrl),
       networkId: endpoints.networkId,
       txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
-      // Every environment this testkit drives runs the ledger-v9-native node line, which reports this
-      // protocol version, so the wallet reaches its V2 variant. Defined once here rather than at
-      // each construction site; the final mainnet fork constant is still an open question.
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
+      // Every environment this testkit drives runs the ledger-v9-native node line, so the wallet reaches its V2
+      // variant; the final mainnet fork constant is still an open question.
+      forks: ProtocolVersion.V9NativeForkSchedule,
     };
   },
   getDustWalletConfig(): DustWalletConfiguration {
@@ -103,7 +102,7 @@ export const makeEnvironment = (
       },
       // The same boundary the shielded configuration names, for the same reason: this testkit's environments all run
       // the ledger-v9-native node line, so the dust wallet reaches its V2 variant too.
-      forks: { v9: ProtocolVersion.V9NativeForkVersion },
+      forks: ProtocolVersion.V9NativeForkSchedule,
     };
   },
   down: options.down ?? (async () => {}),


### PR DESCRIPTION
# Description

`forks` may now be left out of the facade's `DefaultConfiguration`. `WalletFacade.init` fills in `DefaultForkSchedule` — ledger-v9 from the version a 2.x node reports — and hands the completed configuration to every factory in `InitParams`, wallets and services alike. A configuration that does name `forks` is handed exactly what it named.

The wallet packages are unchanged and still require `forks`, because where a chain forks is a fact about the chain. The facade is the one place a preset decides nothing the SDK had not already decided: every application was copying the same constant into its configuration.

# Proposed Solution

- `DefaultConfiguration` is the wallets' configuration with `forks` optional. `ResolvedConfiguration<TConfig>` is the configuration as given with `forks` always present, and is what every factory in `InitParams` is handed, so `shielded: (config) => ShieldedWallet(config)` keeps compiling against a wallet package that requires the field.
- `init` resolves once, before anything is built, so the wallets, the default services and the facade's own boundary cannot be given different schedules.
- `WalletFacade.resolveConfiguration(configuration)` is public, for code outside a factory that needs the configuration the facade will use: building a wallet package directly, or reading `forks` back to author a transaction for the right ledger version. It is idempotent, so `init` accepts its result. The docs snippets use it instead of restating `forks`.
- `ProtocolVersion.V9NativeForkSchedule` joins `V9NativeForkVersion` in the abstractions package: the fork schedule of a chain born on ledger-v9, named once. `DefaultForkSchedule` is that value under the name of what the facade presets. The hand-written `{ v9: ProtocolVersion.V9NativeForkVersion }` literal is replaced with the constant across the testkit, e2e fixtures and package tests.

# Important Changes Introduced

- New public API: `DefaultForkSchedule`, `ResolvedConfiguration`, `WalletFacade.resolveConfiguration` (facade, re-exported by the umbrella) and `ProtocolVersion.V9NativeForkSchedule` (abstractions). Changesets: facade and umbrella minor (new), abstractions minor (added to the existing `fold-fork-constant` changeset).
- `InitParams` factories now receive `ResolvedConfiguration<TConfig>` rather than `TConfig`. Existing factories compile unchanged; the argument only gained a guaranteed field.
- Code that annotates a value `DefaultConfiguration` and passes it to a wallet package directly, outside a factory, now needs `forks` present: resolve it with `WalletFacade.resolveConfiguration` or annotate it `ResolvedConfiguration`.
- The `SilentPendingTransactions` test fake moved to `packages/facade/test/utils/` with the service's full signatures, and the two sibling recording fakes extend it instead of repeating it.
- The facade README gained a "Where the chain forks" section, and CLAUDE.md states that only the facade presets `forks`.

# Testing

- Tests were written first and confirmed failing for the expected reasons, then made to pass: the constant and its shape in the abstractions suite; the preset, an untouched named schedule, added settings with the return type, idempotence, and every factory being handed the resolved configuration in the facade suite; and a runtime check that the facade reads the protocol phase against the preset boundary.
- `typecheck` and `lint` pass for abstractions, facade, docs-snippets, testkit, shielded, unshielded, e2e-tests and wallet-integration-tests. Unit suites pass for abstractions, facade, shielded and unshielded. Effect language-service diagnostics and the fork-vocabulary check are clean.
- The e2e, integration and testkit edits are the constant swap only and were verified by typecheck and lint; they need Docker to run.
