### PR TITLE
fix(sdk): release shielded reservations stranded by the v9 fork, and stamp a finalized transaction with its authored version

### DIFF
--- a/.changeset/finalized-transaction-keeps-its-authored-version.md
+++ b/.changeset/finalized-transaction-keeps-its-authored-version.md
@@ -1,0 +1,17 @@
+---
+'@midnightntwrk/wallet-sdk-facade': patch
+'@midnightntwrk/wallet-sdk': patch
+---
+
+Stamp a finalized transaction with the protocol version it was authored at, rather than the version the wallets have
+reached by the time its proof comes back. Proving is a long await, so an ordinary block — or the hand-over to ledger-v9
+— can land under it; the transaction's bytes were fixed before the prover was called, and the handle returned by
+`finalizeTransaction` and `finalizeRecipe` now says so. Previously such a transaction came back claiming the version
+reached during proving, which sent its bytes to the wrong ledger version on submission, reversion and deserialization,
+and hid it from orphaning. The pending entry these methods record is stamped the same way, so orphaning judges a
+transaction by what authored it.
+
+Finalizing a transaction whose epoch the wallets left while it was being proved now fails with
+`ProtocolVersionMismatchError`, naming the version it was authored for and the range the facade accepts, and reverts
+the reservations it made in the shielded, unshielded and dust wallets. No chain the wallets are on can include such a
+transaction, so it is refused rather than recorded as pending to wait out a TTL.

--- a/.changeset/release-shielded-spends-stranded-by-the-crossing.md
+++ b/.changeset/release-shielded-spends-stranded-by-the-crossing.md
@@ -1,0 +1,19 @@
+---
+'@midnightntwrk/wallet-sdk-shielded': patch
+'@midnightntwrk/wallet-sdk': patch
+---
+
+Release the shielded coins a wallet had booked for a ledger-v8 transaction still in flight when the chain handed over to
+ledger-v9. Those reservations cross the boundary with the rest of the local state, and nothing on the far side could
+ever clear them — the transactions holding them belong to a ledger version the chain has left, so no inclusion will
+report them and the reversion the facade performs on orphaning cannot reach a ledger-v8 transaction from the V2 variant.
+The affected coins were therefore missing from the available set, from coin selection and from the available balance for
+the remainder of the wallet's life.
+
+The first sync update after a crossing now releases every reservation the wallet arrived with, in the same step that
+computes its coin hashes, before the balances are read: the coins return at the Merkle indices the chain gave them, in a
+tree of unchanged height and root, and spend normally. It runs once per crossing, so a reservation made from
+`forks.v9` onwards — whose transaction can still be included — is untouched. The change outputs those stranded
+transactions would have paid back are left as they were, and nothing ever removes them: they stay in `pendingOutputs`
+for the life of the wallet and overstate the pending balance. That is a known limitation, and a mild one — those entries
+reserve no coin and block no spending.

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -1092,12 +1092,25 @@ export class WalletFacade {
     );
   }
 
-  /** Seals a transaction the facade or a wallet produced, at the version the facade is acting at. */
+  /**
+   * Seals a transaction the facade or a wallet produced, at the version its bytes were fixed by.
+   *
+   * @remarks
+   *   The version is the caller's to state, never read from the facade here, because the two can differ: a crossing can
+   *   land while a transaction is at the prover, and what comes back is still the bytes of the ledger version that made
+   *   them. A caller sealing something it has just built passes the version it is building at; a caller sealing
+   *   something that has travelled through an await passes the version stamped on the handle it started from.
+   * @param stage How far along the building of the transaction the sealed handle is.
+   * @param transaction The transaction to seal.
+   * @param protocolVersion The version the transaction's bytes were fixed by.
+   * @returns The sealed handle.
+   */
   private seal<TStage extends WalletTransaction.Stage>(
     stage: TStage,
     transaction: { serialize: () => Uint8Array },
+    protocolVersion: ProtocolVersion.ProtocolVersion,
   ): WalletTransaction<TStage> {
-    return WalletTransaction.adopt(stage, transaction, this.currentVersion());
+    return WalletTransaction.adopt(stage, transaction, protocolVersion);
   }
 
   /** The ledger primitives the facade signs with on its current side of the boundary. */
