### PR TITLE
fix(sdk): preserve finalized transaction history when a late verdict rejects an included transaction

### DIFF
--- a/.changeset/finalized-history-survives-orphaning.md
+++ b/.changeset/finalized-history-survives-orphaning.md
@@ -1,0 +1,18 @@
+---
+'@midnightntwrk/wallet-sdk-abstractions': patch
+'@midnightntwrk/wallet-sdk-facade': patch
+'@midnightntwrk/wallet-sdk': patch
+---
+
+Preserve finalized transaction history when a late verdict rejects a transaction whose inclusion sync has already
+recorded. A delayed pending-status check, a TTL, or a protocol upgrade orphaning a pre-boundary transaction can all
+arrive after the transaction landed, including under a different on-chain hash when it was aggregated. Such a verdict
+now clears the transaction from the pending set instead of recording a rejection, and an included failure still
+releases its unexecuted coin reservations. The facade's protocol-version tracking no longer performs any fallible work,
+so a history storage failure cannot stop it from observing later versions or orphaning stranded transactions.
+
+History storage implementations must give recorded inclusion precedence over a later rejection: `gotRejected` writes
+nothing for a transaction a finalized entry already covers, by hash or by carrying all of its identifiers (an empty
+identifier set covers nothing), and `gotFinalized` clears every pending or rejected entry it covers under another hash.
+The predicate is exported as `TransactionHistoryStorage.coversTransaction`. `mergeWalletEntries` keeps a finalized
+lifecycle over an incoming rejected one.

--- a/packages/abstractions/src/InMemoryTransactionHistoryStorage.ts
+++ b/packages/abstractions/src/InMemoryTransactionHistoryStorage.ts
@@ -19,6 +19,7 @@ import {
   type FinalizedEntryInput,
   type RejectedEntryInput,
   type SerializedTransactionHistory,
+  coversTransaction,
 } from './TransactionHistoryStorage.js';
 
 /**
@@ -61,10 +62,11 @@ export class InMemoryTransactionHistoryStorage<
     const { finalizedBlock, ...rest } = input;
     const entry = { ...rest, lifecycle: { status: 'finalized', finalizedBlock } } as unknown as T;
     await this.#upsert(entry);
-    this.#clearPendingByIdentifiers(entry.identifiers, entry.hash);
+    this.#clearUnfinalizedCoveredBy(entry);
   }
 
   async gotRejected(input: RejectedEntryInput<T>): Promise<void> {
+    if (this.#inclusionRecorded(input)) return;
     const { rejectedAt, reason, ...rest } = input;
     const lifecycle =
       reason !== undefined
@@ -112,18 +114,21 @@ export class InMemoryTransactionHistoryStorage<
     return Promise.resolve();
   }
 
-  #clearPendingByIdentifiers(identifiers: readonly string[], newHash: TransactionHash): void {
-    if (identifiers.length === 0) return;
-    const provided = new Set<string>(identifiers);
-    const match = [...this.#storage.values()].find(
-      (entry) =>
-        entry.identifiers.length > 0 &&
-        entry.identifiers.every((id) => provided.has(id)) &&
-        entry.lifecycle.status === 'pending' &&
-        entry.hash !== newHash,
+  /** Checked synchronously with the write that follows, so a verdict racing sync cannot supersede inclusion. */
+  #inclusionRecorded(key: Pick<T, 'hash' | 'identifiers'>): boolean {
+    return [...this.#storage.values()].some(
+      (entry) => entry.lifecycle.status === 'finalized' && coversTransaction(entry, key),
     );
-    if (match) {
-      this.#storage.delete(match.hash);
-    }
+  }
+
+  #clearUnfinalizedCoveredBy(finalized: T): void {
+    [...this.#storage.values()]
+      .filter(
+        (entry) =>
+          entry.lifecycle.status !== 'finalized' &&
+          entry.hash !== finalized.hash &&
+          coversTransaction(finalized, entry),
+      )
+      .forEach((entry) => this.#storage.delete(entry.hash));
   }
 }

