### PR TITLE
fix(dust-wallet): terminate computeBalancingRecipe instead of looping forever

### DIFF
--- a/.changeset/dust-fee-balancing-terminates.md
+++ b/.changeset/dust-fee-balancing-terminates.md
@@ -1,0 +1,22 @@
+---
+'@midnightntwrk/wallet-sdk-dust-wallet': patch
+---
+
+Fix `computeBalancingRecipe` looping forever instead of terminating on wallets holding several part-drained dust coins.
+
+The loop had no bound on the number of passes and no check that a pass had made progress. Its first pass was seeded
+with the transaction's dust imbalance, which is negative (a deficit); every later pass was seeded with the fee it had
+just computed, which is positive. `getBalanceRecipe` treats a non-negative seed as a surplus of the fee token — it adds
+a change output and selects zero inputs — so any wallet whose first pass under-covered its own fee looped forever,
+rebuilding and proof-erasing an identical transaction on every pass while its memory grew unbounded.
+
+Each pass now seeds the balancer with the outstanding deficit rather than the raw fee, which both corrects the sign
+and bounds the loop: adding an input can only raise the fee, so a pass that does not converge has strictly grown the
+input set, and a finite coin pool bounds the number of passes.
+
+Since the additive loop is only complete when it selects from the top — an ascending order can take a small coin, be
+forced to add a large one to cover the resulting fee, and find the pair still short when the large coin alone would
+have paid — a pass that ends in `InsufficientFundsError` is now retried once, greedily by value, before the error is
+reported. This can select coins in an order other than the caller's configured `coinSelection` on that one retry.
+
+No public API changes.

--- a/.changeset/dust-fee-balancing-terminates.md
+++ b/.changeset/dust-fee-balancing-terminates.md
@@ -6,17 +6,29 @@ Fix `computeBalancingRecipe` looping forever instead of terminating on wallets h
 
 The loop had no bound on the number of passes and no check that a pass had made progress. Its first pass was seeded
 with the transaction's dust imbalance, which is negative (a deficit); every later pass was seeded with the fee it had
-just computed, which is positive. `getBalanceRecipe` treats a non-negative seed as a surplus of the fee token — it adds
-a change output and selects zero inputs — so any wallet whose first pass under-covered its own fee looped forever,
-rebuilding and proof-erasing an identical transaction on every pass while its memory grew unbounded.
+just computed, which is positive. `getBalanceRecipe` treats a non-negative seed as a surplus of dust — it adds a change
+output and selects zero inputs — so any wallet whose first pass under-covered its own fee looped forever, rebuilding and
+proof-erasing an identical transaction on every pass while its memory grew unbounded.
 
-Each pass now seeds the balancer with the outstanding deficit rather than the raw fee, which both corrects the sign
-and bounds the loop: adding an input can only raise the fee, so a pass that does not converge has strictly grown the
-input set, and a finite coin pool bounds the number of passes.
+Each pass now seeds the balancer with the outstanding deficit — the fee still unpaid by the coins already chosen and by
+the dust the transactions already carry — over the coins not yet selected, and passes the per-input fee measured so far
+as `inputFeeOverhead`, so the second pass normally completes what the first left short. A pass that consumes no coin
+fails instead of repeating, which bounds the loop by the pool size. Selected coins keep their selection order, so the
+fee is drained from the coins chosen first, as before.
 
-Since the additive loop is only complete when it selects from the top — an ascending order can take a small coin, be
-forced to add a large one to cover the resulting fee, and find the pair still short when the large coin alone would
-have paid — a pass that ends in `InsufficientFundsError` is now retried once, greedily by value, before the error is
-reported. This can select coins in an order other than the caller's configured `coinSelection` on that one retry.
+Behaviour that changes as a result, all of it previously unreachable because the loop hung first:
 
-No public API changes.
+- Dust the transactions already carry — existing spends, registration allowances — now counts toward coverage, so new
+  inputs pay only the shortfall rather than the whole fee on top of it. The reported fee remains the total fee of the
+  merged result, as `estimateFee` documents.
+- A transaction that already covers its fee produces no balancing intent. `balanceTransactions` returns an empty
+  transaction, which merges as the identity, instead of an intent with empty `DustActions`, which the ledger rejects.
+- If the configured `coinSelection` exhausts the pool without covering the fee, selection is retried once largest-first:
+  an additive selection is only guaranteed to find a covering set when it takes coins from the top. A selector that
+  declines coins is never overridden and reports insufficient funds directly.
+- A selector that returns a coin it was not offered fails with `TransactingError` naming the mismatch, rather than
+  pricing the same transaction repeatedly.
+
+`dryRunFee` gains an optional trailing parameter carrying the proof-erased, merged transactions so a caller pricing
+several input sets need not merge them once per set; with no inputs it now prices the transactions as they are rather
+than with an extra empty intent. No other public API changes.