@@ -1179,7 +1192,12 @@ export class WalletFacade {
    *   boundary is not a failure to compute, it is unrepresentable, and saying so is the whole point of the stamp.
    */
   private mergeUnprovenTransactions(a: UnprovenTx | undefined, b: UnprovenTx | undefined): UnprovenTx | undefined {
-    if (a && b) return this.seal('Unproven', this.accept<CarriedUnproven>(a).merge(this.accept<CarriedUnproven>(b)));
+    if (a && b)
+      return this.seal(
+        'Unproven',
+        this.accept<CarriedUnproven>(a).merge(this.accept<CarriedUnproven>(b)),
+        this.currentVersion(),
+      );
     return a ?? b;
   }
 
@@ -1518,6 +1536,7 @@ export class WalletFacade {
               this.accept<CarriedFinalized>(recipe.originalTransaction).merge(
                 this.accept<CarriedFinalized>(finalizedBalancing),
               ),
+              recipe.originalTransaction.protocolVersion,
             );
           }
           case 'UNBOUND_TRANSACTION': {
@@ -1530,6 +1549,7 @@ export class WalletFacade {
               finalizedBalancingTx
                 ? finalizedTransaction.merge(this.accept<CarriedFinalized>(finalizedBalancingTx))
                 : finalizedTransaction,
+              recipe.baseTransaction.protocolVersion,
             );
           }
           case 'UNPROVEN_TRANSACTION': {
@@ -1540,7 +1560,7 @@ export class WalletFacade {
       .then(async (finalizedTx) => {
         await this.pendingTransactionsService.addPendingTransaction(
           finalizedTx,
-          this.#observedProtocolVersion.getValue(),
+          Option.some(finalizedTx.protocolVersion),
         );
         return finalizedTx;
       });
@@ -1609,11 +1629,19 @@ export class WalletFacade {
    * Proves and binds an unproven transaction, and records it as pending.
    *
    * @remarks
-   *   Proved at the version stamped on the transaction itself, which is the version that fixed its bytes. A fork landing
-   *   between building a transaction and proving it therefore cannot send it to the wrong prover — and a transaction of
-   *   the epoch the facade is no longer in is refused rather than proved into something nobody can include.
+   *   Proved at the version stamped on the transaction itself, which is the version that fixed its bytes, and sealed at
+   *   that same version: proving is a long await, so the wallets can move under it, and neither the prover a
+   *   transaction is routed to nor the stamp it comes back with may be decided by where they have moved to.
+   *
+   *   Where they have moved to decides one thing only, and it is decided again once the proof is back: a crossing while
+   *   the transaction was in flight leaves it belonging to an epoch the wallets have left, and no chain they are on can
+   *   include it. Such a transaction is refused rather than sealed, and nothing is recorded as pending for it — a
+   *   pending entry would only wait out a TTL for an inclusion that cannot happen — while the reservations it made in
+   *   the three wallets are given back like those of any other failure here.
    * @param tx The unproven transaction.
-   * @returns The finalized transaction.
+   * @returns The finalized transaction, stamped with the version it was authored at.
+   * @throws {@link ProtocolVersionMismatchError} When the wallets left the transaction's epoch while it was being
+   *   proved, or were never in it.
    */
   async finalizeTransaction(tx: UnprovenTx): Promise<FinalizedTx> {
     try {
@@ -1623,10 +1651,13 @@ export class WalletFacade {
         this.accept<ledgerV9.UnprovenTransaction>(tx),
         tx.protocolVersion,
       );
-      const finalizedTx = this.seal('Finalized', (unboundTx as unknown as CarriedUnbound).bind());
+      // Read again on the far side of the proof: the epoch is the one thing about the transaction that a crossing
+      // during proving can change, and this is where it is caught.
+      this.accept<CarriedUnproven>(tx);
+      const finalizedTx = this.seal('Finalized', (unboundTx as unknown as CarriedUnbound).bind(), tx.protocolVersion);
       await this.pendingTransactionsService.addPendingTransaction(
         finalizedTx,
-        this.#observedProtocolVersion.getValue(),
+        Option.some(finalizedTx.protocolVersion),
       );
       return finalizedTx;
     } catch (error) {
@@ -1749,7 +1780,11 @@ export class WalletFacade {
     const signature = authoring.signData(fakeSigningKey, intent.signatureData(1));
     const fakeSignedTx = await this.dust.addDustGenerationSignature(fakeUnsignedTx, signature);
 
-    const finalizedFakeTx = this.seal('Finalized', this.accept<CarriedUnproven>(fakeSignedTx).mockProve().bind());
+    const finalizedFakeTx = this.seal(
+      'Finalized',
+      this.accept<CarriedUnproven>(fakeSignedTx).mockProve().bind(),
+      this.currentVersion(),
+    );
 
     const fee = await this.calculateTransactionFee(finalizedFakeTx);
 

--- a/packages/facade/test/provingAcrossFork.test.ts
+++ b/packages/facade/test/provingAcrossFork.test.ts
@@ -1,0 +1,307 @@
+/*
+ * This file is part of MIDNIGHT-WALLET-SDK.
+ * Copyright (C) Midnight Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * What the wallets reach while a transaction is at the prover, and what the finalized handle says afterwards.
+ *
+ * @remarks
+ *   Proving is the one long await between a transaction being authored and being submitted, so it is the window in which
+ *   the three wallets can move — an ordinary block within the same epoch, or the crossing to ledger-v9. The
+ *   transaction's bytes were fixed before the prover was called and no chain movement can change them, so the version
+ *   the finalized handle carries has to be the one it was authored at, whatever the wallets have reached by the time
+ *   the proof comes back.
+ *
+ *   The suite drives that window directly: a prover it holds mid-flight, and three wallet state streams it moves while
+ *   the transaction is waiting there.
+ */
+
+import * as ledgerV8 from '@midnight-ntwrk/ledger-v8';
+import * as ledgerV9 from '@midnightntwrk/ledger-v9';
+import {
+  InMemoryTransactionHistoryStorage,
+  NetworkId,
+  ProtocolVersion,
+  ProtocolVersionMismatchError,
+  WalletTransaction,
+  type FinalizedTx,
+  type UnprovenTx,
+} from '@midnightntwrk/wallet-sdk-abstractions';
+import {
+  type V9UnboundTransaction,
+  type VersionedProvingService,
+} from '@midnightntwrk/wallet-sdk-capabilities/proving';
+import { DustWallet, type DustWalletState } from '@midnightntwrk/wallet-sdk-dust-wallet';
+import { ShieldedWallet, type ShieldedWalletState } from '@midnightntwrk/wallet-sdk-shielded';
+import {
+  createKeystore,
+  PublicKey,
+  UnshieldedWallet,
+  type UnshieldedWalletState,
+} from '@midnightntwrk/wallet-sdk-unshielded-wallet';
+import { Option } from 'effect';
+import * as rx from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type BalancingRecipe,
+  type ResolvedConfiguration,
+  WalletEntrySchema,
+  WalletFacade,
+  mergeWalletEntries,
+} from '../src/index.js';
+
+import {
+  createV8MockProvingService,
+  drivenBy,
+  dustAt,
+  getDustSeed,
+  getShieldedSeed,
+  getUnshieldedSeed,
+  shieldedAt,
+  SilentPendingTransactions,
+  sleep,
+  unshieldedAt,
+} from './utils/index.js';
+
+/** The boundary this chain forks at. */
+const forkVersion = ProtocolVersion.V9NativeForkVersion;
+
+/** Where the three wallets are while the transaction is authored. */
+const v8Version = ProtocolVersion.ProtocolVersion(3n);
+
+/** Where an ordinary block within the same epoch puts them while the proof is in flight. */
+const laterV8Version = ProtocolVersion.ProtocolVersion(5n);
+
+/** Where the crossing puts them: past the boundary, which is where a wallet that has crossed reports from. */
+const v9Version = ProtocolVersion.ProtocolVersion(forkVersion + 1n);
+
+/** A promise the suite settles itself, so a step of the facade can be held open across an assertion. */
+const deferred = (): { readonly promise: Promise<void>; readonly settle: () => void } => {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  return { promise, settle: () => resolve() };
+};
+
+/** A prover that holds every transaction until the suite releases it, then proves it as the mock prover would. */
+class PausableProving implements VersionedProvingService<V9UnboundTransaction> {
+  readonly #proving = createV8MockProvingService();
+  readonly #reached = deferred();
+  readonly #released = deferred();
+
+  /** Settles once a transaction has reached the prover and is waiting there. */
+  readonly reached = this.#reached.promise;
+
+  /** Lets the held transaction go on to be proved. */
+  release(): void {
+    this.#released.settle();
+  }
+
+  async prove(
+    transaction: ledgerV9.UnprovenTransaction,
+    protocolVersion: ProtocolVersion.ProtocolVersion,
+  ): Promise<V9UnboundTransaction> {
+    this.#reached.settle();
+    await this.#released.promise;
+    return await this.#proving.prove(transaction, protocolVersion);
+  }
+}
+
+/** Records what the facade asks to be tracked as pending, and at which version. */
+class RecordingPendingTransactions extends SilentPendingTransactions {
+  readonly added: {
+    tx: FinalizedTx;
+    protocolVersion: Option.Option<ProtocolVersion.ProtocolVersion>;
+  }[] = [];
+
+  override addPendingTransaction(
+    tx: FinalizedTx,
+    protocolVersion: Option.Option<ProtocolVersion.ProtocolVersion>,
+  ): Promise<void> {
+    this.added.push({ tx, protocolVersion });
+    return Promise.resolve();
+  }
+}
+
+describe('a transaction proved while the wallets move', () => {
+  let configuration: ResolvedConfiguration;
+  let facade: WalletFacade;
+  let proving: PausableProving;
+  let pending: RecordingPendingTransactions;
+  let shieldedStates: rx.BehaviorSubject<ShieldedWalletState>;
+  let unshieldedStates: rx.BehaviorSubject<UnshieldedWalletState>;
+  let dustStates: rx.BehaviorSubject<DustWalletState>;
+
+  beforeEach(async () => {
+    configuration = {
+      networkId: NetworkId.NetworkId.Undeployed,
+      forks: { v9: forkVersion },
+      relayURL: new URL('http://localhost:9944'),
+      indexerClientConnection: { indexerHttpUrl: 'http://localhost:8080' },
+      provingServerUrl: new URL('http://localhost:6300'),
+      costParameters: { feeBlocksMargin: 0 },
+      txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema, mergeWalletEntries),
+    };
+    const seed = '0000000000000000000000000000000000000000000000000000000000000004';
+    const keystore = createKeystore({ kind: 'schnorr', secret: getUnshieldedSeed(seed) }, configuration.networkId);
+
+    // Real, shipped wallets, deliberately never started: this suite supplies their state stream, and starting them
+    // would open indexer subscriptions it has no indexer for.
+    const shielded = await ShieldedWallet(configuration).startWithSeed(getShieldedSeed(seed));
+    const unshielded = await UnshieldedWallet(configuration).startWithPublicKey(PublicKey.fromKeyStore(keystore));
+    const dust = await DustWallet(configuration).startWithSeed(
+      getDustSeed(seed),
+      ledgerV9.LedgerParameters.initialParameters().dust,
+    );
+
+    shieldedStates = new rx.BehaviorSubject(shieldedAt(await rx.firstValueFrom(shielded.state), v8Version));
+    unshieldedStates = new rx.BehaviorSubject(unshieldedAt(await rx.firstValueFrom(unshielded.state), v8Version));
+    dustStates = new rx.BehaviorSubject(dustAt(await rx.firstValueFrom(dust.state), v8Version));
+
+    drivenBy(shielded, shieldedStates);
+    drivenBy(unshielded, unshieldedStates);
+    drivenBy(dust, dustStates);
+
+    proving = new PausableProving();
+    pending = new RecordingPendingTransactions();
+
+    facade = await WalletFacade.init({
+      configuration,
+      shielded: () => shielded,
+      unshielded: () => unshielded,
+      dust: () => dust,
+      provingService: () => proving,
+      pendingTransactionsService: () => pending,
+    });
+  });
+
+  afterEach(async () => {
+    proving.release();
+    await facade?.stop();
+  });
+
+  /** A transaction of the epoch below the boundary, stamped at the version the wallets authored it at. */
+  const v8Transaction = (): UnprovenTx =>
+    WalletTransaction.adopt(
+      'Unproven',
+      ledgerV8.Transaction.fromParts(
+        configuration.networkId,
+        undefined,
+        undefined,
+        ledgerV8.Intent.new(new Date(Date.now() + 60_000)),
+      ),
+      v8Version,
+    );
+
+  /** Moves all three wallets to a version, and lets the facade observe it. */
+  const walletsReach = async (version: ProtocolVersion.ProtocolVersion): Promise<void> => {
+    shieldedStates.next(shieldedAt(shieldedStates.value, version));
+    unshieldedStates.next(unshieldedAt(unshieldedStates.value, version));
+    dustStates.next(dustAt(dustStates.value, version));
+    await sleep(0.2);
+  };
+
+  it('stamps the finalized transaction at the version it was authored at, not the one reached while proving', async () => {
+    const tx = v8Transaction();
+    const finalizing = facade.finalizeTransaction(tx);
+    await proving.reached;
+    await walletsReach(laterV8Version);
+    proving.release();
+
+    const finalized = await finalizing;
+
+    expect(finalized.protocolVersion).toBe(tx.protocolVersion);
+  });
+
+  it('records the pending transaction at the version it was authored at, so orphaning judges by that', async () => {
+    const tx = v8Transaction();
+    const finalizing = facade.finalizeTransaction(tx);
+    await proving.reached;
+    await walletsReach(laterV8Version);
+    proving.release();
+
+    const finalized = await finalizing;
+
+    expect(pending.added).toStrictEqual([{ tx: finalized, protocolVersion: Option.some(v8Version) }]);
+  });
+
+  it('refuses a transaction whose epoch the wallets left while it was being proved', async () => {
+    const tx = v8Transaction();
+    const finalizing = facade.finalizeTransaction(tx);
+    await proving.reached;
+    await walletsReach(v9Version);
+    proving.release();
+
+    const failure: unknown = await finalizing.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(ProtocolVersionMismatchError);
+    expect((failure as ProtocolVersionMismatchError)._tag).toBe(
+      '@midnightntwrk/wallet-sdk-abstractions/WalletTransaction/ProtocolVersionMismatchError',
+    );
+    expect((failure as ProtocolVersionMismatchError).authoredFor).toBe(v8Version);
+    expect((failure as ProtocolVersionMismatchError).accepted).toStrictEqual([
+      forkVersion,
+      ProtocolVersion.MaxSupportedVersion,
+    ]);
+  });
+
+  it('gives back what the refused transaction reserved, in all three wallets', async () => {
+    const shieldedRevert = vi.spyOn(facade.shielded, 'revertTransaction');
+    const unshieldedRevert = vi.spyOn(facade.unshielded, 'revertTransaction');
+    const dustRevert = vi.spyOn(facade.dust, 'revertTransaction');
+    const tx = v8Transaction();
+    const finalizing = facade.finalizeTransaction(tx);
+    await proving.reached;
+    await walletsReach(v9Version);
+    proving.release();
+
+    await expect(finalizing).rejects.toBeInstanceOf(ProtocolVersionMismatchError);
+
+    expect(shieldedRevert).toHaveBeenCalledWith(tx);
+    expect(unshieldedRevert).toHaveBeenCalledWith(tx);
+    expect(dustRevert).toHaveBeenCalledWith(tx);
+  });
+
+  it('tracks nothing as pending for a transaction no chain the wallets are on can include', async () => {
+    const finalizing = facade.finalizeTransaction(v8Transaction());
+    await proving.reached;
+    await walletsReach(v9Version);
+    proving.release();
+
+    await expect(finalizing).rejects.toBeInstanceOf(ProtocolVersionMismatchError);
+
+    expect(pending.added).toStrictEqual([]);
+  });
+
+  it('stamps a recipe finalized across a move within the epoch at the version the recipe was built for', async () => {
+    const recipe: BalancingRecipe = {
+      type: 'UNPROVEN_TRANSACTION',
+      transaction: v8Transaction(),
+      protocolVersion: v8Version,
+    };
+    const finalizing = facade.finalizeRecipe(recipe);
+    await proving.reached;
+    await walletsReach(laterV8Version);
+    proving.release();
+
+    const finalized = await finalizing;
+
+    expect(finalized.protocolVersion).toBe(v8Version);
+    expect(pending.added.map((entry) => entry.protocolVersion)).toStrictEqual([
+      Option.some(v8Version),
+      Option.some(v8Version),
+    ]);
+  });
+});

--- a/packages/shielded-wallet/src/ShieldedWallet.ts
+++ b/packages/shielded-wallet/src/ShieldedWallet.ts
@@ -795,6 +795,10 @@ export function CustomForkingShieldedWallet<
      *   so there is nothing of it to release and this resolves having done nothing. That is the one place a version
      *   mismatch is not an error: the facade reverts all three wallets together when a submission fails, and a refusal
      *   here would strand that whole path over a transaction this wallet was never holding anything for.
+     *
+     *   The coins a ledger-v8 transaction did book are not left behind by that no-op: they crossed the boundary as
+     *   reservations, and the first sync update after the crossing releases every one of them, because no transaction
+     *   of that ledger version can be included any more (`v2/CoreWallet.completeCrossing`).
      * @param transaction The transaction to un-record.
      */
     revertTransaction(transaction: AnyTx): Promise<void> {

--- a/packages/shielded-wallet/src/v2/CoinsAndBalances.ts
+++ b/packages/shielded-wallet/src/v2/CoinsAndBalances.ts
@@ -77,7 +77,8 @@ export const makeDefaultCoinsAndBalancesCapability = (): CoinsAndBalancesCapabil
   // local state before it holds the hashes for it — computing a commitment or nullifier needs the secret keys the
   // migration deliberately does not have — so a coin without its hash entry is not yet nameable and is left out of
   // the view, rather than assumed present and dereferenced. The window closes on the first sync update, which
-  // carries the keys and resolves the map (see CoreWallet.resolveCoinHashes).
+  // carries the keys and both resolves the map and releases the spends the state crossed with, so a coin booked for a
+  // transaction the boundary stranded is available again by the time it can be named (see CoreWallet.completeCrossing).
   const getAvailableCoins = (state: CoreWallet): AvailableCoin[] => {
     const pendingSpends = new Set([...state.state.pendingSpends.values()].map(([coin]) => coin.nonce));
     return pipe(

--- a/packages/shielded-wallet/src/v2/CoreWallet.ts
+++ b/packages/shielded-wallet/src/v2/CoreWallet.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 import * as ledger from '@midnightntwrk/ledger-v9';
 import { ProtocolVersion, SyncProgress } from '@midnightntwrk/wallet-sdk-abstractions';
+import { LedgerOps } from '@midnightntwrk/wallet-sdk-utilities';
 import { Either, Iterable, pipe, Record, Array as Arr } from 'effect';
 import { InvalidCoinHashesError, type WalletError } from './WalletError.js';
 
@@ -81,15 +82,49 @@ export type CoreWallet = Readonly<{
    *
    * @remarks
    *   Set by the cross-ledger migration and cleared by the first sync update, which is the first moment secret keys are
-   *   at hand — see {@link CoreWallet.fromPreviousVersion} and {@link CoreWallet.resolveCoinHashes}. Stated as a field
-   *   rather than inferred from "empty map beside a non-empty state" because an empty map is a perfectly good value for
-   *   a wallet holding nothing, and overloading it would make one shape mean two things. Being a field, it is also what
-   *   lets a snapshot taken mid-crossing declare itself: {@link CoreWallet.restoreWithCoinHashes} goes on rejecting a
-   *   snapshot whose hashes do not cover its coins, because only a wallet carrying this marker is permitted the gap.
-   *   `true` is the only inhabitant, so "pending" and "absent" are the only two states.
+   *   at hand — see {@link CoreWallet.fromPreviousVersion} and {@link CoreWallet.completeCrossing}. It is also what marks
+   *   the wallet as freshly crossed, which is how that step knows the reservations in its local state are ones no
+   *   inclusion can ever clear and releases them exactly once. Stated as a field rather than inferred from "empty map
+   *   beside a non-empty state" because an empty map is a perfectly good value for a wallet holding nothing, and
+   *   overloading it would make one shape mean two things. Being a field, it is also what lets a snapshot taken
+   *   mid-crossing declare itself: {@link CoreWallet.restoreWithCoinHashes} goes on rejecting a snapshot whose hashes do
+   *   not cover its coins, because only a wallet carrying this marker is permitted the gap. `true` is the only
+   *   inhabitant, so "pending" and "absent" are the only two states.
    */
   coinHashesPending?: true;
 }>;
+
+/**
+ * Releases every coin reservation a wallet carried across the ledger-version boundary.
+ *
+ * @remarks
+ *   `pendingSpends` crosses with the rest of the local state, and on the far side its entries name transactions of a
+ *   ledger version the chain has left behind: none of them can be included, so no inclusion will ever clear them, and a
+ *   coin held for one would sit outside the available set for the rest of the wallet's life. Re-deriving each spend and
+ *   reporting it failed is the ledger's own way of un-booking one: the reservation goes, and the coin stays at the
+ *   Merkle index the chain gave it, in a tree of unchanged height and root.
+ * @param state The local state as it crossed.
+ * @param secretKeys The keys the first sync update arrived with.
+ * @returns The same state with nothing reserved.
+ */
+const releaseStrandedSpends = (
+  state: ledger.ZswapLocalState,
+  secretKeys: ledger.ZswapSecretKeys,
+): ledger.ZswapLocalState =>
+  pipe(
+    [...state.pendingSpends.values()],
+    Arr.reduce(state, (released, [coin]) =>
+      pipe(
+        LedgerOps.ledgerTry(() => {
+          const [reserved, input] = released.spend(secretKeys, coin, 0);
+          return reserved.applyFailed(ledger.ZswapOffer.fromInput(input, coin.type, coin.value));
+        }),
+        // A reservation the ledger declines to re-derive is left exactly where it already was: one stranded coin is
+        // not worth failing the update every other coin in this wallet is waiting on.
+        Either.getOrElse(() => released),
+      ),
+    ),
+  );
 
 export const CoreWallet = {
   init(localState: ledger.ZswapLocalState, secretKeys: ledger.ZswapSecretKeys, networkId: string): CoreWallet {
@@ -229,8 +264,10 @@ export const CoreWallet = {
    *
    *   The one thing the bytes cannot supply is the coin hashes: commitments and nullifiers are computed from the secret
    *   keys, which a migration by design does not hold. They are therefore left empty and marked
-   *   {@link CoreWallet.coinHashesPending}, for {@link CoreWallet.resolveCoinHashes} to fill in at the first sync update
-   *   — the first place in this variant where keys and state meet.
+   *   {@link CoreWallet.coinHashesPending}, for {@link CoreWallet.completeCrossing} to fill in at the first sync update —
+   *   the first place in this variant where keys and state meet. The same step releases the spends the state crossed
+   *   with: those transactions belong to the ledger version the chain has left behind and can never be included, so
+   *   nothing else would ever free the coins they reserved.
    * @param previous The identity and position read off the previous ledger version's wallet, and its decoded state.
    * @returns A wallet of this ledger version holding what its predecessor held, positioned at the fork.
    */
@@ -253,17 +290,40 @@ export const CoreWallet = {
   },
 
   /**
-   * Computes the coin hashes a wallet crossed the ledger-version boundary without.
+   * Finishes a crossing at the first sync update: the reservations released, then the coin hashes computed.
    *
    * @remarks
    *   The other half of {@link CoreWallet.fromPreviousVersion}. A migrated wallet arrives holding its whole local state
-   *   but no commitments or nullifiers for it, because deriving those needs the secret keys — so the first sync update,
-   *   which carries them, is where the gap closes. Applied at the head of both sync capabilities, before anything else
-   *   they do, so a batch that turns out to be empty still resolves them: a wallet that crossed into a quiet timeline
-   *   must not be left unable to name its own coins.
+   *   but nothing it needs the secret keys for — no commitments or nullifiers, and no way to un-book the spends it
+   *   carried — because a migration is by design handed no key material. The first sync update carries it, so this is
+   *   where both gaps close: {@link releaseStrandedSpends} first, since a released coin is one more coin the hashes have
+   *   to name, and {@link CoreWallet.resolveCoinHashes} over the state that comes back. Applied at the head of both sync
+   *   capabilities, before anything else they do, so a batch that turns out to be empty still runs it: a wallet that
+   *   crossed into a quiet timeline must not be left unable to name or to spend the coins it crossed with.
    *
    *   Idempotent and self-clearing: without the marker this is the identity, so it costs a field read on every update
-   *   thereafter and nothing else.
+   *   thereafter and nothing else. That is also what keeps it away from a reservation made on this side of the
+   *   boundary, whose transaction is live and whose coins are genuinely spoken for.
+   * @param wallet The wallet to complete.
+   * @param secretKeys The keys the update arrived with.
+   * @returns `wallet` unchanged if it never crossed, otherwise a copy whose coins are nameable and spendable again.
+   */
+  completeCrossing(wallet: CoreWallet, secretKeys: ledger.ZswapSecretKeys): CoreWallet {
+    return wallet.coinHashesPending === undefined
+      ? wallet
+      : CoreWallet.resolveCoinHashes({ ...wallet, state: releaseStrandedSpends(wallet.state, secretKeys) }, secretKeys);
+  },
+
+  /**
+   * Computes the coin hashes a wallet crossed the ledger-version boundary without.
+   *
+   * @remarks
+   *   The hash half of {@link CoreWallet.completeCrossing}, which is what the sync capabilities call: a crossing has a
+   *   second gap to close beside this one, so a caller finishing one should go through the combined step rather than
+   *   here. A migrated wallet arrives holding its whole local state but no commitments or nullifiers for it, because
+   *   deriving those needs the secret keys, and the first sync update is what carries them.
+   *
+   *   Idempotent and self-clearing: without the marker this is the identity.
    * @param wallet The wallet to complete.
    * @param secretKeys The keys the update arrived with.
    * @returns `wallet` unchanged if its hashes were never pending, otherwise a copy holding them.

--- a/packages/shielded-wallet/src/v2/Migration.ts
+++ b/packages/shielded-wallet/src/v2/Migration.ts
@@ -113,6 +113,16 @@ export type PreviousLedgerWallet = Readonly<{
  *   could have recovered. `src/v2/test/byteCrossing.test.ts` pins that codec against both real ledgers, and states what
  *   to do if it ever goes red.
  *
+ *   **The coins booked for transactions still in flight cross too, and are released at the first sync update.** Those
+ *   transactions belong to the ledger version the chain has left behind, so none of them can ever be included and no
+ *   inclusion will ever clear the reservations they left in `pendingSpends` — the coins would simply stop being
+ *   spendable. The release cannot happen here, because un-booking a spend needs the secret keys a migration is by
+ *   design handed none of; it happens at the first sync update instead, which is where keys and carried state meet
+ *   (`CoreWallet.completeCrossing`). The change outputs those same transactions would have paid back are left as they
+ *   are, and nothing ever removes them: these entries carry no TTL and `ZswapLocalState.clearPending` does nothing in
+ *   either ledger, so they sit in `pendingOutputs` for the life of the wallet. A known limitation, and a mild one —
+ *   they overstate the pending balance, but they reserve no coin and block no spending.
+ *
  *   Read through `LedgerOps.ledgerTry`, so a codec that has moved is a `WalletError` at the boundary and never a throw:
  *   the failure mode of a future major moving `zswap-local-state` is loud, and lands here, where the
  *   {@link StateMigration} seam can be given the ledger team's own translation instead.

--- a/packages/shielded-wallet/src/v2/Sync.ts
+++ b/packages/shielded-wallet/src/v2/Sync.ts
@@ -612,10 +612,10 @@ export const makeEventsSyncCapability = (): SyncCapability<CoreWallet, WalletSyn
       }
 
       // First, and before any early return: a wallet that crossed the ledger-version boundary arrives with its whole
-      // local state but no hashes for it, and this update is the first place its keys are at hand. An empty batch is
-      // exactly the case that must not skip this — a wallet whose timeline has gone quiet still has to be able to name
-      // the coins it crossed with.
-      const state = CoreWallet.resolveCoinHashes(wallet, wrappedUpdate.secretKeys);
+      // local state but neither hashes for it nor a way to un-book the spends it carried, and this update is the first
+      // place its keys are at hand. An empty batch is exactly the case that must not skip this — a wallet whose
+      // timeline has gone quiet still has to be able to name and to spend the coins it crossed with.
+      const state = CoreWallet.completeCrossing(wallet, wrappedUpdate.secretKeys);
 
       if (wrappedUpdate.updates.length === 0) {
         return [state, noChanges(state)];
@@ -732,7 +732,7 @@ export const makeSimulatorSyncCapability = (): SyncCapability<CoreWallet, Simula
 
       // The same first step as the indexer capability's, for the same reason: this is where a migrated wallet's keys
       // and its carried state first meet, and a block that turns out to hold nothing must not skip it.
-      const state = CoreWallet.resolveCoinHashes(wallet, secretKeys);
+      const state = CoreWallet.completeCrossing(wallet, secretKeys);
 
       const lastBlock = getLastBlock(simulatorState);
       if (lastBlock === undefined) {

--- a/packages/shielded-wallet/src/v2/test/strandedSpends.test.ts
+++ b/packages/shielded-wallet/src/v2/test/strandedSpends.test.ts
@@ -1,0 +1,219 @@
+// This file is part of MIDNIGHT-WALLET-SDK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * What becomes of coins a wallet reserved for a ledger-v8 transaction that the chain then forked away from.
+ *
+ * @remarks
+ *   A wallet crosses the ledger-version boundary as bytes, and `pendingSpends` — the coins it had booked for transactions
+ *   still in flight — crosses with everything else. Those transactions belong to a ledger version the chain has left:
+ *   none of them can ever be included, so nothing on the far side will ever clear the reservation, and a coin whose
+ *   reservation is never cleared is one `getAvailableCoins` never offers again. The remedy under test is the first sync
+ *   update, the first place the carried state and the secret keys meet: it releases every reservation the wallet
+ *   arrived holding, once, and leaves a wallet that never crossed alone.
+ *
+ *   Both ledgers are the real modules, and the reservation under test is a real one — a ledger-v8 spend built against a
+ *   ledger-v8 tree, carried over by the migration itself. Nothing here is stubbed: whether a ledger-v9 state will
+ *   re-derive and drop a reservation minted by ledger-v8 is a question only the two modules can answer, and whether the
+ *   coin is still spendable afterwards is one only a chain can.
+ */
+
+import * as ledgerV8 from '@midnight-ntwrk/ledger-v8';
+import * as ledger from '@midnightntwrk/ledger-v9';
+import { NetworkId, ProtocolVersion, type SyncProgress } from '@midnightntwrk/wallet-sdk-abstractions';
+import { Effect, Either, pipe } from 'effect';
+import { describe, expect, it, vi } from 'vitest';
+import { makeDefaultCoinsAndBalancesCapability } from '../CoinsAndBalances.js';
+import { CoreWallet } from '../CoreWallet.js';
+import { type PreviousLedgerWallet, makeCrossLedgerMigration } from '../Migration.js';
+import { WalletSyncUpdate, makeEventsSyncCapability } from '../Sync.js';
+
+// Real cryptography in two WASM ledgers at once, which on a loaded runner outlasts the 30s default.
+vi.setConfig({ testTimeout: 120_000 });
+
+const networkId = NetworkId.NetworkId.Undeployed;
+const seed = Buffer.alloc(32, 3);
+const v8Keys = (): ledgerV8.ZswapSecretKeys => ledgerV8.ZswapSecretKeys.fromSeed(seed);
+const keys = (): ledger.ZswapSecretKeys => ledger.ZswapSecretKeys.fromSeed(seed);
+
+const tokenType = ledgerV8.shieldedToken().raw;
+const value = 500n;
+
+/** The version that triggered the hand-over, and the range the V2 variant owns from it. */
+const forkVersion = ProtocolVersion.ProtocolVersion(7n);
+const activeRange = ProtocolVersion.makeRange(forkVersion, ProtocolVersion.MaxSupportedVersion);
+
+const parkedProgress: SyncProgress.SyncProgressData = {
+  appliedIndex: 4321n,
+  highestRelevantWalletIndex: 4400n,
+  highestIndex: 4400n,
+  highestRelevantIndex: 4400n,
+  isConnected: true,
+};
+
+const capability = makeEventsSyncCapability();
+const coinsAndBalances = makeDefaultCoinsAndBalancesCapability();
+
+/** An empty batch, which is the case that matters: a quiet timeline must not skip the release. */
+const emptyUpdate = (): WalletSyncUpdate => WalletSyncUpdate.create([], keys());
+
+/** One payment of `value` to this wallet, on the ledger the chain ran below `forks.v9`. */
+const v8Payment = (): Readonly<{
+  coin: ledgerV8.ShieldedCoinInfo;
+  offer: ledgerV8.ZswapOffer<ledgerV8.PreProof>;
+}> => {
+  const mine = v8Keys();
+  const coin = ledgerV8.createShieldedCoinInfo(tokenType, value);
+  const output = ledgerV8.ZswapOutput.new(coin, 0, mine.coinPublicKey, mine.encryptionPublicKey);
+  return { coin, offer: ledgerV8.ZswapOffer.fromOutput<ledgerV8.PreProof>(output, coin.type, coin.value) };
+};
+
+const payment = v8Payment();
+
+/**
+ * A ledger-v8 wallet holding one coin it has already booked for a transaction in flight.
+ *
+ * @remarks
+ *   Exactly the shape a wallet is in when a hard fork catches it mid-submission: the coin is still in the tree, and a
+ *   nullifier for it sits in `pendingSpends` waiting for an inclusion that the boundary makes impossible.
+ */
+const v8StateWithReservedSpend = (): ledgerV8.ZswapLocalState => {
+  const mine = v8Keys();
+  const settled = new ledgerV8.ZswapLocalState().apply(mine, payment.offer);
+  const [reserved] = settled.spend(mine, [...settled.coins][0], 0);
+  return reserved;
+};
+
+/** A wallet of the previous ledger version, as the runtime hands one over. */
+const previousWallet = (state: ledgerV8.ZswapLocalState): PreviousLedgerWallet => {
+  const mine = v8Keys();
+  return {
+    publicKeys: { coinPublicKey: mine.coinPublicKey, encryptionPublicKey: mine.encryptionPublicKey },
+    networkId,
+    protocolVersion: forkVersion,
+    progress: parkedProgress,
+    state,
+  };
+};
+
+const crossed = (): Promise<CoreWallet> =>
+  Effect.runPromise(makeCrossLedgerMigration().migrate(previousWallet(v8StateWithReservedSpend())));
+
+/**
+ * The ledger-v9 chain the fork left behind, holding the ledger-v8 commitment.
+ *
+ * @remarks
+ *   The translation stub's construction: re-paying the same coin to the same public keys reproduces the ledger-v8
+ *   commitment, because a commitment is a function of the coin and its owner alone. It is what gives "the coin still
+ *   spends" its teeth — a spend carries a Merkle path, and a chain accepts it only if that path resolves to a root the
+ *   chain holds.
+ */
+const v9Chain = (): ledger.ZswapChainState => {
+  const mine = keys();
+  const coin = { type: payment.coin.type, nonce: payment.coin.nonce, value: payment.coin.value };
+  const output = ledger.ZswapOutput.new(coin, 0, mine.coinPublicKey, mine.encryptionPublicKey);
+  const [applied] = new ledger.ZswapChainState().tryApply(
+    ledger.ZswapOffer.fromOutput<ledger.PreProof>(output, coin.type, coin.value),
+  );
+  return applied.postBlockUpdate(new Date(1_000), 3_600n);
+};
+
+/** Builds a spend of `coin` off `state` and offers it to `chain`, keeping whatever the ledger said if it refuses. */
+const spendAgainst = (
+  chain: ledger.ZswapChainState,
+  state: ledger.ZswapLocalState,
+  coin: ledger.QualifiedShieldedCoinInfo,
+): Either.Either<ledger.ZswapChainState, string> =>
+  Either.try({
+    try: () => {
+      const [, input] = state.spend(keys(), coin, 0);
+      const [applied] = chain.tryApply(ledger.ZswapOffer.fromInput(input, coin.type, coin.value));
+      return applied;
+    },
+    catch: (error) => (error instanceof Error ? error.message : String(error)),
+  });
+
+describe('a spend a wallet reserved coins for below `forks.v9`', () => {
+  it('crosses the boundary as a reservation nothing on the far side can ever clear', async () => {
+    // The premise, read off the migration rather than assumed: the bytes carry `pendingSpends` too, and while the
+    // reservation stands the coin is not in the available set, nor in the balance the wallet reports.
+    const wallet = await crossed();
+    const resolved = CoreWallet.resolveCoinHashes(wallet, keys());
+
+    expect(wallet.state.pendingSpends.size).toBe(1);
+    expect([...wallet.state.coins].length).toBe(1);
+    expect(coinsAndBalances.getAvailableCoins(resolved)).toEqual([]);
+    expect(coinsAndBalances.getAvailableBalances(resolved)).toEqual({});
+  });
+
+  it('is released by the first sync update, even an empty one, and the coin comes back whole', async () => {
+    const wallet = await crossed();
+    const rootBeforeRelease = wallet.state.merkleTreeRoot;
+    const firstFreeBeforeRelease = wallet.state.firstFree;
+
+    const [state] = capability.applyUpdate(wallet, emptyUpdate(), activeRange);
+
+    expect(state.state.pendingSpends.size).toBe(0);
+
+    const available = coinsAndBalances.getAvailableCoins(state);
+    expect(available.map(({ coin }) => coin.nonce)).toEqual([payment.coin.nonce]);
+    expect(coinsAndBalances.getAvailableBalances(state)).toEqual({ [tokenType]: value });
+
+    // The release must not disturb the tree the coin hangs off: same root, same height, same Merkle index.
+    expect(state.state.merkleTreeRoot).toBe(rootBeforeRelease);
+    expect(state.state.firstFree).toBe(firstFreeBeforeRelease);
+    expect(available[0].coin.mt_index).toBe([...wallet.state.coins][0].mt_index);
+
+    // And the coin is money again, by the only measure that counts: the chain the fork left behind takes the spend.
+    expect(spendAgainst(v9Chain(), state.state, available[0].coin)).toStrictEqual(Either.right(expect.anything()));
+  });
+});
+
+describe('a spend of a wallet that never crossed', () => {
+  /** A wallet of this ledger version, holding one coin, built the way a syncing wallet builds one. */
+  const settledWallet = (): CoreWallet => {
+    const mine = keys();
+    const coin = ledger.createShieldedCoinInfo(ledger.shieldedToken().raw, value);
+    const output = ledger.ZswapOutput.new(coin, 0, mine.coinPublicKey, mine.encryptionPublicKey);
+    const offer = ledger.ZswapOffer.fromOutput<ledger.PreProof>(output, coin.type, coin.value);
+    return CoreWallet.init(new ledger.ZswapLocalState().apply(mine, offer), mine, networkId);
+  };
+
+  const withReservedSpend = (wallet: CoreWallet): CoreWallet =>
+    pipe(CoreWallet.spendCoins(wallet, keys(), [[...wallet.state.coins][0]], 0), ([, reserved]) => reserved);
+
+  it('stands through the same update, because that transaction can still be included', () => {
+    const wallet = withReservedSpend(settledWallet());
+    expect(wallet.coinHashesPending).toBeUndefined();
+
+    const [state] = capability.applyUpdate(wallet, emptyUpdate(), activeRange);
+
+    expect(state.state.pendingSpends.size).toBe(1);
+    expect(coinsAndBalances.getAvailableCoins(state)).toEqual([]);
+  });
+
+  it('stands through the same update once the wallet has crossed and been released, because the marker is spent', async () => {
+    // The release is a one-off tied to the crossing, not a standing policy: a reservation this wallet makes on the far
+    // side is a live transaction of this ledger version, and dropping it would let the wallet double-spend its own coin.
+    const [released] = capability.applyUpdate(await crossed(), emptyUpdate(), activeRange);
+    expect(released.state.pendingSpends.size).toBe(0);
+
+    const reserved = withReservedSpend(released);
+    expect(reserved.state.pendingSpends.size).toBe(1);
+
+    const [state] = capability.applyUpdate(reserved, emptyUpdate(), activeRange);
+
+    expect(state.state.pendingSpends.size).toBe(1);
+    expect(coinsAndBalances.getAvailableCoins(state)).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Description

Two hard-fork defects found in review of the fork-crossing work, both reproduced before fixing. Stacked on #729, which fixes the third finding from the same review (finalized history overwritten by a late verdict); this PR's diff shows only the two changes below.

1. **Shielded coins reserved for a ledger-v8 transaction stayed unavailable for the life of the wallet after the crossing.** The migration carries `ZswapLocalState` across as bytes, `pendingSpends` included. Past the fork no ledger-v8 transaction can be included, so nothing ever cleared those reservations, and the V2 variant's `revertTransaction` is a deliberate no-op for a ledger-v8 handle. `getAvailableCoins` filters by `pendingSpends`, so the coins vanished from the available set, coin selection and the available balance.
2. **A proof completing after the crossing stamped ledger-v8 bytes with a ledger-v9 version.** `finalizeTransaction` routed proving by the handle's version but sealed the result with the facade's version at completion time. Reproduced with a paused prover: authored at 0, stamped 2000001 on a chain forking at 2000000. The pending item then took the observed version too, so orphaning never touched it, submission accepted it in the wrong epoch, and a revert would have handed a ledger-v8 object to ledger-v9.

# Proposed Solution

1. `CoreWallet.completeCrossing` (v2 only, since V1 is never on the receiving end of a crossing) runs at the head of both sync capabilities under the existing `coinHashesPending` marker: for each carried pending spend it re-derives the spend with this ledger's keys and `applyFailed`s the offer, then resolves coin hashes from the released state. The marker keeps it to one run per crossing. This is the only key-based path the ledger offers; `clearPending` is a no-op in both ledger versions and there is no key-less release (ledger issue midnightntwrk/midnight-ledger#746 asks for one). Stranded `pendingOutputs` are left as a documented limitation: they overstate the pending balance but block nothing.
2. `seal` now requires an explicit version. `finalizeTransaction` and `finalizeRecipe` seal at the handle's authored version and stamp the pending item with it. After the proof returns, `finalizeTransaction` re-accepts the input handle, so a crossing during proving raises `ProtocolVersionMismatchError`, the existing catch reverts the three wallets, and nothing is recorded as pending.

# Important Changes Introduced

- New public `CoreWallet.completeCrossing` in `@midnightntwrk/wallet-sdk-shielded` v2; `resolveCoinHashes` keeps its contract as the hash half.
- `finalizeTransaction` can now reject with `ProtocolVersionMismatchError` after proving, not only before it.
- Pending items recorded by `finalizeTransaction` / `finalizeRecipe` carry the transaction's authored version rather than the observed chain version.
- Two changesets (shielded patch, facade patch).

# Testing

- `packages/shielded-wallet/src/v2/test/strandedSpends.test.ts`: real ledger-v8 state with a reservation crosses through `makeCrossLedgerMigration` and an empty first update; asserts the reservation is released, the coin is available and in the balance, root/height/leaf index unchanged, and the coin spends against a ledger-v9 chain. Also covers a never-crossed wallet and a reservation made after release.
- `packages/facade/test/provingAcrossFork.test.ts`: pausable prover; drift within the epoch keeps the authored stamp on the handle and the pending item; a crossing mid-proof rejects, reverts all three wallets, records nothing.
- Verified independently with separate throwaway tests against both real ledgers and the facade harness (not committed). Full unit suites green for shielded (34 files, 253 tests) and facade (18 files, 105 tests); typecheck, lint, format, Effect diagnostics and the fork-vocabulary check clean.