--- a/packages/abstractions/src/TransactionHistoryStorage.ts
+++ b/packages/abstractions/src/TransactionHistoryStorage.ts
@@ -122,6 +122,24 @@ export type RejectedTransactionHistoryCommon = TransactionHistoryEntryCommon & {
 export type SerializedTransactionHistory = string;
 
 /**
+ * Whether `entry` records the transaction `key` names: the same hash, or every one of `key`'s identifiers. Identifiers
+ * are per-build commitments, so an entry carrying all of them is the same transaction included under an aggregated
+ * hash. An empty identifier set names no transaction and therefore neither covers nor is covered.
+ *
+ * @param entry - The recorded entry.
+ * @param key - The hash and identifiers of the transaction being asked about.
+ * @returns Whether `entry` is a record of that transaction.
+ */
+export const coversTransaction = (
+  entry: Pick<TransactionHistoryEntryCommon, 'hash' | 'identifiers'>,
+  key: Pick<TransactionHistoryEntryCommon, 'hash' | 'identifiers'>,
+): boolean => {
+  if (entry.hash === key.hash) return true;
+  const recorded = new Set(entry.identifiers);
+  return key.identifiers.length > 0 && key.identifiers.every((id) => recorded.has(id));
+};
+
+/**
  * An entry with common fields plus any additional properties (wallet sections). Used by wallet packages for
  * projection/filtering when the exact type is not known.
  */
@@ -177,6 +195,11 @@ export interface TransactionHistoryReader<T extends { hash: TransactionHash } = 
  * keys (in particular: clearing a prior `pending` entry keyed by an identifier when its `finalized` or `rejected`
  * counterpart arrives keyed by the tx hash).
  *
+ * Recorded inclusion takes precedence over a later rejection. Sync records inclusion independently of the
+ * pending-status poller, so a verdict may arrive after a `finalized` entry {@link coversTransaction covers} the
+ * transaction, and that verdict must neither overwrite the entry nor leave a rejected duplicate under the submission's
+ * own hash. Implementations check this atomically with the write.
+ *
  * `T` appears only in input position, so this interface is **contravariant** in T: a `TransactionHistoryWriter<Wider>`
  * is assignable to `TransactionHistoryWriter<Narrower>`.
  */
@@ -184,13 +207,14 @@ export interface TransactionHistoryWriter<T extends TransactionHistoryEntryCommo
   /** Record that a tx has been submitted and is awaiting confirmation. */
   gotPending(entry: PendingEntryInput<T>): Promise<void>;
   /**
-   * Record that a tx has been confirmed on-chain. Inserts/merges the entry under its tx hash and clears any earlier
-   * `pending` entry whose identifiers are contained in this entry's identifier set.
+   * Record that a tx has been confirmed on-chain. Inserts/merges the entry under its tx hash and clears every earlier
+   * `pending` or `rejected` entry this entry {@link coversTransaction covers} under another hash.
    */
   gotFinalized(entry: FinalizedEntryInput<T>): Promise<void>;
   /**
    * Record that a tx will not land — failed, partial-success, TTL-expired, or otherwise reverted. Keyed the same way as
-   * `gotPending` so the lifecycle transition is in-place.
+   * `gotPending` so the lifecycle transition is in-place. Writes nothing when a `finalized` entry already covers the
+   * tx.
    */
   gotRejected(entry: RejectedEntryInput<T>): Promise<void>;
 }