--- a/packages/dust-wallet/src/v1/Transacting.ts
+++ b/packages/dust-wallet/src/v1/Transacting.ts
@@ -10,7 +10,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { Either, pipe, BigInt as BigIntOps, Iterable as IterableOps, Option } from 'effect';
+import {
+  Array as EArray,
+  BigInt as BigIntOps,
+  Data,
+  Either,
+  Iterable as IterableOps,
+  Match,
+  Option,
+  pipe,
+} from 'effect';
 import {
   DustActions,
   DustRegistration,
@@ -213,10 +222,67 @@ const distributeFeeAcrossInputs = <T extends { value: bigint }>(
     { result: [], remaining: fee },
   ).result;
 
+/** The transactions being balanced, proof-erased and merged once, with the segment a balancing intent may use. */
+type MergedTransactions = {
+  readonly transaction: ProofErasedTransaction;
+  readonly segmentId: number;
+};
+
 /**
- * Picks the largest-value coin from the pool. Used only as a fallback inside `computeBalancingRecipe` when the caller's
- * configured selection order leaves an affordable set of coins unselected (see the comment there) — not exported, since
- * overriding the configured order is this loop's own last resort, not a general-purpose selector.
+ * Proof-erases and merges the transactions being balanced. This does not depend on which dust inputs are being priced,
+ * so callers pricing several input sets against the same transactions do it once, not once per pass. `None` when there
+ * is nothing to balance against. May throw: it is ledger arithmetic, and callers wrap it in `LedgerOps.ledgerTry`.
+ */
+const mergeErasedTransactions = (
+  transactions: ReadonlyArray<FinalizedTransaction | UnprovenTransaction>,
+): Option.Option<MergedTransactions> =>
+  pipe(
+    transactions.map((tx) => tx.eraseProofs()),
+    EArray.match({
+      onEmpty: () => Option.none(),
+      onNonEmpty: ([first, ...rest]) => {
+        const transaction = rest.reduce((acc, tx) => acc.merge(tx), first);
+        return Option.some({
+          transaction,
+          segmentId: Option.getOrElse(findAvailableSegmentId(transaction), () => 1),
+        });
+      },
+    }),
+  );
+
+/** What `computeBalancingRecipe` produces: the total fee of the balanced result and what each selected coin pays. */
+type DustBalancingRecipe = {
+  readonly fee: bigint;
+  readonly recipeInputs: ReadonlyArray<CoinWithValue<Dust>>;
+};
+
+/** The pool ran out under the configured order before the fee was covered — an ordering artefact, retried largest-first. */
+class SelectionExhausted extends Data.TaggedError('DustBalancing.SelectionExhausted')<{
+  readonly message: string;
+}> {}
+
+/** The configured selector declined the coins it was offered — a policy, honoured as-is and never retried. */
+class SelectionRefused extends Data.TaggedError('DustBalancing.SelectionRefused')<{
+  readonly remaining: number;
+}> {}
+
+/** The selector returned coins that were not among those offered, so a pass consumed nothing and could not progress. */
+class SelectionMadeNoProgress extends Data.TaggedError('DustBalancing.SelectionMadeNoProgress')<{
+  readonly returned: number;
+  readonly remaining: number;
+}> {}
+
+/** `getBalanceRecipe` threw something other than its insufficient-funds error. */
+class BalancerFailed extends Data.TaggedError('DustBalancing.BalancerFailed')<{
+  readonly cause: unknown;
+}> {}
+
+type SelectionFailure = SelectionExhausted | SelectionRefused | SelectionMadeNoProgress | BalancerFailed;
+
+/**
+ * Picks the largest-value coin from the pool. Used only for the one retry inside `computeBalancingRecipe`, when the
+ * configured order exhausts the pool with an affordable set of coins left unselected; not exported, since it is that
+ * loop's last resort rather than a general-purpose selector.
  */
 const largestFirst: CoinSelection = (coins) =>
   coins
@@ -225,54 +291,159 @@ const largestFirst: CoinSelection = (coins) =>
     .at(0);
 
 /**
- * Selects dust inputs, under one coin-selection order, until they cover the fee of the transaction they produce. Each
- * pass hands the balancer only the fee still unpaid by the coins already chosen — the deficit, expressed as a negative
- * imbalance — over the coins not yet selected, then re-prices the transaction with everything selected so far via
- * `feeFor`. Adding an input can only raise the fee, so a pass that does not converge has strictly grown the input set;
- * with a finite coin pool that bounds the number of passes by the pool's size. Throws the balancer's own
- * `BalancingInsufficientFundsError` when the pool cannot cover the fee under this order — including when
- * `coinSelection` itself returns nothing from a non-empty pool.
+ * A selector declines by returning `undefined`, and the balancer folds that into the same `InsufficientFundsError` it
+ * throws for an exhausted pool. The two must stay distinguishable — declining is the caller's policy and must never be
+ * overridden by the largest-first retry — so a decline on a non-empty pool is surfaced as its own failure here.
+ * Throwing is the only way out of `getBalanceRecipe`, whose failure contract is exceptions; it is caught by the
+ * `Either.try` in `selectForDeficit` and never leaves this module.
  */
-const runBalancingPasses = (
-  coins: ReadonlyArray<CoinWithValue<Dust>>,
-  initialImbalance: bigint,
-  feeFor: (inputs: ReadonlyArray<CoinWithValue<Dust>>) => bigint,
+const surfacingRefusal =
+  (coinSelection: CoinSelection): CoinSelection =>
+  (coins) => {
+    const chosen = coinSelection(coins);
+    if (chosen === undefined && coins.length > 0) {
+      throw new SelectionRefused({ remaining: coins.length });
+    }
+    return chosen;
+  };
+
+/**
+ * One pass of selection: coins from `remaining`, in the configured order, until their value covers `deficit` plus
+ * `inputFeeOverhead` for each coin taken. Returned in selection order — `distributeFeeAcrossInputs` relies on that to
+ * drain the coins chosen first (under the default order, the smaller ones) before touching the later ones.
+ */
+const selectForDeficit = (
+  remaining: ReadonlyArray<CoinWithValue<Dust>>,
+  deficit: bigint,
+  inputFeeOverhead: bigint,
   coinSelection: CoinSelection,
-): { fee: bigint; recipeInputs: ReadonlyArray<CoinWithValue<Dust>> } => {
-  const inputs: CoinWithValue<Dust>[] = [];
-  let remaining = coins;
-  let fee = -initialImbalance;
+): Either.Either<EArray.NonEmptyReadonlyArray<CoinWithValue<Dust>>, SelectionFailure> =>
+  pipe(
+    Either.try({
+      try: () =>
+        getBalanceRecipe({
+          coins: remaining.map((coin) => ({ type: 'dust', value: coin.value, token: coin.token })),
+          initialImbalances: CapImbalances.fromEntry('dust', -deficit),
+          feeTokenType: 'dust',
+          coinSelection: surfacingRefusal(coinSelection),
+          transactionCostModel: { inputFeeOverhead, outputFeeOverhead: 0n },
+          createOutput: (coin) => coin,
+          isCoinEqual: (a, b) => a.token.nonce === b.token.nonce,
+        }),
+      catch: (err): SelectionFailure =>
+        err instanceof SelectionRefused
+          ? err
+          : err instanceof BalancingInsufficientFundsError
+            ? new SelectionExhausted({ message: err.message })
+            : new BalancerFailed({ cause: err }),
+    }),
+    Either.flatMap((recipe) => {
+      const added = EArray.filterMap(recipe.inputs, (input) =>
+        EArray.findFirst(remaining, (coin) => coin.token.nonce === input.token.nonce),
+      );
+      return EArray.isNonEmptyReadonlyArray(added)
+        ? Either.right(added)
+        : Either.left(new SelectionMadeNoProgress({ returned: recipe.inputs.length, remaining: remaining.length }));
+    }),
+  );
 
-  // Every pass either returns or consumes at least one coin from `remaining`, so this bound
-  // is never actually reached; it turns a broken invariant into a thrown error instead of an
-  // infinite loop.
-  for (let pass = 0; pass <= coins.length; pass++) {
-    const covered = inputs.reduce((sum, input) => sum + input.value, 0n);
-    if (fee <= covered) {
-      return { fee, recipeInputs: distributeFeeAcrossInputs(inputs, fee) };
-    }
+/**
+ * The fee grows with every dust input, and the balancer can anticipate that through `inputFeeOverhead`, which it
+ * subtracts from the outstanding deficit per coin it takes. The ledger's cost model does not expose the figure, so it
+ * is measured: the fee increase over the base fee so far, averaged over the inputs taken, rounded up. Zero until the
+ * first pass has priced something, so that pass selects on raw value and later passes complete what it left short.
+ */
+const marginalFeePerInput = (feeIncrease: bigint, inputs: number): bigint =>
+  inputs === 0 || feeIncrease <= 0n ? 0n : (feeIncrease + BigInt(inputs) - 1n) / BigInt(inputs);
 
-    const recipe = getBalanceRecipe({
-      coins: remaining.map((coin) => ({ type: 'dust', value: coin.value, token: coin.token })),
-      initialImbalances: CapImbalances.fromEntry('dust', covered - fee),
-      feeTokenType: 'dust',
-      coinSelection,
-      transactionCostModel: { inputFeeOverhead: 0n, outputFeeOverhead: 0n },
-      createOutput: (coin) => coin,
-      isCoinEqual: (a, b) => a.token.nonce === b.token.nonce,
+/**
+ * Selects dust inputs until, together with the dust the transactions already carry, they cover the fee of the
+ * transaction they produce. Each pass covers only the outstanding deficit from the coins not yet selected, then
+ * re-prices with everything selected so far. A pass that takes no coin fails as `SelectionMadeNoProgress`, so every
+ * pass shrinks `remaining` and the recursion is bounded by the pool size.
+ */
+const selectDustInputs = (args: {
+  readonly coins: ReadonlyArray<CoinWithValue<Dust>>;
+  readonly baseFee: bigint;
+  readonly existingDust: bigint;
+  readonly feeWith: (
+    inputs: EArray.NonEmptyReadonlyArray<CoinWithValue<Dust>>,
+  ) => Either.Either<bigint, LedgerOps.LedgerError>;
+  readonly coinSelection: CoinSelection;
+}): Either.Either<DustBalancingRecipe, SelectionFailure | LedgerOps.LedgerError> => {
+  const { baseFee, existingDust, feeWith, coinSelection } = args;
+  const go = (
+    remaining: ReadonlyArray<CoinWithValue<Dust>>,
+    inputs: ReadonlyArray<CoinWithValue<Dust>>,
+    fee: bigint,
+  ): Either.Either<DustBalancingRecipe, SelectionFailure | LedgerOps.LedgerError> =>
+    Either.gen(function* () {
+      const covered = BigIntOps.sumAll(inputs.map((input) => input.value));
+      const deficit = fee - existingDust - covered;
+      if (deficit <= 0n) {
+        return { fee, recipeInputs: distributeFeeAcrossInputs(inputs, fee - existingDust) };
+      }
+      const added = yield* selectForDeficit(
+        remaining,
+        deficit,
+        marginalFeePerInput(fee - baseFee, inputs.length),
+        coinSelection,
+      );
+      const nextInputs = EArray.appendAll(inputs, added);
+      const nextFee = yield* feeWith(nextInputs);
+      const rest = remaining.filter((coin) => !added.some((taken) => taken.token.nonce === coin.token.nonce));
+      return yield* go(rest, nextInputs, nextFee);
     });
-
-    const chosen = new Set(recipe.inputs.map((input) => input.token.nonce));
-    for (const coin of remaining) {
-      if (chosen.has(coin.token.nonce)) inputs.push(coin);
-    }
-    remaining = remaining.filter((coin) => !chosen.has(coin.token.nonce));
-
-    fee = feeFor(inputs);
-  }
-
-  throw new Error(`DUST fee balancing failed to converge after ${coins.length + 1} passes`);
+  return go(args.coins, [], baseFee);
 };
+
+/**
+ * Runs selection under the configured order and, only if that exhausts the pool, once more largest-first: an additive
+ * selection is guaranteed to find a covering set only when it takes coins from the top, since the k largest coins
+ * dominate every other k-subset. Any other failure — a declining selector above all — is reported as it is.
+ */
+const selectWithLargestFirstRetry = (
+  select: (
+    coinSelection: CoinSelection,
+  ) => Either.Either<DustBalancingRecipe, SelectionFailure | LedgerOps.LedgerError>,
+  configured: CoinSelection,
+): Either.Either<DustBalancingRecipe, SelectionFailure | LedgerOps.LedgerError> =>
+  pipe(
+    select(configured),
+    Either.orElse((failure) =>
+      failure._tag === 'DustBalancing.SelectionExhausted' ? select(largestFirst) : Either.left(failure),
+    ),
+  );
+
+const toWalletError = (failure: SelectionFailure | LedgerOps.LedgerError): WalletError =>
+  Match.value(failure).pipe(
+    Match.tag(
+      'DustBalancing.SelectionExhausted',
+      ({ message }) => new InsufficientFundsError({ message, tokenType: 'dust' }),
+    ),
+    Match.tag(
+      'DustBalancing.SelectionRefused',
+      ({ remaining }) =>
+        new InsufficientFundsError({
+          message: `Insufficient Funds: the configured coin selection declined the remaining ${remaining} dust coin(s)`,
+          tokenType: 'dust',
+        }),
+    ),
+    Match.tag(
+      'DustBalancing.SelectionMadeNoProgress',
+      ({ returned, remaining }) =>
+        new TransactingError({
+          message: `Coin selection returned ${returned} coin(s), none of them among the ${remaining} offered; a selector must pick from the coins it is given`,
+        }),
+    ),
+    Match.tag(
+      'DustBalancing.BalancerFailed',
+      ({ cause }) =>
+        new OtherWalletError({ message: cause instanceof Error ? cause.message : 'Dust balancing failed', cause }),
+    ),
+    Match.tag('LedgerError', (error) => error),
+    Match.exhaustive,
+  );
 
 export class TransactingCapabilityImplementation<TTransaction extends AnyTransaction> implements TransactingCapability<
   DustSecretKey,
@@ -628,6 +799,12 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
     );
   }
 
+  /**
+   * The fee the transactions would carry with `recipeInputs` attached as dust spends in a balancing intent. With no
+   * inputs there is no intent to attach — an intent with empty `DustActions` is not well-formed — so it is the fee of
+   * the transactions as they are. Nothing is persisted. `merged` lets a caller pricing several input sets against the
+   * same transactions proof-erase and merge them once; it is derived from `transactions` when omitted.
+   */
   dryRunFee(
     recipeInputs: ReadonlyArray<CoinWithValue<Dust>>,
     transactions: ReadonlyArray<FinalizedTransaction | UnprovenTransaction>,
@@ -636,33 +813,40 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
     ttl: Date,
     currentTime: Date,
     ledgerParams: LedgerParameters,
+    merged: Option.Option<MergedTransactions> = mergeErasedTransactions(transactions),
   ): bigint {
-    const network = this.networkId;
-
-    // Create a balancing tx from recipe inputs without persisting state changes
-    const [spends] = CoreWallet.spendCoins(state, secretKey, recipeInputs, currentTime);
-
-    const intent = Intent.new(ttl);
-    intent.dustActions = new DustActions<SignatureEnabled, PreProof>(
-      SignatureMarker.signature,
-      ProofMarker.preProof,
-      currentTime,
-      [...spends],
-      [],
+    const priced = EArray.match(recipeInputs, {
+      onEmpty: () => Option.map(merged, (existing) => existing.transaction),
+      onNonEmpty: (inputs) => {
+        const [spends] = CoreWallet.spendCoins(state, secretKey, inputs, currentTime);
+        const intent = Intent.new(ttl);
+        intent.dustActions = new DustActions<SignatureEnabled, PreProof>(
+          SignatureMarker.signature,
+          ProofMarker.preProof,
+          currentTime,
+          [...spends],
+          [],
+        );
+        const segmentId = pipe(
+          merged,
+          Option.map((existing) => existing.segmentId),
+          Option.getOrElse(() => 1),
+        );
+        const balancing = Transaction.fromParts(this.networkId)
+          .addIntent({ tag: 'specific', value: segmentId }, intent)
+          .eraseProofs();
+        return Option.some(
+          pipe(
+            merged,
+            Option.match({ onNone: () => balancing, onSome: (existing) => existing.transaction.merge(balancing) }),
+          ),
+        );
+      },
+    });
+    return pipe(
+      priced,
+      Option.match({ onNone: () => 0n, onSome: (transaction) => this.calculateFee(transaction, ledgerParams) }),
     );
-
-    // Merge existing transactions first so we can pick a segment that doesn't collide
-    const [first, ...rest] = transactions.map((tx) => tx.eraseProofs());
-    const mergedExisting = first ? rest.reduce((acc, tx) => acc.merge(tx), first) : undefined;
-
-    const segmentId = mergedExisting ? Option.getOrElse(findAvailableSegmentId(mergedExisting), () => 1) : 1;
-
-    const balancingTx = Transaction.fromParts(network).addIntent({ tag: 'specific', value: segmentId }, intent);
-    const erasedBalancing = balancingTx.eraseProofs();
-
-    const mergedTx = mergedExisting ? mergedExisting.merge(erasedBalancing) : erasedBalancing;
-
-    return this.calculateFee(mergedTx, ledgerParams);
   }
 
   static feeImbalance(transaction: AnyTransaction, totalFee: bigint): bigint {
@@ -676,16 +860,14 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
   }
 
   /**
-   * Balances a fee-paying dust intent: selects enough dust to cover the transaction's fee, and reports the fee those
-   * inputs must pay.
+   * Selects the dust inputs a balancing intent needs so that, merged with `transactions`, the result covers its own fee
+   * — including the fee those inputs add — net of any dust the transactions already carry. `fee` is the total fee of
+   * that merged result, the figure {@link estimateFee} reports; `recipeInputs` lists the selected coins in selection
+   * order, each valued at the part of the shortfall it pays. Both are empty when the transactions already cover their
+   * fee.
    *
-   * The previous implementation of this method (`Effect.iterate`) had no bound on the number of passes and no check
-   * that a pass had made progress. Its first pass was seeded with the transaction's dust imbalance, which is negative
-   * (a deficit); every later pass was seeded with the fee it had just computed, which is positive. `getBalanceRecipe`
-   * treats a non-negative seed as a surplus of the fee token — it adds a change output and selects zero inputs — so any
-   * wallet whose first pass under-covered its own fee looped forever, rebuilding and proof-erasing an identical
-   * transaction on every pass. `runBalancingPasses` fixes this by seeding every pass with the outstanding deficit
-   * rather than the raw fee, which both corrects the sign and bounds the loop: see its own comment for why.
+   * Selection runs under the configured {@link CoinSelection} and is retried once largest-first only if that order
+   * exhausts the pool; a selector that declines coins is honoured and reports insufficient funds directly.
    */
   computeBalancingRecipe(
     secretKey: DustSecretKey,
@@ -694,47 +876,39 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
     ttl: Date,
     currentTime: Date,
     ledgerParams: LedgerParameters,
-  ): Either.Either<{ fee: bigint; recipeInputs: ReadonlyArray<CoinWithValue<Dust>> }, WalletError> {
-    const initialFees = transactions.reduce(
-      (total, transaction) =>
-        total +
-        TransactingCapabilityImplementation.feeImbalance(transaction, this.calculateFee(transaction, ledgerParams)),
-      0n,
-    );
-
-    // A non-negative imbalance means the transaction already carries enough dust of its own;
-    // nothing to select. Reported via `feeFor([])`, not `-initialFees`, since the two coincide
-    // only in the (usual) case where the imbalance is exactly the negated fee.
-    const feeFor = (inputs: ReadonlyArray<CoinWithValue<Dust>>): bigint =>
-      this.dryRunFee(inputs, transactions, secretKey, state, ttl, currentTime, ledgerParams);
-    if (initialFees >= 0n) {
-      return Either.right({ fee: feeFor([]), recipeInputs: [] });
-    }
-
-    const dust = this.getCoins().getAvailableCoinsWithGeneratedDust(state, currentTime);
-    const coinSelection = this.getCoinSelection();
-
-    return Either.try({
-      try: () => {
-        try {
-          return runBalancingPasses(dust, initialFees, feeFor, coinSelection);
-        } catch (err) {
-          if (!(err instanceof BalancingInsufficientFundsError)) throw err;
-          // The additive loop above is complete only when it selects from the top: adding a
-          // coin can only raise the fee, so under an ascending order it can take a small coin,
-          // be forced to add a large one to cover the resulting fee, and find the pair's fee
-          // exceeds the pool — when the large coin alone would have paid the fee for one input.
-          // Retrying once, greedily by value, recovers exactly that case before giving up.
-          return runBalancingPasses(dust, initialFees, feeFor, largestFirst);
-        }
-      },
-      catch: (err) =>
-        err instanceof BalancingInsufficientFundsError
-          ? new InsufficientFundsError({ message: err.message, tokenType: err.tokenType })
-          : new OtherWalletError({
-              message: err instanceof Error ? err.message : 'Dust balancing failed',
-              cause: err,
-            }),
+  ): Either.Either<DustBalancingRecipe, WalletError> {
+    return Either.gen(this, function* () {
+      const merged = yield* LedgerOps.ledgerTry(() => mergeErasedTransactions(transactions));
+      const standaloneFees = yield* LedgerOps.ledgerTry(() =>
+        transactions.map((transaction) => this.calculateFee(transaction, ledgerParams)),
+      );
+      // `feeImbalance` nets the dust a transaction already carries (spends, registration allowances) against its own
+      // fee. Adding the fees back isolates that dust, which counts toward coverage on every pass.
+      const existingDust = yield* LedgerOps.ledgerTry(
+        () =>
+          BigIntOps.sumAll(
+            EArray.zipWith(transactions, standaloneFees, (transaction, fee) =>
+              TransactingCapabilityImplementation.feeImbalance(transaction, fee),
+            ),
+          ) + BigIntOps.sumAll(standaloneFees),
+      );
+      const baseFee = yield* LedgerOps.ledgerTry(() =>
+        pipe(
+          merged,
+          Option.match({
+            onNone: () => 0n,
+            onSome: (existing) => this.calculateFee(existing.transaction, ledgerParams),
+          }),
+        ),
+      );
+      const coins = this.getCoins().getAvailableCoinsWithGeneratedDust(state, currentTime);
+      const feeWith = (inputs: EArray.NonEmptyReadonlyArray<CoinWithValue<Dust>>) =>
+        LedgerOps.ledgerTry(() =>
+          this.dryRunFee(inputs, transactions, secretKey, state, ttl, currentTime, ledgerParams, merged),
+        );
+      const select = (coinSelection: CoinSelection) =>
+        selectDustInputs({ coins, baseFee, existingDust, feeWith, coinSelection });
+      return yield* Either.mapLeft(selectWithLargestFirstRetry(select, this.getCoinSelection()), toWalletError);
     });
   }
 
@@ -764,32 +938,36 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
 
     return pipe(
       this.computeBalancingRecipe(secretKey, state, transactions, ttl, currentTime, ledgerParams),
-      Either.flatMap(({ recipeInputs }) => {
-        return LedgerOps.ledgerTry(() => {
-          const intent = Intent.new(ttl);
-          const [spends, updatedState] = CoreWallet.spendCoins(state, secretKey, recipeInputs, currentTime);
-
-          intent.dustActions = new DustActions<SignatureEnabled, PreProof>(
-            SignatureMarker.signature,
-            ProofMarker.preProof,
-            currentTime,
-            [...spends],
-            [],
-          );
-
-          // Merge existing transactions first so we can pick a segment that doesn't collide
-          const [first, ...rest] = transactions.map((tx) => tx.eraseProofs());
-          const mergedExisting = first ? rest.reduce((acc, tx) => acc.merge(tx), first) : undefined;
-          const segmentId = mergedExisting ? Option.getOrElse(findAvailableSegmentId(mergedExisting), () => 1) : 1;
-
-          const feeTransaction = Transaction.fromParts(networkId).addIntent(
-            { tag: 'specific', value: segmentId },
-            intent,
-          );
-
-          return [feeTransaction, updatedState];
-        });
-      }),
+      Either.flatMap(({ recipeInputs }) =>
+        LedgerOps.ledgerTry((): [UnprovenTransaction, CoreWallet] =>
+          EArray.match(recipeInputs, {
+            // The transactions already cover their fee. An intent with empty `DustActions` is not well-formed, so
+            // there is nothing to add: an empty transaction merges into anything as the identity, and no dust is
+            // booked as pending.
+            onEmpty: () => [Transaction.fromParts(networkId), state],
+            onNonEmpty: (inputs) => {
+              const [spends, updatedState] = CoreWallet.spendCoins(state, secretKey, inputs, currentTime);
+              const intent = Intent.new(ttl);
+              intent.dustActions = new DustActions<SignatureEnabled, PreProof>(
+                SignatureMarker.signature,
+                ProofMarker.preProof,
+                currentTime,
+                [...spends],
+                [],
+              );
+              const segmentId = pipe(
+                mergeErasedTransactions(transactions),
+                Option.map((existing) => existing.segmentId),
+                Option.getOrElse(() => 1),
+              );
+              return [
+                Transaction.fromParts(networkId).addIntent({ tag: 'specific', value: segmentId }, intent),
+                updatedState,
+              ];
+            },
+          }),
+        ),
+      ),
     );
   }
 

--- a/packages/dust-wallet/src/v1/Transacting.ts
+++ b/packages/dust-wallet/src/v1/Transacting.ts
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { Effect, Either, pipe, BigInt as BigIntOps, Iterable as IterableOps, Option } from 'effect';
+import { Either, pipe, BigInt as BigIntOps, Iterable as IterableOps, Option } from 'effect';
 import {
   DustActions,
   DustRegistration,
@@ -212,6 +212,67 @@ const distributeFeeAcrossInputs = <T extends { value: bigint }>(
     },
     { result: [], remaining: fee },
   ).result;
+
+/**
+ * Picks the largest-value coin from the pool. Used only as a fallback inside `computeBalancingRecipe` when the caller's
+ * configured selection order leaves an affordable set of coins unselected (see the comment there) — not exported, since
+ * overriding the configured order is this loop's own last resort, not a general-purpose selector.
+ */
+const largestFirst: CoinSelection = (coins) =>
+  coins
+    .filter((coin) => coin.value > 0n)
+    .toSorted((a, b) => (b.value > a.value ? 1 : b.value < a.value ? -1 : 0))
+    .at(0);
+
+/**
+ * Selects dust inputs, under one coin-selection order, until they cover the fee of the transaction they produce. Each
+ * pass hands the balancer only the fee still unpaid by the coins already chosen — the deficit, expressed as a negative
+ * imbalance — over the coins not yet selected, then re-prices the transaction with everything selected so far via
+ * `feeFor`. Adding an input can only raise the fee, so a pass that does not converge has strictly grown the input set;
+ * with a finite coin pool that bounds the number of passes by the pool's size. Throws the balancer's own
+ * `BalancingInsufficientFundsError` when the pool cannot cover the fee under this order — including when
+ * `coinSelection` itself returns nothing from a non-empty pool.
+ */
+const runBalancingPasses = (
+  coins: ReadonlyArray<CoinWithValue<Dust>>,
+  initialImbalance: bigint,
+  feeFor: (inputs: ReadonlyArray<CoinWithValue<Dust>>) => bigint,
+  coinSelection: CoinSelection,
+): { fee: bigint; recipeInputs: ReadonlyArray<CoinWithValue<Dust>> } => {
+  const inputs: CoinWithValue<Dust>[] = [];
+  let remaining = coins;
+  let fee = -initialImbalance;
+
+  // Every pass either returns or consumes at least one coin from `remaining`, so this bound
+  // is never actually reached; it turns a broken invariant into a thrown error instead of an
+  // infinite loop.
+  for (let pass = 0; pass <= coins.length; pass++) {
+    const covered = inputs.reduce((sum, input) => sum + input.value, 0n);
+    if (fee <= covered) {
+      return { fee, recipeInputs: distributeFeeAcrossInputs(inputs, fee) };
+    }
+
+    const recipe = getBalanceRecipe({
+      coins: remaining.map((coin) => ({ type: 'dust', value: coin.value, token: coin.token })),
+      initialImbalances: CapImbalances.fromEntry('dust', covered - fee),
+      feeTokenType: 'dust',
+      coinSelection,
+      transactionCostModel: { inputFeeOverhead: 0n, outputFeeOverhead: 0n },
+      createOutput: (coin) => coin,
+      isCoinEqual: (a, b) => a.token.nonce === b.token.nonce,
+    });
+
+    const chosen = new Set(recipe.inputs.map((input) => input.token.nonce));
+    for (const coin of remaining) {
+      if (chosen.has(coin.token.nonce)) inputs.push(coin);
+    }
+    remaining = remaining.filter((coin) => !chosen.has(coin.token.nonce));
+
+    fee = feeFor(inputs);
+  }
+
+  throw new Error(`DUST fee balancing failed to converge after ${coins.length + 1} passes`);
+};
 
 export class TransactingCapabilityImplementation<TTransaction extends AnyTransaction> implements TransactingCapability<
   DustSecretKey,
@@ -614,6 +675,18 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
     return imbalance ?? 0n;
   }
 
+  /**
+   * Balances a fee-paying dust intent: selects enough dust to cover the transaction's fee, and reports the fee those
+   * inputs must pay.
+   *
+   * The previous implementation of this method (`Effect.iterate`) had no bound on the number of passes and no check
+   * that a pass had made progress. Its first pass was seeded with the transaction's dust imbalance, which is negative
+   * (a deficit); every later pass was seeded with the fee it had just computed, which is positive. `getBalanceRecipe`
+   * treats a non-negative seed as a surplus of the fee token — it adds a change output and selects zero inputs — so any
+   * wallet whose first pass under-covered its own fee looped forever, rebuilding and proof-erasing an identical
+   * transaction on every pass. `runBalancingPasses` fixes this by seeding every pass with the outstanding deficit
+   * rather than the raw fee, which both corrects the sign and bounds the loop: see its own comment for why.
+   */
   computeBalancingRecipe(
     secretKey: DustSecretKey,
     state: CoreWallet,
@@ -629,76 +702,40 @@ export class TransactingCapabilityImplementation<TTransaction extends AnyTransac
       0n,
     );
 
+    // A non-negative imbalance means the transaction already carries enough dust of its own;
+    // nothing to select. Reported via `feeFor([])`, not `-initialFees`, since the two coincide
+    // only in the (usual) case where the imbalance is exactly the negated fee.
+    const feeFor = (inputs: ReadonlyArray<CoinWithValue<Dust>>): bigint =>
+      this.dryRunFee(inputs, transactions, secretKey, state, ttl, currentTime, ledgerParams);
+    if (initialFees >= 0n) {
+      return Either.right({ fee: feeFor([]), recipeInputs: [] });
+    }
+
     const dust = this.getCoins().getAvailableCoinsWithGeneratedDust(state, currentTime);
+    const coinSelection = this.getCoinSelection();
 
-    return pipe(
-      Effect.iterate(
-        { currentFee: initialFees, recipeInputs: [] as ReadonlyArray<CoinWithValue<Dust>>, converged: false } as {
-          currentFee: bigint;
-          recipeInputs: ReadonlyArray<CoinWithValue<Dust>>;
-          converged: boolean;
-        },
-        {
-          while: (s) => !s.converged,
-          body: ({ currentFee }) =>
-            Effect.try({
-              try: () => {
-                const recipe = getBalanceRecipe({
-                  coins: dust.map((coin) => ({
-                    type: 'dust',
-                    value: coin.value,
-                    token: coin.token,
-                  })),
-                  initialImbalances: CapImbalances.fromEntry('dust', currentFee),
-                  feeTokenType: 'dust',
-                  coinSelection: this.getCoinSelection(),
-                  transactionCostModel: {
-                    inputFeeOverhead: 0n,
-                    outputFeeOverhead: 0n,
-                  },
-                  createOutput: (coin) => coin,
-                  isCoinEqual: (a, b) => a.token.nonce === b.token.nonce,
-                });
-
-                const recipeInputs = recipe.inputs.map(({ token, value }) => ({ token, value }));
-
-                const newFee = this.dryRunFee(
-                  recipeInputs,
-                  transactions,
-                  secretKey,
-                  state,
-                  ttl,
-                  currentTime,
-                  ledgerParams,
-                );
-
-                const recipeAmountCoverage = recipeInputs.reduce((sum, input) => sum + input.value, 0n);
-
-                return { currentFee: newFee, recipeInputs, converged: newFee <= recipeAmountCoverage };
-              },
-              catch: (err) => {
-                if (err instanceof BalancingInsufficientFundsError) {
-                  return new InsufficientFundsError({
-                    message: err.message,
-                    tokenType: err.tokenType,
-                  });
-                } else {
-                  return new OtherWalletError({
-                    message: err instanceof Error ? err.message : 'Dust balancing failed',
-                    cause: err,
-                  });
-                }
-              },
+    return Either.try({
+      try: () => {
+        try {
+          return runBalancingPasses(dust, initialFees, feeFor, coinSelection);
+        } catch (err) {
+          if (!(err instanceof BalancingInsufficientFundsError)) throw err;
+          // The additive loop above is complete only when it selects from the top: adding a
+          // coin can only raise the fee, so under an ascending order it can take a small coin,
+          // be forced to add a large one to cover the resulting fee, and find the pair's fee
+          // exceeds the pool — when the large coin alone would have paid the fee for one input.
+          // Retrying once, greedily by value, recovers exactly that case before giving up.
+          return runBalancingPasses(dust, initialFees, feeFor, largestFirst);
+        }
+      },
+      catch: (err) =>
+        err instanceof BalancingInsufficientFundsError
+          ? new InsufficientFundsError({ message: err.message, tokenType: err.tokenType })
+          : new OtherWalletError({
+              message: err instanceof Error ? err.message : 'Dust balancing failed',
+              cause: err,
             }),
-        },
-      ),
-      Effect.either,
-      Effect.runSync,
-      Either.map(({ currentFee, recipeInputs }) => ({
-        fee: currentFee,
-        recipeInputs: distributeFeeAcrossInputs(recipeInputs, currentFee),
-      })),
-    );
+    });
   }
 
   estimateFee(

--- a/packages/dust-wallet/src/v1/test/transacting.test.ts
+++ b/packages/dust-wallet/src/v1/test/transacting.test.ts
@@ -14,7 +14,7 @@ import * as ledger from '@midnight-ntwrk/ledger-v8';
 import { NetworkId } from '@midnightntwrk/wallet-sdk-abstractions';
 import { DustAddress } from '@midnightntwrk/wallet-sdk-address-format';
 import { EitherOps } from '@midnightntwrk/wallet-sdk-utilities';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   chooseCoin,
   makeDefaultCoinsAndBalancesCapability,
@@ -274,22 +274,40 @@ describe('addDustRegistrationSignature', () => {
 });
 
 describe('computeBalancingRecipe', () => {
-  // `dryRunFee` and `calculateFee` are the WASM-backed parts of balancing — they build and
-  // erase proofs on a real ledger transaction. These tests exercise the balancing loop itself
-  // (progress, termination, the fallback selector), so they replace both with a fee model
-  // whose one relevant property matches the real one: the fee grows with the number of dust
-  // inputs. `computeBalancingRecipe` itself, and every SDK function it calls
-  // (`getBalanceRecipe`, `Imbalances`), are exercised unmodified.
+  // `dryRunFee` and `calculateFee` are the WASM-backed parts of balancing — they build and erase proofs on a real
+  // ledger transaction. These tests exercise the selection loop itself, so both are replaced by an analytic fee model
+  // whose one relevant property matches the real one: the fee grows with each dust input. Everything else —
+  // `computeBalancingRecipe`, `balanceTransactions`, the SDK's `getBalanceRecipe` and `Imbalances` — runs unmodified.
   const FEE_BASE = 1_400_000_000_000_000n;
   const FEE_PER_INPUT = 3_750_000_000_000n;
-  const feeFor = (inputs: number): bigint => FEE_BASE + FEE_PER_INPUT * BigInt(inputs);
+  const linearFee = (inputs: number): bigint => FEE_BASE + FEE_PER_INPUT * BigInt(inputs);
 
   class TestableTransacting extends TransactingCapabilityImplementation<ledger.FinalizedTransaction> {
+    readonly #feeModel: (inputs: number) => bigint;
+
+    constructor(
+      coins: ReadonlyArray<CoinWithValue<Dust>>,
+      coinSelection: CoinSelection,
+      feeModel: (inputs: number) => bigint = linearFee,
+    ) {
+      // Type cast required because: only `getAvailableCoinsWithGeneratedDust` is reached from `computeBalancingRecipe`.
+      const coinsAndBalancesCapability = {
+        getAvailableCoinsWithGeneratedDust: () => coins,
+      } as unknown as CoinsAndBalancesCapability<never>;
+      super(
+        config.networkId,
+        config.costParameters,
+        () => coinSelection,
+        () => coinsAndBalancesCapability,
+        () => keysCapability,
+      );
+      this.#feeModel = feeModel;
+    }
     override calculateFee(): bigint {
-      return feeFor(0);
+      return this.#feeModel(0);
     }
     override dryRunFee(recipeInputs: ReadonlyArray<CoinWithValue<Dust>>): bigint {
-      return feeFor(recipeInputs.length);
+      return this.#feeModel(recipeInputs.length);
     }
   }
 
@@ -304,109 +322,171 @@ describe('computeBalancingRecipe', () => {
   });
   const coin = (value: bigint, n: number): CoinWithValue<Dust> => ({ value, token: dustToken(n) });
 
-  // A transaction whose dust imbalance at its own fee is the ledger's usual sign: negative,
-  // i.e. a deficit of `feeFor(0)`.
-  const fakeTx = {
-    imbalances: () => new Map([[{ tag: 'dust' }, -feeFor(0)]]),
-  } as unknown as ledger.FinalizedTransaction;
+  // A transaction that, at its own fee, carries `carriedDust` of dust already: its dust imbalance is the ledger's
+  // netted figure, `carriedDust - fee`. Proof-erasure and merging are inert here; the fee model stands in for pricing.
+  const fakeTx = (carriedDust: bigint = 0n): ledger.FinalizedTransaction =>
+    // Type cast required because: the fee model replaces every ledger call `computeBalancingRecipe` would make on it.
+    ({
+      imbalances: () => new Map([[{ tag: 'dust' }, carriedDust - linearFee(0)]]),
+      eraseProofs: () => ({ merge: (other: unknown) => other, intents: undefined }),
+    }) as unknown as ledger.FinalizedTransaction;
 
-  const makeTransacting = (
-    coins: ReadonlyArray<CoinWithValue<Dust>>,
-    coinSelection: CoinSelection,
-  ): TestableTransacting => {
-    const coinsAndBalancesCapability = {
-      getAvailableCoinsWithGeneratedDust: () => coins,
-    } as unknown as CoinsAndBalancesCapability<never>;
-    return new TestableTransacting(
-      config.networkId,
-      config.costParameters,
-      () => coinSelection,
-      () => coinsAndBalancesCapability,
-      () => keysCapability,
-    );
-  };
+  // Type cast required because: with `dryRunFee` and `spendCoins` never reached, the state is only passed through.
+  const state = { untouched: true } as unknown as never;
 
-  const run = (transacting: TestableTransacting) =>
+  const run = (transacting: TestableTransacting, tx: ledger.FinalizedTransaction = fakeTx()) =>
     transacting.computeBalancingRecipe(
       ledger.sampleDustSecretKey(),
-      undefined as never,
-      [fakeTx],
+      state,
+      [tx],
       TTL,
       NOW,
       ledger.LedgerParameters.initialParameters(),
     );
 
-  it('converges once the deficit-seeded pass covers the fee, even when the first pass falls short', () => {
-    // Twelve part-drained coins beside two near their generation cap — ascending selection
-    // takes eight of the small ones on pass 1, which is short of the fee that spending eight
-    // coins costs; a second pass, seeded with the remaining deficit, adds one more and covers it.
+  const sumOf = (inputs: ReadonlyArray<CoinWithValue<Dust>>): bigint => inputs.reduce((sum, i) => sum + i.value, 0n);
+
+  it('converges on a second pass when the first under-covers the fee its own inputs add', () => {
+    // Twelve part-drained coins beside two near their generation cap. Ascending selection takes eight small ones on
+    // the first pass — enough for the base fee, short of the fee that spending eight coins costs — and the second pass,
+    // seeded with that shortfall and the marginal fee measured on the first, adds one more and covers it. Two prices.
     const drained = Array.from({ length: 12 }, (_, i) => coin(176_250_000_000_000n, i));
     const full = [coin(50_000_000_000_000_000n, 90), coin(30_000_000_000_000_000n, 91)];
-    const result = run(makeTransacting([...drained, ...full], chooseCoin)).pipe(EitherOps.getOrThrowLeft);
+    const transacting = new TestableTransacting([...drained, ...full], chooseCoin);
+    const dryRuns = vi.spyOn(transacting, 'dryRunFee');
+
+    const result = run(transacting).pipe(EitherOps.getOrThrowLeft);
 
     expect(result.recipeInputs).toHaveLength(9);
-    expect(result.fee).toBe(feeFor(9));
-    expect(result.recipeInputs.reduce((sum, i) => sum + i.value, 0n)).toBe(result.fee);
+    expect(result.fee).toBe(linearFee(9));
+    expect(sumOf(result.recipeInputs)).toBe(result.fee);
+    expect(dryRuns).toHaveBeenCalledTimes(2);
   });
 
-  it('falls back to largest-first when ascending order strands the coin that could pay alone', () => {
-    // Adding a coin can only raise the fee, so the additive loop is complete only when it
-    // selects from the top. `getBalanceRecipe` itself has no notion of that growth — its
-    // `inputFeeOverhead` is 0n here, same as the SDK's own call site — so a single call keeps
-    // taking coins, smallest first, until their raw sum covers the *seeded* deficit, with no
-    // regard for what selecting them will do to the *real* fee once `dryRunFee` re-prices the
-    // result. Here that means ascending order's one call to `getBalanceRecipe` takes both
-    // coins (their sum clears the seeded fee(0) deficit) — but the real fee for two inputs,
-    // fee(2), is still short of what was collected, and the pool is now empty: insufficient
-    // funds, on a wallet where the large coin alone would have covered fee(1).
+  it('keeps selection order, so the coins chosen first are drained first and no input pays nothing', () => {
+    // Pool order is ledger-state order, here the large coin first. Ascending selection takes the small coin, then
+    // the large one; the fee must be split in that order, or the small coin would be nullified and re-committed for
+    // a zero fee while the large one is drained instead.
+    const big = coin(2_000_000_000_000_000n, 0);
+    const small = coin(1_000_000_000_000n, 1);
+
+    const result = run(new TestableTransacting([big, small], chooseCoin)).pipe(EitherOps.getOrThrowLeft);
+
+    expect(result.recipeInputs.map((i) => i.token.nonce)).toEqual([small.token.nonce, big.token.nonce]);
+    expect(result.recipeInputs.map((i) => i.value)).toEqual([small.value, linearFee(2) - small.value]);
+    expect(result.recipeInputs.every((i) => i.value > 0n)).toBe(true);
+  });
+
+  it('retries largest-first when ascending order exhausts the pool but the large coin alone could pay', () => {
+    // The balancer takes coins until their raw value covers the seeded deficit, with no notion that each input raises
+    // the real fee. Ascending order therefore takes both coins here; the fee for two inputs is still short of them,
+    // the pool is empty, and the configured order is exhausted — while the large coin alone covers the fee for one.
     const small = coin(1_000_000_000_000n, 0);
-    const large = coin(1_404_000_000_000_000n, 1); // > fee(1) = 1_403_750_000_000_000n
-    const result = run(makeTransacting([small, large], chooseCoin)).pipe(EitherOps.getOrThrowLeft);
+    const large = coin(1_404_000_000_000_000n, 1); // > linearFee(1) = 1_403_750_000_000_000n
+    const transacting = new TestableTransacting([small, large], chooseCoin);
+    const dryRuns = vi.spyOn(transacting, 'dryRunFee');
 
-    // Exactly the large coin was chosen, not the small one — `distributeFeeAcrossInputs`
-    // reports how much of it pays the fee, which is the whole fee since one input suffices.
+    const result = run(transacting).pipe(EitherOps.getOrThrowLeft);
+
     expect(result.recipeInputs.map((i) => i.token.nonce)).toEqual([large.token.nonce]);
-    expect(result.recipeInputs.map((i) => i.value)).toEqual([feeFor(1)]);
-    expect(result.fee).toBe(feeFor(1));
+    expect(result.recipeInputs.map((i) => i.value)).toEqual([linearFee(1)]);
+    expect(result.fee).toBe(linearFee(1));
+    // One price under the configured order (two coins), one under the retry (one coin).
+    expect(dryRuns).toHaveBeenCalledTimes(2);
   });
 
-  it('reports InsufficientFundsError, not a hang, when no order of the pool can pay', () => {
-    const coins = [coin(1n, 0), coin(2n, 1)];
-    const error = run(makeTransacting(coins, chooseCoin)).pipe(EitherOps.getOrThrowRight);
+  it('honours a selector that declines coins: no retry spends what the policy excluded', () => {
+    // A selector that never offers coins above a cap is a policy, not an order. When the coins it allows cannot pay,
+    // the answer is insufficient funds — not a largest-first retry that spends the excluded coin.
+    const cap = 10_000_000_000_000n;
+    const capped: CoinSelection = (coins) => chooseCoin(coins.filter((c) => c.value <= cap));
+    const allowed = coin(1_000_000_000_000n, 0);
+    const excluded = coin(5_000_000_000_000_000n, 1);
+    const transacting = new TestableTransacting([allowed, excluded], capped);
+    const dryRuns = vi.spyOn(transacting, 'dryRunFee');
+
+    const error = run(transacting).pipe(EitherOps.getOrThrowRight);
 
     expect(error).toBeInstanceOf(InsufficientFundsError);
-    expect((error as InsufficientFundsError).tokenType).toBe('dust');
+    expect((error as InsufficientFundsError).message).toMatch(/declined/);
+    expect(dryRuns).not.toHaveBeenCalled();
   });
 
-  it('never terminates worse than the coin count: converges on a uniformly tiny wallet too', () => {
-    // The one shape neither selection order can rescue by picking a different coin: every
-    // coin is far below fee size, so covering the fee needs several of them regardless of
-    // order. The loop must still terminate — in at most `coins.length + 1` passes.
-    const coins = Array.from({ length: 12 }, (_, i) => coin(176_250_000_000_000n, i));
-    const result = run(makeTransacting(coins, chooseCoin)).pipe(EitherOps.getOrThrowLeft);
+  it('fails fast when the selector returns a coin that was not offered, instead of repeating identical passes', () => {
+    // The balancer books whatever coin the selector returns, so a selector ignoring its argument satisfies the deficit
+    // with a coin the pool never had. Nothing can be consumed from the pool, so nothing can change between passes.
+    const foreign = coin(9_000_000_000_000_000n, 999);
+    const ignoresItsArgument: CoinSelection = <T extends { value: bigint }>(_coins: readonly T[]): T | undefined =>
+      // Type cast required because: the point of the test is a selector that returns a coin of the right shape
+      // that is not one of `_coins`.
+      ({ type: 'dust', value: foreign.value, token: foreign.token }) as unknown as T;
+    const transacting = new TestableTransacting([coin(1_000_000_000_000n, 0)], ignoresItsArgument);
+    const dryRuns = vi.spyOn(transacting, 'dryRunFee');
 
-    expect(result.recipeInputs.length).toBeLessThanOrEqual(coins.length);
-    expect(result.recipeInputs.reduce((sum, i) => sum + i.value, 0n)).toBeGreaterThanOrEqual(result.fee);
+    const error = run(transacting).pipe(EitherOps.getOrThrowRight);
+
+    expect(error).toBeInstanceOf(TransactingError);
+    expect((error as TransactingError).message).toMatch(/none of them among the 1 offered/);
+    expect(dryRuns).not.toHaveBeenCalled();
   });
 
-  it('selects nothing and reports the real fee when the transaction already carries enough dust', () => {
-    const positiveImbalanceTx = {
-      imbalances: () => new Map([[{ tag: 'dust' }, 5n]]),
-    } as unknown as ledger.FinalizedTransaction;
-    const transacting = makeTransacting([coin(1_000_000n, 0)], chooseCoin);
+  it('nets off dust the transactions already carry, so new inputs pay only the shortfall', () => {
+    // The transaction already carries 60% of its base fee in dust. The new input must pay the remaining 40% plus what
+    // its own presence adds — not the whole fee on top — while the reported fee is the total the merged result pays.
+    const carried = (linearFee(0) * 6n) / 10n;
+    const only = coin(linearFee(0), 0);
 
-    const result = transacting
-      .computeBalancingRecipe(
+    const result = run(new TestableTransacting([only], chooseCoin), fakeTx(carried)).pipe(EitherOps.getOrThrowLeft);
+
+    expect(result.fee).toBe(linearFee(1));
+    expect(result.recipeInputs.map((i) => i.value)).toEqual([linearFee(1) - carried]);
+  });
+
+  it('selects nothing when the transactions already cover their fee, and then adds no intent at all', () => {
+    // An intent with empty `DustActions` is not well-formed, so a fully-covered transaction must get an empty balancing
+    // transaction — the identity under merge — not an intent with nothing in it. The fee reported is the fee as it is,
+    // not the price of a merged result carrying an extra empty intent.
+    const covered = fakeTx(linearFee(0) + 5n);
+    const transacting = new TestableTransacting([coin(1_000_000_000_000_000_000n, 0)], chooseCoin);
+    const dryRuns = vi.spyOn(transacting, 'dryRunFee');
+
+    const recipe = run(transacting, covered).pipe(EitherOps.getOrThrowLeft);
+    expect(recipe.recipeInputs).toEqual([]);
+    expect(recipe.fee).toBe(linearFee(0));
+    expect(dryRuns).not.toHaveBeenCalled();
+
+    const [balancing, nextState] = transacting
+      .balanceTransactions(
         ledger.sampleDustSecretKey(),
-        undefined as never,
-        [positiveImbalanceTx],
+        state,
+        [covered],
         TTL,
         NOW,
         ledger.LedgerParameters.initialParameters(),
       )
       .pipe(EitherOps.getOrThrowLeft);
+    expect(balancing.intents?.size ?? 0).toBe(0);
+    expect(nextState).toBe(state);
+  });
 
-    expect(result.recipeInputs).toEqual([]);
-    expect(result.fee).toBe(feeFor(0));
+  it('reports InsufficientFundsError when no order of the pool can pay', () => {
+    const error = run(new TestableTransacting([coin(1n, 0), coin(2n, 1)], chooseCoin)).pipe(EitherOps.getOrThrowRight);
+
+    expect(error).toBeInstanceOf(InsufficientFundsError);
+    expect((error as InsufficientFundsError).tokenType).toBe('dust');
+  });
+
+  it('terminates on a fee model that can never be covered, pricing at most once per coin per attempt', () => {
+    // Each input costs exactly its own value, so no set of inputs can ever cover the fee it produces. Every pass still
+    // consumes at least one coin, so both the configured attempt and the retry run out of pool and stop.
+    const value = 100_000_000_000_000n;
+    const coins = Array.from({ length: 5 }, (_, i) => coin(value, i));
+    const transacting = new TestableTransacting(coins, chooseCoin, (inputs) => FEE_BASE + value * BigInt(inputs));
+    const dryRuns = vi.spyOn(transacting, 'dryRunFee');
+
+    const error = run(transacting).pipe(EitherOps.getOrThrowRight);
+
+    expect(error).toBeInstanceOf(InsufficientFundsError);
+    expect(dryRuns.mock.calls.length).toBeLessThanOrEqual(2 * coins.length);
   });
 });

--- a/packages/dust-wallet/src/v1/test/transacting.test.ts
+++ b/packages/dust-wallet/src/v1/test/transacting.test.ts
@@ -25,9 +25,12 @@ import {
   type DefaultTransactingConfiguration,
   type DefaultTransactingContext,
   makeDefaultTransactingCapability,
+  TransactingCapabilityImplementation,
 } from '../Transacting.js';
 import { ProofMarker, SignatureMarker } from '../Utils.js';
-import { TransactingError } from '../WalletError.js';
+import { InsufficientFundsError, TransactingError } from '../WalletError.js';
+import { type CoinsAndBalancesCapability, type CoinSelection, type CoinWithValue } from '../CoinsAndBalances.js';
+import { type Dust } from '../types/index.js';
 
 const NIGHT = ledger.nativeToken().raw;
 
@@ -267,5 +270,143 @@ describe('addDustRegistrationSignature', () => {
 
     expect(error).toBeInstanceOf(TransactingError);
     expect((error as TransactingError).message).toContain('No registrations');
+  });
+});
+
+describe('computeBalancingRecipe', () => {
+  // `dryRunFee` and `calculateFee` are the WASM-backed parts of balancing — they build and
+  // erase proofs on a real ledger transaction. These tests exercise the balancing loop itself
+  // (progress, termination, the fallback selector), so they replace both with a fee model
+  // whose one relevant property matches the real one: the fee grows with the number of dust
+  // inputs. `computeBalancingRecipe` itself, and every SDK function it calls
+  // (`getBalanceRecipe`, `Imbalances`), are exercised unmodified.
+  const FEE_BASE = 1_400_000_000_000_000n;
+  const FEE_PER_INPUT = 3_750_000_000_000n;
+  const feeFor = (inputs: number): bigint => FEE_BASE + FEE_PER_INPUT * BigInt(inputs);
+
+  class TestableTransacting extends TransactingCapabilityImplementation<ledger.FinalizedTransaction> {
+    override calculateFee(): bigint {
+      return feeFor(0);
+    }
+    override dryRunFee(recipeInputs: ReadonlyArray<CoinWithValue<Dust>>): bigint {
+      return feeFor(recipeInputs.length);
+    }
+  }
+
+  const dustToken = (n: number): Dust => ({
+    initialValue: 0n,
+    owner: 0n,
+    nonce: BigInt(n),
+    seq: 0,
+    ctime: NOW,
+    backingNight: String(n).padStart(64, '0'),
+    mtIndex: 0n,
+  });
+  const coin = (value: bigint, n: number): CoinWithValue<Dust> => ({ value, token: dustToken(n) });
+
+  // A transaction whose dust imbalance at its own fee is the ledger's usual sign: negative,
+  // i.e. a deficit of `feeFor(0)`.
+  const fakeTx = {
+    imbalances: () => new Map([[{ tag: 'dust' }, -feeFor(0)]]),
+  } as unknown as ledger.FinalizedTransaction;
+
+  const makeTransacting = (
+    coins: ReadonlyArray<CoinWithValue<Dust>>,
+    coinSelection: CoinSelection,
+  ): TestableTransacting => {
+    const coinsAndBalancesCapability = {
+      getAvailableCoinsWithGeneratedDust: () => coins,
+    } as unknown as CoinsAndBalancesCapability<never>;
+    return new TestableTransacting(
+      config.networkId,
+      config.costParameters,
+      () => coinSelection,
+      () => coinsAndBalancesCapability,
+      () => keysCapability,
+    );
+  };
+
+  const run = (transacting: TestableTransacting) =>
+    transacting.computeBalancingRecipe(
+      ledger.sampleDustSecretKey(),
+      undefined as never,
+      [fakeTx],
+      TTL,
+      NOW,
+      ledger.LedgerParameters.initialParameters(),
+    );
+
+  it('converges once the deficit-seeded pass covers the fee, even when the first pass falls short', () => {
+    // Twelve part-drained coins beside two near their generation cap — ascending selection
+    // takes eight of the small ones on pass 1, which is short of the fee that spending eight
+    // coins costs; a second pass, seeded with the remaining deficit, adds one more and covers it.
+    const drained = Array.from({ length: 12 }, (_, i) => coin(176_250_000_000_000n, i));
+    const full = [coin(50_000_000_000_000_000n, 90), coin(30_000_000_000_000_000n, 91)];
+    const result = run(makeTransacting([...drained, ...full], chooseCoin)).pipe(EitherOps.getOrThrowLeft);
+
+    expect(result.recipeInputs).toHaveLength(9);
+    expect(result.fee).toBe(feeFor(9));
+    expect(result.recipeInputs.reduce((sum, i) => sum + i.value, 0n)).toBe(result.fee);
+  });
+
+  it('falls back to largest-first when ascending order strands the coin that could pay alone', () => {
+    // Adding a coin can only raise the fee, so the additive loop is complete only when it
+    // selects from the top. `getBalanceRecipe` itself has no notion of that growth — its
+    // `inputFeeOverhead` is 0n here, same as the SDK's own call site — so a single call keeps
+    // taking coins, smallest first, until their raw sum covers the *seeded* deficit, with no
+    // regard for what selecting them will do to the *real* fee once `dryRunFee` re-prices the
+    // result. Here that means ascending order's one call to `getBalanceRecipe` takes both
+    // coins (their sum clears the seeded fee(0) deficit) — but the real fee for two inputs,
+    // fee(2), is still short of what was collected, and the pool is now empty: insufficient
+    // funds, on a wallet where the large coin alone would have covered fee(1).
+    const small = coin(1_000_000_000_000n, 0);
+    const large = coin(1_404_000_000_000_000n, 1); // > fee(1) = 1_403_750_000_000_000n
+    const result = run(makeTransacting([small, large], chooseCoin)).pipe(EitherOps.getOrThrowLeft);
+
+    // Exactly the large coin was chosen, not the small one — `distributeFeeAcrossInputs`
+    // reports how much of it pays the fee, which is the whole fee since one input suffices.
+    expect(result.recipeInputs.map((i) => i.token.nonce)).toEqual([large.token.nonce]);
+    expect(result.recipeInputs.map((i) => i.value)).toEqual([feeFor(1)]);
+    expect(result.fee).toBe(feeFor(1));
+  });
+
+  it('reports InsufficientFundsError, not a hang, when no order of the pool can pay', () => {
+    const coins = [coin(1n, 0), coin(2n, 1)];
+    const error = run(makeTransacting(coins, chooseCoin)).pipe(EitherOps.getOrThrowRight);
+
+    expect(error).toBeInstanceOf(InsufficientFundsError);
+    expect((error as InsufficientFundsError).tokenType).toBe('dust');
+  });
+
+  it('never terminates worse than the coin count: converges on a uniformly tiny wallet too', () => {
+    // The one shape neither selection order can rescue by picking a different coin: every
+    // coin is far below fee size, so covering the fee needs several of them regardless of
+    // order. The loop must still terminate — in at most `coins.length + 1` passes.
+    const coins = Array.from({ length: 12 }, (_, i) => coin(176_250_000_000_000n, i));
+    const result = run(makeTransacting(coins, chooseCoin)).pipe(EitherOps.getOrThrowLeft);
+
+    expect(result.recipeInputs.length).toBeLessThanOrEqual(coins.length);
+    expect(result.recipeInputs.reduce((sum, i) => sum + i.value, 0n)).toBeGreaterThanOrEqual(result.fee);
+  });
+
+  it('selects nothing and reports the real fee when the transaction already carries enough dust', () => {
+    const positiveImbalanceTx = {
+      imbalances: () => new Map([[{ tag: 'dust' }, 5n]]),
+    } as unknown as ledger.FinalizedTransaction;
+    const transacting = makeTransacting([coin(1_000_000n, 0)], chooseCoin);
+
+    const result = transacting
+      .computeBalancingRecipe(
+        ledger.sampleDustSecretKey(),
+        undefined as never,
+        [positiveImbalanceTx],
+        TTL,
+        NOW,
+        ledger.LedgerParameters.initialParameters(),
+      )
+      .pipe(EitherOps.getOrThrowLeft);
+
+    expect(result.recipeInputs).toEqual([]);
+    expect(result.fee).toBe(feeFor(0));
   });
 });


### PR DESCRIPTION
# Description

`TransactingCapabilityImplementation.computeBalancingRecipe` in `@midnightntwrk/wallet-sdk-dust-wallet` can loop forever. When it does, the calling process stops responding and its memory grows without bound (measured: ~16 MB/s for the first two minutes, then ~1.2 MB/s sustained with no plateau — 3.4 GB at 15 minutes on a live devnet, killed by our timeout rather than by the OS), because every pass builds and proof-erases a fresh WASM transaction on the calling thread.

The loop is an `Effect.iterate` whose only exit is `newFee <= coverage`. It has no iteration cap and no check that a pass has made progress, and it has a sign bug:

| Pass | Seeded with | Sign | What `getBalanceRecipe` does |
|---|---|---|---|
| 1 | `transaction.imbalances(0, fee)['dust']` | negative (a deficit) | selects inputs until the deficit is covered |
| 2+ | the `dryRunFee` it just computed | **positive** | reads it as a *surplus*: adds a change output, selects **zero** inputs |

`getBalanceRecipe` is called with `inputFeeOverhead: 0n`, so it cannot know that selecting inputs raises the real fee — that is exactly why the outer loop exists. But once pass 1 under-covers its own fee, pass 2 is seeded with a positive number, selects nothing, and produces a state identical to itself. Nothing can ever change again. Only pass 1 can converge; every pass after a failed pass 1 is dead work.

This is easy to reach. Measured through the real `dryRunFee` on a devnet (node 1.0.1 / ledger 8.1.0), each dust input adds ~3.36e14 to the fee — a dust spend roughly doubles it. A wallet that has paid many fees holds several part-drained coins that are each below fee size; pass 1 spends several of them, the fee grows past what they cover, and the loop never returns.

# Proposed Solution

Each pass seeds the balancer with the **outstanding deficit** — the fee still unpaid by the coins already chosen *and by the dust the transactions already carry* — as a negative imbalance, over the coins not yet selected, then re-prices with everything selected so far via `dryRunFee`. That fixes the sign (every pass is a deficit, so every pass selects). The balancer is also handed the per-input fee measured over the passes so far as `inputFeeOverhead`, so it anticipates the growth the first pass could not see, and a second pass normally completes what the first left short.

Termination is structural, not a counter: a pass that consumes no coin from the pool fails (`SelectionMadeNoProgress`), so every pass shrinks the pool and the recursion is bounded by its size. The loop is a tail-recursive `Either.gen` over `const` bindings — no `let`, no loops, no mutation — with one `Data.TaggedError` per failure mode, mapped to `WalletError` exhaustively at the boundary.

**The largest-first retry, narrowed.** An additive selection is complete — finds a covering set whenever one exists — only when it takes coins from the top, since the k largest coins dominate every other k-subset. Under the default ascending `chooseCoin` it can take a small coin, be forced to add a large one to cover the resulting fee, and find the pair still short — when the large coin alone would have paid the fee for one input (a real devnet wallet holding 6.4e13 and 9.7e14 against a 7.3e14 fee did exactly that). So when the configured order **exhausts the pool**, selection is retried once largest-first. It is *not* retried when the configured selector **declines** coins: a selector returning `undefined` on a non-empty pool is expressing a policy, and that failure is surfaced as its own tagged error and reported as insufficient funds. The two were indistinguishable in the first revision of this PR; they are distinct now.

Alternatives considered: an iteration cap alone would bound the damage but is a heuristic; the no-progress failure is exact. Probing the marginal fee up front (`dryRunFee([anyCoin])`) would cost one WASM dry run on every call, including the common one-coin case; measuring it from the first pass costs nothing extra and collapses multi-coin wallets to two passes in practice.

# Important Changes Introduced

- `computeBalancingRecipe` is rewritten; its signature and return type are unchanged, and `estimateFee` still routes through it. Dust the transactions already carry (existing spends, registration allowances) now counts toward coverage, so new inputs pay only the shortfall. The reported `fee` remains the **total** fee of the merged result, which is what the facade's `estimateTransactionFee` documents ("the total fee for the given transaction plus the fee of the balancing transaction").
- A transaction that already covers its fee produces **no balancing intent**: `balanceTransactions` returns an empty transaction (which merges as the identity — verified against the ledger) with the state untouched, instead of an intent with empty `DustActions`, which `DustActions::well_formed` rejects. The fee reported is that of the transactions as they are.
- Selected coins keep **selection order**, so `distributeFeeAcrossInputs` drains the coins chosen first (under the default order, the smaller ones) and no coin is spent for a zero `vFee`.
- `dryRunFee` gains an optional trailing `merged` parameter carrying the proof-erased, merged transactions and their segment id, so a caller pricing several input sets merges once; the 7-argument form still works unchanged. With no inputs it now prices the transactions as they are rather than with an extra empty intent. `balanceTransactions` uses the same merge helper instead of its own copy.
- Every ledger call — including the merge and the base-fee computation — runs inside `LedgerOps.ledgerTry`, so the declared `Either<_, WalletError>` is honoured on every path; nothing escapes as a raw throw.
- The `effect` import drops `Effect` and adds `Array as EArray` (the alias the language service enforces), `Data` and `Match`. No public API changes.
- Not touched, deliberately: the default `chooseCoin` selector (ascending). That is a legitimate default for tokens whose small coins are fragments worth consolidating; for dust — whose coins are bound one-to-one to registered NIGHT UTXOs, spend one-in-one-out, and regenerate toward a cap — largest-first is cheaper (7.27e14 with one input vs 1.97e15 with five, same transaction, on our devnet). A separate conversation from this correctness fix.

# Testing

Nine tests in `src/v1/test/transacting.test.ts` drive the real `computeBalancingRecipe` and `balanceTransactions` — including the real `getBalanceRecipe` and `Imbalances` — with `dryRunFee`/`calculateFee` replaced by an analytic model whose one relevant property matches the real one (the fee grows with each input). Where a test's title is a claim about work done, a spy on `dryRunFee` asserts the count:

- the classic shape (twelve part-drained coins beside two full ones) converges on the second pass, **two** prices, where the old loop never returned;
- selection order is kept, so the small coin is drained first and no input pays `0n`;
- the stranded-large-coin case recovers via the retry, two prices in total;
- a selector that declines coins gets insufficient funds and **no** retry — the excluded coin is never spent, zero prices;
- a selector returning a coin it was not offered fails fast with `TransactingError`, zero prices;
- a transaction already carrying 60% of its fee in dust has its new input pay only the shortfall, while the reported fee is the total;
- a fully-covered transaction selects nothing, and `balanceTransactions` returns an empty transaction with the state untouched;
- a genuinely unaffordable pool still reports `InsufficientFundsError`;
- a fee model that can never be covered still terminates, with dry runs bounded by the pool per attempt.

Run against the previous revision of this PR, the order, decline, no-progress, existing-dust and empty-intent tests **fail**; the other four pass on both, as regression guards for behaviour the first revision already had.

All 45 unit tests in the package pass, including the pre-existing `DustWallet.test.ts` spend/revert/deregister cases that exercise the rewritten methods end-to-end against the real ledger. Lint clean (`eslint --max-warnings 0`), `tsc` clean for the touched files.

Downstream this was first shipped as a client-side wrapper and verified against a live devnet with the real WASM fee loop — an A/B on one wallet with identical coin snapshots: SDK loop never returned (killed at 150 s), this loop converged in 51 ms, and with largest-first selection in 13 ms; the memory curve above is from that run. Details, traces and the RSS series are in shieldedtech/moth-wallet#141 and shieldedtech/moth-wallet#142. This PR is the same loop, applied where it belongs.

# Links

- shieldedtech/moth-wallet#142 — the same fix as a downstream wrapper, with the devnet traces and memory measurements
- shieldedtech/moth-wallet#141 — the largest-first selector, and the unit reproduction of the spin