--- a/packages/abstractions/src/test/inMemoryTransactionHistoryStorage.test.ts
+++ b/packages/abstractions/src/test/inMemoryTransactionHistoryStorage.test.ts
@@ -113,6 +113,42 @@ describe('InMemoryTransactionHistoryStorage gotFinalized respects the merge func
 });
 
 describe('InMemoryTransactionHistoryStorage gotPending / gotRejected', () => {
+  it('removes superseded rejection entries when inclusion arrives after orphaning', async () => {
+    const storage = new InMemoryTransactionHistoryStorage(TransactionHistoryEntryCommonSchema);
+    await storage.gotRejected(rejectedInput('submission-a', ['id-a'], new Date()));
+    await storage.gotRejected(rejectedInput('submission-b', ['id-b'], new Date()));
+    await storage.gotFinalized(finalizedInput('chain-hash', { identifiers: ['id-a', 'id-b'] }));
+    expect((await storage.getAll()).map((entry) => entry.hash)).toEqual(['chain-hash']);
+  });
+  it.each(['chain-hash', 'submission-hash'])('preserves inclusion over rejection keyed by %s', async (hash) => {
+    // Even a caller-provided merge that blindly takes incoming fields cannot downgrade inclusion.
+    const storage = new InMemoryTransactionHistoryStorage(TransactionHistoryEntryCommonSchema, mergeEntries);
+    await Promise.all([
+      storage.gotFinalized(finalizedInput('chain-hash', { identifiers: ['id-a', 'id-b'] })),
+      storage.gotRejected(rejectedInput(hash, ['id-a'], new Date(), 'orphaned-by-protocol-upgrade')),
+    ]);
+    expect(await storage.getAll()).toHaveLength(1);
+    expect((await storage.get('chain-hash'))?.lifecycle.status).toBe('finalized');
+  });
+
+  it('writes nothing for a rejection under the submission hash once inclusion is recorded under the chain hash', async () => {
+    const storage = new InMemoryTransactionHistoryStorage(TransactionHistoryEntryCommonSchema, mergeEntries);
+    await storage.gotFinalized(finalizedInput('chain-hash', { identifiers: ['id-a', 'id-b'] }));
+
+    await storage.gotRejected(rejectedInput('submission-hash', ['id-a'], new Date()));
+
+    const entries = await storage.getAll();
+    expect(entries.map((entry) => [entry.hash, entry.lifecycle.status])).toEqual([['chain-hash', 'finalized']]);
+  });
+
+  it('does not treat partial identifier overlap or empty identifiers as inclusion', async () => {
+    const storage = new InMemoryTransactionHistoryStorage(TransactionHistoryEntryCommonSchema);
+    await storage.gotFinalized(finalizedInput('chain-hash', { identifiers: ['id-a'] }));
+    await storage.gotRejected(rejectedInput('overlapping', ['id-a', 'id-b'], new Date()));
+    await storage.gotRejected(rejectedInput('empty', [], new Date()));
+    expect((await storage.get('overlapping'))?.lifecycle.status).toBe('rejected');
+    expect((await storage.get('empty'))?.lifecycle.status).toBe('rejected');
+  });
   it('should store a pending entry under its hash with a pending lifecycle', async () => {
     const storage = new InMemoryTransactionHistoryStorage(TransactionHistoryEntryCommonSchema, mergeEntries);
 
@@ -200,13 +236,13 @@ describe('InMemoryTransactionHistoryStorage clears pending entries precisely', (
     expect(await storage.get('p-empty')).toBeDefined();
   });
 
-  it('only clears pending entries, leaving a finalized sibling with overlapping identifiers intact', async () => {
+  it('leaves a finalized sibling with overlapping identifiers intact', async () => {
     const storage = new InMemoryTransactionHistoryStorage(TransactionHistoryEntryCommonSchema, mergeEntries);
 
     await storage.gotFinalized(finalizedInput('k1', { identifiers: ['id-a'] }));
     await storage.gotFinalized(finalizedInput('k2', { identifiers: ['id-a'] }));
 
-    // k1 must not be deleted by k2's finalize — clearing targets pending entries only.
+    // k1 must not be deleted by k2's finalize — both record known inclusion.
     expect(await storage.get('k1')).toBeDefined();
     expect(await storage.get('k2')).toBeDefined();
   });

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -143,7 +143,7 @@ export const isFinalizedWalletEntry = (entry: WalletEntry): entry is FinalizedWa
  *   wallet has set the value, later writes are no-ops for these fields. This is correct because the value is the same
  *   across all wallets (it's a property of the on-chain tx, not the wallet's view of it).
  * - **`identifiers`** — unioned (each wallet may surface a different identifier subset).
- * - **`lifecycle`** — incoming wins (this is how `pending → finalized` transitions are recorded).
+ * - **`lifecycle`** — incoming wins, except that a late rejection cannot overwrite recorded on-chain inclusion.
  * - **Wallet sections** (`shielded`, `unshielded`, `dust`) — combined via per-section merge when both sides have them;
  *   otherwise whichever side is present is used.
  */
@@ -178,8 +178,10 @@ export function mergeWalletEntries(existing: WalletEntry, incoming: WalletEntry)
     status: existing.status ?? incoming.status,
     timestamp: existing.timestamp ?? incoming.timestamp,
     fees: existing.fees ?? incoming.fees,
-    // lifecycle: incoming wins — this is how pending → finalized/rejected transitions are recorded
-    lifecycle: incoming.lifecycle,
+    lifecycle:
+      existing.lifecycle.status === 'finalized' && incoming.lifecycle.status === 'rejected'
+        ? existing.lifecycle
+        : incoming.lifecycle,
     ...(shielded !== undefined ? { shielded } : {}),
     ...(unshielded !== undefined ? { unshielded } : {}),
     ...(dust !== undefined ? { dust } : {}),
@@ -1021,7 +1023,11 @@ export class WalletFacade {
       .state()
       .pipe(
         concatMap((pending) => PendingTransactions.allRejected(pending)),
-        concatMap((item) => this.revert(item.tx, rejectionReason(item.result))),
+        concatMap(async (item) => {
+          if (!(await this.reconcileFinalizedTransaction(item.tx, await this.#txHistoryStorage.getAll()))) {
+            await this.revert(item.tx, rejectionReason(item.result));
+          }
+        }),
       )
       .subscribe();
     // Deliberately built from the wallets' own states rather than from `state()`: `state()` includes the pending set,
@@ -1037,6 +1043,8 @@ export class WalletFacade {
         ),
         distinctUntilChanged(),
         tap((version) => this.#observedProtocolVersion.next(Option.some(version))),
+        // Nothing fallible belongs here: this chain is the only writer of the observed version, and an orphaned
+        // transaction sync already saw included is reconciled by the pending subscription like any other verdict.
         concatMap((version) => this.pendingTransactionsService.orphanBeyond(version)),
       )
       .subscribe();
@@ -1887,6 +1895,39 @@ export class WalletFacade {
       : [txOrRecipe];
 
     await Promise.all(transactionsToRevert.map((tx) => this.revertTransaction(tx, reason)));
+  }
+
+  /**
+   * The finalized entry recording `tx`, if sync has written one, even under the hash aggregation gave it on-chain. A
+   * transaction whose stamp no epoch can read has no entry, rather than an error, so a verdict on it still resolves.
+   */
+  private finalizedEntryFor(tx: AnyTx, history: readonly WalletEntry[]): FinalizedWalletEntry | undefined {
+    return Option.match(
+      Either.getRight(WalletTransaction.unwrapWithin<Carried>(tx, this.epochOf(tx.protocolVersion))),
+      {
+        onNone: () => undefined,
+        onSome: (carried) => {
+          const key = submitTxHistoryKey(carried);
+          return history.find(
+            (entry): entry is FinalizedWalletEntry =>
+              isFinalizedWalletEntry(entry) && TransactionHistoryStorage.coversTransaction(entry, key),
+          );
+        },
+      },
+    );
+  }
+
+  /** Sync can record inclusion before the independent pending-status poller observes it. */
+  private async reconcileFinalizedTransaction(tx: FinalizedTx, history: readonly WalletEntry[]): Promise<boolean> {
+    const entry = this.finalizedEntryFor(tx, history);
+    if (entry === undefined) return false;
+    // Included failures still need their unexecuted coin reservations released.
+    if (entry.status === 'FAILURE' || entry.status === 'PARTIAL_SUCCESS') {
+      await this.revertTransaction(tx);
+    } else {
+      await this.pendingTransactionsService.clear(tx);
+    }
+    return true;
   }
 
   async revertTransaction(tx: AnyTx, reason?: string): Promise<void> {

--- a/packages/facade/test/lateVerdictAcrossFork.test.ts
+++ b/packages/facade/test/lateVerdictAcrossFork.test.ts
@@ -37,7 +37,7 @@ import {
   WalletTransaction,
   type FinalizedTx,
 } from '@midnightntwrk/wallet-sdk-abstractions';
-import { type PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
+import { PendingTransactions } from '@midnightntwrk/wallet-sdk-capabilities/pendingTransactions';
 import type { SubmissionService } from '@midnightntwrk/wallet-sdk-capabilities';
 import { DustWallet, type DustWalletState } from '@midnightntwrk/wallet-sdk-dust-wallet';
 import { ShieldedWallet, type ShieldedWalletState } from '@midnightntwrk/wallet-sdk-shielded';
@@ -49,7 +49,8 @@ import {
 } from '@midnightntwrk/wallet-sdk-unshielded-wallet';
 import { DateTime, Option } from 'effect';
 import * as rx from 'rxjs';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { finalizedTransactionTraits } from '../src/transaction.js';
 import {
   type ResolvedConfiguration,
   WalletEntrySchema,
@@ -244,5 +245,89 @@ describe('a verdict that arrives after the wallets have crossed the boundary', (
     await verdictArrives(finalized, { status: 'FAILURE', segments: [] });
 
     expect(pending.cleared).toContain(finalized);
+  });
+
+  it.each(['orphan', 'TTL', 'partial success'] as const)(
+    'preserves on-chain history when a late %s verdict arrives under the submission hash',
+    async (verdict) => {
+      const tx = await submitThenCross();
+      const [submitted] = await facade.getAllFromTxHistory();
+      // Aggregation can give the included transaction a different hash and additional identifiers.
+      await configuration.txHistoryStorage.gotFinalized({
+        hash: 'aggregated-chain-hash',
+        identifiers: [...submitted.identifiers, 'another-intent'],
+        status: verdict === 'partial success' ? 'PARTIAL_SUCCESS' : 'SUCCESS',
+        protocolVersion: Number(v8Version),
+        finalizedBlock: { hash: 'ledger-v8-block', height: 10, timestamp: new Date() },
+      });
+      const revert = vi.spyOn(facade.shielded, 'revertTransaction');
+      await verdictArrives(
+        tx,
+        verdict === 'orphan'
+          ? { status: 'ORPHANED_BY_FORK', authoredFor: tx.protocolVersion, chainNow: v9Version }
+          : { status: verdict === 'TTL' ? 'FAILURE' : 'PARTIAL_SUCCESS', segments: [] },
+      );
+
+      const entries = await facade.getAllFromTxHistory();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].hash).toBe('aggregated-chain-hash');
+      expect(entries[0].lifecycle.status).toBe('finalized');
+      expect(pending.cleared).toContain(tx);
+      if (verdict === 'partial success') expect(revert).toHaveBeenCalledWith(tx);
+      else expect(revert).not.toHaveBeenCalled();
+    },
+  );
+
+  it('clears a pending transaction the fork orphaned once its inclusion is known, recording no rejection', async () => {
+    const tx = await facade.finalizeTransaction(v8Transaction());
+    await facade.submitTransaction(tx);
+    const [submitted] = await facade.getAllFromTxHistory();
+    await configuration.txHistoryStorage.gotFinalized({
+      hash: submitted.hash,
+      identifiers: submitted.identifiers,
+      status: 'SUCCESS',
+      finalizedBlock: { hash: 'ledger-v8-block', height: 10, timestamp: new Date() },
+    });
+    const traits = finalizedTransactionTraits(forkVersion);
+    pending.states.next({
+      all: [{ tx, creationTime: DateTime.unsafeMake(Date.now()), protocolVersion: Option.some(tx.protocolVersion) }],
+    });
+    vi.spyOn(pending, 'clear').mockImplementation((transaction) => {
+      pending.states.next(PendingTransactions.clear(pending.states.value, transaction, traits));
+      return Promise.resolve();
+    });
+    const orphan = vi.spyOn(pending, 'orphanBeyond').mockImplementation((version) => {
+      pending.states.next(PendingTransactions.orphanBeyond(pending.states.value, traits, version));
+      return Promise.resolve();
+    });
+
+    shieldedStates.next(shieldedAt(shieldedStates.value, v9Version));
+    unshieldedStates.next(unshieldedAt(unshieldedStates.value, v9Version));
+    dustStates.next(dustAt(dustStates.value, v9Version));
+
+    await vi.waitFor(() => expect(orphan).toHaveBeenCalledWith(v9Version));
+    await vi.waitFor(() => expect(pending.states.value.all).toHaveLength(0));
+    expect((await facade.getAllFromTxHistory()).map((entry) => entry.lifecycle.status)).toEqual(['finalized']);
+  });
+
+  it('keeps orphaning at each version the wallets reach when the history storage cannot be read', async () => {
+    const tx = await facade.finalizeTransaction(v8Transaction());
+    await facade.submitTransaction(tx);
+    pending.states.next({
+      all: [{ tx, creationTime: DateTime.unsafeMake(Date.now()), protocolVersion: Option.some(tx.protocolVersion) }],
+    });
+    vi.spyOn(configuration.txHistoryStorage, 'getAll').mockRejectedValue(new Error('history storage unavailable'));
+    const orphan = vi.spyOn(pending, 'orphanBeyond');
+
+    shieldedStates.next(shieldedAt(shieldedStates.value, v9Version));
+    unshieldedStates.next(unshieldedAt(unshieldedStates.value, v9Version));
+    dustStates.next(dustAt(dustStates.value, v9Version));
+    await vi.waitFor(() => expect(orphan).toHaveBeenCalledWith(v9Version));
+
+    const later = ProtocolVersion.ProtocolVersion(v9Version + 1n);
+    shieldedStates.next(shieldedAt(shieldedStates.value, later));
+    unshieldedStates.next(unshieldedAt(unshieldedStates.value, later));
+    dustStates.next(dustAt(dustStates.value, later));
+    await vi.waitFor(() => expect(orphan).toHaveBeenCalledWith(later));
   });
 });

--- a/packages/facade/test/transactionHistory.test.ts
+++ b/packages/facade/test/transactionHistory.test.ts
@@ -291,7 +291,17 @@ describe('mergeWalletEntries does not lose information', () => {
   });
 });
 
-describe('mergeWalletEntries records lifecycle transitions (incoming wins)', () => {
+describe('mergeWalletEntries records lifecycle transitions', () => {
+  it('preserves finalized inclusion over a late rejection', () => {
+    const existing = baseEntry('tx1');
+    const incoming: WalletEntry = {
+      hash: 'tx1',
+      identifiers: [],
+      lifecycle: { status: 'rejected', rejectedAt: new Date(), reason: 'orphaned-by-protocol-upgrade' },
+    };
+    expect(mergeWalletEntries(existing, incoming).lifecycle).toEqual(existing.lifecycle);
+    expect(mergeWalletEntries(incoming, existing).lifecycle).toEqual(existing.lifecycle);
+  });
   it('should transition a pending entry to finalized when its finalized counterpart arrives', () => {
     const existing = pendingEntry('tx1');
     const incoming = baseEntry('tx1'); // finalized
@@ -301,9 +311,7 @@ describe('mergeWalletEntries records lifecycle transitions (incoming wins)', () 
     expect(merged.lifecycle.status).toBe('finalized');
   });
 
-  it('should let the incoming lifecycle win unconditionally (even pending over an existing finalized)', () => {
-    // The rule is purely "incoming wins" — it does not rank lifecycles. This documents that raw behaviour; in practice
-    // a finalized entry is never re-written as pending.
+  it('preserves the existing behavior of explicitly writing pending over finalized', () => {
     const existing = baseEntry('tx1'); // finalized
     const incoming = pendingEntry('tx1');
 


### PR DESCRIPTION
# Description

Wallet sync and the pending set write transaction history independently. Sync records `finalized` when it sees a
transaction in a block; the facade records `rejected` when the pending set gives a verdict, whether a failure the poller
reports, a TTL that ran out, or `orphanBeyond` giving up on a transaction authored below `forks.v9`. The pending set never
learns of inclusion, so a verdict can arrive after sync has already recorded the transaction as included, sometimes under
a different hash because the node aggregated it. Until now that late verdict won: the finalized entry was overwritten to
`rejected`, or a phantom `rejected` entry appeared beside it under the submission hash, and the wallets released
reservations for coins that had really been spent.

The race predates the fork work, but the fork made it frequent: at the crossing, `orphanBeyond` produces a verdict for
every stranded pending transaction at once.

# Proposed Solution

Recorded inclusion takes precedence over a later rejection, at every layer that writes history.

- **Storage.** `gotRejected` writes nothing when a finalized entry covers the transaction: the same hash, or an entry
  carrying every one of its identifiers (identifiers are per-build commitments, so a superset is the same transaction
  under an aggregated hash; an empty set covers nothing). `gotFinalized` clears every `pending` or `rejected` entry it
  covers under another hash, so the rejection-first ordering heals too. The predicate is exported as
  `TransactionHistoryStorage.coversTransaction` and the `TransactionHistoryWriter` JSDoc states the obligation.
- **Facade.** A rejected verdict first looks for a covering finalized entry. On `SUCCESS` it only clears the pending set.
  On `FAILURE` or `PARTIAL_SUCCESS` it still reverts the wallets, releasing the unexecuted reservations, and the storage
  drops the rejected write.
- **Merge.** `mergeWalletEntries` keeps a finalized lifecycle over an incoming rejected one.
- **Protocol-version tracking** stays a single infallible `orphanBeyond` call. An earlier draft reconciled history in
  that chain, which would have let one storage failure freeze the observed version and stop orphaning for the session.

# Important Changes Introduced

- Third-party `TransactionHistoryStorage` implementations must apply the precedence rule; see the changeset.
- `revertTransaction` no longer reads history before calling `gotRejected`; the storage owns the precedence.
- Out of scope and pre-existing: a resubmission of an already included transaction can still write a `pending` entry
  over or beside the finalized one. That is a separate change.

# Testing

- Storage: a rejection under the submission hash after inclusion under the chain hash writes nothing; rejected entries
  are removed when inclusion arrives later; partial identifier overlap and empty identifier sets are not inclusion.
- Facade: a late orphan, TTL, or partial-success verdict under the submission hash leaves history finalized and only the
  partial success reverts the wallets; an orphaned transaction sync saw included is cleared with no rejection recorded;
  orphaning continues at each version the wallets reach while the history storage rejects every read.
- `yarn test:unit`, typecheck, lint, Effect diagnostics, and the fork-vocabulary check pass for abstractions and facade.
